### PR TITLE
Allow ODK Collect and derivative versions to be installed on the same device.

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -38,9 +38,9 @@
     -->
 
     <permission
-          android:name="org.odk.collect.android.permission.MAPS_RECEIVE"
+          android:name="${packageName}.permission.MAPS_RECEIVE"
           android:protectionLevel="signature" />
-    <uses-permission android:name="org.odk.collect.android.permission.MAPS_RECEIVE" />
+    <uses-permission android:name="${packageName}.permission.MAPS_RECEIVE" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
 
     <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="8" />
@@ -65,11 +65,11 @@
         <provider
             android:exported="true"
             android:name="org.odk.collect.android.provider.FormsProvider"
-            android:authorities="org.odk.collect.android.provider.odk.forms" />
+            android:authorities="${packageName}.provider.odk.forms" />
         <provider
             android:exported="true"
             android:name="org.odk.collect.android.provider.InstanceProvider"
-            android:authorities="org.odk.collect.android.provider.odk.instances" />
+            android:authorities="${packageName}.provider.odk.instances" />
 
         <activity
             android:name=".activities.MainMenuActivity"


### PR DESCRIPTION
When used in conjunction with a new app ID or flavor (`applicationId` or `productFlavors` respectively in `build.gradle`).
