### PR TITLE
Replaced deprecated (Activity)getContext() method with getContext() method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
@@ -175,7 +175,7 @@ public class ExPrinterWidget extends QuestionWidget implements IBinaryWidget {
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "launchPrinter",
                 intentName, mPrompt.getIndex());
         Intent i = new Intent(intentName);
-        ((Activity) getContext()).startActivity(i);
+        (getContext()).startActivity(i);
 
         String[] splits;
         if (s != null) {
@@ -213,7 +213,7 @@ public class ExPrinterWidget extends QuestionWidget implements IBinaryWidget {
         //send the printDataBundle to the activity via broadcast intent
         Intent bcastIntent = new Intent(intentName + ".data");
         bcastIntent.putExtra("DATA", printDataBundle);
-        ((Activity) getContext()).sendBroadcast(bcastIntent);
+        ( getContext()).sendBroadcast(bcastIntent);
     }
 
     @Override


### PR DESCRIPTION

#657 fixed