### PR TITLE
Fix for issue #313. Missing signature.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
@@ -143,7 +143,7 @@ public class SignatureWidget extends QuestionWidget implements IBinaryWidget {
                 }
             });
 
-            addView(mImageView);
+            answerLayout.addView(mImageView);
         }
         addAnswerView(answerLayout);
 


### PR DESCRIPTION
Added the signature view to the answer layout.  Tested in the fieldTask fork.  The signature you create now appears under the gather signature button.