### PR TITLE
Crash in FormEntryActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2231,10 +2231,12 @@ public class FormEntryActivity extends Activity implements AnimationListener,
 
     private void cancelSaveToDiskTask() {
         synchronized (saveDialogLock) {
-            mSaveToDiskTask.setFormSavedListener(null);
-            boolean cancelled = mSaveToDiskTask.cancel(true);
-            Timber.w("Cancelled SaveToDiskTask! (%s)", cancelled);
-            mSaveToDiskTask = null;
+            if (mSaveToDiskTask != null) {
+                mSaveToDiskTask.setFormSavedListener(null);
+                boolean cancelled = mSaveToDiskTask.cancel(true);
+                Timber.w("Cancelled SaveToDiskTask! (%s)", cancelled);
+                mSaveToDiskTask = null;
+            }
         }
     }
 


### PR DESCRIPTION
This PR is in reference to resolve #1014 

I've investigate attached stacktraces and I was able to reproduce the issue slowing down SaveToDiskTask programmatically. Then if I close the app using physical button (when the saving form dialog is visible) I run into a crash when I open the app again and try to close the dialog. You need to wait until the app is destroyed so you may need to check "Don'y keep activities" option in your device settings then it's much easier as you don't need to wait.

I wasn't able to find better solution and this solution is temporary as similar problems might occurr in other dialogs as well. I'm pretty sure I run into a crash if I do the same with SAVING_IMAGE_DIALOG but it's less common problem I guess and we don't have to fix that now. 

I said it's temporary fix as we need to improve our dialogs then we should be safer: https://github.com/opendatakit/collect/issues/541