### PR TITLE
Icon resized fixes #842

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridWidget.java
@@ -150,6 +150,7 @@ public class GridWidget extends QuestionWidget {
         if (numColumns > 0) {
             resizeWidth = ((screenWidth - 2 * HORIZONTAL_PADDING - SCROLL_WIDTH
                     - (IMAGE_PADDING + SPACING) * numColumns) / numColumns);
+            resizeWidth =  (resizeWidth * 95)/100;
         }
 
         // Build view
@@ -197,6 +198,7 @@ public class GridWidget extends QuestionWidget {
                             }
 
                             ImageView imageView = (ImageView) imageViews[i];
+
 
 
                             if (numColumns > 0) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -155,8 +155,12 @@ public class WidgetFactory {
                     }
 
                     if (appearance.startsWith("quick")) {
+                        if (numColumns == -1)
+                            numColumns = 2;
                         questionWidget = new GridWidget(context, fep, numColumns, true);
                     } else {
+                        if (numColumns == -1)
+                            numColumns = 2;
                         questionWidget = new GridWidget(context, fep, numColumns, false);
                     }
                 } else if (appearance.startsWith("minimal")) {


### PR DESCRIPTION
<!-- 

Thank you for taking the time to report an ODK Collect issue!

This space is for submitting problems and feature requests. For general usage or form design questions, please email opendatakit@googlegroups.com or for ODK Collect source code questions, please email opendatakit-developers@googlegroups.com

Before filling this form, visit https://github.com/opendatakit/collect/issues?q=is%3Aissue and search to see whether your issue was already reported or fixed. If you find a match, comment on it or add a +1 rather than posting a new issue. If you find a problem you know how to fix, submit a pull request. 🎉

For all problem reports, please use the template below. Also include any relevant stack traces or error messages.

For feature requests, please include the problem description (what problem do you have that can't currently be solved?) and a proposed solution if you have one in mind (optional). You can delete the template. 

-->

#### Software and hardware versions 
Collect v1.4.16, Android v6.0, Nexus 5

#### Cause of issue

1. The issue occured becuase numColumns was being assigned a default value of -1 (line 144 WidgetFactory.java).

#### Solution description
1. I have changed the default value of numColumns to 2. So, by default there will be 2 columns if the value of numColumns is not specified.

#### Changes Made

1. I added an if block to check for the value of numColumns and made it 2 if the value was -1.
2. I made the imageresize attribute a little smaller as the earlier value was not producing the desired results (without this I was getting small images, but they were arranged in a single column instead of 2).

#### Final Result


<img src="https://cloud.githubusercontent.com/assets/24683388/24770686/79ee76fe-1b28-11e7-9713-7bbeaaa69629.png" width="250" padding = "10">



