### PR TITLE
Fix #512.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -44,6 +44,13 @@ public class FormsDao {
         return getFormsCursor(null, selection, selectionArgs, null);
     }
 
+    public int deleteFormsForFormId(String formId) {
+        String selection = FormsProviderAPI.FormsColumns.JR_FORM_ID + "=?";
+        String selectionArgs[] = {formId};
+
+        return deleteFormsForFormId(selection, selectionArgs);
+    }
+
     public Cursor getFormsCursorForFormId(String formId) {
         String selection = FormsProviderAPI.FormsColumns.JR_FORM_ID + "=?";
         String selectionArgs[] = {formId};
@@ -67,6 +74,10 @@ public class FormsDao {
 
     public Cursor getFormsCursor(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
         return Collect.getInstance().getContentResolver().query(FormsProviderAPI.FormsColumns.CONTENT_URI, projection, selection, selectionArgs, sortOrder);
+    }
+
+    public int deleteFormsForFormId(String selection, String[] selectionArgs) {
+        return Collect.getInstance().getContentResolver().delete(FormsProviderAPI.FormsColumns.CONTENT_URI, selection, selectionArgs);
     }
 
     public void deleteFormsDatabase() {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -44,12 +44,29 @@ public class FormsDao {
         return getFormsCursor(null, selection, selectionArgs, null);
     }
 
-    public int deleteFormsForFormId(String[] selectionArgs) {
+    public void deleteFormsForFormId(List<String> selectionArgs) {
         String selection = FormsProviderAPI.FormsColumns._ID + " in (";
-        for(int i = 0; i < selectionArgs.length-1; i++)
+        List<String> tempSelectionArgs=new ArrayList<String>();
+        int i=0;
+        for(String args:selectionArgs)
+        {
+            i++;
             selection += "?, ";
-        selection += "? )";
-        return deleteFormsForFormId(selection, selectionArgs);
+            tempSelectionArgs.add(args);
+            if(i%999==0)
+            {
+                selection = selection.substring(0,selection.length()-2)+" )";
+                deleteFormsForFormId(selection, tempSelectionArgs.toArray(new String[tempSelectionArgs.size()]));
+                tempSelectionArgs=new ArrayList<String>();
+                i=0;
+                selection = FormsProviderAPI.FormsColumns._ID + " in (";
+            }
+        }
+        if(i%999!=0)
+        {
+            selection = selection.substring(0,selection.length()-2)+" )";
+            deleteFormsForFormId(selection, tempSelectionArgs.toArray(new String[tempSelectionArgs.size()]));
+        }
     }
 
     public Cursor getFormsCursorForFormId(String formId) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -44,10 +44,11 @@ public class FormsDao {
         return getFormsCursor(null, selection, selectionArgs, null);
     }
 
-    public int deleteFormsForFormId(String formId) {
-        String selection = FormsProviderAPI.FormsColumns._ID + "=?";
-        String selectionArgs[] = {formId};
-
+    public int deleteFormsForFormId(String[] selectionArgs) {
+        String selection = FormsProviderAPI.FormsColumns._ID + " in (";
+        for(int i = 0; i < selectionArgs.length-1; i++)
+            selection += "?, ";
+        selection += "? )";
         return deleteFormsForFormId(selection, selectionArgs);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -45,7 +45,7 @@ public class FormsDao {
     }
 
     public int deleteFormsForFormId(String formId) {
-        String selection = FormsProviderAPI.FormsColumns.JR_FORM_ID + "=?";
+        String selection = FormsProviderAPI.FormsColumns._ID + "=?";
         String selectionArgs[] = {formId};
 
         return deleteFormsForFormId(selection, selectionArgs);

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -43,7 +43,6 @@ public final class FormsProviderAPI {
         public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.odk.form";
 
         // These are the only things needed for an insert
-        public static final String ID = "_id";
         public static final String DISPLAY_NAME = "displayName";
         public static final String DESCRIPTION = "description";  // can be null
         public static final String JR_FORM_ID = "jrFormId";

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -43,6 +43,7 @@ public final class FormsProviderAPI {
         public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.odk.form";
 
         // These are the only things needed for an insert
+        public static final String ID = "_id";
         public static final String DISPLAY_NAME = "displayName";
         public static final String DESCRIPTION = "description";  // can be null
         public static final String JR_FORM_ID = "jrFormId";

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -100,6 +100,7 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                 // parse and update; this is quick, as we only calculate the md5
                 // and see if it has changed.
                 List<UriFile> uriToUpdate = new ArrayList<UriFile>();
+                List<String> idsToDelete = new ArrayList<String>();
                 Cursor mCursor = null;
                 // open the cursor within a try-catch block so it can always be closed.
                 try {
@@ -137,13 +138,16 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                             }
                         } else {
                             // remove it from the database also
-                            mFormsDao.deleteFormsForFormId(mCursor.getString(
-                                                        mCursor.getColumnIndex(FormsColumns._ID)));
+                            idsToDelete.add(mCursor.getString(
+                                    mCursor.getColumnIndex(FormsColumns._ID)));
                             Log.w(t, "[" + instance
                                     + "] file referenced by content provider does not exist, hence removed "
                                     + sqlFile);
                         }
                     }
+                    // remove the list from the database
+                    mFormsDao.deleteFormsForFormId(idsToDelete.toArray(new String[idsToDelete.size()]));
+					Log.i(t, "the files which does not exist are removed from the database");
                 } finally {
                     if (mCursor != null) {
                         mCursor.close();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -146,8 +146,8 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                         }
                     }
                     // remove the list from the database
-                    mFormsDao.deleteFormsForFormId(idsToDelete.toArray(new String[idsToDelete.size()]));
-					Log.i(t, "the files which does not exist are removed from the database");
+                    mFormsDao.deleteFormsForFormId(idsToDelete);
+                    Log.i(t, "the files which does not exist are removed from the database");
                 } finally {
                     if (mCursor != null) {
                         mCursor.close();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -138,7 +138,7 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                         } else {
                             // remove it from the database also
                             mFormsDao.deleteFormsForFormId(mCursor.getString(
-                                                        mCursor.getColumnIndex(FormsColumns.ID)));
+                                                        mCursor.getColumnIndex(FormsColumns._ID)));
                             Log.w(t, "[" + instance
                                     + "] file referenced by content provider does not exist, hence removed "
                                     + sqlFile);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -136,8 +136,11 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                                 uriToUpdate.add(new UriFile(updateUri, sqlFile));
                             }
                         } else {
+                            // remove it from the database also
+                            mFormsDao.deleteFormsForFormId(mCursor.getString(
+                                                        mCursor.getColumnIndex(FormsColumns.ID)));
                             Log.w(t, "[" + instance
-                                    + "] file referenced by content provider does not exist "
+                                    + "] file referenced by content provider does not exist, hence removed "
                                     + sqlFile);
                         }
                     }


### PR DESCRIPTION
Issue: #512 
> When you push form to Collect's SD card (e.g., adb push my_form.xml /sdcard/odk/forms) and go to Fill Blank Form, the app scans the SD card and adds the form to the DB. It even updates the form title when you push a new form with new data.
> 
> But when you remove the form, it does nothing. Instead, when you tap on the form, it shows you a form not found dialog. It would be nice if removing the form also removed the DB entry. But, there's probably a reason why it was left it in the DB...

When the user taps on _Fill Blank Form_, DiskSyncTask is run. During this task, if an entry from the database is not found in the filesystem (/sdcard/odk/forms), this entry is removed from the database. 