### PR TITLE
Allow date, datetime and time widgets to show 'null' values

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -55,7 +55,7 @@ public class DateTimeWidget extends QuestionWidget {
             linearLayout.addView(mTimeWidget);
         }
         addAnswerView(linearLayout);
-        if (mDateWidget.isCalendarShown()) {
+        if (mDateWidget.isCalendarShown() && mTimeWidget.getAnswer() == null) {
             mTimeWidget.setTimeToCurrent();
             mTimeWidget.setTimeLabel();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -56,8 +56,8 @@ public class DateTimeWidget extends QuestionWidget {
         }
         addAnswerView(linearLayout);
         if (mDateWidget.isCalendarShown()) {
-            mTimeWidget.setNullAnswer(false);
             mTimeWidget.setTimeToCurrent();
+            mTimeWidget.setTimeLabel();
         }
     }
 
@@ -69,8 +69,8 @@ public class DateTimeWidget extends QuestionWidget {
             return null;
         } else {
             if (mTimeWidget.isNullAnswer()) {
-                mTimeWidget.setNullAnswer(false);
                 mTimeWidget.setTimeToCurrent();
+                mTimeWidget.setTimeLabel();
             }
             boolean hideDay = mDateWidget.isDayHidden();
             boolean hideMonth = mDateWidget.isMonthHidden();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -71,7 +71,11 @@ public class DateTimeWidget extends QuestionWidget {
             if (mTimeWidget.isNullAnswer()) {
                 mTimeWidget.setTimeToCurrent();
                 mTimeWidget.setTimeLabel();
+            } else if (mDateWidget.isNullAnswer()) {
+                mDateWidget.setDateToCurrent();
+                mDateWidget.setDateLabel();
             }
+            
             boolean hideDay = mDateWidget.isDayHidden();
             boolean hideMonth = mDateWidget.isMonthHidden();
             boolean showCalendar = mDateWidget.isCalendarShown();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -55,38 +55,52 @@ public class DateTimeWidget extends QuestionWidget {
             linearLayout.addView(mTimeWidget);
         }
         addAnswerView(linearLayout);
+        if (mDateWidget.isCalendarShown()) {
+            mTimeWidget.setNullAnswer(false);
+            mTimeWidget.setTimeToCurrent();
+        }
     }
 
     @Override
     public IAnswerData getAnswer() {
         clearFocus();
 
-        boolean hideDay = mDateWidget.isDayHidden();
-        boolean hideMonth = mDateWidget.isMonthHidden();
-        boolean showCalendar = mDateWidget.isCalendarShown();
+        if (mDateWidget.isNullAnswer() && mTimeWidget.isNullAnswer()) {
+            return null;
+        } else {
+            if (mTimeWidget.isNullAnswer()) {
+                mTimeWidget.setNullAnswer(false);
+                mTimeWidget.setTimeToCurrent();
+            }
+            boolean hideDay = mDateWidget.isDayHidden();
+            boolean hideMonth = mDateWidget.isMonthHidden();
+            boolean showCalendar = mDateWidget.isCalendarShown();
 
-        int year = mDateWidget.getYear();
-        int month = mDateWidget.getMonth();
-        int day = mDateWidget.getDay();
-        int hour = mTimeWidget.getHour();
-        int minute = mTimeWidget.getMinute();
+            int year = mDateWidget.getYear();
+            int month = mDateWidget.getMonth();
+            int day = mDateWidget.getDay();
+            int hour = mTimeWidget.getHour();
+            int minute = mTimeWidget.getMinute();
 
-        LocalDateTime ldt = new LocalDateTime()
-                .withYear(year)
-                .withMonthOfYear((!showCalendar && hideMonth) ? 1 : month)
-                .withDayOfMonth((!showCalendar && (hideMonth || hideDay)) ? 1 : day)
-                .withHourOfDay((!showCalendar && (hideMonth || hideDay)) ? 0 : hour)
-                .withMinuteOfHour((!showCalendar && (hideMonth || hideDay)) ? 0 : minute)
-                .withSecondOfMinute(0);
+            LocalDateTime ldt = new LocalDateTime()
+                    .withYear(year)
+                    .withMonthOfYear((!showCalendar && hideMonth) ? 1 : month)
+                    .withDayOfMonth((!showCalendar && (hideMonth || hideDay)) ? 1 : day)
+                    .withHourOfDay((!showCalendar && (hideMonth || hideDay)) ? 0 : hour)
+                    .withMinuteOfHour((!showCalendar && (hideMonth || hideDay)) ? 0 : minute)
+                    .withSecondOfMinute(0);
 
-        ldt = skipDaylightSavingGapIfExists(ldt);
-        return new DateTimeData(ldt.toDate());
+            ldt = skipDaylightSavingGapIfExists(ldt);
+            return new DateTimeData(ldt.toDate());
+        }
     }
 
     @Override
     public void clearAnswer() {
-        mDateWidget.clearAnswer();
-        mTimeWidget.clearAnswer();
+        if (!mDateWidget.isCalendarShown()) {
+            mDateWidget.clearAnswer();
+            mTimeWidget.clearAnswer();
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -126,6 +126,11 @@ public class DateWidget extends QuestionWidget {
         if (mNullAnswer && !mShowCalendar) {
             return null;
         } else {
+            if (mShowCalendar) {
+                mYear = mDatePickerDialog.getDatePicker().getYear();
+                mMonth = mDatePickerDialog.getDatePicker().getMonth() + 1;
+                mDayOfMonth = mDatePickerDialog.getDatePicker().getDayOfMonth();
+            }
             LocalDateTime ldt = new LocalDateTime()
                     .withYear(mYear)
                     .withMonthOfYear((!mShowCalendar && mHideMonth) ? 1 : mMonth)

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -61,6 +61,8 @@ public class DateWidget extends QuestionWidget {
     private int mMonth;
     private int mDayOfMonth;
 
+    private boolean mNullAnswer;
+
     public DateWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
 
@@ -105,17 +107,10 @@ public class DateWidget extends QuestionWidget {
         }
     }
 
-    /**
-     * Resets date to today.
-     */
     @Override
     public void clearAnswer() {
-        DateTime dt = new DateTime();
-        mYear = dt.getYear();
-        mMonth = dt.getMonthOfYear();
-        mDayOfMonth = dt.getDayOfMonth();
-        mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
-        setDate();
+        mNullAnswer = true;
+        mDateTextView.setText(R.string.no_date_selected);
     }
 
     @Override
@@ -129,7 +124,7 @@ public class DateWidget extends QuestionWidget {
                 .withHourOfDay(0)
                 .withMinuteOfHour(0);
 
-        return new DateData(ldt.toDate());
+        return mNullAnswer ? null : new DateData(ldt.toDate());
     }
 
     @Override
@@ -168,6 +163,12 @@ public class DateWidget extends QuestionWidget {
         mDateButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if (mNullAnswer) {
+                    DateTime dt = new DateTime();
+                    mYear = dt.getYear();
+                    mMonth = dt.getMonthOfYear();
+                    mDayOfMonth = dt.getDayOfMonth();
+                }
                 mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
                 mDatePickerDialog.show();
             }
@@ -207,6 +208,7 @@ public class DateWidget extends QuestionWidget {
                 new DatePickerDialog.OnDateSetListener() {
                     @Override
                     public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
+                        mNullAnswer = false;
                         mYear = year;
                         mMonth = monthOfYear + 1;
                         mDayOfMonth = dayOfMonth;
@@ -214,17 +216,14 @@ public class DateWidget extends QuestionWidget {
                     }
                 }, 0, 0, 0);
 
-        // If there's an answer, use it.
-        if (mPrompt.getAnswerValue() != null) {
-            // create a new date from date object using default time zone
-            DateTime ldt = new DateTime(((Date) mPrompt.getAnswerValue().getValue()).getTime());
-            mYear = ldt.getYear();
-            mMonth = ldt.getMonthOfYear();
-            mDayOfMonth = ldt.getDayOfMonth();
-            setDate();
-        } else {
-            // create date widget with current time as of right now
+        if (mPrompt.getAnswerValue() == null) {
             clearAnswer();
+        } else {
+            DateTime dt = new DateTime(((Date) mPrompt.getAnswerValue().getValue()).getTime());
+            mYear = dt.getYear();
+            mMonth = dt.getMonthOfYear();
+            mDayOfMonth = dt.getDayOfMonth();
+            setDate();
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -123,7 +123,7 @@ public class DateWidget extends QuestionWidget {
     public IAnswerData getAnswer() {
         clearFocus();
 
-        if (mNullAnswer) {
+        if (mNullAnswer && !mShowCalendar) {
             return null;
         } else {
             LocalDateTime ldt = new LocalDateTime()
@@ -264,6 +264,10 @@ public class DateWidget extends QuestionWidget {
 
     public int getDay() {
         return mDatePickerDialog.getDatePicker().getDayOfMonth();
+    }
+
+    public boolean isNullAnswer() {
+        return mNullAnswer;
     }
 
     private class CustomDatePickerDialog extends DatePickerDialog {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -213,10 +213,8 @@ public class DateWidget extends QuestionWidget {
         }
     }
 
-    private void setDate(int year, int month, int dayOfMonth) {
-        mYear = year;
-        mMonth = month;
-        mDayOfMonth = dayOfMonth;
+    private void setDateLabel() {
+        mNullAnswer = false;
         mDateTextView.setText(getAnswer().getDisplayText());
     }
 
@@ -225,8 +223,10 @@ public class DateWidget extends QuestionWidget {
                 new DatePickerDialog.OnDateSetListener() {
                     @Override
                     public void onDateSet(DatePicker view, int year, int monthOfYear, int dayOfMonth) {
-                        mNullAnswer = false;
-                        setDate(year, monthOfYear + 1, dayOfMonth);
+                        mYear = year;
+                        mMonth = monthOfYear + 1;
+                        mDayOfMonth = dayOfMonth;
+                        setDateLabel();
                     }
                 }, 0, 0, 0);
 
@@ -242,8 +242,11 @@ public class DateWidget extends QuestionWidget {
             }
         } else {
             DateTime dt = new DateTime(((Date) mPrompt.getAnswerValue().getValue()).getTime());
-            setDate(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth());
-            mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
+            mYear = dt.getYear();
+            mMonth = dt.getMonthOfYear();
+            mDayOfMonth = dt.getDayOfMonth();
+            setDateLabel();
+            mDatePickerDialog.updateDate(dt.getYear(), dt.getMonthOfYear() - 1, dt.getDayOfMonth());
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -178,12 +178,10 @@ public class DateWidget extends QuestionWidget {
             @Override
             public void onClick(View v) {
                 if (mNullAnswer) {
-                    DateTime dt = new DateTime();
-                    mYear = dt.getYear();
-                    mMonth = dt.getMonthOfYear();
-                    mDayOfMonth = dt.getDayOfMonth();
+                    setDateToCurrent();
+                } else {
+                    mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
                 }
-                mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
                 mDatePickerDialog.show();
             }
         });
@@ -213,7 +211,7 @@ public class DateWidget extends QuestionWidget {
         }
     }
 
-    private void setDateLabel() {
+    public void setDateLabel() {
         mNullAnswer = false;
         mDateTextView.setText(getAnswer().getDisplayText());
     }
@@ -232,11 +230,7 @@ public class DateWidget extends QuestionWidget {
 
         if (mPrompt.getAnswerValue() == null) {
             if (mShowCalendar) {
-                DateTime dt = new DateTime();
-                mYear = dt.getYear();
-                mMonth = dt.getMonthOfYear();
-                mDayOfMonth = dt.getDayOfMonth();
-                mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
+                setDateToCurrent();
             } else {
                 clearAnswer();
             }
@@ -276,6 +270,14 @@ public class DateWidget extends QuestionWidget {
 
     public boolean isNullAnswer() {
         return mNullAnswer;
+    }
+
+    public void setDateToCurrent() {
+        DateTime dt = new DateTime();
+        mYear = dt.getYear();
+        mMonth = dt.getMonthOfYear();
+        mDayOfMonth = dt.getDayOfMonth();
+        mDatePickerDialog.updateDate(mYear, mMonth - 1, mDayOfMonth);
     }
 
     private class CustomDatePickerDialog extends DatePickerDialog {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -151,8 +151,6 @@ public class TimeWidget extends QuestionWidget {
                     @Override
                     public void onTimeSet(TimePicker view, int hourOfDay, int minuteOfHour) {
                         mNullAnswer = false;
-                        mHourOfDay = hourOfDay;
-                        mMinuteOfHour = minuteOfHour;
                         setTime(hourOfDay, minuteOfHour);
                     }
                 }, 0, 0);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -61,7 +61,7 @@ public class TimeWidget extends QuestionWidget {
         createTimePickerDialog();
         addViews();
     }
-    
+
     @Override
     public void clearAnswer() {
         mNullAnswer = true;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -137,10 +137,8 @@ public class TimeWidget extends QuestionWidget {
         addAnswerView(linearLayout);
     }
 
-    private void setTime(int hourOfDay, int minuteOfHour) {
-        mHourOfDay = hourOfDay;
-        mMinuteOfHour = minuteOfHour;
-
+    public void setTimeLabel() {
+        mNullAnswer = false;
         mTimeTextView.setText(getAnswer().getDisplayText());
     }
 
@@ -149,8 +147,9 @@ public class TimeWidget extends QuestionWidget {
                 new TimePickerDialog.OnTimeSetListener() {
                     @Override
                     public void onTimeSet(TimePicker view, int hourOfDay, int minuteOfHour) {
-                        mNullAnswer = false;
-                        setTime(hourOfDay, minuteOfHour);
+                        mHourOfDay = hourOfDay;
+                        mMinuteOfHour = minuteOfHour;
+                        setTimeLabel();
                     }
                 }, 0, 0);
 
@@ -158,7 +157,9 @@ public class TimeWidget extends QuestionWidget {
             clearAnswer();
         } else {
             DateTime dt = new DateTime(((Date) mPrompt.getAnswerValue().getValue()).getTime());
-            setTime(dt.getHourOfDay(), dt.getMinuteOfHour());
+            mHourOfDay = dt.getHourOfDay();
+            mMinuteOfHour = dt.getMinuteOfHour();
+            setTimeLabel();
             mTimePickerDialog.updateTime(mHourOfDay, mMinuteOfHour);
         }
     }
@@ -180,11 +181,6 @@ public class TimeWidget extends QuestionWidget {
         mHourOfDay = dt.getHourOfDay();
         mMinuteOfHour = dt.getMinuteOfHour();
         mTimePickerDialog.updateTime(mHourOfDay, mMinuteOfHour);
-        setTime(mHourOfDay, mMinuteOfHour);
-    }
-
-    public void setNullAnswer(boolean value){
-        mNullAnswer = value;
     }
 
     private class CustomTimePickerDialog extends TimePickerDialog {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -72,8 +72,8 @@ public class TimeWidget extends QuestionWidget {
     public IAnswerData getAnswer() {
         clearFocus();
         // use picker time, convert to today's date, store as utc
-        DateTime ldt = (new DateTime()).withTime(mHourOfDay, mMinuteOfHour, 0, 0);
-        return mNullAnswer ? null : new TimeData(ldt.toDate());
+        DateTime dt = (new DateTime()).withTime(mHourOfDay, mMinuteOfHour, 0, 0);
+        return mNullAnswer ? null : new TimeData(dt.toDate());
     }
 
     @Override
@@ -113,11 +113,10 @@ public class TimeWidget extends QuestionWidget {
             @Override
             public void onClick(View v) {
                 if (mNullAnswer) {
-                    DateTime dt = new DateTime();
-                    mHourOfDay = dt.getHourOfDay();
-                    mMinuteOfHour = dt.getMinuteOfHour();
+                    setTimeToCurrent();
+                } else {
+                    mTimePickerDialog.updateTime(mHourOfDay, mMinuteOfHour);
                 }
-                mTimePickerDialog.updateTime(mHourOfDay, mMinuteOfHour);
                 mTimePickerDialog.show();
             }
         });
@@ -170,6 +169,22 @@ public class TimeWidget extends QuestionWidget {
 
     public int getMinute() {
         return mMinuteOfHour;
+    }
+
+    public boolean isNullAnswer() {
+        return mNullAnswer;
+    }
+
+    public void setTimeToCurrent() {
+        DateTime dt = new DateTime();
+        mHourOfDay = dt.getHourOfDay();
+        mMinuteOfHour = dt.getMinuteOfHour();
+        mTimePickerDialog.updateTime(mHourOfDay, mMinuteOfHour);
+        setTime(mHourOfDay, mMinuteOfHour);
+    }
+
+    public void setNullAnswer(boolean value){
+        mNullAnswer = value;
     }
 
     private class CustomTimePickerDialog extends TimePickerDialog {

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -501,4 +501,5 @@
 <string name="sim_serial_id">SIM serial number</string>
 <string name="select_date">Select date</string>
 <string name="select_time">Select time</string>
+<string name="no_time_selected">No time selected</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -502,5 +502,6 @@
 <string name="select_date">Select date</string>
 <string name="select_time">Select time</string>
 <string name="no_date_selected">No date selected</string>
+<string name="no_time_selected">No time selected</string>
 <string name="use_phone_language">Use phone language</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -502,4 +502,5 @@
 <string name="select_date">Select date</string>
 <string name="select_time">Select time</string>
 <string name="no_time_selected">No time selected</string>
+<string name="no_date_selected">No date selected</string>
 </resources>


### PR DESCRIPTION
This PR is in reference to resolve #81

I've tested my changes and I haven't noticed any crash. I've noticed that constraint doesn't work properly when the answer is null (it allows to go to next question).

@lognaturel I wasn't able to use relevant for dates (only simple relevant false) is it possible to use for example something like `relevant="/widgets/Date > date('2017-11-12')"` with date? there is no example for [dates](https://opendatakit.org/help/form-design/binding/)
 
Here is a form for testing: 
[dates.txt](https://github.com/opendatakit/collect/files/947023/dates.txt)
