### PR TITLE
Fixes the font size of TabTextview in SlidingTabLayout

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FileManagerTabs.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FileManagerTabs.java
@@ -57,7 +57,6 @@ public class FileManagerTabs extends FragmentActivity {
         slidingTabLayout.setDistributeEvenly(true);
         slidingTabLayout.setFontColor(android.R.color.white);
         slidingTabLayout.setBackgroundColor(Color.DKGRAY);
-        slidingTabLayout.setFontSize(Collect.getQuestionFontsize());
         slidingTabLayout.setViewPager(viewPager);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/SlidingTabLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/SlidingTabLayout.java
@@ -51,7 +51,7 @@ import android.widget.TextView;
 public class SlidingTabLayout extends HorizontalScrollView {
     private static final int TITLE_OFFSET_DIPS = 24;
     private static final int TAB_VIEW_PADDING_DIPS = 10;
-    private static final int TAB_VIEW_TEXT_SIZE_SP = 12;
+    private static final int TAB_VIEW_TEXT_SIZE_SP = 21;
     private final SlidingTabStrip mTabStrip;
     private int mTitleOffset;
 


### PR DESCRIPTION
Fixes #636 
Converts the font size of TabTextView from dynamic to static.
Until now, the fontSize was set according to the Question FontSize from SharedPrefs. This was breaking the slider tabs UI when the font size was changed from the General Settings.
