### PR TITLE
Fix for #288 to keep the 'Connection to Server' popup from appearing …

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -245,7 +245,7 @@ public class FormDownloadList extends ListActivity implements FormListDownloader
                 }
                 mDownloadFormsTask = null;
             }
-        } else if (getLastNonConfigurationInstance() == null) {
+        } else if (mFormNamesAndURLs.isEmpty() && getLastNonConfigurationInstance() == null) {
             // first time, so get the formlist
             downloadFormList();
         }


### PR DESCRIPTION
…in the Get Blank Form after the device orientation changes.

The <tt>downloadFormList()</tt> method now only gets executed, when there are no entries in the <tt>mFormNamesAndUrls</tt> map and <tt>getLastNonConfigurationInstance()</tt> method returns null.

This is necessary because the <tt>mDownloadFormListTask</tt> gets set to null in the <tt>formListDownloadingComplete()</tt> method, after the <tt>mDownloadFormListTask</tt> is executed. Therefore, the <tt>getLastNonConfigurationInstance()</tt> method always returns null, for an instance of <tt>mDownloadFormListTask</tt>, after a full initialization cycle of the activity.<br>
While trying to figure out, what was causing the problem, I found it a lot harder than expected, to find the cause. I believe, that this was in part, because of the class design, which I found very hard to follow, because of the many side effects and responsibilities the class has.<br>
I think implementing this change, is like a drop on hot a stone. @lognaturel Maybe this class should be refactored because I only see it getting worse in the future, if not addressed.
