### PR TITLE
Disable forward swipe at end screen. #96

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1306,8 +1306,16 @@ public class FormEntryActivity extends Activity implements AnimationListener,
             }
 
             View next;
+
+            int originalEvent = formController.getEvent();
             int event = formController.stepToNextScreenEvent();
 
+            // Helps prevent transition animation at the end of the form (if user swipes left
+            // she will stay on the same screen)
+            if (originalEvent == event && originalEvent == FormEntryController.EVENT_END_OF_FORM) {
+                mBeenSwiped = false;
+                return;
+            }
 
             switch (event) {
                 case FormEntryController.EVENT_QUESTION:


### PR DESCRIPTION
Scenarios tested:
* Filling out form, reaching end screen and swiping right
* Filling out form and then navigating back & forth between last few screens.
* Saving form, opening it up, going to structure and swiping right.
