### PR TITLE
Avoid error when picking video that was just recorded

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -271,10 +271,6 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
 
     @Override
     public void setBinaryData(Object binaryuri) {
-        // you are replacing an answer. remove the media.
-        if (mBinaryName != null) {
-            deleteMedia();
-        }
 
         // get the file path and create a copy in the instance folder
         String binaryPath = MediaUtils.getPathFromUri(this.getContext(), (Uri) binaryuri,
@@ -300,6 +296,10 @@ public class VideoWidget extends QuestionWidget implements IBinaryWidget {
             Log.i(t, "Inserting VIDEO returned uri = " + VideoURI.toString());
         } else {
             Log.e(t, "Inserting Video file FAILED");
+        }
+        // you are replacing an answer. remove the media.
+        if (mBinaryName != null && !mBinaryName.equals(newVideo.getName())) {
+            deleteMedia();
         }
 
         mBinaryName = newVideo.getName();


### PR DESCRIPTION
Hi @lognaturel,
Please review this.Also,please let me know if this fixes #660.

**Reason for the crash**
The variable mBinaryName was being assigned the name of the video that was recorded by mCaptureButton.Now clicking on the Choose button called setBinaryData method which in turn deleted the file whose name was stored in mBinaryName deleting the video just created.

**Fix**
I compared the value of mBinaryName with the selected video and deleted the video only if the two filenames were not the same.

Thank You :smile:  