### PR TITLE
Fix minification for release APKs

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -71,10 +71,8 @@ android {
 
     buildTypes {
         release {
-            // Proguard rules will need to be carefully revised before turning on minification --
-            // the current configuration breaks Google Drive API.
-            // minifyEnabled(true)
-            // proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            minifyEnabled(true)
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
         debug {
             debuggable(true)

--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -5,3 +5,5 @@
 -dontwarn org.xmlpull.v1.**
 
 -keep class org.javarosa.**
+
+-dontobfuscate


### PR DESCRIPTION
This PR is in reference to resolve #271

We still need `-dontobfuscate` as I said [here](https://github.com/opendatakit/collect/issues/271#issuecomment-275400927) (for Google Analytics and Google Drive)

I've tested all our activities and everything works well. I've used monkey with various devices as well and everything haven't noticed any problem.