### PR TITLE
Remove null pointer exception bug on getVersionedAppName() method

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -57,13 +57,13 @@ def getVersionName = { ->
 }
 
 android {
-    compileSdkVersion(22)
-    buildToolsVersion("25.0.0")
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId("org.odk.collect.android")
         minSdkVersion(16)
-        targetSdkVersion(22)
+        targetSdkVersion(25)
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner("android.support.test.runner.AndroidJUnitRunner")

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -176,7 +176,7 @@ public class Collect extends Application {
             versionName = getPackageManager()
                     .getPackageInfo(getPackageName(), 0)
                     .versionName;
-            versionName = " " + versionName.replaceFirst("-", "\n");
+            if(versionName !=null) versionName = " " + versionName.replaceFirst("-", "\n");
         } catch (NameNotFoundException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
Updated gradle file to target 25 SDK instead of 22 Plus Solved the App crash Bug on getVersionedAppName() method due to null pointer exception