### PR TITLE
'Get Selected' button is disabled although there is selected form after canceling downloading process

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -140,7 +140,6 @@ public class FormDownloadList extends ListActivity implements FormListDownloader
                 //    Collect.getInstance().getActivityLogger().logAction(this,
                 // "downloadSelectedFiles", ...);
                 downloadSelectedFiles();
-                clearChoices();
             }
         });
 


### PR DESCRIPTION
This PR is in reference to resolve #330