### PR TITLE
Forces double conversions in Locale.US

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import java.text.NumberFormat;
+import java.util.Locale;
 
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
@@ -70,7 +71,7 @@ public class DecimalWidget extends StringWidget {
 
         Double d = getDoubleAnswerValue();
 
-        NumberFormat nf = NumberFormat.getNumberInstance();
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
         nf.setMaximumFractionDigits(15);
         nf.setMaximumIntegerDigits(15);
         nf.setGroupingUsed(false);


### PR DESCRIPTION
This avoids unparsable strings in Double.parseDouble when numbers
are converted into non-latin characters (under an Arabic locale
for example).

Fixes #1181
