### PR TITLE
Lint error broke build: string marked unformatted, but used in String.format.

### DIFF
--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -420,7 +420,7 @@
 <string name="detection_frequency">detection frequency</string>
 <string name="two_hundred">200</string>
 <string name="record_geopoint">Record GeoPoint</string>
-<string name="gps_result" formatted="false">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$sm</string>
+<string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$sm</string>
 <string name="parser_exception">XPathParser Exception: \"%s\"</string>
 <string name="selected_answer">Selected: %s</string>
 <string name="version_number">Version: %s</string>


### PR DESCRIPTION
A lint problem caused by a poorly attributed string is causing automated builds to fail after merging #279.

The linter output describing the problem and identifying the line is attached.

[COLLECT-335-lint-report.zip](https://github.com/opendatakit/collect/files/711053/COLLECT-335-lint-report.zip)