### PR TITLE
Remove non printable characters from barcode response. Fix #213.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -129,7 +129,7 @@ public class BarcodeWidget extends QuestionWidget implements IBinaryWidget {
     public void setBinaryData(Object answer) {
         String sResponse = (String) answer;
         if (sResponse != null) {      // It looks like the answer is not set to null even if no barcode captured, however it seems prudent to check
-            sResponse = sResponse.replaceAll("\\p{C}", ".");
+            sResponse = sResponse.replaceAll("\\p{C}", "");
         }
         mStringAnswer.setText(sResponse);
         Collect.getInstance().getFormController().setIndexWaitingForData(null);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -127,7 +127,11 @@ public class BarcodeWidget extends QuestionWidget implements IBinaryWidget {
      */
     @Override
     public void setBinaryData(Object answer) {
-        mStringAnswer.setText((String) answer);
+        String sResponse = (String) answer;
+        if (sResponse != null) {      // It looks like the answer is not set to null even if no barcode captured, however it seems prudent to check
+            sResponse = sResponse.replaceAll("\\p{C}", ".");
+        }
+        mStringAnswer.setText(sResponse);
         Collect.getInstance().getFormController().setIndexWaitingForData(null);
     }
 


### PR DESCRIPTION
Non printable characters in a barcode answer will be replaced with a dot ".".  This will allow the form to be saved.  However binary data will not be usable. A separate issue https://github.com/opendatakit/xforms-spec/issues/80 to discuss adding support for binary data in barcodes.