### PR TITLE
Fix CirceCI timeouts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
         # Cache Android SDK to avoid unnecessary downloads
         # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
         - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
-        - if ! $(grep -q "Revision=25.0.2" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
+        - if ! $(grep -q "Revision=25.0.3" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
         - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
         - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
         - if ! $(grep -q "Revision=45.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi

--- a/circle.yml
+++ b/circle.yml
@@ -11,21 +11,10 @@ machine:
         
 dependencies:
     pre:
-        # Cache Android SDK to avoid unnecessary downloads
-        # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
-        - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
-        - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
-        - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
-        - if ! $(grep -q "Revision=45.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-        - if ! $(grep -q "Revision=44.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
-    
-    cache_directories:
-        - /usr/local/android-sdk-linux/tools
-        - /usr/local/android-sdk-linux/build-tools/25.0.2
-        - /usr/local/android-sdk-linux/platforms/android-25
-        - /usr/local/android-sdk-linux/extras/android/m2repository
-        - /usr/local/android-sdk-linux/extras/google/m2repository
-
+        # We need latest versions of: tools,platform-tools,build-tools-25.0.2,android-25,extra-google-m2repository,extra-android-m2repository
+        # But there some already installed: https://circleci.com/docs/1.0/build-image-trusty/#android
+        # Don't cache SDKs because it's faster to download than to restore from cache
+        - echo y | android update sdk --no-ui --all --filter tools,platform-tools,build-tools-25.0.2
 test:
 
     override:

--- a/circle.yml
+++ b/circle.yml
@@ -31,9 +31,9 @@ test:
     override:
         # Disable incremental dexing to speed up clean builds
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
-        - ./gradlew lintRelease -Pandroid.useDexArchive=false
-        - ./gradlew testReleaseUnitTest -Pandroid.useDexArchive=false
-        - ./gradlew assembleRelease -Pandroid.useDexArchive=false:
+        - ./gradlew lintDebug -Pandroid.useDexArchive=false
+        - ./gradlew testDebugUnitTest -Pandroid.useDexArchive=false
+        - ./gradlew assembleDebug -Pandroid.useDexArchive=false:
             timeout: 900
 
     post:

--- a/circle.yml
+++ b/circle.yml
@@ -11,13 +11,20 @@ machine:
         
 dependencies:
     pre:
-        # Almost packages are pre installed
-        # https://circleci.com/docs/build-image-precise/#android
-         - echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2,extra-android-m2repository,extra-google-m2repository"
+        # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
+        - if [ ! -d "/usr/local/android-sdk-linux/tools" ]; then echo y | android update sdk --no-ui --all --filter "tools"; fi
+        - if [ ! -d "/usr/local/android-sdk-linux/platform-tools" ]; then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
+        - if [ ! -d "/usr/local/android-sdk-linux/build-tools/25.0.2" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
+        - if [ ! -d "/usr/local/android-sdk-linux/platforms/android-25" ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
+        - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+        - if [ ! -d "/usr/local/android-sdk-linux/extras/google/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
     
     cache_directories:
-        - /usr/local/android-sdk-linux
-        - ~/.android
+        - /usr/local/android-sdk-linux/tools
+        - /usr/local/android-sdk-linux/platform-tools
+        - /usr/local/android-sdk-linux/build-tools/25.0.2
+        - /usr/local/android-sdk-linux/extras/android/m2repository
+        - /usr/local/android-sdk-linux/extras/google/m2repository
 
 test:
     override:

--- a/circle.yml
+++ b/circle.yml
@@ -27,13 +27,18 @@ dependencies:
         - /usr/local/android-sdk-linux/extras/google/m2repository
 
 test:
+
+    pre: 
+        - ./gradlew lintRelease
+
     override:
         # Disable incremental dexing to speed up clean builds
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
-        - ./gradlew lint testReleaseUnitTest assembleRelease -Pandroid.useDexArchive=false:
-            timeout: 1200
+        - ./gradlew testReleaseUnitTest -Pandroid.useDexArchive=false
 
     post:
+        - ./gradlew assembleRelease -Pandroid.useDexArchive=false
+
         # APKs
         - cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,23 +8,22 @@ machine:
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
         # https://docs.gradle.org/current/userguide/build_environment.html
         GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError"'
-
-        ANDROID_HOME: /usr/local/android-sdk-linux
         
 dependencies:
     pre:
-        - if ! $(grep -q "Revision=25.3.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
-        - if [ ! -e $ANDROID_HOME/platforms/build-tools/25.0.3 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.3"; fi
-        - if [ ! -e $ANDROID_HOME/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
-        - if ! $(grep -q "Revision=45.0.0" $ANDROID_HOME/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-        - if ! $(grep -q "Revision=44" $ANDROID_HOME/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
+        # Cache Android SDK to speed up build
+        - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
+        - if ! $(grep -q "Revision=45.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+        - if ! $(grep -q "Revision=44.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
     
     cache_directories:
-        - $ANDROID_HOME/tools
-        - $ANDROID_HOME/build-tools/25.0.3
-        - $ANDROID_HOME/platforms/android-25
-        - $ANDROID_HOME/extras/android/m2repository
-        - $ANDROID_HOME/extras/google/m2repository
+        - /usr/local/android-sdk-linux/tools
+        - /usr/local/android-sdk-linux/build-tools/25.0.3
+        - /usr/local/android-sdk-linux/platforms/android-25
+        - /usr/local/android-sdk-linux/extras/android/m2repository
+        - /usr/local/android-sdk-linux/extras/google/m2repository
 
 test:
     override:

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
         
 dependencies:
     pre:
-        # Cache Android SDK to speed up build
+        # Cache Android SDK to avoid unnecessary downloads
         # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
         - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
         - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
@@ -34,7 +34,7 @@ test:
         - ./gradlew lintRelease -Pandroid.useDexArchive=false
         - ./gradlew testReleaseUnitTest -Pandroid.useDexArchive=false
         - ./gradlew assembleRelease -Pandroid.useDexArchive=false
-        
+
     post:
         # APKs
         - cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS

--- a/circle.yml
+++ b/circle.yml
@@ -32,13 +32,13 @@ test:
         # Disable incremental dexing to speed up clean builds
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
         - ./gradlew lintDebug -Pandroid.useDexArchive=false
-        - ./gradlew testDebugUnitTest -Pandroid.useDexArchive=false
-        - ./gradlew assembleDebug -Pandroid.useDexArchive=false:
-            timeout: 900
+        - ./gradlew testDebugUnitTest -Pandroid.useDexArchive=false 
+        #- ./gradlew assembleDebug -Pandroid.useDexArchive=false:
+        #    timeout: 900
 
     post:
         # APKs
-        - cp -r collect_app/build/outputs/apk/ $CIRCLE_ARTIFACTS
+        # - cp -r collect_app/build/outputs/apk/ $CIRCLE_ARTIFACTS
 
         # Tests
         - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/circle.yml
+++ b/circle.yml
@@ -8,23 +8,23 @@ machine:
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
         # https://docs.gradle.org/current/userguide/build_environment.html
         GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError"'
+
+        ANDROID_HOME: /usr/local/android-sdk-linux
         
 dependencies:
     pre:
-        # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
-        - if [ ! -d "/usr/local/android-sdk-linux/tools" ]; then echo y | android update sdk --no-ui --all --filter "tools"; fi
-        - if [ ! -d "/usr/local/android-sdk-linux/platform-tools" ]; then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
-        - if [ ! -d "/usr/local/android-sdk-linux/build-tools/25.0.2" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
-        - if [ ! -d "/usr/local/android-sdk-linux/platforms/android-25" ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
-        - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-        - if [ ! -d "/usr/local/android-sdk-linux/extras/google/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
+        - if ! $(grep -q "Revision=25.3.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
+        - if [ ! -e $ANDROID_HOME/platforms/build-tools/25.0.3 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.3"; fi
+        - if [ ! -e $ANDROID_HOME/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
+        - if ! $(grep -q "Revision=45.0.0" $ANDROID_HOME/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+        - if ! $(grep -q "Revision=44" $ANDROID_HOME/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
     
     cache_directories:
-        - /usr/local/android-sdk-linux/tools
-        - /usr/local/android-sdk-linux/platform-tools
-        - /usr/local/android-sdk-linux/build-tools/25.0.2
-        - /usr/local/android-sdk-linux/extras/android/m2repository
-        - /usr/local/android-sdk-linux/extras/google/m2repository
+        - $ANDROID_HOME/tools
+        - $ANDROID_HOME/build-tools/25.0.3
+        - $ANDROID_HOME/platforms/android-25
+        - $ANDROID_HOME/extras/android/m2repository
+        - $ANDROID_HOME/extras/google/m2repository
 
 test:
     override:

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,8 @@ test:
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
         - ./gradlew lintRelease -Pandroid.useDexArchive=false
         - ./gradlew testReleaseUnitTest -Pandroid.useDexArchive=false
-        - ./gradlew assembleRelease -Pandroid.useDexArchive=false
+        - ./gradlew assembleRelease -Pandroid.useDexArchive=false:
+            timeout: 900
 
     post:
         # APKs

--- a/circle.yml
+++ b/circle.yml
@@ -28,17 +28,14 @@ dependencies:
 
 test:
 
-    pre: 
-        - ./gradlew lintRelease
-
     override:
         # Disable incremental dexing to speed up clean builds
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
+        - ./gradlew lintRelease -Pandroid.useDexArchive=false
         - ./gradlew testReleaseUnitTest -Pandroid.useDexArchive=false
-
-    post:
         - ./gradlew assembleRelease -Pandroid.useDexArchive=false
-
+        
+    post:
         # APKs
         - cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS
 

--- a/circle.yml
+++ b/circle.yml
@@ -37,12 +37,12 @@ test:
 
     post:
         # APKs
-        - cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS
+        - cp -r collect_app/build/outputs/apk/ $CIRCLE_ARTIFACTS
 
         # Tests
         - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-        - find . -type f -regex ".*/build/test-results/.*.xml"  -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+        - find . -type f -regex ".*/collect_app/build/test-results/.*.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
         # Lint
         - mkdir -p $CIRCLE_TEST_REPORTS/lint/
-        - find . -type f -regex ".*/collect_app/build/reports/lint-results-*.*" -exec cp --parent {} $CIRCLE_TEST_REPORTS/lint/ \;
+        - find . -type f -regex ".*/collect_app/build/reports/lint-results-*.*" -exec cp {} $CIRCLE_TEST_REPORTS/lint/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -27,8 +27,7 @@ dependencies:
 
 test:
     override:
-        # http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance
-        - ./gradlew lint testReleaseUnitTest assembleRelease -PdisablePreDex
+        - ./gradlew lint testReleaseUnitTest assembleRelease
 
     post:
         # APKs

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ dependencies:
 test:
     override:
         # http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance
-        - ./gradlew lint assembleAndroidTest assembleRelease -PdisablePreDex
+        - ./gradlew lint testReleaseUnitTest assembleRelease -PdisablePreDex
 
     post:
         # APKs
@@ -40,4 +40,4 @@ test:
 
         # Lint
         - mkdir -p $CIRCLE_TEST_REPORTS/lint/
-        - find . -type f -regex ".*/collect_app/build/outputs/lint-results-*.*" -exec cp --parent {} $CIRCLE_TEST_REPORTS/lint/ \;
+        - find . -type f -regex ".*/collect_app/build/reports/lint-results-*.*" -exec cp --parent {} $CIRCLE_TEST_REPORTS/lint/ \;

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,8 @@ machine:
 
         # Out of memory errors in Android builds
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+        # https://docs.gradle.org/current/userguide/build_environment.html
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError"'
         
 dependencies:
     pre:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
         # Out of memory errors in Android builds
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
         # https://docs.gradle.org/current/userguide/build_environment.html
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError"'
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3072M -XX:+HeapDumpOnOutOfMemoryError"'
         
 dependencies:
     pre:

--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,9 @@ dependencies:
          - echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2,extra-android-m2repository,extra-google-m2repository"
     
     cache_directories:
+        - /usr/local/android-sdk-linux
         - ~/.android
-        
+
 test:
     override:
         # http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance

--- a/circle.yml
+++ b/circle.yml
@@ -1,23 +1,32 @@
 machine:
     environment:
-        ANDROID_HOME: /usr/local/android-sdk-linux
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+        # Set memory limits for the JVM
+        # https://circleci.com/docs/oom/#setting-memory-limits-for-the-jvm
         _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+
+        # Out of memory errors in Android builds
+        # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
         
 dependencies:
-    override:
-        - echo y | android update sdk --no-ui --all --filter tools,platform-tools,build-tools-25.0.2,android-22,extra-google-m2repository,extra-google-google_play_services,extra-android-support
-        - ANDROID_HOME=/usr/local/android-sdk-linux ./gradlew dependencies
+    pre:
+        # Almost packages are pre installed
+        # https://circleci.com/docs/build-image-precise/#android
+         - echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2,extra-android-m2repository,extra-google-m2repository"
+    
+    cache_directories:
+        - ~/.android
         
 test:
-    pre:
-        - ./gradlew lint assembleRelease assembleAndroidTest
-
     override:
-        - ./gradlew testReleaseUnitTest
-        - cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS
+        # http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Server-performance
+        - ./gradlew lint assembleAndroidTest assembleRelease -PdisablePreDex
 
     post:
+        # APKs
+        - cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS
+
+        # Tests
         - mkdir -p $CIRCLE_TEST_REPORTS/junit/
         - find . -type f -regex ".*/build/test-results/.*.xml"  -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
     
     cache_directories:
         - /usr/local/android-sdk-linux/tools
-        - /usr/local/android-sdk-linux/build-tools/25.0.3
+        - /usr/local/android-sdk-linux/build-tools/25.0.2
         - /usr/local/android-sdk-linux/platforms/android-25
         - /usr/local/android-sdk-linux/extras/android/m2repository
         - /usr/local/android-sdk-linux/extras/google/m2repository

--- a/circle.yml
+++ b/circle.yml
@@ -11,12 +11,24 @@ machine:
         
 dependencies:
     pre:
-        # We need latest versions of: tools,platform-tools,build-tools-25.0.2,android-25,extra-google-m2repository,extra-android-m2repository
-        # But there some already installed: https://circleci.com/docs/1.0/build-image-trusty/#android
-        # Don't cache SDKs because it's faster to download than to restore from cache
-        - echo y | android update sdk --no-ui --all --filter tools,platform-tools,build-tools-25.0.2
-test:
+        # Cache Android SDK to avoid unnecessary downloads
+        # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
+        - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
+        - if ! $(grep -q "Revision=25.0.2" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
+        - if ! $(grep -q "Revision=45.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+        - if ! $(grep -q "Revision=44.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
 
+    cache_directories:
+        - /usr/local/android-sdk-linux/tools
+        - /usr/local/android-sdk-linux/platform-tools
+        - /usr/local/android-sdk-linux/build-tools/25.0.2
+        - /usr/local/android-sdk-linux/platforms/android-25
+        - /usr/local/android-sdk-linux/extras/android/m2repository
+        - /usr/local/android-sdk-linux/extras/google/m2repository
+
+test:
     override:
         # Disable incremental dexing to speed up clean builds
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,8 @@ test:
     override:
         # Disable incremental dexing to speed up clean builds
         # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
-        - ./gradlew lint testReleaseUnitTest assembleRelease -Pandroid.useDexArchive=false
+        - ./gradlew lint testReleaseUnitTest assembleRelease -Pandroid.useDexArchive=false:
+            timeout: 1200
 
     post:
         # APKs

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,12 @@ machine:
         # Out of memory errors in Android builds
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
         # https://docs.gradle.org/current/userguide/build_environment.html
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3072M -XX:+HeapDumpOnOutOfMemoryError"'
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError"'
         
 dependencies:
     pre:
         # Cache Android SDK to speed up build
+        # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
         - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
         - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
         - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
@@ -27,7 +28,9 @@ dependencies:
 
 test:
     override:
-        - ./gradlew lint testReleaseUnitTest assembleRelease
+        # Disable incremental dexing to speed up clean builds
+        # https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/2-5-alpha-gradle-plugin/trying-gradle-plugin-2-5
+        - ./gradlew lint testReleaseUnitTest assembleRelease -Pandroid.useDexArchive=false
 
     post:
         # APKs

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/PermissionsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/PermissionsTest.java
@@ -21,7 +21,7 @@ public class PermissionsTest {
 
     @Test
     public void permissionCheck() {
-        AndroidManifest androidManifest = new AndroidManifest(Fs.fileFromPath("build/intermediates/manifests/full/release/AndroidManifest.xml"), null, null);
+        AndroidManifest androidManifest = new AndroidManifest(Fs.fileFromPath("build/intermediates/manifests/full/debug/AndroidManifest.xml"), null, null);
         List<String> permissions = androidManifest.getUsedPermissions();
 
         //List of expected permissions to be present in AndroidManifest.xml

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/PermissionsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/PermissionsTest.java
@@ -21,7 +21,7 @@ public class PermissionsTest {
 
     @Test
     public void permissionCheck() {
-        AndroidManifest androidManifest = new AndroidManifest(Fs.fileFromPath("build/intermediates/manifests/full/debug/AndroidManifest.xml"), null, null);
+        AndroidManifest androidManifest = new AndroidManifest(Fs.fileFromPath("build/intermediates/manifests/full/release/AndroidManifest.xml"), null, null);
         List<String> permissions = androidManifest.getUsedPermissions();
 
         //List of expected permissions to be present in AndroidManifest.xml


### PR DESCRIPTION
* Increase GRADLE_OPTS memory per warning output by Gradle
* Update Android platform to 25
* Cache Android SDKs to prevent multiple downloads
* Run gradle on debug builds
* Disable generation of apk to speed builds
* Set Pandroid.useDexArchive=false to speed up clean builds
* Split gradle commands to reduce likelihood of timeouts
* Copy lint reports from updated location 
* Copy artifacts to base folders