### PR TITLE
updating all widgets to use relativelayout instead of linearlayout so…

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -14,7 +14,6 @@
 
 package org.odk.collect.android.views;
 
-import android.text.method.LinkMovementMethod;
 import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.TextUtils;
 
@@ -73,7 +72,6 @@ public class HierarchyElementView extends RelativeLayout {
 
     public void setPrimaryText(String text) {
         mPrimaryTextView.setText(TextUtils.textToHtml(text));
-        mPrimaryTextView.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -355,7 +355,12 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
 
             if (mImageView != null || mMissingImage != null) {
                 imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
-                imageParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
+                imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                if (mVideoButton != null) {
+                    imageParams.addRule(RelativeLayout.LEFT_OF, mVideoButton.getId());
+                } else if (mAudioButton != null) {
+                    imageParams.addRule(RelativeLayout.LEFT_OF, mAudioButton.getId());
+                }
                 imageParams.addRule(RelativeLayout.BELOW, mView_Text.getId());
             } else {
                 textParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -101,8 +101,6 @@ public class AlignedImageWidget extends QuestionWidget implements IBinaryWidget 
         mInstanceFolder =
                 Collect.getInstance().getFormController().getInstancePath().getParent();
 
-        setOrientation(LinearLayout.VERTICAL);
-
         TableLayout.LayoutParams params = new TableLayout.LayoutParams();
         params.setMargins(7, 5, 7, 5);
 
@@ -193,9 +191,11 @@ public class AlignedImageWidget extends QuestionWidget implements IBinaryWidget 
         });
 
         // finish complex layout
-        addView(mCaptureButton);
-        addView(mChooseButton);
-        addView(mErrorTextView);
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(mCaptureButton);
+        answerLayout.addView(mChooseButton);
+        answerLayout.addView(mErrorTextView);
 
         // and hide the capture and choose button if read-only
         if ( prompt.isReadOnly() ) {
@@ -252,8 +252,9 @@ public class AlignedImageWidget extends QuestionWidget implements IBinaryWidget 
                 }
             });
 
-            addView(mImageView);
+            answerLayout.addView(mImageView);
         }
+        addAnswerView(answerLayout);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.io.File;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -40,12 +42,6 @@ import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Image widget that supports annotations on the image.
@@ -74,8 +70,6 @@ public class AnnotateWidget extends QuestionWidget implements IBinaryWidget {
 
 		mInstanceFolder = Collect.getInstance().getFormController()
 				.getInstancePath().getParent();
-
-		setOrientation(LinearLayout.VERTICAL);
 
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
@@ -195,10 +189,13 @@ public class AnnotateWidget extends QuestionWidget implements IBinaryWidget {
 		});
 
 		// finish complex layout
-		addView(mCaptureButton);
-		addView(mChooseButton);
-		addView(mAnnotateButton);
-		addView(mErrorTextView);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+
+		answerLayout.addView(mCaptureButton);
+		answerLayout.addView(mChooseButton);
+		answerLayout.addView(mAnnotateButton);
+		answerLayout.addView(mErrorTextView);
 
 		// and hide the capture, choose and annotate button if read-only
 		if (prompt.isReadOnly()) {
@@ -249,8 +246,9 @@ public class AnnotateWidget extends QuestionWidget implements IBinaryWidget {
 				}
 			});
 
-			addView(mImageView);
+			answerLayout.addView(mImageView);
 		}
+		addAnswerView(answerLayout);
 	}
 
 	private void launchAnnotateActivity() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.io.File;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -36,10 +38,6 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.Toast;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -64,8 +62,6 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
 
 		mInstanceFolder = Collect.getInstance().getFormController()
 				.getInstancePath().getParent();
-
-		setOrientation(LinearLayout.VERTICAL);
 
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
@@ -189,9 +185,12 @@ public class AudioWidget extends QuestionWidget implements IBinaryWidget {
 		}
 
 		// finish complex layout
-		addView(mCaptureButton);
-		addView(mChooseButton);
-		addView(mPlayButton);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mCaptureButton);
+		answerLayout.addView(mChooseButton);
+		answerLayout.addView(mPlayButton);
+		addAnswerView(answerLayout);
 
 		// and hide the capture and choose button if read-only
 		if (mPrompt.isReadOnly()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.widgets;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -29,11 +31,6 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Widget that allows user to scan barcodes and add them to the form.
@@ -46,7 +43,6 @@ public class BarcodeWidget extends QuestionWidget implements IBinaryWidget {
 
 	public BarcodeWidget(Context context, FormEntryPrompt prompt) {
 		super(context, prompt);
-		setOrientation(LinearLayout.VERTICAL);
 
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
@@ -100,8 +96,11 @@ public class BarcodeWidget extends QuestionWidget implements IBinaryWidget {
 			mStringAnswer.setText(s);
 		}
 		// finish complex layout
-		addView(mGetBarcodeButton);
-		addView(mStringAnswer);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mGetBarcodeButton);
+		answerLayout.addView(mStringAnswer);
+		addAnswerView(answerLayout);
 	}
 
 	@Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.widgets;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -29,10 +31,6 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
 
 /**
  * BearingWidget is the widget that allows the user to get a compass heading.
@@ -46,8 +44,6 @@ public class BearingWidget extends QuestionWidget implements IBinaryWidget {
 
     public BearingWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
-
-        setOrientation(LinearLayout.VERTICAL);
 
         TableLayout.LayoutParams params = new TableLayout.LayoutParams();
         params.setMargins(7, 5, 7, 5);
@@ -99,8 +95,11 @@ public class BearingWidget extends QuestionWidget implements IBinaryWidget {
             }
         });
 
-        addView(mGetBearingButton);
-        addView(mAnswerDisplay);
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(mGetBearingButton);
+        answerLayout.addView(mAnswerDisplay);
+        addAnswerView(answerLayout);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.res.Resources;
+import android.widget.*;
 import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -27,11 +28,6 @@ import android.os.Build;
 import android.view.Gravity;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.CalendarView;
-import android.widget.DatePicker;
-import android.widget.HorizontalScrollView;
-import android.widget.LinearLayout;
-import android.widget.TimePicker;
 
 import java.lang.reflect.Field;
 import java.util.Calendar;
@@ -118,17 +114,20 @@ public class DateTimeWidget extends QuestionWidget {
 		});
 
         setGravity(Gravity.LEFT);
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
         if ( showCalendar ) {
         	scrollView = new HorizontalScrollView(context);
         	LinearLayout ll = new LinearLayout(context);
         	ll.addView(mDatePicker);
         	ll.setPadding(10, 10, 10, 10);
         	scrollView.addView(ll);
-        	addView(scrollView);
+            answerLayout.addView(scrollView);
         } else {
-        	addView(mDatePicker);
+            answerLayout.addView(mDatePicker);
         }
-        addView(mTimePicker);
+        answerLayout.addView(mTimePicker);
+        addAnswerView(answerLayout);
 
         // If there's an answer, use it.
         setAnswer();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -102,9 +102,9 @@ public class DateWidget extends QuestionWidget {
         	ll.addView(mDatePicker);
         	ll.setPadding(10, 10, 10, 10);
         	scrollView.addView(ll);
-        	addView(scrollView);
+        	addAnswerView(scrollView);
         } else {
-        	addView(mDatePicker);
+            addAnswerView(mDatePicker);
         }
 
         // If there's an answer, use it.

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.io.File;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -40,12 +42,6 @@ import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Free drawing widget.
@@ -72,7 +68,6 @@ public class DrawWidget extends QuestionWidget implements IBinaryWidget {
 		mInstanceFolder = Collect.getInstance().getFormController()
 				.getInstancePath().getParent();
 
-		setOrientation(LinearLayout.VERTICAL);
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
 		// setup Blank Image Button
@@ -96,8 +91,10 @@ public class DrawWidget extends QuestionWidget implements IBinaryWidget {
 		});
 
 		// finish complex layout
-		addView(mDrawButton);
-		addView(mErrorTextView);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mDrawButton);
+		answerLayout.addView(mErrorTextView);
 
 		if (mPrompt.isReadOnly()) {
 			mDrawButton.setVisibility(View.GONE);
@@ -142,8 +139,9 @@ public class DrawWidget extends QuestionWidget implements IBinaryWidget {
 				}
 			});
 
-			addView(mImageView);
+			answerLayout.addView(mImageView);
 		}
+		addAnswerView(answerLayout);
 
 	}
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.util.Map;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -37,10 +39,6 @@ import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.TableLayout;
-import android.widget.Toast;
 
 
 /**
@@ -187,8 +185,11 @@ public class ExStringWidget extends QuestionWidget implements IBinaryWidget {
         });
 
         // finish complex layout
-        addView(mLaunchIntentButton);
-        addView(mAnswer);
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(mLaunchIntentButton);
+        answerLayout.addView(mAnswer);
+        addAnswerView(answerLayout);
     }
 
     protected void fireActivity(Intent i) throws ActivityNotFoundException {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.text.DecimalFormat;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -34,10 +36,6 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
 
 /**
  * GeoPointWidget is the widget that allows the user to get GPS readings.
@@ -113,7 +111,6 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
 		mReadOnly = prompt.isReadOnly();
 
 		// assemble the widget...
-		setOrientation(LinearLayout.VERTICAL);
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
 
@@ -213,9 +210,12 @@ public class GeoPointWidget extends QuestionWidget implements IBinaryWidget {
 
 		// finish complex layout
 		// control what gets shown with setVisibility(View.GONE)
-		addView(mGetLocationButton);
-		addView(mViewButton);
-		addView(mAnswerDisplay);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mGetLocationButton);
+		answerLayout.addView(mViewButton);
+		answerLayout.addView(mAnswerDisplay);
+		addAnswerView(answerLayout);
 
 		// figure out what text and buttons to enable or to show...
 		boolean dataAvailable = false;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
@@ -343,7 +343,7 @@ public class GridMultiWidget extends QuestionWidget {
         // Use the custom image adapter and initialize the grid view
         ImageAdapter ia = new ImageAdapter(getContext(), choices);
         gridview.setAdapter(ia);
-        addView(gridview,  new LinearLayout.LayoutParams(LinearLayout.LayoutParams.FILL_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        addAnswerView(gridview);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridWidget.java
@@ -335,7 +335,7 @@ public class GridWidget extends QuestionWidget {
         // Use the custom image adapter and initialize the grid view
         ImageAdapter ia = new ImageAdapter(getContext(), choices);
         gridview.setAdapter(ia);
-        addView(gridview,  new LinearLayout.LayoutParams(LinearLayout.LayoutParams.FILL_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        addAnswerView(gridview);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -17,6 +17,8 @@ package org.odk.collect.android.widgets;
 import java.io.File;
 import java.util.Date;
 
+import android.view.*;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -35,18 +37,9 @@ import android.net.Uri;
 import android.provider.MediaStore.Images;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.Display;
-import android.view.MotionEvent;
-import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -131,8 +124,6 @@ public class ImageWebViewWidget extends QuestionWidget implements IBinaryWidget 
 
 		mInstanceFolder = Collect.getInstance().getFormController()
 				.getInstancePath().getParent();
-
-		setOrientation(LinearLayout.VERTICAL);
 
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
@@ -231,9 +222,11 @@ public class ImageWebViewWidget extends QuestionWidget implements IBinaryWidget 
 		});
 
 		// finish complex layout
-		addView(mCaptureButton);
-		addView(mChooseButton);
-		addView(mErrorTextView);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mCaptureButton);
+		answerLayout.addView(mChooseButton);
+		answerLayout.addView(mErrorTextView);
 
 		// and hide the capture and choose button if read-only
 		if (prompt.isReadOnly()) {
@@ -261,8 +254,9 @@ public class ImageWebViewWidget extends QuestionWidget implements IBinaryWidget 
 
 			mImageDisplay.loadDataWithBaseURL("file:///" + mInstanceFolder
 					+ File.separator, html, "text/html", "utf-8", "");
-			addView(mImageDisplay);
+			answerLayout.addView(mImageDisplay);
 		}
+		addAnswerView(answerLayout);
 	}
 
     private void deleteMedia() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.io.File;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -39,12 +41,6 @@ import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the form.
@@ -71,8 +67,6 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
 
         mInstanceFolder =
                 Collect.getInstance().getFormController().getInstancePath().getParent();
-
-        setOrientation(LinearLayout.VERTICAL);
 
         TableLayout.LayoutParams params = new TableLayout.LayoutParams();
         params.setMargins(7, 5, 7, 5);
@@ -159,10 +153,12 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
         });
 
         // finish complex layout
-        addView(mCaptureButton);
-        addView(mChooseButton);
-        addView(mErrorTextView);
-     
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(mCaptureButton);
+        answerLayout.addView(mChooseButton);
+        answerLayout.addView(mErrorTextView);
+
         // and hide the capture and choose button if read-only
         if ( prompt.isReadOnly() ) {
         	mCaptureButton.setVisibility(View.GONE);
@@ -217,9 +213,9 @@ public class ImageWidget extends QuestionWidget implements IBinaryWidget {
                     }
                 }
             });
-
-            addView(mImageView);
+            answerLayout.addView(mImageView);
         }
+        addAnswerView(answerLayout);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
@@ -165,7 +165,7 @@ public class ItemsetWidget extends QuestionWidget implements
                 e.printStackTrace();
                 TextView error = new TextView(context);
                 error.setText("XPathParser Exception:  \"" + arguments.get(i) + "\"");
-                addView(error);
+                addAnswerView(error);
                 break;
             }
 
@@ -248,11 +248,11 @@ public class ItemsetWidget extends QuestionWidget implements
                 ida.close();
             }
 
-            addView(mButtons);
+            addAnswerView(mButtons);
         } else {
             TextView error = new TextView(context);
             error.setText(getContext().getString(R.string.file_missing, itemsetFile.getAbsolutePath()));
-            addView(error);
+            addAnswerView(error);
         }
 
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ListMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ListMultiWidget.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.view.*;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
@@ -38,10 +39,6 @@ import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.Display;
-import android.view.Gravity;
-import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -74,6 +71,7 @@ public class ListMultiWidget extends QuestionWidget {
     private List<SelectChoice> mItems; // may take a while to compute...
 
     private ArrayList<CheckBox> mCheckboxes;
+    private View center;
 
 
     @SuppressWarnings("unchecked")
@@ -249,29 +247,20 @@ public class ListMultiWidget extends QuestionWidget {
 
                 // /Each button gets equal weight
                 LinearLayout.LayoutParams answerParams =
-                    new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT,
-                            LayoutParams.WRAP_CONTENT);
+                    new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT,
+                            LayoutParams.MATCH_PARENT);
                 answerParams.weight = 1;
 
                 buttonLayout.addView(answer, answerParams);
-
             }
         }
 
         // Align the buttons so that they appear horizonally and are right justified
-        // buttonLayout.setGravity(Gravity.RIGHT);
         buttonLayout.setOrientation(LinearLayout.HORIZONTAL);
-        // LinearLayout.LayoutParams params = new
-        // LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-        // buttonLayout.setLayoutParams(params);
 
-        // The buttons take up the right half of the screen
-        LinearLayout.LayoutParams buttonParams =
-            new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
-        buttonParams.weight = 1;
-
-        questionLayout.addView(buttonLayout, buttonParams);
-        addView(questionLayout);
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        params.addRule(RelativeLayout.RIGHT_OF, center.getId());
+        addView(buttonLayout, params);
 
     }
 
@@ -338,11 +327,6 @@ public class ListMultiWidget extends QuestionWidget {
         LinearLayout.LayoutParams labelParams =
             new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
         labelParams.weight = 1;
-
-        questionLayout = new LinearLayout(getContext());
-        questionLayout.setOrientation(LinearLayout.HORIZONTAL);
-
-        questionLayout.addView(questionText, labelParams);
     }
 
 
@@ -360,5 +344,18 @@ public class ListMultiWidget extends QuestionWidget {
         for (CheckBox c : mCheckboxes) {
             c.cancelLongPress();
         }
+    }
+
+    @Override
+    protected void addQuestionMediaLayout(View v) {
+        center = new View(getContext());
+        RelativeLayout.LayoutParams centerParams = new RelativeLayout.LayoutParams(0, 0);
+        centerParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+        center.setId(QuestionWidget.newUniqueId());
+        addView(center, centerParams);
+
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        params.addRule(RelativeLayout.LEFT_OF, center.getId());
+        addView(v, params);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ListWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ListWidget.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.view.*;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
@@ -38,10 +39,6 @@ import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.Display;
-import android.view.Gravity;
-import android.view.View;
-import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
@@ -72,6 +69,7 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     List<SelectChoice> mItems; // may take a while to compute
     
     ArrayList<RadioButton> buttons;
+    View center;
 
     public ListWidget(Context context, FormEntryPrompt prompt, boolean displayLabel) {
         super(context, prompt);
@@ -192,15 +190,16 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
                 }
 
                 // answer layout holds the label text/image on top and the radio button on bottom
-                RelativeLayout answer = new RelativeLayout(getContext());
-                RelativeLayout.LayoutParams headerParams =
-                        new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-                headerParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-                headerParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
-                
-                RelativeLayout.LayoutParams buttonParams =
-                        new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-                buttonParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
+                LinearLayout answer = new LinearLayout(getContext());
+                answer.setOrientation(LinearLayout.VERTICAL);
+                LinearLayout.LayoutParams headerParams =
+                        new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+                headerParams.gravity = Gravity.CENTER_HORIZONTAL;
+
+
+                LinearLayout.LayoutParams buttonParams =
+                        new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
+                buttonParams.gravity = Gravity.CENTER_HORIZONTAL;
 
                 if (mImageView != null) {
                 	mImageView.setScaleType(ScaleType.CENTER);
@@ -217,40 +216,25 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
                     }
 
                 }
-                if ( displayLabel ) {
-                	buttonParams.addRule(RelativeLayout.BELOW, labelId );
-                }
                 answer.addView(r, buttonParams);
                 answer.setPadding(4, 0, 4, 0);
 
                 // Each button gets equal weight
                 LinearLayout.LayoutParams answerParams =
-                    new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT,
-                            LayoutParams.WRAP_CONTENT);
+                    new LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT,
+                            LayoutParams.MATCH_PARENT);
                 answerParams.weight = 1;
 
                 buttonLayout.addView(answer, answerParams);
-
             }
         }
 
-        // Align the buttons so that they appear horizonally and are right justified
-        // buttonLayout.setGravity(Gravity.RIGHT);
+
         buttonLayout.setOrientation(LinearLayout.HORIZONTAL);
-        // LinearLayout.LayoutParams params = new
-        // LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
-        // buttonLayout.setLayoutParams(params);
 
-        // The buttons take up the right half of the screen
-        LinearLayout.LayoutParams buttonParams =
-            new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
-        buttonParams.weight = 1;
-
-        // questionLayout is created and populated with the question text in the
-        // super() constructor via a call to addQuestionText
-        questionLayout.addView(buttonLayout, buttonParams);
-        addView(questionLayout);
-
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        params.addRule(RelativeLayout.RIGHT_OF, center.getId());
+        addView(buttonLayout, params);
     }
 
 
@@ -314,37 +298,6 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
     }
 
 
-    // Override QuestionWidget's add question text. Build it the same
-    // but add it to the relative layout
-    protected void addQuestionText(FormEntryPrompt p) {
-
-        // Add the text view. Textview always exists, regardless of whether there's text.
-        TextView questionText = new TextView(getContext());
-        questionText.setText(p.getLongText());
-        questionText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, mQuestionFontsize);
-        questionText.setTypeface(null, Typeface.BOLD);
-        questionText.setPadding(0, 0, 0, 7);
-        questionText.setId(QuestionWidget.newUniqueId()); // assign random id
-
-        // Wrap to the size of the parent view
-        questionText.setHorizontallyScrolling(false);
-
-        if (p.getLongText() == null) {
-            questionText.setVisibility(GONE);
-        }
-
-        // Put the question text on the left half of the screen
-        LinearLayout.LayoutParams labelParams =
-            new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT);
-        labelParams.weight = 1;
-
-        questionLayout = new LinearLayout(getContext());
-        questionLayout.setOrientation(LinearLayout.HORIZONTAL);
-
-        questionLayout.addView(questionText, labelParams);
-    }
-
-
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         for (RadioButton r : buttons) {
@@ -361,4 +314,16 @@ public class ListWidget extends QuestionWidget implements OnCheckedChangeListene
         }
     }
 
+    @Override
+    protected void addQuestionMediaLayout(View v) {
+        center = new View(getContext());
+        RelativeLayout.LayoutParams centerParams = new RelativeLayout.LayoutParams(0, 0);
+        centerParams.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+        center.setId(QuestionWidget.newUniqueId());
+        addView(center, centerParams);
+
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
+        params.addRule(RelativeLayout.LEFT_OF, center.getId());
+        addView(v, params);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -3,6 +3,8 @@ package org.odk.collect.android.widgets;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.apache.http.protocol.HTTP;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
@@ -27,10 +29,6 @@ import android.graphics.Typeface;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
 
 /**
  * Widget that allows the user to launch OpenMapKit to get an OSM Feature with a
@@ -75,9 +73,7 @@ public class OSMWidget extends QuestionWidget implements IBinaryWidget {
 		mInstanceDirectory = formController.getInstancePath().getParent();
 		mInstanceId = formController.getSubmissionMetadata().instanceId;
 		mFormId = formController.getFormDef().getID();
-		
-		setOrientation(LinearLayout.VERTICAL);
-        
+
         mErrorTextView = new TextView(context);
         mErrorTextView.setId(QuestionWidget.newUniqueId());
         mErrorTextView.setText("Something went wrong. We did not get valid OSM data.");
@@ -145,10 +141,13 @@ public class OSMWidget extends QuestionWidget implements IBinaryWidget {
 
         
         // finish complex layout
-        addView(mLaunchOpenMapKitButton);
-        addView(mErrorTextView);
-        addView(mOSMFileNameHeaderTextView);
-        addView(mOSMFileNameTextView);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mLaunchOpenMapKitButton);
+        answerLayout.addView(mErrorTextView) ;
+        answerLayout.addView(mOSMFileNameHeaderTextView);
+        answerLayout.addView(mOSMFileNameTextView);
+		addAnswerView(answerLayout);
         
         // Hide Launch button if read-only
         if ( prompt.isReadOnly() ) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -14,9 +14,16 @@
 
 package org.odk.collect.android.widgets;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import android.content.Context;
+import android.media.MediaPlayer;
+import android.media.MediaPlayer.OnCompletionListener;
+import android.text.method.LinkMovementMethod;
+import android.util.TypedValue;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.text.method.LinkMovementMethod;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
@@ -31,15 +38,8 @@ import org.odk.collect.android.external.ExternalSelectChoice;
 import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.views.MediaLayout;
 
-import android.content.Context;
-import android.media.MediaPlayer;
-import android.media.MediaPlayer.OnCompletionListener;
-import android.util.TypedValue;
-import android.view.inputmethod.InputMethodManager;
-import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * SelctMultiWidget handles multiple selection fields using checkboxes.
@@ -71,13 +71,13 @@ public class SelectMultiWidget extends QuestionWidget {
             mItems = prompt.getSelectChoices();
         }
 
-        setOrientation(LinearLayout.VERTICAL);
-
         List<Selection> ve = new ArrayList<Selection>();
         if (prompt.getAnswerValue() != null) {
             ve = (List<Selection>) prompt.getAnswerValue().getValue();
         }
 
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
         if (mItems != null) {
             for (int i = 0; i < mItems.size(); i++) {
                 // no checkbox group so id by answer + offset
@@ -137,17 +137,18 @@ public class SelectMultiWidget extends QuestionWidget {
 
                 MediaLayout mediaLayout = new MediaLayout(getContext(), mPlayer);
                 mediaLayout.setAVT(prompt.getIndex(), "." + Integer.toString(i), c, audioURI, imageURI, videoURI, bigImageURI);
-                addView(mediaLayout);
+
                 playList.add(mediaLayout);
 
                 // Last, add the dividing line between elements (except for the last element)
-                ImageView divider = new ImageView(getContext());
-                divider.setBackgroundResource(android.R.drawable.divider_horizontal_bright);
                 if (i != mItems.size() - 1) {
-                    addView(divider);
+                    ImageView divider = new ImageView(getContext());
+                    divider.setBackgroundResource(android.R.drawable.divider_horizontal_bright);
+                    mediaLayout.addDivider(divider);
                 }
-
+                answerLayout.addView(mediaLayout);
             }
+            addAnswerView(answerLayout);
         }
 
         mCheckboxInit = false;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneAutoAdvanceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneAutoAdvanceWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.view.ViewGroup;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
@@ -83,6 +84,8 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
                								R.drawable.expander_ic_right);
 
         if (mItems != null) {
+            LinearLayout answerLayout = new LinearLayout(getContext());
+            answerLayout.setOrientation(LinearLayout.VERTICAL);
             for (int i = 0; i < mItems.size(); i++) {
 
                 RelativeLayout thisParentLayout =
@@ -137,8 +140,9 @@ public class SelectOneAutoAdvanceWidget extends QuestionWidget implements OnChec
                     mediaLayout.addDivider(divider);
                 }
                 questionLayout.addView(mediaLayout);
-                addView(thisParentLayout);
+                answerLayout.addView(thisParentLayout);
             }
+            addAnswerView(answerLayout);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
@@ -137,10 +137,7 @@ public class SelectOneWidget extends QuestionWidget implements
 		buttonLayout.setOrientation(LinearLayout.VERTICAL);
 
 		// The buttons take up the right half of the screen
-		LayoutParams buttonParams = new LayoutParams(LayoutParams.FILL_PARENT,
-				LayoutParams.WRAP_CONTENT);
-
-		addView(buttonLayout, buttonParams);
+		addAnswerView(buttonLayout);
 	}
 
 	@Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.widgets;
 
 import java.io.File;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -40,12 +42,6 @@ import android.view.Display;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
 
 /**
  * Signature widget.
@@ -68,8 +64,6 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
 		mInstanceFolder = 
 				Collect.getInstance().getFormController().getInstancePath().getParent();
 
-		setOrientation(LinearLayout.VERTICAL);
-		
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
         params.setMargins(7, 5, 7, 5);
 		
@@ -99,9 +93,11 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
         
         
         // finish complex layout
-        addView(mSignButton);
-        addView(mErrorTextView);
-     
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(mSignButton);
+        answerLayout.addView(mErrorTextView);
+
         // and hide the sign button if read-only
         if ( prompt.isReadOnly() ) {
         	mSignButton.setVisibility(View.GONE);
@@ -146,6 +142,7 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
 
             addView(mImageView);
         }
+        addAnswerView(answerLayout);
 
 	}
 	

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -17,6 +17,9 @@ package org.odk.collect.android.widgets;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
@@ -175,9 +178,11 @@ public class SpinnerMultiWidget extends QuestionWidget {
             }
         }
 
-        addView(button);
-        addView(selectionText);
-
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(button);
+        answerLayout.addView(selectionText);
+        addAnswerView(answerLayout);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
@@ -117,7 +117,7 @@ public class SpinnerWidget extends QuestionWidget {
 				
 			}});
         
-        addView(spinner);
+        addAnswerView(spinner);
 
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -102,7 +102,7 @@ public class StringWidget extends QuestionWidget {
             mAnswer.setClickable(false);
         }
 
-        addView(mAnswer);
+        addAnswerView(mAnswer);
     }
 
     protected void setupChangeListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -77,7 +77,7 @@ public class TimeWidget extends QuestionWidget {
 		});
 
         setGravity(Gravity.LEFT);
-        addView(mTimePicker);
+        addAnswerView(mTimePicker);
 
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
@@ -52,8 +52,6 @@ public class TriggerWidget extends QuestionWidget {
         super(context, prompt);
         mPrompt = prompt;
 
-        this.setOrientation(LinearLayout.VERTICAL);
-
         mTriggerButton = new CheckBox(getContext());
         mTriggerButton.setId(QuestionWidget.newUniqueId());
         mTriggerButton.setText(getContext().getString(R.string.trigger));
@@ -93,8 +91,7 @@ public class TriggerWidget extends QuestionWidget {
         }
 
         // finish complex layout
-        this.addView(mTriggerButton);
-        // this.addView(mStringAnswer);
+        addAnswerView(mTriggerButton);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -14,12 +14,6 @@
 
 package org.odk.collect.android.widgets;
 
-import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.StringData;
-import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
-
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -27,11 +21,12 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
-import android.widget.Toast;
+import android.widget.*;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 
 /**
  * Widget that allows user to open URLs from within the form
@@ -44,7 +39,6 @@ public class UrlWidget extends QuestionWidget {
 
     public UrlWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
-        setOrientation(LinearLayout.VERTICAL);
 
         TableLayout.LayoutParams params = new TableLayout.LayoutParams();
         params.setMargins(7, 5, 7, 5);
@@ -89,8 +83,11 @@ public class UrlWidget extends QuestionWidget {
             mStringAnswer.setText(s);
         }
         // finish complex layout
-        addView(mOpenUrlButton);
-        addView(mStringAnswer);
+        LinearLayout answerLayout = new LinearLayout(getContext());
+        answerLayout.setOrientation(LinearLayout.VERTICAL);
+        answerLayout.addView(mOpenUrlButton);
+        answerLayout.addView(mStringAnswer);
+        addAnswerView(answerLayout);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -19,6 +19,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import android.view.ViewGroup;
+import android.widget.*;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -44,10 +46,6 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.Toast;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -80,8 +78,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
 
 		mInstanceFolder = Collect.getInstance().getFormController()
 				.getInstancePath().getParent();
-
-		setOrientation(LinearLayout.VERTICAL);
 
 		TableLayout.LayoutParams params = new TableLayout.LayoutParams();
 		params.setMargins(7, 5, 7, 5);
@@ -226,9 +222,12 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
 		}
 
 		// finish complex layout
-		addView(mCaptureButton);
-		addView(mChooseButton);
-		addView(mPlayButton);
+		LinearLayout answerLayout = new LinearLayout(getContext());
+		answerLayout.setOrientation(LinearLayout.VERTICAL);
+		answerLayout.addView(mCaptureButton);
+		answerLayout.addView(mChooseButton);
+		answerLayout.addView(mPlayButton);
+		addAnswerView(answerLayout);
 
 		// and hide the capture and choose button if read-only
 		if (mPrompt.isReadOnly()) {


### PR DESCRIPTION
… that they're all consistent

Previously all widgets were LinearLayouts, but several specialized layouts basically overwrote the linearlayouts with RelativeLayouts, and updates to the base QuestionView class would potentially break those layouts. This makes all widgets RelativeLayouts, and should make it easier to add customized layouts in the future.

Also removes the linkMovementMethod from the hierarchy view which prevents the user from selecting/jumping to a question.
