### PR TITLE
Right arrow isn't centered in vertical in cascading select with quick attribute

### DIFF
--- a/collect_app/src/main/res/layout/quick_select_layout.xml
+++ b/collect_app/src/main/res/layout/quick_select_layout.xml
@@ -17,6 +17,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
         android:contentDescription="@+string/select_answer" />
 
 </RelativeLayout>


### PR DESCRIPTION
This PR is in reference to resolve #365 