### PR TITLE
Wrong settings file path

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -130,7 +130,7 @@ public class MainMenuActivity extends Activity {
 
         setTitle(getString(R.string.main_menu));
 
-        File f = new File(Collect.ODK_ROOT + "/collect.settings");
+        File f = new File(Collect.SETTINGS + "/collect.settings");
         if (f.exists()) {
             boolean success = loadSharedPreferencesFromFile(f);
             if (success) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -65,6 +65,7 @@ public class Collect extends Application {
     public static final String LOG_PATH = ODK_ROOT + File.separator + "log";
     public static final String DEFAULT_FONTSIZE = "21";
     public static final String OFFLINE_LAYERS = ODK_ROOT + File.separator + "layers";
+    public static final String SETTINGS = ODK_ROOT + File.separator + "settings";
     private static Collect singleton = null;
 
     static {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesActivity.java
@@ -209,7 +209,7 @@ public class AdminPreferencesActivity extends PreferenceActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case SAVE_PREFS_MENU:
-                File writeDir = new File(Collect.ODK_ROOT + "/settings");
+                File writeDir = new File(Collect.SETTINGS);
                 if (!writeDir.exists()) {
                     if (!writeDir.mkdirs()) {
                         Toast.makeText(


### PR DESCRIPTION
This PR is in reference to resolve #456 

I fixed the problem with wrong path but there is another one. We load settings in MainMenuActivity#onCreate so we do that every time oure app is lunched. Then we delete this file so it's unuseful. I think it was added to give a possibility to load the settings file when user install the app again. Am I wrong?
I think we should add an option to load settings manually or do that if the app is luched for the first time after installation otherwise it's unuseful.