### PR TITLE
Update build tools and gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -58,7 +58,7 @@ def getVersionName = { ->
 
 android {
     compileSdkVersion(22)
-    buildToolsVersion("25.0.0")
+    buildToolsVersion("25.0.2")
 
     defaultConfig {
         applicationId("org.odk.collect.android")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 02 08:59:15 PDT 2016
+#Fri Mar 03 09:12:28 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Adds support for Android Studio 2.3 which has "performance improvements and new features". I've tried a quick smoke test with a clean build to a Moto G4 and it works.