### PR TITLE
Fix Non closed polygons #200. Array index reference issue

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -308,7 +308,7 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
         String temp_string = "";
         //Add the first marker to the end of the array, so the first and the last are the same
         if (markerArray.size() > 1 ){
-            markerArray.add(markerArray.get(1));
+            markerArray.add(markerArray.get(0));
             for (int i = 0 ; i < markerArray.size();i++){
                 String lat = Double.toString(markerArray.get(i).getPosition().latitude);
                 String lng = Double.toString(markerArray.get(i).getPosition().longitude);


### PR DESCRIPTION
Resolving issue in geoshape for google maps. In a polygon the first and the last point should be the same. In this issue the second and the last polygon were being displayed and stored. I have attached two images highlighting the issue in an example geoshape. This fix was not needed in the OSM maps. 

https://github.com/opendatakit/collect/issues/200 

ODK issue image results

![odk-geoshape-bug](https://cloud.githubusercontent.com/assets/11786919/20311567/4d8c529a-ab1e-11e6-97d8-280d715537d0.png)

ODK issue fix results 

![odk-geoshape-fix](https://cloud.githubusercontent.com/assets/11786919/20311581/5a827ad8-ab1e-11e6-8b43-7c887667189f.png)

