### PR TITLE
Use system language or that of collect. Fixes #890

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -265,8 +265,8 @@ public class Collect extends Application {
         super.onConfigurationChanged(newConfig);
 
         defaultSysLanguage = newConfig.locale.getLanguage();
-        boolean isUsingSysLanguage = PreferenceManager.getDefaultSharedPreferences(this).
-                getString(PreferenceKeys.KEY_APP_LANGUAGE, "").equals("");
+        boolean isUsingSysLanguage = PreferenceManager.getDefaultSharedPreferences(this)
+                .getString(PreferenceKeys.KEY_APP_LANGUAGE, "").equals("");
         if ( !isUsingSysLanguage ) {
             new LocaleHelper().updateLocale(this);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -91,7 +91,6 @@ public class Collect extends Application {
     private Tracker mTracker;
 
     public static String defaultSysLanguage;
-    public static boolean isUsingSysLanguage = true;
 
     public static Collect getInstance() {
         return singleton;
@@ -239,6 +238,7 @@ public class Collect extends Application {
     @Override
     public void onCreate() {
         defaultSysLanguage = Locale.getDefault().getLanguage();
+        new LocaleHelper().updateLocale(this);
         singleton = this;
 
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
@@ -265,7 +265,9 @@ public class Collect extends Application {
         super.onConfigurationChanged(newConfig);
 
         defaultSysLanguage = newConfig.locale.getLanguage();
-        if (!Collect.isUsingSysLanguage) {
+        boolean isUsingSysLanguage = PreferenceManager.getDefaultSharedPreferences(this).
+                getString(PreferenceKeys.KEY_APP_LANGUAGE, "").equals("");
+        if ( !isUsingSysLanguage ) {
             new LocaleHelper().updateLocale(this);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.application;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Environment;
@@ -50,6 +51,7 @@ import org.opendatakit.httpclientandroidlib.protocol.BasicHttpContext;
 import org.opendatakit.httpclientandroidlib.protocol.HttpContext;
 
 import java.io.File;
+import java.util.Locale;
 
 import timber.log.Timber;
 
@@ -87,6 +89,9 @@ public class Collect extends Application {
     private FormController mFormController = null;
     private ExternalDataManager externalDataManager;
     private Tracker mTracker;
+
+    public static String defaultSysLanguage;
+    public static boolean isUsingSysLanguage = true;
 
     public static Collect getInstance() {
         return singleton;
@@ -233,7 +238,7 @@ public class Collect extends Application {
 
     @Override
     public void onCreate() {
-        new LocaleHelper().updateLocale(this);
+        defaultSysLanguage = Locale.getDefault().getLanguage();
         singleton = this;
 
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
@@ -252,6 +257,16 @@ public class Collect extends Application {
             Timber.plant(new Timber.DebugTree());
         } else {
             Timber.plant(new CrashReportingTree());
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        defaultSysLanguage = newConfig.locale.getLanguage();
+        if (!Collect.isUsingSysLanguage) {
+            new LocaleHelper().updateLocale(this);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesFragment.java
@@ -167,7 +167,7 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
             pref.setEntryValues(entryValues.toArray(new String[length]));
             ArrayList<String> entries = new ArrayList<>();
             entries.add(0, getActivity().getResources()
-                    .getString(R.string.use_phone_locale));
+                    .getString(R.string.use_phone_language));
             entries.addAll(languageList.keySet());
             pref.setEntries(entries.toArray(new String[length]));
             if (pref.getValue() == null ) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesFragment.java
@@ -18,8 +18,10 @@ import com.google.android.gms.analytics.GoogleAnalytics;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.LocaleHelper;
 
+import java.util.ArrayList;
 import java.util.TreeMap;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.ARRAY_INDEX_GOOGLE_MAPS;
@@ -159,9 +161,20 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
         if (pref != null) {
             final LocaleHelper localeHelper = new LocaleHelper();
             TreeMap<String, String> languageList = localeHelper.getEntryListValues();
-            int length = languageList.size();
-            pref.setEntryValues(languageList.values().toArray(new String[length]));
-            pref.setEntries(languageList.keySet().toArray(new String[length]));
+            int length = languageList.size() + 1;
+            ArrayList<String> entryValues = new ArrayList<>();
+            entryValues.add(0, "");
+            entryValues.addAll(languageList.values());
+            pref.setEntryValues(entryValues.toArray(new String[length]));
+            ArrayList<String> entries = new ArrayList<>();
+            entries.add(0, getActivity().getResources()
+                    .getString(R.string.use_phone_locale));
+            entries.addAll(languageList.keySet());
+            pref.setEntries(entries.toArray(new String[length]));
+            if (pref.getValue() == null ) {
+                //set Default value to "Use phone locale"
+                pref.setValueIndex(0);
+            }
             pref.setSummary(pref.getEntry());
             pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
 
@@ -175,7 +188,15 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
                             .getDefaultSharedPreferences(getActivity()).edit();
                     edit.putString(KEY_APP_LANGUAGE, newValue.toString());
                     edit.apply();
-                    localeHelper.updateLocale(getActivity());
+
+                    if (index == 0) {
+                        Collect.isUsingSysLanguage = true;
+                        //Pass updated defaultSysLanguage
+                        localeHelper.updateLocale(getActivity(), Collect.defaultSysLanguage);
+                    } else {
+                        Collect.isUsingSysLanguage = false;
+                        localeHelper.updateLocale(getActivity());
+                    }
 
                     Intent intent = new Intent(getActivity().getBaseContext(), MainMenuActivity.class);
                     getActivity().startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesFragment.java
@@ -18,7 +18,6 @@ import com.google.android.gms.analytics.GoogleAnalytics;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.LocaleHelper;
 
 import java.util.ArrayList;
@@ -189,14 +188,7 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
                     edit.putString(KEY_APP_LANGUAGE, newValue.toString());
                     edit.apply();
 
-                    if (index == 0) {
-                        Collect.isUsingSysLanguage = true;
-                        //Pass updated defaultSysLanguage
-                        localeHelper.updateLocale(getActivity(), Collect.defaultSysLanguage);
-                    } else {
-                        Collect.isUsingSysLanguage = false;
-                        localeHelper.updateLocale(getActivity());
-                    }
+                    localeHelper.updateLocale(getActivity());
 
                     Intent intent = new Intent(getActivity().getBaseContext(), MainMenuActivity.class);
                     getActivity().startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/LocaleHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/LocaleHelper.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.DisplayMetrics;
 
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.preferences.PreferenceKeys;
 
 import java.util.Locale;
@@ -35,7 +36,11 @@ public class LocaleHelper {
 
     public void updateLocale(Context context) {
         String localeCode = PreferenceManager.getDefaultSharedPreferences(context)
-                .getString(PreferenceKeys.KEY_APP_LANGUAGE, "en");
+                .getString(PreferenceKeys.KEY_APP_LANGUAGE, "");
+        boolean isUsingSysLanguage = localeCode.equals("");
+        if ( isUsingSysLanguage ) {
+            localeCode = Collect.defaultSysLanguage;
+        }
         updateLocale(context, localeCode);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/LocaleHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/LocaleHelper.java
@@ -19,9 +19,7 @@ import java.util.TreeMap;
 
 public class LocaleHelper {
 
-    public void updateLocale(Context context) {
-        String localeCode = PreferenceManager.getDefaultSharedPreferences(context)
-                .getString(PreferenceKeys.KEY_APP_LANGUAGE, "en");
+    public void updateLocale(Context context, String localeCode) {
         Locale locale = getLocale(localeCode);
         Locale.setDefault(locale);
         Configuration configuration = new Configuration();
@@ -33,6 +31,12 @@ public class LocaleHelper {
         }
         context.getResources().updateConfiguration(configuration, displayMetrics);
         context.getApplicationContext().getResources().updateConfiguration(configuration, displayMetrics);
+    }
+
+    public void updateLocale(Context context) {
+        String localeCode = PreferenceManager.getDefaultSharedPreferences(context)
+                .getString(PreferenceKeys.KEY_APP_LANGUAGE, "en");
+        updateLocale(context, localeCode);
     }
 
     public TreeMap<String, String> getEntryListValues() {

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -501,4 +501,5 @@
 <string name="sim_serial_id">SIM serial number</string>
 <string name="select_date">Select date</string>
 <string name="select_time">Select time</string>
+<string name="use_phone_locale">Use phone locale</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -501,5 +501,5 @@
 <string name="sim_serial_id">SIM serial number</string>
 <string name="select_date">Select date</string>
 <string name="select_time">Select time</string>
-<string name="use_phone_locale">Use phone locale</string>
+<string name="use_phone_language">Use phone language</string>
 </resources>

--- a/collect_app/src/main/res/xml/preferences.xml
+++ b/collect_app/src/main/res/xml/preferences.xml
@@ -64,7 +64,6 @@
             android:title="@string/font_size" />
         <ListPreference
             android:id="@+id/app_language"
-            android:defaultValue="en"
             android:dialogTitle="@string/language"
             android:key="app_language"
             android:title="@string/language" />


### PR DESCRIPTION
@yanokwa @lognaturel I can confirm that the language now persists after Collect is restarted. It switches languages as required. But one subtle problem in this fix is that i don't verify if the system language is supported by collect. I noticed that collect supports a wide number of languages (even those not supported by my android device like Afrikaans) and it will be very rare to find a system language not supported by collect. But in a such case what should be done ? 