### PR TITLE
Specifically make sure OSM files are uploaded to the server.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -317,6 +317,8 @@ public class InstanceUploaderTask extends AsyncTask<Long, Integer, InstanceUploa
                 files.add(f);
             } else if (extension.equals("mp4")) { // legacy 0.9x
                 files.add(f);
+            } else if (extension.equals("osm")) { // legacy 0.9x
+                files.add(f);
             } else {
                 Log.w(t, "unrecognized file type " + f.getName());
             }


### PR DESCRIPTION
Though this block of code should not be reached in an OpenRosa compliant server, an aggregate server that I am currently working on doesn't have the headers quite perfect.

Nonetheless, could you pull this in, just in case a server at some point makes this same mistake. Form submissions work fine with this minor fix.

As discussed with Waylon...

cc/ @mitchellsundt @dalekunce
