### PR TITLE
Java Null Pointer Exception on Higher Versions of Android because of versionName object reference avoided. Fix #466.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -176,7 +176,9 @@ public class Collect extends Application {
             versionName = getPackageManager()
                     .getPackageInfo(getPackageName(), 0)
                     .versionName;
+            if(versionName!=null){
             versionName = " " + versionName.replaceFirst("-", "\n");
+            }
         } catch (NameNotFoundException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
Please review code and give suggestions if required.

Thanks and Regards
Vikas Desale