### PR TITLE
Use something like TriggerWidget when type boolean is specified in form

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
@@ -22,6 +22,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import org.javarosa.core.model.data.BooleanData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -41,15 +42,17 @@ public class TriggerWidget extends QuestionWidget {
 
     private FormEntryPrompt mPrompt;
 
+    private boolean mIsBooleanDataType;
 
     public FormEntryPrompt getPrompt() {
         return mPrompt;
     }
 
 
-    public TriggerWidget(Context context, FormEntryPrompt prompt) {
+    public TriggerWidget(Context context, FormEntryPrompt prompt, boolean isBooleanDataType) {
         super(context, prompt);
         mPrompt = prompt;
+        mIsBooleanDataType = isBooleanDataType;
 
         mTriggerButton = new CheckBox(getContext());
         mTriggerButton.setId(QuestionWidget.newUniqueId());
@@ -82,7 +85,7 @@ public class TriggerWidget extends QuestionWidget {
 
         String s = prompt.getAnswerText();
         if (s != null) {
-            if (s.equals(mOK)) {
+            if (s.equals(mOK) || s.equals("True")) {
                 mTriggerButton.setChecked(true);
             } else {
                 mTriggerButton.setChecked(false);
@@ -109,7 +112,7 @@ public class TriggerWidget extends QuestionWidget {
         if (s == null || s.equals("")) {
             return null;
         } else {
-            return new StringData(s);
+            return mIsBooleanDataType ? new BooleanData(mTriggerButton.isChecked()) : new StringData(s);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -208,7 +208,7 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_TRIGGER:
-                questionWidget = new TriggerWidget(context, fep);
+                questionWidget = new TriggerWidget(context, fep, fep.getDataType() == Constants.DATATYPE_BOOLEAN);
                 break;
             default:
                 questionWidget = new StringWidget(context, fep, readOnlyOverride);


### PR DESCRIPTION
This PR is in reference to resolve #908 

@lognaturel 
> When a form that has a type bind attribute of boolean is read by Collect, the string widget is displayed because WidgetFactory here doesn't specify a particular widget for boolean. Instead, a widget like the existing TriggerWidget should be used and write out either 'true' or 'false' as its value.

I think you are wrong. it's still TriggerWidget we just need to check dataType look at my changes.

here is a for for testing: 
[trigger.txt](https://github.com/opendatakit/collect/files/947283/trigger.txt)

and here are two result instances:
both checkboxes are checked
`<?xml version='1.0' ?><data id="build_Untitled-Form_1492780873"><meta><instanceID>uuid:07f3c9ce-700b-4fae-82eb-4edfbd3c9238</instanceID></meta><my_trigger>OK</my_trigger><my_triggerBollean>1</my_triggerBollean></data>`

both checkboxes aren't checked
`<?xml version='1.0' ?><data id="build_Untitled-Form_1492780873"><meta><instanceID>uuid:d6ab081e-46ae-41ac-8ef0-ec4e8c79360c</instanceID></meta><my_trigger /><my_triggerBollean /></data>`

