### PR TITLE
Collect does not resize large annotated images. #121

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -460,8 +460,17 @@ public class DrawActivity extends Activity {
         }
 
         public void resetImage(int w, int h) {
+
+            // Because this activity is used in a fixed landscape mode only, sometimes resetImage()
+            // is called upon with flipped w/h (before orientation changes have been applied)
+            if (w > h) {
+                int temp = w;
+                w = h;
+                h = temp;
+            }
+
             if (mBackgroundBitmapFile.exists()) {
-                mBitmap = FileUtils.getBitmapScaledToDisplay(
+                mBitmap = FileUtils.getBitmapAccuratelyScaledToDisplay(
                         mBackgroundBitmapFile, w, h).copy(
                         Bitmap.Config.ARGB_8888, true);
                 // mBitmap =

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -213,6 +213,43 @@ public class FileUtils {
         return b;
     }
 
+    /**
+     * With this method we do not care about efficient decoding and focus
+     * more on a precise scaling to maximize use of space on the screen
+     */
+    public static Bitmap getBitmapAccuratelyScaledToDisplay(File f, int screenHeight,
+            int screenWidth) {
+        // Determine image size of f
+        BitmapFactory.Options o = new BitmapFactory.Options();
+        o.inJustDecodeBounds = true;
+        BitmapFactory.decodeFile(f.getAbsolutePath(), o);
+
+        // Load full size bitmap image
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inInputShareable = true;
+        options.inPurgeable = true;
+        Bitmap bitmap = BitmapFactory.decodeFile(f.getAbsolutePath(), options);
+
+        // Figure out scale
+        double heightScale = ((double) (o.outHeight)) / screenHeight;
+        double widthScale = ((double) o.outWidth) / screenWidth;
+        double scale = Math.max(widthScale, heightScale);
+
+        double newHeight = Math.ceil(o.outHeight / scale);
+        double newWidth = Math.ceil(o.outWidth / scale);
+
+        bitmap = Bitmap.createScaledBitmap(bitmap, (int) newWidth, (int) newHeight, false);
+
+        if (bitmap != null) {
+            Log.i(t,
+                    "Screen is " + screenHeight + "x" + screenWidth
+                            + ".  Image has been scaled down by "
+                            + scale + " to " + bitmap.getHeight() + "x" + bitmap.getWidth());
+        }
+
+        return bitmap;
+    }
+
 
     public static String copyFile(File sourceFile, File destFile) {
         if (sourceFile.exists()) {


### PR DESCRIPTION
This is for #121 issue.

In general it seems like there are 2 nuances that led to that behavior:
* Even though draw activity requests landscape orientation, calculations could be done while it's still in portrait mode (which affects screen width & height).
* FileUtils.getBitmapScaledToDisplay() uses sampling for loading images which means exact size of loaded image can be impresize.

Tested changes on the phone in portrait & landscape:
* Taking a landscape picture, then sketching
* Taking a portrait picture, then sketching
* Choosing a landscape picture, then sketching
* Choosing a portrait picture, then sketching