### PR TITLE
Replace the use of 'or' with an sql 'in' when selecting instances for…

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -522,16 +522,19 @@ public class InstanceUploaderTask extends AsyncTask<Long, Integer, InstanceUploa
     protected Outcome doInBackground(Long... values) {
         Outcome outcome = new Outcome();
 
-        String selection = InstanceColumns._ID + "=?";
+        StringBuffer selectionBuf = new StringBuffer(InstanceColumns._ID + " IN (");
         String[] selectionArgs = new String[(values == null) ? 0 : values.length];
-        if (values != null) {
+        if(values != null) {
             for (int i = 0; i < values.length; i++) {
-                if (i != values.length - 1) {
-                    selection += " or " + InstanceColumns._ID + "=?";
+                if(i > 0) {
+                    selectionBuf.append(",");
                 }
+                selectionBuf.append("?");
                 selectionArgs[i] = values[i].toString();
             }
         }
+        selectionBuf.append(")");
+        String selection = selectionBuf.toString();
 
         String deviceId = new PropertyManager(Collect.getInstance().getApplicationContext())
                 .getSingularProperty(PropertyManager.OR_DEVICE_ID_PROPERTY);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -524,9 +524,9 @@ public class InstanceUploaderTask extends AsyncTask<Long, Integer, InstanceUploa
 
         StringBuffer selectionBuf = new StringBuffer(InstanceColumns._ID + " IN (");
         String[] selectionArgs = new String[(values == null) ? 0 : values.length];
-        if(values != null) {
+        if (values != null) {
             for (int i = 0; i < values.length; i++) {
-                if(i > 0) {
+                if (i > 0) {
                     selectionBuf.append(",");
                 }
                 selectionBuf.append("?");


### PR DESCRIPTION
… upload. Fix #323 

This is more of a suggestion than a "fix".  I've not reproduced the error which appeared to be caused by having a large number of instances to upload and hence have not demonstrated that the code changes here fix the issue.  

However based on an internet search it looks like using "IN" instead of "OR" is supposed to be a fix.  http://stackoverflow.com/questions/20838301/android-sqlite-correct-way-to-build-a-cursor-with-a-large-array-of-selection 

The code changes have also been tested in the fieldTask odk fork and instance uploads still work. 
