### PR TITLE
Include User-Agent header in HTTP requests

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -164,6 +164,7 @@ dependencies {
     androidTestCompile group: 'com.android.support', name: 'support-annotations', version: '25.1.0'
     androidTestCompile group: 'com.android.support.test', name: 'runner', version: '0.5'
     androidTestCompile group: 'com.android.support.test', name: 'rules', version: '0.5'
+    androidTestCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.2.0'
 }
 
 // Must be at bottom to prevent dependency collisions

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/WebUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/WebUtilsTest.java
@@ -1,0 +1,55 @@
+package org.odk.collect.android.utilities;
+
+import android.test.*;
+
+import okhttp3.mockwebserver.*;
+
+import java.net.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.*;
+import org.odk.collect.android.application.*;
+import org.opendatakit.httpclientandroidlib.*;
+import org.opendatakit.httpclientandroidlib.client.*;
+import org.opendatakit.httpclientandroidlib.client.methods.*;
+import org.opendatakit.httpclientandroidlib.protocol.*;
+
+import static org.junit.Assert.*;
+
+public class WebUtilsTest {
+    private MockWebServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        // server hangs without a response queued:
+        server.enqueue(new MockResponse());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void httpRequests_shouldHaveUseragentHeader() throws Exception {
+        // given
+        String url = String.format("http://uname:pword@localhost:%s/some-path", server.getPort());
+
+        // when
+        doRequest(url);
+
+        // then
+        RecordedRequest r = server.takeRequest(1, TimeUnit.MILLISECONDS);
+        assertEquals("GET /some-path HTTP/1.1", r.getRequestLine());
+        assertTrue(r.getHeader("User-Agent").matches("Dalvik/.* org.odk.collect.android/.*"));
+    }
+
+    private static void doRequest(String url) throws Exception {
+        HttpContext localContext = Collect.getInstance().getHttpContext();
+        HttpClient httpclient = WebUtils.createHttpClient(WebUtils.CONNECTION_TIMEOUT);
+        HttpGet req = WebUtils.createOpenRosaHttpGet(new URI(url));
+        HttpResponse response = httpclient.execute(req, localContext);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebUtils.java
@@ -22,6 +22,7 @@ import android.util.Log;
 
 import org.kxml2.io.KXmlParser;
 import org.kxml2.kdom.Document;
+import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.preferences.PreferenceKeys;
@@ -74,6 +75,8 @@ import java.util.zip.GZIPInputStream;
  */
 public final class WebUtils {
     public static final String t = "WebUtils";
+
+    private static final String USER_AGENT_HEADER = "User-Agent";
 
     public static final String OPEN_ROSA_VERSION_HEADER = "X-OpenRosa-Version";
     public static final String OPEN_ROSA_VERSION = "1.0";
@@ -180,6 +183,14 @@ public final class WebUtils {
         }
     }
 
+    private static final void setCollectHeaders(HttpRequest req) {
+        String userAgent = String.format("%s %s/%s",
+                System.getProperty("http.agent"),
+                BuildConfig.APPLICATION_ID,
+                BuildConfig.VERSION_NAME);
+        req.setHeader(USER_AGENT_HEADER, userAgent);
+    }
+
     private static final void setOpenRosaHeaders(HttpRequest req) {
         req.setHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION);
         GregorianCalendar g = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
@@ -190,12 +201,14 @@ public final class WebUtils {
 
     public static final HttpHead createOpenRosaHttpHead(Uri u) {
         HttpHead req = new HttpHead(URI.create(u.toString()));
+        setCollectHeaders(req);
         setOpenRosaHeaders(req);
         return req;
     }
 
     public static final HttpGet createOpenRosaHttpGet(URI uri) {
         HttpGet req = new HttpGet();
+        setCollectHeaders(req);
         setOpenRosaHeaders(req);
         setGoogleHeaders(req);
         req.setURI(uri);
@@ -220,6 +233,7 @@ public final class WebUtils {
 
     public static final HttpPost createOpenRosaHttpPost(Uri u) {
         HttpPost req = new HttpPost(URI.create(u.toString()));
+        setCollectHeaders(req);
         setOpenRosaHeaders(req);
         setGoogleHeaders(req);
         return req;


### PR DESCRIPTION
Closes #167

Example UA:

```
Dalvik/2.1.0 (Linux; U; Android 5.1.1; hi6210sft Build/LMY47X) org.odk.collect.android/v1.5.1-10-ge20fa334-dirty
```