### PR TITLE
Let color of empty lists be set by the operating system #728 issue fixed

### DIFF
--- a/collect_app/src/main/res/layout/chooser_list_layout.xml
+++ b/collect_app/src/main/res/layout/chooser_list_layout.xml
@@ -55,7 +55,6 @@ the License.
 			android:paddingEnd="20dip"
 			android:paddingRight="20dp"
 			android:gravity="center"
-			android:background="@drawable/white"
 			android:textColor="@drawable/black" />
 	</LinearLayout>
 


### PR DESCRIPTION
The color was previously hardcoded as white so removing that line makes operating system to set the color 