### PR TITLE
fix #660 crash when taking a video from nexus 5 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -710,7 +710,11 @@ public class FormEntryActivity extends Activity implements AnimationListener,
                 if (filePath != null) {
                     new File(filePath).delete();
                 }
+                        try{
                 getContentResolver().delete(mediaUri, null, null);
+                        }catch (Exception e){
+                            Log.d(t,e.getMessage());
+                        }
                 break;
             case AUDIO_CHOOSER:
             case VIDEO_CHOOSER:


### PR DESCRIPTION
In FormEntryActivity -> onActivityResult -> switch (requestCode) -> case VIDEO_CAPTURE -> 
getContentResolver().delete(mediaUri, null, null); was throwing an exception . Adding try catch block on it fixed the bug on Nexus 5 . 