### PR TITLE
For bug #78, add RelativeList to DataManager view to separate text...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 local.properties
 *.iml
 .DS_Store
+*.sublime-project

--- a/collect_app/src/main/res/layout/two_item_multiple_choice.xml
+++ b/collect_app/src/main/res/layout/two_item_multiple_choice.xml
@@ -1,64 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2009 University of Washington Licensed under the Apache 
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2009 University of Washington Licensed under the Apache
 	License, Version 2.0 (the "License"); you may not use this file except in 
 	compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
 	Unless required by applicable law or agreed to in writing, software distributed 
 	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
 	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
 	the specific language governing permissions and limitations under the License. -->
-<org.odk.collect.android.views.TwoItemMultipleChoiceView
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:orientation="horizontal"
-	android:layout_width="fill_parent"
-	android:layout_height="wrap_content"
-	android:paddingStart="8dip"
-	android:paddingLeft="8dip"
-	android:paddingEnd="8dip"
-	android:paddingRight="8dip"
-	android:paddingTop="4dip"
-	android:paddingBottom="8dip"
-	android:minHeight="?android:attr/listPreferredItemHeight">
+<org.odk.collect.android.views.TwoItemMultipleChoiceView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:paddingBottom="8dip"
+    android:paddingEnd="8dip"
+    android:paddingLeft="8dip"
+    android:paddingRight="8dip"
+    android:paddingStart="8dip"
+    android:paddingTop="4dip">
 
-	<RelativeLayout
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_above="@+id/checkbox"
-		android:layout_centerHorizontal="true"
-		android:id="@+id/instance_item">
+    <RelativeLayout
+        android:id="@+id/instance_item"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/checkbox"
+        android:layout_centerHorizontal="true">
 
-		<TextView
-                android:id="@+id/text1"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:layout_alignParentTop="true"
-                android:layout_alignParentLeft="true"
-                android:text="text1"
-                android:textAppearance="?android:attr/textAppearanceLarge"
-			android:layout_toLeftOf="@+id/checkbox"
-			android:ellipsize="end"
-			android:maxLines="2"
-			android:singleLine="false" />
+        <TextView
+            android:id="@+id/text1"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentTop="true"
+            android:layout_toLeftOf="@+id/checkbox"
+            android:gravity="center_vertical"
+            android:text="text1"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
 
-		<TextView
-                android:id="@+id/text2"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:layout_below="@+id/text1"
-                android:layout_alignParentLeft="true"
-                android:text="text2"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-			android:layout_toLeftOf="@+id/checkbox" />
+        <TextView
+            android:id="@+id/text2"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_below="@+id/text1"
+            android:layout_toLeftOf="@+id/checkbox"
+            android:gravity="center_vertical"
+            android:text="text2"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
-		<CheckBox
+        <CheckBox
             android:id="@+id/checkbox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:focusable="false"
-            android:clickable="false"
+            android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
-            android:layout_alignParentRight="true" />
-	</RelativeLayout>
+            android:layout_gravity="center_vertical"
+            android:clickable="false"
+            android:focusable="false" />
+    </RelativeLayout>
 </org.odk.collect.android.views.TwoItemMultipleChoiceView>

--- a/collect_app/src/main/res/layout/two_item_multiple_choice.xml
+++ b/collect_app/src/main/res/layout/two_item_multiple_choice.xml
@@ -18,31 +18,47 @@
 	android:paddingTop="4dip"
 	android:paddingBottom="8dip"
 	android:minHeight="?android:attr/listPreferredItemHeight">
-    <TextView
-            android:id="@+id/text1"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentLeft="true"
-            android:text="text1"
-            android:textAppearance="?android:attr/textAppearanceLarge"/>
-    <TextView
-            android:id="@+id/text2"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:layout_below="@+id/text1"
-            android:layout_alignParentLeft="true"
-            android:text="text2"
-            android:textAppearance="?android:attr/textAppearanceSmall"/>
-	<CheckBox
-		android:id="@+id/checkbox"
-		android:layout_width="wrap_content"
+
+	<RelativeLayout
+		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
-		android:layout_gravity="center_vertical"
-		android:focusable="false"
-		android:clickable="false"
-		android:layout_centerVertical="true"
-		android:layout_alignParentRight="true" />
+		android:layout_above="@+id/checkbox"
+		android:layout_centerHorizontal="true"
+		android:id="@+id/instance_item">
+
+		<TextView
+                android:id="@+id/text1"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentLeft="true"
+                android:text="text1"
+                android:textAppearance="?android:attr/textAppearanceLarge"
+			android:layout_toLeftOf="@+id/checkbox"
+			android:ellipsize="end"
+			android:maxLines="2"
+			android:singleLine="false" />
+
+		<TextView
+                android:id="@+id/text2"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:layout_below="@+id/text1"
+                android:layout_alignParentLeft="true"
+                android:text="text2"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+			android:layout_toLeftOf="@+id/checkbox" />
+
+		<CheckBox
+            android:id="@+id/checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:clickable="false"
+            android:layout_centerVertical="true"
+            android:layout_alignParentRight="true" />
+	</RelativeLayout>
 </org.odk.collect.android.views.TwoItemMultipleChoiceView>


### PR DESCRIPTION
…and checkbox. Add ellipsize.

This will prevent long instance names from crashing into the checkbox in the DataManagerList. (See screen grab in issue #78) I used a RelativeLayout to place the checkbox to the right of the two TextViews. Additionally, I added a maxLines of 2 and an ellipsis at the end for items longer than two lines. I think this gives a good user experience. Only a layout change was needed, no Java changes.

Thoughts?

![Effect of the fix](https://cloud.githubusercontent.com/assets/791168/20867674/f85f9f60-ba41-11e6-8995-cb963830252b.PNG)


_Edited for typo_