### PR TITLE
Instances synchronization resolved

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
@@ -146,9 +146,9 @@ public class InstancesDao {
         Collect.getInstance().getContentResolver().delete(InstanceProviderAPI.InstanceColumns.CONTENT_URI, null, null);
     }
 
-    public void deleteInstancesFromIDs(String ids[]){
-        int count = ids.length;
-        int i = 0 ;
+    public void deleteInstancesFromIDs(List<String> ids){
+        int count = ids.size();
+        int counter = 0;
         while (count > 0) {
             String[] selectionArgs = null;
             if (count > ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER ) {
@@ -162,16 +162,16 @@ public class InstancesDao {
             selection.append(InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH + " IN (");
             int j = 0 ;
             while (j < selectionArgs.length) {
-                selectionArgs[j] = ids[i];
+                selectionArgs[j] = ids.get(
+                        counter * ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER + j);
                 selection.append("?");
 
                 if (j != selectionArgs.length - 1) {
                     selection.append(",");
                 }
-                i++;
                 j++;
             }
-
+            counter++;
             count -= selectionArgs.length;
             selection.append(")");
             Collect.getInstance().getContentResolver()

--- a/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dto.Instance;
 import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.utilities.ApplicationConstants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -143,6 +144,41 @@ public class InstancesDao {
 
     public void deleteInstancesDatabase() {
         Collect.getInstance().getContentResolver().delete(InstanceProviderAPI.InstanceColumns.CONTENT_URI, null, null);
+    }
+
+    public void deleteInstancesFromIDs(String ids[]){
+        int count = ids.length;
+        int i = 0 ;
+        while (count > 0) {
+            String[] selectionArgs = null;
+            if (count > ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER ) {
+                selectionArgs = new String[
+                        ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER];
+            } else {
+                selectionArgs = new String[count];
+            }
+
+            StringBuilder selection = new StringBuilder();
+            selection.append(InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH + " IN (");
+            int j = 0 ;
+            while (j < selectionArgs.length) {
+                selectionArgs[j] = ids[i];
+                selection.append("?");
+
+                if (j != selectionArgs.length - 1) {
+                    selection.append(",");
+                }
+                i++;
+                j++;
+            }
+
+            count -= selectionArgs.length;
+            selection.append(")");
+            Collect.getInstance().getContentResolver()
+                    .delete(InstanceProviderAPI.InstanceColumns.CONTENT_URI
+                            , selection.toString(), selectionArgs);
+
+        }
     }
 
     public List<Instance> getInstancesFromCursor(Cursor cursor) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -121,7 +121,7 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                 }
 
                 InstancesDao instancesDao = new InstancesDao();
-                instancesDao.deleteInstancesFromIDs(filesToRemove.toArray(new String[filesToRemove.size()]));
+                instancesDao.deleteInstancesFromIDs(filesToRemove);
 
                 final boolean instanceSyncFlag = PreferenceManager.getDefaultSharedPreferences(
                         Collect.getInstance().getApplicationContext()).getBoolean(

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -107,7 +107,6 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                     while (instanceCursor.moveToNext()) {
                         String instanceFilename = instanceCursor.getString(
                                 instanceCursor.getColumnIndex(InstanceColumns.INSTANCE_FILE_PATH));
-                        System.out.println("INSTANCE : " + instanceFilename);
                         if (candidateInstances.contains(instanceFilename)) {
                             candidateInstances.remove(instanceFilename);
                         } else {


### PR DESCRIPTION
Fix #625 
Slicing is also done on deletion of forms if number of forms deleted is greater than the SQLITE_MAX_VARIABLE_NUMBER then slicing is done so that we don't get "Expression tree is too large " error.