### PR TITLE
Add option to hide/show analytics preference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -482,7 +482,7 @@ public class MainMenuActivity extends Activity {
     private void setupGoogleAnalytics() {
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(Collect
                 .getInstance());
-        boolean isAnalyticsEnabled = settings.getBoolean(PreferencesActivity.KEY_ENABLE_ANALYTICS, true);
+        boolean isAnalyticsEnabled = settings.getBoolean(PreferencesActivity.KEY_ANALYTICS, true);
         GoogleAnalytics googleAnalytics = GoogleAnalytics.getInstance(getApplicationContext());
         googleAnalytics.setAppOptOut(!isAnalyticsEnabled);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesActivity.java
@@ -96,6 +96,8 @@ public class AdminPreferencesActivity extends PreferenceActivity {
     public static String KEY_SHOW_MAP_SDK = "show_map_sdk";
     public static String KEY_SHOW_MAP_BASEMAP = "show_map_basemap";
 
+    public static String KEY_ANALYTICS = "analytics";
+
     private static final int SAVE_PREFS_MENU = Menu.FIRST;
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -66,7 +66,7 @@ public class PreferencesActivity extends PreferenceActivity implements OnPrefere
     public static final String KEY_SPLASH_PATH = "splashPath";
     public static final String KEY_FONT_SIZE = "font_size";
     public static final String KEY_DELETE_AFTER_SEND = "delete_send";
-    public static final String KEY_ENABLE_ANALYTICS = "enable_analytics";
+    public static final String KEY_ANALYTICS = "analytics";
 
     public static final String KEY_PROTOCOL = "protocol";
     public static final String KEY_OPEN_SOURCE_LICENSES = "open_source_licenses";
@@ -133,6 +133,8 @@ public class PreferencesActivity extends PreferenceActivity implements OnPrefere
     protected ListPreference mMapSdk;
     protected ListPreference mMapBasemap;
 
+    private CheckBoxPreference mAnalyticsPreference;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -181,6 +183,10 @@ public class PreferencesActivity extends PreferenceActivity implements OnPrefere
 
         mMapSdk = (ListPreference) findPreference(KEY_MAP_SDK);
         mMapBasemap = (ListPreference) findPreference(KEY_MAP_BASEMAP);
+
+        PreferenceCategory analyticsCategory = (PreferenceCategory) findPreference(
+                getString(R.string.analytics_preferences));
+        mAnalyticsPreference = (CheckBoxPreference) findPreference(KEY_ANALYTICS);
 
         boolean autosendWifiAvailable = adminPreferences.getBoolean(
                 AdminPreferencesActivity.KEY_AUTOSEND_WIFI, true);
@@ -407,12 +413,19 @@ public class PreferencesActivity extends PreferenceActivity implements OnPrefere
             clientCategory.removePreference(highResolution);
         }
 
-        final CheckBoxPreference enableAnalyticsPreference = (CheckBoxPreference) findPreference(KEY_ENABLE_ANALYTICS);
-        enableAnalyticsPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+        boolean analyticsAvailable = adminPreferences.getBoolean(
+                AdminPreferencesActivity.KEY_ANALYTICS, true);
+        if (!(analyticsAvailable || adminMode)) {
+            analyticsCategory.removePreference(mAnalyticsPreference);
+            getPreferenceScreen().removePreference(analyticsCategory);
+
+        }
+
+        mAnalyticsPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 GoogleAnalytics googleAnalytics = GoogleAnalytics.getInstance(getApplicationContext());
-                googleAnalytics.setAppOptOut(!enableAnalyticsPreference.isChecked());
+                googleAnalytics.setAppOptOut(!mAnalyticsPreference.isChecked());
                 return true;
             }
         });

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -442,8 +442,8 @@
 <string name="invalid_rsa_public_key">Invalid RSA public key.</string>
 <string name="encryption_error_message">%s Form has not been saved as finalized.</string>
 <string name="analytics_preferences">Analytics Options</string>
-<string name="enable_analytics">Enable Analytics</string>
-<string name="enable_analytics_summary">Uncheck to disable Analytics</string>
+<string name="analytics">Enable Analytics</string>
+<string name="analytics_summary">Uncheck to disable Analytics</string>
 <string name="select_all">Select All</string>
 <string name="clear_all">Clear All</string>
 <string name="reset_settings">Settings</string>

--- a/collect_app/src/main/res/xml/admin_preferences.xml
+++ b/collect_app/src/main/res/xml/admin_preferences.xml
@@ -151,6 +151,12 @@
             android:key="show_map_basemap"
             android:summary="@string/found_in_settings"
             android:title="@string/show_map_basemap" />
+        <CheckBoxPreference
+            android:id="@+id/analytics"
+            android:defaultValue="true"
+            android:key="analytics"
+            android:summary="@string/found_in_settings"
+            android:title="@string/analytics" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/user_access_form_entry" >
         <CheckBoxPreference

--- a/collect_app/src/main/res/xml/preferences.xml
+++ b/collect_app/src/main/res/xml/preferences.xml
@@ -142,11 +142,11 @@
         android:title="@string/analytics_preferences" >
 
         <CheckBoxPreference
-            android:id="@+id/enable_analytics"
+            android:id="@+id/analytics"
             android:defaultValue="true"
-            android:key="enable_analytics"
-            android:summary="@string/enable_analytics_summary"
-            android:title="@string/enable_analytics" />
+            android:key="analytics"
+            android:summary="@string/analytics_summary"
+            android:title="@string/analytics" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This PR adds option to hide/show analytics preference in Admin Settings. I've changed some key names for consistency, so you should try this from a fresh install! I tested the following:
* In General Settings, the analytics setting and the analytics header appear and disappear based on the admin setting.
* The settings restore properly when I save to disk and restore from disk.
* Analytics are reported on GA when enabled and are not reported when disabled.