### PR TITLE
Crash when browsing GDrive with a fresh Google account

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -18,6 +18,7 @@
 
 package org.odk.collect.android.activities;
 
+import android.annotation.TargetApi;
 import android.app.ActionBar.LayoutParams;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -32,6 +33,7 @@ import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.Gravity;
@@ -71,6 +73,7 @@ import org.odk.collect.android.listeners.GoogleDriveFormDownloadListener;
 import org.odk.collect.android.listeners.TaskListener;
 import org.odk.collect.android.logic.DriveListItem;
 import org.odk.collect.android.preferences.PreferencesActivity;
+import org.odk.collect.android.utilities.ODKDialogFragment;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -493,6 +496,23 @@ public class GoogleDriveActivity extends ListActivity implements OnConnectionFai
         mAlertDialog.show();
     }
 
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    private void createExceptionAlertDialog() {
+        ODKDialogFragment.ODKDialogBundle.Builder odkDialogBundle = new ODKDialogFragment.ODKDialogBundle.Builder();
+        odkDialogBundle
+                .setDialogTitle(getString(R.string.download_forms_result))
+                .setDialogMessage(getString(R.string.gdrive_exception_message))
+                .setLeftButtonText(getString(R.string.cancel))
+                .setLeftButtonAction(ODKDialogFragment.Action.FINISH)
+                .setRightButtonText(getString(R.string.ok))
+                .setRightButtonAction(ODKDialogFragment.Action.TRY_TO_LIST_FILES_FROM_GDRIVE_AGAIN)
+                .setIcon(android.R.drawable.ic_dialog_info)
+                .setCancelable(false);
+
+        ODKDialogFragment odkDialogFragment = ODKDialogFragment.newInstance(odkDialogBundle.build());
+        odkDialogFragment.show(getFragmentManager(), "ODKDialogFragment");
+    }
+
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode,
             final Intent data) {
@@ -529,6 +549,7 @@ public class GoogleDriveActivity extends ListActivity implements OnConnectionFai
             AsyncTask<String, HashMap<String, Object>, HashMap<String, Object>> {
 
         private TaskListener listener;
+        private boolean exceptionOccurred;
 
         public void setTaskListener(TaskListener tl) {
             listener = tl;
@@ -567,6 +588,8 @@ public class GoogleDriveActivity extends ListActivity implements OnConnectionFai
                     return null;
                 } catch (IOException e) {
                     e.printStackTrace();
+                    exceptionOccurred = true;
+                    return null;
                 }
 
                 rootId = rootfile.getId();
@@ -634,6 +657,9 @@ public class GoogleDriveActivity extends ListActivity implements OnConnectionFai
         protected void onPostExecute(HashMap<String, Object> results) {
             super.onPostExecute(results);
             if (results == null) {
+                if (exceptionOccurred) {
+                    listener.taskException();
+                }
                 // was an auth request
                 return;
             }
@@ -894,6 +920,12 @@ public class GoogleDriveActivity extends ListActivity implements OnConnectionFai
     }
 
     @Override
+    public void taskException() {
+        MyDrive = false;
+        createExceptionAlertDialog();
+    }
+
+    @Override
     protected void onPause() {
         if (mRetrieveDriveFileContentsAsyncTask != null) {
             mRetrieveDriveFileContentsAsyncTask.setTaskListener(null);
@@ -974,6 +1006,11 @@ public class GoogleDriveActivity extends ListActivity implements OnConnectionFai
 
     public void listFiles(String dir) {
         listFiles(dir, null);
+    }
+
+    public void tryListFilesAgain() {
+        MyDrive = true;
+        listFiles(ROOT_KEY, null);
     }
 
 }

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/TaskListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/TaskListener.java
@@ -20,4 +20,6 @@ import java.util.HashMap;
  */
 public interface TaskListener {
     void taskComplete(HashMap<String, Object> results);
+
+    void taskException();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ODKDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ODKDialogFragment.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.odk.collect.android.utilities;
+
+import android.annotation.TargetApi;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Build;
+import android.os.Bundle;
+
+import org.odk.collect.android.activities.GoogleDriveActivity;
+
+import java.io.Serializable;
+
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
+public class ODKDialogFragment extends DialogFragment {
+
+    public enum Action { FINISH, TRY_TO_LIST_FILES_FROM_GDRIVE_AGAIN
+    }
+
+    public static final String ODK_DIALOG_BUNDLE = "odkDialogBundle";
+
+    public static ODKDialogFragment newInstance(ODKDialogBundle odkDialogBundle) {
+        ODKDialogFragment odkDialogFragment = new ODKDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(ODK_DIALOG_BUNDLE, odkDialogBundle);
+        odkDialogFragment.setArguments(bundle);
+        return odkDialogFragment;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final ODKDialogBundle odkDialogBundle = (ODKDialogBundle) getArguments().getSerializable(ODK_DIALOG_BUNDLE);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder
+                .setTitle(odkDialogBundle.getDialogTitle())
+                .setMessage(odkDialogBundle.getDialogMessage())
+                .setCancelable(odkDialogBundle.isCancelable());
+
+        if (odkDialogBundle.getLeftButtonText() != null) {
+            builder.setNegativeButton(odkDialogBundle.getLeftButtonText(), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    resolveButtonAction(odkDialogBundle.getLeftButtonAction());
+                }
+            });
+        }
+
+        if (odkDialogBundle.getRightButtonText() != null) {
+            builder.setPositiveButton(odkDialogBundle.getRightButtonText(), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    resolveButtonAction(odkDialogBundle.getRightButtonAction());
+                }
+            });
+        }
+
+        if (odkDialogBundle.getIcon() != null) {
+            builder.setIcon(odkDialogBundle.getIcon());
+        }
+
+        return builder.create();
+    }
+
+    private void resolveButtonAction(final Action action) {
+        switch (action) {
+            case FINISH:
+                dismiss();
+                getActivity().finish();
+                break;
+            case TRY_TO_LIST_FILES_FROM_GDRIVE_AGAIN:
+                dismiss();
+                ((GoogleDriveActivity) getActivity()).tryListFilesAgain();
+                break;
+            default:
+        }
+    }
+
+    public static class ODKDialogBundle implements Serializable {
+        private String mDialogTitle;
+        private String mDialogMessage;
+        private String mLeftButtonText;
+        private String mRightButtonText;
+
+        private Action mLeftButtonAction;
+        private Action mRightButtonAction;
+
+        private boolean mCancelable;
+
+        private int mIcon;
+
+        public ODKDialogBundle(Builder builder) {
+            mDialogTitle = builder.mDialogTitle;
+            mDialogMessage = builder.mDialogMessage;
+            mLeftButtonText = builder.mLeftButtonText;
+            mRightButtonText = builder.mRightButtonText;
+            mLeftButtonAction = builder.mLeftButtonAction;
+            mRightButtonAction = builder.mRightButtonAction;
+            mCancelable = builder.mCancelable;
+            mIcon = builder.mIcon;
+        }
+
+        public String getDialogTitle() {
+            return  mDialogTitle;
+        }
+
+        public String getDialogMessage() {
+            return  mDialogMessage;
+        }
+
+        public String getLeftButtonText() {
+            return mLeftButtonText;
+        }
+
+        public String getRightButtonText() {
+            return mRightButtonText;
+        }
+
+        public Action getLeftButtonAction() {
+            return mLeftButtonAction;
+        }
+
+        public Action getRightButtonAction() {
+            return mRightButtonAction;
+        }
+
+        public boolean isCancelable() {
+            return mCancelable;
+        }
+
+        public Integer getIcon() {
+            return mIcon;
+        }
+
+        public static class Builder {
+            private String mDialogTitle;
+            private String mDialogMessage;
+            private String mLeftButtonText;
+            private String mRightButtonText;
+
+            private Action mLeftButtonAction;
+            private Action mRightButtonAction;
+
+            private boolean mCancelable;
+
+            private int mIcon;
+
+            public Builder() {
+            }
+
+            public Builder setDialogTitle(String dialogTitle) {
+                mDialogTitle = dialogTitle;
+                return this;
+            }
+
+            public Builder setDialogMessage(String dialogMessage) {
+                mDialogMessage = dialogMessage;
+                return this;
+            }
+
+            public Builder setLeftButtonText(String leftButtonText) {
+                mLeftButtonText = leftButtonText;
+                return this;
+            }
+
+            public Builder setRightButtonText(String rightButtonText) {
+                mRightButtonText = rightButtonText;
+                return this;
+            }
+
+            public Builder setLeftButtonAction(Action leftButtonAction) {
+                mLeftButtonAction = leftButtonAction;
+                return this;
+            }
+
+            public Builder setRightButtonAction(Action rightButtonAction) {
+                mRightButtonAction = rightButtonAction;
+                return this;
+            }
+
+            public Builder setCancelable(Boolean cancelable) {
+                mCancelable = cancelable;
+                return this;
+            }
+
+            public Builder setIcon(int icon) {
+                mIcon = icon;
+                return this;
+            }
+
+            public ODKDialogBundle build() {
+                return new ODKDialogBundle(this);
+            }
+        }
+    }
+}

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -404,4 +404,5 @@
 <string name="direction">Direction: %s</string>
 <string name="general_settings_about">About</string>
 <string name="all_open_source_licenses">Open source licenses</string>
+<string name="gdrive_exception_message">An error occurred. Do you want to try again?</string>
 </resources>


### PR DESCRIPTION
This PR is in reference to resolve #289 

As it's really strange issue and it works so randomly we decided to handle occured exception in order to avoid a crash.
Additionally our current apporach for managing dialogs is not good I think. In the same class I edited exists other dialog and you can see how many addtional code lines we need (for example for creating this dialog again after changing device orientation). I decided to implement my proposal otherwise it would be a spaghetti code. 
I hope you like my proposal. The class I created doesn't have all functionality yet (only that I needed for my dialog) but we can extend this class and use for managing other dialogs too.