### PR TITLE
Added code to protect against NullPointerException in QuestionWidget.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -107,9 +107,12 @@ public abstract class QuestionWidget extends LinearLayout implements AudioPlayLi
             } catch (IllegalArgumentException e) {
                 e.printStackTrace();
             }
-        } 
-        mediaLayout.setPlayTextColor(mPlayColor);
-        
+        }
+
+        if (mediaLayout != null) {
+            mediaLayout.setPlayTextColor(mPlayColor);
+        }
+
         String playBackgroundColorString = p.getFormElement().getAdditionalAttribute(null, "playBackgroundColor");
         if (playBackgroundColorString != null) {
             try {
@@ -117,8 +120,11 @@ public abstract class QuestionWidget extends LinearLayout implements AudioPlayLi
             } catch (IllegalArgumentException e) {
                 e.printStackTrace();
             }
-        } 
-        mediaLayout.setPlayTextBackgroundColor(mPlayBackgroundColor);
+        }
+
+        if (mediaLayout != null) {
+            mediaLayout.setPlayTextBackgroundColor(mPlayBackgroundColor);
+        }
     }
 
     public void playAudio() {


### PR DESCRIPTION
The previous commit  that changed the QuestionWidget class placed code to initialize object member `MediaLayout mediaLayout` in method `addQuestionText`. This method, however is overridden in various widgets, including `LabelWidget`.

Thus later code in the constructor could try to call a method on `null`.

In my experience, a question that has appearance::label appearance::list-nolabel produced this runtime error (caught safely in a dialog, but needs fixing).

P.S. This SO question helped figure out git: http://stackoverflow.com/questions/5256021/send-a-pull-request-on-github-for-only-latest-commit
