### PR TITLE
Fixed #197: Device id using wi-fi MAC is always the same on Android M and up

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
@@ -39,6 +39,8 @@ import android.util.Log;
 
 public class PropertyManager implements IPropertyManager {
 
+    public static final String ANDROID6_FAKE_MAC = "02:00:00:00:00:00";
+
     private String t = "PropertyManager";
 
     private Context mContext;
@@ -94,7 +96,7 @@ public class PropertyManager implements IPropertyManager {
 
     		// Get WiFi status
     		WifiInfo info = wifi.getConnectionInfo();
-    		if ( info != null ) {
+    		if ( info != null && !ANDROID6_FAKE_MAC.equals(info.getMacAddress())) {
     			deviceId = info.getMacAddress();
     			orDeviceId = "mac:" + deviceId;
     		}


### PR DESCRIPTION
This fixes the deviceid property calculation so that it never considers the special fake MAC returned by Android M and up, '02:00:00:00:00:00'.

The following screenshots show it running on a pre-M and M+ device respectively. You can see that the M device now defaults to the android id instead.

|<img src="https://cloud.githubusercontent.com/assets/478997/18635697/e961ffbe-7e53-11e6-8a71-6527bd5db90f.png" width="200">|<img src="https://cloud.githubusercontent.com/assets/478997/18635703/ed706410-7e53-11e6-8ea6-b7df4e3b3d22.png" width="200">|
