### PR TITLE
Expected parameters for drive added

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -827,6 +827,7 @@ public class GoogleDriveActivity extends ListActivity implements
 
                 }
             }
+            request.setFields("nextPageToken, files(modifiedTime,id,name, mimeType)");
 
             results.put(PARENT_ID_KEY, parentId);
             results.put(CURRENT_ID_KEY, currentDir);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -827,7 +827,7 @@ public class GoogleDriveActivity extends ListActivity implements
 
                 }
             }
-            request.setFields("nextPageToken, files(modifiedTime,id,name, mimeType)");
+            request.setFields("nextPageToken, files(modifiedTime, id, name, mimeType)");
 
             results.put(PARENT_ID_KEY, parentId);
             results.put(CURRENT_ID_KEY, currentDir);


### PR DESCRIPTION
I think Collect app is using Drive API v2. In Drive API v2 it might be giving the expected parameters like Id, name, modifiedTime ,mimeType without explicitly asking for each of them but they migrated from v2 to v3 in which by default only 3 fields are returned id, name and mimeType. This is the reason why app is getting crashed whenever it gets paused because the field modifiedTime which was expected to be returned is not returned and it gets null value.
The fields that are needed can be retrieved by calling setFields method by passing field name(s). 

For more info [visit this link](https://developers.google.com/drive/v3/web/migration)

Fix #771 #770 