### PR TITLE
Add Suite for running all unit test

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/AllTestsSuite.java
+++ b/collect_app/src/test/java/org/odk/collect/android/AllTestsSuite.java
@@ -1,0 +1,23 @@
+package org.odk.collect.android;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.odk.collect.android.activities.MainActivityTest;
+import org.odk.collect.android.utilities.PermissionsTest;
+import org.odk.collect.android.utilities.TextUtilsTest;
+
+/**
+ * Suite for running all unit tests from one place
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        //Name of tests which are going to be run by suite
+        MainActivityTest.class,
+        PermissionsTest.class,
+        TextUtilsTest.class
+})
+
+public class AllTestsSuite {
+    // the class remains empty,
+    // used only as a holder for the above annotations
+}


### PR DESCRIPTION
Add `Suite` for running all unit test from one class.

**Description**: 
`Suite` as a runner allows us to manually build a suite containing tests from many classes.  Annotating a class with `@RunWith(Suite.class)` helps in running all the tests in the suite class.

**Necessity**:
As the number of tests is going to be increased very soon, hence it would be a very tedious task to check them one by one manually. Hence it is necessary to have a suite which will help running some selective tests or all tests simultaneously.