### PR TITLE
Daylight saving test

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -31,6 +31,7 @@ import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.DateWidgetUtils;
@@ -279,4 +280,17 @@ public class DateTimeWidget extends QuestionWidget {
         mTimePicker.cancelLongPress();
     }
 
+
+    // Skip over a "daylight savings gap". This is needed on the day and time of a daylight savings
+    // transition because that date/time doesn't exist.
+    // Today clocks are almost always set one hour back or ahead.
+    // Throughout history there have been several variations, like half adjustments (30 minutes) or
+    // double adjustment (two hours). Adjustments of 20 and 40 minutes have also been used.
+    // https://www.timeanddate.com/time/dst/
+    private LocalDateTime skipDaylightSavingGapIfExists(LocalDateTime ldt) {
+        while (DateTimeZone.getDefault().isLocalDateTimeGap(ldt)) {
+            ldt = ldt.plusMinutes(1);
+        }
+        return ldt;
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -213,7 +213,6 @@ public class DateWidget extends QuestionWidget {
                 .withHourOfDay(0)
                 .withMinuteOfHour(0);
 
-        ldt = skipDaylightSavingGapIfExists(ldt);
         return new DateData(ldt.toDate());
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -36,8 +36,6 @@ import android.widget.TextView;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.joda.time.DateTimeZone;
-import org.joda.time.LocalDateTime;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.listeners.AudioPlayListener;
@@ -374,19 +372,6 @@ public abstract class QuestionWidget extends RelativeLayout implements AudioPlay
             mPlayer.stop();
             mPlayer.reset();
         }
-    }
-
-    // Skip over a "daylight savings gap". This is needed on the day and time of a daylight savings
-    // transition because that date/time doesn't exist.
-    // Today clocks are almost always set one hour back or ahead.
-    // Throughout history there have been several variations, like half adjustments (30 minutes) or
-    // double adjustment (two hours). Adjustments of 20 and 40 minutes have also been used.
-    // https://www.timeanddate.com/time/dst/
-    protected LocalDateTime skipDaylightSavingGapIfExists(LocalDateTime ldt) {
-        while (DateTimeZone.getDefault().isLocalDateTimeGap(ldt)) {
-            ldt = ldt.plusMinutes(1);
-        }
-        return ldt;
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.odk.collect.android.utilities;
+
+import android.widget.DatePicker;
+import android.widget.TimePicker;
+
+import org.javarosa.core.model.IFormElement;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.odk.collect.android.BuildConfig;
+import org.odk.collect.android.widgets.DateTimeWidget;
+import org.odk.collect.android.widgets.DateWidget;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.stub;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = "src/main/AndroidManifest.xml",
+        packageName = "org.odk.collect")
+// https://github.com/opendatakit/collect/issues/356
+// The purpose of this test is to confirm that the app doesn't crash anymore in that case
+public class DaylightSavingTest {
+
+    private static final String EST_TIME_ZONE = "America/Los_Angeles";
+    private static final String CET_TIME_ZONE = "Europe/Warsaw";
+
+    private TimeZone mCurrentTimeZone;
+
+    @Before
+    public void setUp() {
+        mCurrentTimeZone = TimeZone.getDefault();
+    }
+
+    @After
+    public void tearDown() {
+        TimeZone.setDefault(mCurrentTimeZone);
+    }
+
+    @Test
+    // 12 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
+    public void testESTTimeZoneWithDateTimeWidget() {
+        TimeZone.setDefault(TimeZone.getTimeZone(EST_TIME_ZONE));
+        DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 2, 12, 2, 0);
+
+        IAnswerData answerData = dateTimeWidget.getAnswer();
+        assertNotNull(answerData);
+        assertDate(answerData, 2017, 2, 12, 3, 0);
+    }
+
+    @Test
+    // 12 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
+    public void testESTTimezoneWithDateWidget() {
+        TimeZone.setDefault(TimeZone.getTimeZone(EST_TIME_ZONE));
+        DateWidget dateWidget = prepareDateWidget(2017, 2, 12);
+
+        IAnswerData answerData = dateWidget.getAnswer();
+        assertNotNull(answerData);
+        assertDate(answerData, 2017, 2, 12, 0, 0);
+    }
+
+    @Test
+    // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
+    public void testCETTimeZoneWithDateTimeWidget() {
+        TimeZone.setDefault(TimeZone.getTimeZone(CET_TIME_ZONE));
+        DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 2, 26, 2, 0);
+
+        IAnswerData answerData = dateTimeWidget.getAnswer();
+        assertNotNull(answerData);
+        assertDate(answerData, 2017, 2, 26, 3, 0);
+    }
+
+    @Test
+    // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
+    public void testCETTimezoneWithDateWidget() {
+        TimeZone.setDefault(TimeZone.getTimeZone(CET_TIME_ZONE));
+        DateWidget dateWidget = prepareDateWidget(2017, 2, 26);
+
+        IAnswerData answerData = dateWidget.getAnswer();
+        assertNotNull(answerData);
+        assertDate(answerData, 2017, 2, 26, 0, 0);
+    }
+
+    private void assertDate(IAnswerData answerData, int year, int month, int day, int hour, int minute) {
+        Date date = (Date) answerData.getValue();
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+
+        assertEquals(year, calendar.get(Calendar.YEAR));
+        assertEquals(month, calendar.get(Calendar.MONTH));
+        assertEquals(day, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(hour, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(minute, calendar.get(Calendar.MINUTE));
+    }
+
+    private DateWidget prepareDateWidget(int year, int month, int day) {
+        QuestionDef questionDefStub = mock(QuestionDef.class);
+        IFormElement iFormElementStub = mock(IFormElement.class);
+        FormEntryPrompt formEntryPromptStub = mock(FormEntryPrompt.class);
+
+        stub(iFormElementStub.getAdditionalAttribute(anyString(), anyString())).toReturn(null);
+        stub(formEntryPromptStub.getQuestion()).toReturn(questionDefStub);
+        stub(formEntryPromptStub.getFormElement()).toReturn(iFormElementStub);
+        stub(formEntryPromptStub.getQuestion().getAppearanceAttr()).toReturn("no-calendar");
+
+        DatePicker datePicker = mock(DatePicker.class);
+        stub(datePicker.getYear()).toReturn(year);
+        stub(datePicker.getMonth()).toReturn(month);
+        stub(datePicker.getDayOfMonth()).toReturn(day);
+
+        DateWidget dateWidget = new DateWidget(RuntimeEnvironment.application, formEntryPromptStub);
+        Whitebox.setInternalState(dateWidget, "mDatePicker", datePicker);
+
+        return dateWidget;
+    }
+
+    private DateTimeWidget prepareDateTimeWidget(int year, int month, int day, int hour, int minute) {
+        QuestionDef questionDefStub = mock(QuestionDef.class);
+        IFormElement iFormElementStub = mock(IFormElement.class);
+        FormEntryPrompt formEntryPromptStub = mock(FormEntryPrompt.class);
+
+        stub(iFormElementStub.getAdditionalAttribute(anyString(), anyString())).toReturn(null);
+        stub(formEntryPromptStub.getQuestion()).toReturn(questionDefStub);
+        stub(formEntryPromptStub.getFormElement()).toReturn(iFormElementStub);
+        stub(formEntryPromptStub.getQuestion().getAppearanceAttr()).toReturn("no-calendar");
+
+        DatePicker datePicker = mock(DatePicker.class);
+        stub(datePicker.getYear()).toReturn(year);
+        stub(datePicker.getMonth()).toReturn(month);
+        stub(datePicker.getDayOfMonth()).toReturn(day);
+
+        TimePicker timePicker = mock(TimePicker.class);
+        stub(timePicker.getCurrentHour()).toReturn(hour);
+        stub(timePicker.getCurrentMinute()).toReturn(minute);
+
+        DateTimeWidget dateTimeWidget = new DateTimeWidget(RuntimeEnvironment.application, formEntryPromptStub);
+        Whitebox.setInternalState(dateTimeWidget, "mDatePicker", datePicker);
+        Whitebox.setInternalState(dateTimeWidget, "mTimePicker", timePicker);
+
+        return dateTimeWidget;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
@@ -45,10 +45,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.stub;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 21, manifest = "src/main/AndroidManifest.xml",
-        packageName = "org.odk.collect")
-// https://github.com/opendatakit/collect/issues/356
-// The purpose of this test is to confirm that the app doesn't crash anymore in that case
+@Config(constants = BuildConfig.class)
+/* https://github.com/opendatakit/collect/issues/356
+ * Verify that the date and datetime widget skips over "daylight savings gaps".
+ * This is needed on the day and time of a daylight savings transition because that date/time
+ * doesn't exist.*/
 public class DaylightSavingTest {
 
     private static final String EST_TIME_ZONE = "America/Los_Angeles";

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
@@ -20,7 +20,6 @@ import android.widget.TimePicker;
 
 import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
-import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.After;
 import org.junit.Before;
@@ -34,25 +33,23 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import java.util.Calendar;
-import java.util.Date;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.stub;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class)
-/* https://github.com/opendatakit/collect/issues/356
- * Verify that the date and datetime widget skips over "daylight savings gaps".
+/** https://github.com/opendatakit/collect/issues/356
+ * Verify that the {@link DateWidget} and {@link DateTimeWidget} widget skips over
+ * "daylight savings gaps".
  * This is needed on the day and time of a daylight savings transition because that date/time
- * doesn't exist.*/
+ * doesn't exist.
+ * In this test we set time to daylight saving gap and check if any crash occur*/
 public class DaylightSavingTest {
 
-    private static final String EST_TIME_ZONE = "America/Los_Angeles";
+    private static final String EAT_IME_ZONE = "Africa/Nairobi";
     private static final String CET_TIME_ZONE = "Europe/Warsaw";
 
     private TimeZone mCurrentTimeZone;
@@ -68,59 +65,29 @@ public class DaylightSavingTest {
     }
 
     @Test
-    // 12 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
+    // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00.
     public void testESTTimeZoneWithDateTimeWidget() {
-        TimeZone.setDefault(TimeZone.getTimeZone(EST_TIME_ZONE));
-        DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 2, 12, 2, 0);
-
-        IAnswerData answerData = dateTimeWidget.getAnswer();
-        assertNotNull(answerData);
-        assertDate(answerData, 2017, 2, 12, 3, 0);
-    }
-
-    @Test
-    // 12 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
-    public void testESTTimezoneWithDateWidget() {
-        TimeZone.setDefault(TimeZone.getTimeZone(EST_TIME_ZONE));
-        DateWidget dateWidget = prepareDateWidget(2017, 2, 12);
-
-        IAnswerData answerData = dateWidget.getAnswer();
-        assertNotNull(answerData);
-        assertDate(answerData, 2017, 2, 12, 0, 0);
-    }
-
-    @Test
-    // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
-    public void testCETTimeZoneWithDateTimeWidget() {
         TimeZone.setDefault(TimeZone.getTimeZone(CET_TIME_ZONE));
-        DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 2, 26, 2, 0);
+        DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 2, 26, 2, 30);
 
-        IAnswerData answerData = dateTimeWidget.getAnswer();
-        assertNotNull(answerData);
-        assertDate(answerData, 2017, 2, 26, 3, 0);
+        /**
+         * We would get crash in this place using old approach {@link org.joda.time.DateTime} instead of
+         * {@link org.joda.time.LocalDateTime}
+         */
+        dateTimeWidget.getAnswer();
     }
 
     @Test
-    // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00
-    public void testCETTimezoneWithDateWidget() {
-        TimeZone.setDefault(TimeZone.getTimeZone(CET_TIME_ZONE));
-        DateWidget dateWidget = prepareDateWidget(2017, 2, 26);
+    // 1 Jan 1960 at 00:00:00 clocks were turned forward to 00:15:00
+    public void testEATTimezoneWithDateWidget() {
+        TimeZone.setDefault(TimeZone.getTimeZone(EAT_IME_ZONE));
+        DateWidget dateWidget = prepareDateWidget(1960, 0, 1);
 
-        IAnswerData answerData = dateWidget.getAnswer();
-        assertNotNull(answerData);
-        assertDate(answerData, 2017, 2, 26, 0, 0);
-    }
-
-    private void assertDate(IAnswerData answerData, int year, int month, int day, int hour, int minute) {
-        Date date = (Date) answerData.getValue();
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(date);
-
-        assertEquals(year, calendar.get(Calendar.YEAR));
-        assertEquals(month, calendar.get(Calendar.MONTH));
-        assertEquals(day, calendar.get(Calendar.DAY_OF_MONTH));
-        assertEquals(hour, calendar.get(Calendar.HOUR_OF_DAY));
-        assertEquals(minute, calendar.get(Calendar.MINUTE));
+        /**
+         * We would get crash in this place using old approach {@link org.joda.time.DateTime} instead of
+         * {@link org.joda.time.LocalDateTime}
+         */
+        dateWidget.getAnswer();
     }
 
     private DateWidget prepareDateWidget(int year, int month, int day) {


### PR DESCRIPTION
I discovered skipDaylightSavingGapIfExists method is necessary only in DateTimeWidget. Unfortunatelly it doesn't work well in DateWidget as time is rounded by javarosa so if we use DateWidget and try eg. 1 Jan 1960 in Nairobi timezone the date is changed to 31 Dec 1959. I think we should add this case to known issues. The workaround here is using DateTimeWidget instead. It's not a big problem because nowadays time isn't changed at midnight these are rather historical cases.