### PR TITLE
On migration, only create column if it doesn't exist

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -101,7 +101,7 @@ public class InstanceProvider extends ContentProvider {
                         + InstanceColumns.JR_VERSION + " text;");
             }
             if (oldVersion == 3) {
-                Cursor cursor = db.rawQuery("PRAGMA table_info(" + INSTANCES_TABLE_NAME + ")", null);
+                Cursor cursor = db.rawQuery("SELECT * FROM " + INSTANCES_TABLE_NAME + " LIMIT 0", null);
                 int columnIndex = cursor.getColumnIndex(InstanceColumns.DELETED_DATE);
                 cursor.close();
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -106,7 +106,7 @@ public class InstanceProvider extends ContentProvider {
                 cursor.close();
 
                 // Only add the column if it doesn't already exist
-                if (columnIndex != -1) {
+                if (columnIndex == -1) {
                     db.execSQL("ALTER TABLE " + INSTANCES_TABLE_NAME + " ADD COLUMN "
                             + InstanceColumns.DELETED_DATE + " date;");
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -101,8 +101,15 @@ public class InstanceProvider extends ContentProvider {
                         + InstanceColumns.JR_VERSION + " text;");
             }
             if (oldVersion == 3) {
-                db.execSQL("ALTER TABLE " + INSTANCES_TABLE_NAME + " ADD COLUMN "
-                        + InstanceColumns.DELETED_DATE + " date;");
+                Cursor cursor = db.rawQuery("PRAGMA table_info(" + INSTANCES_TABLE_NAME + ")", null);
+                int columnIndex = cursor.getColumnIndex(InstanceColumns.DELETED_DATE);
+                cursor.close();
+
+                // Only add the column if it doesn't already exist
+                if (columnIndex != -1) {
+                    db.execSQL("ALTER TABLE " + INSTANCES_TABLE_NAME + " ADD COLUMN "
+                            + InstanceColumns.DELETED_DATE + " date;");
+                }
             }
             Timber.w("Successfully upgraded database from version %d to %d, without destroying all the old data",
                     initialVersion, newVersion);


### PR DESCRIPTION
I verified that this makes it possible to switch back to old versions of Collect and then forward again which is part of #997.

I'm not totally sure that I understand the case when an old Collect fork such as KoboCollect is also installed. I can replicate the problem when updating from an old version through the Play Store. I can't replicate it when pushing builds from source. I don't think that this fixes it so we should keep the issue open and watch crash reports.