### PR TITLE
Clear list before refresh to avoid duplicates

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -155,7 +155,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 Collect.getInstance().getActivityLogger().logAction(this, "refreshForms", "");
 
                 downloadFormList();
-                FormDownloadList.this.getListView().clearChoices();
+                mFilteredFormList.clear();
                 clearChoices();
             }
         });


### PR DESCRIPTION
When clicking refresh button, new items are added to the list but previous are still there causing the list to have duplicates of already existing item

**Changes**
* Added a statement to clear the list