### PR TITLE
fix #660 crash when taking a video from nexus 5

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -32,6 +32,7 @@ import android.provider.MediaStore.Images;
 import android.text.InputFilter;
 import android.text.Spanned;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.GestureDetector;
@@ -705,8 +706,12 @@ public class FormEntryActivity extends Activity implements AnimationListener,
                 if (filePath != null) {
                     new File(filePath).delete();
                 }
-                getContentResolver().delete(mediaUri, null, null);
-                break;
+                try {
+                    getContentResolver().delete(mediaUri, null, null);
+                } catch(Exception e){
+                    Toast.makeText(this, e.getMessage() , Toast.LENGTH_SHORT).show();
+                }
+                    break;
             case AUDIO_CHOOSER:
             case VIDEO_CHOOSER:
                 saveAudioVideoAnswer(intent.getData());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -32,7 +32,6 @@ import android.provider.MediaStore.Images;
 import android.text.InputFilter;
 import android.text.Spanned;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.GestureDetector;
@@ -708,10 +707,12 @@ public class FormEntryActivity extends Activity implements AnimationListener,
                 }
                 try {
                     getContentResolver().delete(mediaUri, null, null);
-                } catch(Exception e){
-                    Toast.makeText(this, e.getMessage() , Toast.LENGTH_SHORT).show();
+                } catch (Exception e) {
+                    Toast.makeText(this,e.getMessage(),Toast.LENGTH_SHORT).show();
                 }
-                    break;
+                break;
+
+
             case AUDIO_CHOOSER:
             case VIDEO_CHOOSER:
                 saveAudioVideoAnswer(intent.getData());


### PR DESCRIPTION
In FormEntryActivity -> onActivityResult -> switch (requestCode) -> case VIDEO_CAPTURE ->
getContentResolver().delete(mediaUri, null, null); was throwing an exception . Adding try catch block on it fixed the bug on Nexus 5 .