### PR TITLE
Null pointer checks to prevent crash (Fix #132)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -130,8 +130,9 @@ public class GeoPointActivity extends Activity implements LocationListener {
         super.onPause();
 
         // stops the GPS. Note that this will turn off the GPS if the screen goes to sleep.
-        if(mLocationManager!=null)
+        if (mLocationManager != null) {
             mLocationManager.removeUpdates(this);
+        }
 
         // We're not using managed dialogs, so we have to dismiss the dialog to prevent it from
         // leaking memory.
@@ -144,7 +145,7 @@ public class GeoPointActivity extends Activity implements LocationListener {
     @Override
     protected void onResume() {
         super.onResume();
-        if(mLocationManager!=null) {
+        if (mLocationManager != null) {
             if (mGPSOn) {
                 mLocationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
             }
@@ -152,8 +153,9 @@ public class GeoPointActivity extends Activity implements LocationListener {
                 mLocationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, this);
             }
         }
-        if(mLocationDialog!=null)
+        if (mLocationDialog != null) {
             mLocationDialog.show();
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -130,7 +130,8 @@ public class GeoPointActivity extends Activity implements LocationListener {
         super.onPause();
 
         // stops the GPS. Note that this will turn off the GPS if the screen goes to sleep.
-        mLocationManager.removeUpdates(this);
+        if(mLocationManager!=null)
+            mLocationManager.removeUpdates(this);
 
         // We're not using managed dialogs, so we have to dismiss the dialog to prevent it from
         // leaking memory.
@@ -143,13 +144,16 @@ public class GeoPointActivity extends Activity implements LocationListener {
     @Override
     protected void onResume() {
         super.onResume();
-        if (mGPSOn) {
-            mLocationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
+        if(mLocationManager!=null) {
+            if (mGPSOn) {
+                mLocationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
+            }
+            if (mNetworkOn) {
+                mLocationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, this);
+            }
         }
-        if (mNetworkOn) {
-            mLocationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, this);
-        }
-        mLocationDialog.show();
+        if(mLocationDialog!=null)
+            mLocationDialog.show();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -183,7 +183,8 @@ public class GeoPointMapActivity extends FragmentActivity implements LocationLis
     @Override
     protected void onPause() {
         super.onPause();
-        mLocationManager.removeUpdates(this);
+        if(mLocationManager!=null)
+            mLocationManager.removeUpdates(this);
     }
 
     private void setupMap(GoogleMap googleMap) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -183,8 +183,9 @@ public class GeoPointMapActivity extends FragmentActivity implements LocationLis
     @Override
     protected void onPause() {
         super.onPause();
-        if(mLocationManager!=null)
+        if (mLocationManager != null) {
             mLocationManager.removeUpdates(this);
+        }
     }
 
     private void setupMap(GoogleMap googleMap) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -317,19 +317,21 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
     @Override
     protected void onPause() {
         super.onPause();
-        if(mLocationManager!=null)
+        if (mLocationManager != null) {
             mLocationManager.removeUpdates(this);
+        }
     }
 
 
     @Override
     protected void onResume() {
         super.onResume();
-        if(mMap!=null)
+        if (mMap != null) {
             mHelper.setBasemap();
-        if(mLocationManager!=null)
+        }
+        if (mLocationManager != null) {
             upMyLocationOverlayLayers();
-
+        }
     }
 
     private void upMyLocationOverlayLayers() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -317,15 +317,18 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
     @Override
     protected void onPause() {
         super.onPause();
-        mLocationManager.removeUpdates(this);
+        if(mLocationManager!=null)
+            mLocationManager.removeUpdates(this);
     }
 
 
     @Override
     protected void onResume() {
         super.onResume();
-        mHelper.setBasemap();
-        upMyLocationOverlayLayers();
+        if(mMap!=null)
+            mHelper.setBasemap();
+        if(mLocationManager!=null)
+            upMyLocationOverlayLayers();
 
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -117,7 +117,8 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
     @Override
     protected void onPause() {
         super.onPause();
-        mLocationManager.removeUpdates(this);
+        if(mLocationManager!=null)
+            mLocationManager.removeUpdates(this);
 
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -117,9 +117,9 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
     @Override
     protected void onPause() {
         super.onPause();
-        if(mLocationManager!=null)
+        if (mLocationManager != null) {
             mLocationManager.removeUpdates(this);
-
+        }
     }
 
     private void setupMap(GoogleMap googleMap) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
@@ -200,7 +200,9 @@ public class GeoShapeOsmMapActivity extends Activity implements IRegisterReceive
     @Override
     protected void onResume() {
         super.onResume();
-        mHelper.setBasemap();
+        if(mMap!=null)
+            mHelper.setBasemap();
+
         upMyLocationOverlayLayers();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
@@ -200,9 +200,9 @@ public class GeoShapeOsmMapActivity extends Activity implements IRegisterReceive
     @Override
     protected void onResume() {
         super.onResume();
-        if(mMap!=null)
+        if (mMap != null) {
             mHelper.setBasemap();
-
+        }
         upMyLocationOverlayLayers();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -415,7 +415,8 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     }
 
     private void disableMyLocation() {
-        mLocationManager.removeUpdates(this);
+        if(mLocationManager!=null)
+            mLocationManager.removeUpdates(this);
     }
 
     private String generateReturnString() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -415,8 +415,9 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     }
 
     private void disableMyLocation() {
-        if(mLocationManager!=null)
+        if (mLocationManager != null) {
             mLocationManager.removeUpdates(this);
+        }
     }
 
     private String generateReturnString() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -352,16 +352,18 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     @Override
     protected void onResume() {
         super.onResume();
-        if(mapView!=null)
+        if (mapView != null) {
             mHelper.setBasemap();
+        }
         upMyLocationOverlayLayers();
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        if(mMyLocationOverlay!=null)
+        if (mMyLocationOverlay != null) {
             mMyLocationOverlay.enableMyLocation();
+        }
 //		if(mMyLocationOverlay.getMyLocation()!= null){
 //			mMyLocationOverlay.runOnFirstFix(centerAroundFix);
 //		}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -352,14 +352,16 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     @Override
     protected void onResume() {
         super.onResume();
-        mHelper.setBasemap();
+        if(mapView!=null)
+            mHelper.setBasemap();
         upMyLocationOverlayLayers();
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-        mMyLocationOverlay.enableMyLocation();
+        if(mMyLocationOverlay!=null)
+            mMyLocationOverlay.enableMyLocation();
 //		if(mMyLocationOverlay.getMyLocation()!= null){
 //			mMyLocationOverlay.runOnFirstFix(centerAroundFix);
 //		}


### PR DESCRIPTION
#132 

Location crashes were happening on devices not having google play services installed. The thing was that locationManager couldn't be initialized ( due to no Google Play) and methods were called on it's object in onResume(), onPause() etc. which were causing the NPE. 
Now, the app wouldn't crash. But we also need to provide some visual feedback to the user to install Play Services. 