### PR TITLE
Clean up temp files and DB before starting InstanceUploaderTaskTest

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceUploaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceUploaderTaskTest.java
@@ -23,7 +23,9 @@ import static org.odk.collect.android.test.MockedServerTestUtils.mockWebServer;
 import static org.odk.collect.android.test.MockedServerTestUtils.nextRequestFor;
 import static org.odk.collect.android.test.MockedServerTestUtils.willRespond;
 import static org.odk.collect.android.test.TestUtils.assertMatches;
+import static org.odk.collect.android.test.TestUtils.cleanUpTempFiles;
 import static org.odk.collect.android.test.TestUtils.createTempFile;
+import static org.odk.collect.android.test.TestUtils.resetInstancesContentProvider;
 
 @Suppress
 // Pending fix https://github.com/opendatakit/collect/pull/930
@@ -33,6 +35,8 @@ public class InstanceUploaderTaskTest {
 
     @Before
     public void setUp() throws Exception {
+        resetInstancesContentProvider();
+
         dao = new InstancesDao();
         server = mockWebServer();
     }
@@ -40,6 +44,8 @@ public class InstanceUploaderTaskTest {
     @After
     public void tearDown() throws Exception {
         server.shutdown();
+        cleanUpTempFiles();
+        resetInstancesContentProvider();
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/TestUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/TestUtils.java
@@ -7,6 +7,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.provider.InstanceProviderAPI;
+
 public final class TestUtils {
     private TestUtils() {}
 
@@ -27,11 +30,24 @@ public final class TestUtils {
     public static File createTempFile() throws Exception {
         // Create our own directory, because 2-arg `createTempFile()` sometimes fails with:
         //     java.io.IOException: open failed: ENOENT (No such file or directory)
-        File dir = new File(Environment.getExternalStorageDirectory(), "test");
+        File dir = tempFileDirectory();
         dir.mkdirs();
         File tempFile = File.createTempFile("tst", null, dir);
         dir.deleteOnExit(); // Not fail-safe on android )¬;
         return tempFile;
+    }
+
+    public static void cleanUpTempFiles() {
+        File[] tempFiles = tempFileDirectory().listFiles();
+        if (tempFiles != null) {
+            for (File f : tempFiles) {
+                f.delete();
+            }
+        }
+    }
+
+    private static File tempFileDirectory() {
+        return new File(Environment.getExternalStorageDirectory(), "test-tmp");
     }
 
     public static void closeSafely(Closeable c) {
@@ -42,6 +58,10 @@ public final class TestUtils {
                 // not much you can do at this point
             }
         }
+    }
+
+    public static void resetInstancesContentProvider() {
+        Collect.getInstance().getContentResolver().delete(InstanceProviderAPI.InstanceColumns.CONTENT_URI, null, null);
     }
 
     public static void assertMatches(String expectedPattern, Object actual) {


### PR DESCRIPTION
@lognaturel this may sort out your issue when re-running tests on a long-lasting emulator instance