### PR TITLE
Can't use custom functions like jr:itext for external application params

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IntegerData;
@@ -93,9 +94,9 @@ public class ExternalAppsUtils {
     }
 
     public static void populateParameters(Intent intent, Map<String, String> exParams, TreeReference reference) throws ExternalParamsException {
-        FormInstance formInstance = Collect.getInstance().getFormController().getFormDef().getInstance();
-        EvaluationContext baseEvaluationContext = new EvaluationContext(formInstance);
-        EvaluationContext evaluationContext = new EvaluationContext(baseEvaluationContext, reference);
+        FormDef formDef = Collect.getInstance().getFormController().getFormDef();
+        FormInstance formInstance = formDef.getInstance();
+        EvaluationContext evaluationContext = new EvaluationContext(formDef.getEvaluationContext(), reference);
 
         if (exParams != null) {
             for (Map.Entry<String, String> paramEntry : exParams.entrySet()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -128,10 +128,9 @@ public class ExStringWidget extends QuestionWidget implements IBinaryWidget {
             mAnswer.setClickable(false);
         }
 
-        String appearance = prompt.getAppearanceHint();
-        String[] attrs = appearance.split(":");
-        final String intentName = ExternalAppsUtils.extractIntentName(attrs[1]);
-        final Map<String, String> exParams = ExternalAppsUtils.extractParameters(attrs[1]);
+        String exSpec = prompt.getAppearanceHint().replaceFirst("^ex[:]", "");
+        final String intentName = ExternalAppsUtils.extractIntentName(exSpec);
+        final Map<String, String> exParams = ExternalAppsUtils.extractParameters(exSpec);
         final String buttonText;
         final String errorString;
     	String v = mPrompt.getSpecialFormQuestionText("buttonText");


### PR DESCRIPTION
Due to a couple of relatively minor defects, it it is not possible to use an external application specification string such as:

```
ex:com.example.myapp.ACTION(label=jr:itext('label'))
```

The first issue is that the string specification is split on colon which mangles the specification into:

[ "ex", "com.example.myapp.ACTION(label=jr", "itext('label'))"]

The intent name and params are only extracted from the second element. This is a problem for any string that includes colons, not just namespace prefixes for functions like _jr:_. String literals like 'system normal: nothing wrong' corrupt the spec string as well.

Once the parsing is fixed, using custom functions like _jr:itext_  still doesn't work because the evaluation context used doesn't contain the custom functions. This is remedied simply by using the form definiton's evaluation context, which includes them.
