### PR TITLE
Issue #561 Fixed : Printer widget layout puts label and hint outside button

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
@@ -23,6 +23,7 @@ import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.Toast;
 
@@ -161,7 +162,10 @@ public class ExPrinterWidget extends QuestionWidget implements IBinaryWidget {
         });
 
         // finish complex layout
-        addView(mLaunchIntentButton);
+        LinearLayout mPrintLayout = new LinearLayout(getContext());
+        mPrintLayout.setOrientation(LinearLayout.VERTICAL);
+        mPrintLayout.addView(mLaunchIntentButton);
+        addAnswerView( mPrintLayout);
     }
 
     protected void firePrintingActivity(String intentName) throws ActivityNotFoundException {


### PR DESCRIPTION
Printer widget layout puts label and hint outside and before button

Tested with Android version 5.1 and 7.1

![screenshot_20170311-201817](https://cloud.githubusercontent.com/assets/16884938/23824187/06bbdc5c-0698-11e7-9767-84f31fff68c4.png)




