### PR TITLE
Avoid using Log in the future

### DIFF
--- a/collect_app/lint.xml
+++ b/collect_app/lint.xml
@@ -20,4 +20,5 @@
     <issue id="WifiManagerPotentialLeak"  severity="error" />
     <issue id="InefficientWeight" severity="error" />
     <issue id="MergeRootFrame" severity="error" />
+    <issue id="LogNotTimber" severity="error" />
 </lint>


### PR DESCRIPTION
Now we use Timber instead of Log. This change is to avoid using Log in the future.