### PR TITLE
Buttons at the bottom of Send Finalized Form screen should each take up half the width #529

### DIFF
--- a/collect_app/src/main/res/layout/data_manage_list.xml
+++ b/collect_app/src/main/res/layout/data_manage_list.xml
@@ -29,7 +29,7 @@ the License.
         
          <Button
             android:id="@+id/toggle_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:padding="12dp"
@@ -38,7 +38,7 @@ the License.
          
         <Button
             android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:padding="12dp"

--- a/collect_app/src/main/res/layout/form_manage_list.xml
+++ b/collect_app/src/main/res/layout/form_manage_list.xml
@@ -30,7 +30,7 @@ the License.
         
         <Button
             android:id="@+id/toggle_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:padding="12dp"
@@ -39,7 +39,7 @@ the License.
          
         <Button
             android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:padding="12dp"

--- a/collect_app/src/main/res/layout/instance_uploader_list.xml
+++ b/collect_app/src/main/res/layout/instance_uploader_list.xml
@@ -27,7 +27,7 @@ the License.
 		<Button
 			android:id="@+id/toggle_button"
 			android:text="@string/select_all"
-			android:layout_width="wrap_content"
+			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:padding="12dp"
 			android:textSize="16sp"
@@ -35,7 +35,7 @@ the License.
 		<Button
 			android:id="@+id/upload_button"
 			android:text="@string/send_selected_data"
-			android:layout_width="wrap_content"
+			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:padding="12dp"
 			android:textSize="16sp"


### PR DESCRIPTION
Fixes button width in send finalized and delete saved forms screens