### PR TITLE
Use embedded zxing lib in BarcodeWidget. Fixes #1021

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -58,6 +58,9 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.zxing.integration.android.IntentIntegrator;
+import com.google.zxing.integration.android.IntentResult;
+
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.TreeElement;
@@ -595,12 +598,23 @@ public class FormEntryActivity extends Activity implements AnimationListener,
             return;
         }
 
-        switch (requestCode) {
-            case BARCODE_CAPTURE:
+        // For handling results returned by the Zxing Barcode scanning library
+        IntentResult barcodeScannerResult = IntentIntegrator.parseActivityResult(requestCode, resultCode, intent);
+        if (barcodeScannerResult != null) {
+            if (barcodeScannerResult.getContents() == null) {
+                // request was canceled...
+                Timber.i("QR code scanning cancelled");
+            } else {
                 String sb = intent.getStringExtra("SCAN_RESULT");
                 ((ODKView) currentView).setBinaryData(sb);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
-                break;
+                return;
+            }
+        }
+
+
+        switch (requestCode) {
+
             case OSM_CAPTURE:
                 String osmFileName = intent.getStringExtra("OSM_FILE_NAME");
                 ((ODKView) currentView).setBinaryData(osmFileName);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -608,6 +608,7 @@ public class FormEntryActivity extends Activity implements AnimationListener,
                 String sb = intent.getStringExtra("SCAN_RESULT");
                 ((ODKView) currentView).setBinaryData(sb);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
+                refreshCurrentView();
                 return;
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -28,6 +28,8 @@ import android.widget.TableLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.zxing.integration.android.IntentIntegrator;
+
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -68,21 +70,10 @@ public class BarcodeWidget extends QuestionWidget implements IBinaryWidget {
                         .getActivityLogger()
                         .logInstanceAction(this, "recordBarcode", "click",
                                 formEntryPrompt.getIndex());
-                Intent i = new Intent("com.google.zxing.client.android.SCAN");
-                try {
-                    Collect.getInstance().getFormController()
-                            .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.BARCODE_CAPTURE);
-                } catch (ActivityNotFoundException e) {
-                    Toast.makeText(
-                            getContext(),
-                            getContext().getString(
-                                    R.string.barcode_scanner_error),
-                            Toast.LENGTH_SHORT).show();
-                    Collect.getInstance().getFormController()
-                            .setIndexWaitingForData(null);
-                }
+
+                Collect.getInstance().getFormController()
+                        .setIndexWaitingForData(formEntryPrompt.getIndex());
+                new IntentIntegrator((Activity) getContext()).initiateScan();
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -15,9 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
-import android.content.Intent;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -26,7 +24,6 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.zxing.integration.android.IntentIntegrator;
 
@@ -34,7 +31,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 
 /**

--- a/collect_app/src/main/res/values-af/strings.xml
+++ b/collect_app/src/main/res/values-af/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Geen oudio leêr is gespesifiseer nie.</string>
   <string name="audio_file_invalid">Leêr: %s is nie \'n geldige oudio leêr nie.</string>
   <string name="backup">terug na\nvorige\nvraag</string>
-  <string name="barcode_scanner_error">Jammer, Barcode Skandeerder is nie geïnstalleer nie!</string>
   <string name="cancel">Kanselleer</string>
   <string name="cancel_loading_form">Kanselleer</string>
   <string name="cancel_location">Kanselleer</string>

--- a/collect_app/src/main/res/values-ar/strings.xml
+++ b/collect_app/src/main/res/values-ar/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">لم يتم تحديد ملف الصوت</string>
   <string name="audio_file_invalid">الملف: %s ملف صوتي غير صالح</string>
   <string name="backup">الى الخلف/السابق/موجه</string>
-  <string name="barcode_scanner_error">عذرا, لم يتم تثبيت ماسح الباركود! أرجو تنزيل التطبيق من المتجر.</string>
   <string name="cancel">إلغاء</string>
   <string name="cancel_loading_form">إلغاء</string>
   <string name="cancel_location">إلغاء</string>

--- a/collect_app/src/main/res/values-bn/strings.xml
+++ b/collect_app/src/main/res/values-bn/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">কোন অডিও ফাইল নির্দিষ্ট করা হয় নি। </string>
   <string name="audio_file_invalid">%s নামের ফাইলটি যুক্তিসিদ্ধ অডিও ফাইল নয়।</string>
   <string name="backup">পূর্ববর্তী পাতা</string>
-  <string name="barcode_scanner_error">দুঃখিত, বারকোড স্ক্যানার সংযুক্ত করা নেই!</string>
   <string name="cancel">বাতিল</string>
   <string name="cancel_loading_form">বাতিল</string>
   <string name="cancel_location">বাতিল</string>

--- a/collect_app/src/main/res/values-ca/strings.xml
+++ b/collect_app/src/main/res/values-ca/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">No s\'ha especificat cap arxiu de so.</string>
   <string name="audio_file_invalid">Arxiu: %s és un arxiu d\'audio invàlid.</string>
   <string name="backup">Recular a \nprevious\nprompt</string>
-  <string name="barcode_scanner_error">Ho sentim, lector de codi de barres no instal·lat!</string>
   <string name="cancel">Cancel·lar</string>
   <string name="cancel_loading_form">Cancel·lar</string>
   <string name="cancel_location">Cancel·lar</string>

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Nebyl vybrán žádný audio soubor</string>
   <string name="audio_file_invalid">Soubor: %s není platný audio soubor.</string>
   <string name="backup">zpět k\npředchozí\notázce</string>
-  <string name="barcode_scanner_error">Scanner čárových kódů není instalován!</string>
   <string name="cancel">Zrušit</string>
   <string name="cancel_loading_form">Zrušit</string>
   <string name="cancel_location">Zrušit</string>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Keine Audio-Datei angegeben.</string>
   <string name="audio_file_invalid">Datei: %s ist keine lesbare Audio-Datei.</string>
   <string name="backup">Zurück zur\nvorherigen\nEingabe</string>
-  <string name="barcode_scanner_error">Barcode-Scanner ist nicht installiert!</string>
   <string name="cancel">Abbrechen</string>
   <string name="cancel_loading_form">Abbrechen</string>
   <string name="cancel_location">Abbrechen</string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Ningún archivo de audio fue especificado.</string>
   <string name="audio_file_invalid">Archivo: %s no es un archivo de audio válido.</string>
   <string name="backup">de vuelta a la\npregunta\nprevia</string>
-  <string name="barcode_scanner_error">¡El lector de codigo de barra no esta instalado!</string>
   <string name="cancel">Cancelar</string>
   <string name="cancel_loading_form">Cancelar</string>
   <string name="cancel_location">Cancelar</string>

--- a/collect_app/src/main/res/values-et/strings.xml
+++ b/collect_app/src/main/res/values-et/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Helifail jäi määramata</string>
   <string name="audio_file_invalid">Fail: %s ei ole lubatud helifail</string>
   <string name="backup">Liigu \neelmisele\nekraanile</string>
-  <string name="barcode_scanner_error">Tiipkoodi lugejat ei ole kahjuks paigaldatud!</string>
   <string name="cancel">Tühista</string>
   <string name="cancel_loading_form">Tühista</string>
   <string name="cancel_location">Tühista</string>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Äänitiedostoa ei määritelty.</string>
   <string name="audio_file_invalid">Tiedosto %s ei ole käypä äänitiedosto.</string>
   <string name="backup">taaksepäin\nedelliseen\nkysymykseen</string>
-  <string name="barcode_scanner_error">Pahoittelut, viivakoodiskanneria ei ole asennettu!</string>
   <string name="cancel">Peruuta</string>
   <string name="cancel_loading_form">Peruuta</string>
   <string name="cancel_location">Peruuta</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Aucun fichier audio spécifié.</string>
   <string name="audio_file_invalid">%s n\'est pas un fichier audio valide.</string>
   <string name="backup">Reculer à\nla question\nprécédente</string>
-  <string name="barcode_scanner_error">Désolé, Barcode Scanner n\'est pas installé.</string>
   <string name="cancel">Annuler</string>
   <string name="cancel_loading_form">Annuler</string>
   <string name="cancel_location">Annuler</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Belum ada berkas audio yang dipilih.</string>
   <string name="audio_file_invalid">Berkas: %s bukan termasuk berkas audio.</string>
   <string name="backup">kembali ke\npertanyaan\nsebelumnya</string>
-  <string name="barcode_scanner_error">Maaf, pemindai Barcode belum terpasang!</string>
   <string name="cancel">Batal</string>
   <string name="cancel_loading_form">Batal</string>
   <string name="cancel_location">Batal</string>

--- a/collect_app/src/main/res/values-it/strings.xml
+++ b/collect_app/src/main/res/values-it/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Nessun file audio è stato specificato.</string>
   <string name="audio_file_invalid">File: %s non è un file di audio valido.</string>
   <string name="backup">indietro</string>
-  <string name="barcode_scanner_error">Spiacenti, Barcode Scanner non è installato!</string>
   <string name="cancel">Annulla</string>
   <string name="cancel_loading_form">Annulla</string>
   <string name="cancel_location">Annulla</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">オーディオファイルが指定されていません。</string>
   <string name="audio_file_invalid">ファイル: %s は正しいオーディオファイルではありません。</string>
   <string name="backup">前の\nプロンプト\nに戻る</string>
-  <string name="barcode_scanner_error">申し訳ありません、バーコードスキャナーがインストールされていません!</string>
   <string name="cancel">キャンセル</string>
   <string name="cancel_loading_form">キャンセル</string>
   <string name="cancel_location">キャンセル</string>

--- a/collect_app/src/main/res/values-ka/strings.xml
+++ b/collect_app/src/main/res/values-ka/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">აუდიო-ფაილი არ იყო მითითებული.</string>
   <string name="audio_file_invalid">ფაილი: %s არ წარმოადგენს ვალიდურ აუდიო-ფაილს.</string>
   <string name="backup">უკან გადმოსვლა \nprevious\npromptზე</string>
-  <string name="barcode_scanner_error">უკაცრავად, ბარკოდის სკანერი არ არის დაყენებული!</string>
   <string name="cancel">გაუქმება</string>
   <string name="cancel_loading_form">გაუქმება</string>
   <string name="cancel_location">გაუქმება</string>

--- a/collect_app/src/main/res/values-km/strings.xml
+++ b/collect_app/src/main/res/values-km/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">គ្មានឯកសារអូឌីយ៉ូដែលបានបញ្ជាក់.</string>
   <string name="audio_file_invalid">ឯកសារ: %s មិនមែនជាឯកសារសម្លេងត្រឹមត្រូវ</string>
   <string name="backup">ថយក្រោយទៅ\nពីមុន\nprompt</string>
-  <string name="barcode_scanner_error">សុំ​អភ័យ​ទោស​ កម្មវិធី​ស្កែនបារកូដមិនទាន់ដំឡើង</string>
   <string name="cancel">បោះបង់</string>
   <string name="cancel_loading_form">បោះបង់</string>
   <string name="cancel_location">បោះបង់</string>

--- a/collect_app/src/main/res/values-lo-rLA/strings.xml
+++ b/collect_app/src/main/res/values-lo-rLA/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">ຍັງບໍ່ໄດ້ເລືອກເອ​ກະ​ສານ​ປະ​ເພດ​ສຽງ</string>
   <string name="audio_file_invalid">ເອ​ກະ​ສານ: %s ບໍ່ແມ່ນປະ​ເພດສຽງ</string>
   <string name="backup">ກັບໄປ\nກ່ອນໜ້າ\nໄປຫາ</string>
-  <string name="barcode_scanner_error">​ເຄື່ອງອ່ານບາໂຄດຍັງບໍ່ທັນຕິດຕັ້ງ​ເທື່ອ</string>
   <string name="cancel">ຍົກເລິກ</string>
   <string name="cancel_loading_form">ຍົກເລີກ</string>
   <string name="cancel_location">ຍົກເລີກ</string>

--- a/collect_app/src/main/res/values-lt/strings.xml
+++ b/collect_app/src/main/res/values-lt/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Altitudė</string>
   <string name="audio_file_error">Nebuvo nurodytas joks audio failas.</string>
   <string name="audio_file_invalid">Failas: %s nėra tinkamas audio failas.</string>
-  <string name="barcode_scanner_error">Deja brūkšninio kodo skeneris nėra įdiegtas!</string>
   <string name="cancel">Atšaukti</string>
   <string name="cancel_loading_form">Atšaukti</string>
   <string name="cancel_location">Atšaukti</string>

--- a/collect_app/src/main/res/values-my/strings.xml
+++ b/collect_app/src/main/res/values-my/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">ေျမမ်က္ႏွာျပင္အျမင့္</string>
   <string name="audio_file_error">အသံသြင္းဖိုင္မဟုတ္ပါ</string>
   <string name="audio_file_invalid">ဖိုင္: %s အသံသြင္း၍မရပါ</string>
-  <string name="barcode_scanner_error">ဘားကုတ္(ဒ္)ပံုရိပ္ဖမ္းစနစ္ ထည့္သြင္းထားသြင္းထားျခင္း မရိွပါ</string>
   <string name="cancel">ပယ္ရန္</string>
   <string name="cancel_loading_form">ပယ္ရန္</string>
   <string name="cancel_location">ပယ္ရန္</string>

--- a/collect_app/src/main/res/values-ne-rNP/strings.xml
+++ b/collect_app/src/main/res/values-ne-rNP/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">कुनै पनि अडियो फाइल उल्लेख छैन।</string>
   <string name="audio_file_invalid">फाइल: %s मान्य अडियो फाइल होइन |</string>
   <string name="backup">अघिल्लो \nप्रश्नमा\nजान</string>
-  <string name="barcode_scanner_error">माफ गर्नुहोला, बारकोड स्क्यानर जडान गरिएको छैन ! </string>
   <string name="cancel">फिर्ता जानुहोस्</string>
   <string name="cancel_loading_form">फिर्ता जानुहोस्</string>
   <string name="cancel_location">फिर्ता जानुहोस्</string>

--- a/collect_app/src/main/res/values-nl/strings.xml
+++ b/collect_app/src/main/res/values-nl/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Geen audio bestand geselecteerd.</string>
   <string name="audio_file_invalid">Bestand: %s is geen geldig audio bestand.</string>
   <string name="backup">tergu naar\nvorige\nvraag</string>
-  <string name="barcode_scanner_error">Sorry, Barcode Scanner is niet geinstalleerd!</string>
   <string name="cancel">Terug</string>
   <string name="cancel_loading_form">Terug</string>
   <string name="cancel_location">Terug</string>

--- a/collect_app/src/main/res/values-no/strings.xml
+++ b/collect_app/src/main/res/values-no/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Uspesifisert lydfil</string>
   <string name="audio_file_invalid">Filen: %s er ikke en gyldig lydfil</string>
   <string name="backup">bakover til\nprevious\nprompt</string>
-  <string name="barcode_scanner_error">Beklager, strekkode skanner er ikke installert!</string>
   <string name="cancel">Avbryt</string>
   <string name="cancel_loading_form">Avbryt</string>
   <string name="cancel_location">Avbryt</string>

--- a/collect_app/src/main/res/values-pl/strings.xml
+++ b/collect_app/src/main/res/values-pl/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Nie został wskazany plik audio.</string>
   <string name="audio_file_invalid">Plik: %s nie jest poprawnym plikiem audio.</string>
   <string name="backup">cofnij do\npoprzedniego\npytania</string>
-  <string name="barcode_scanner_error">Przepraszam, skaner kodu kreskowego nie jest zainstalowany!</string>
   <string name="cancel">Anuluj</string>
   <string name="cancel_loading_form">Anuluj</string>
   <string name="cancel_location">Anuluj</string>

--- a/collect_app/src/main/res/values-pt/strings.xml
+++ b/collect_app/src/main/res/values-pt/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Altitude</string>
   <string name="audio_file_error">Não foi especificado arquivo de áudio</string>
   <string name="audio_file_invalid">Arquivo de áudio %s inválido.</string>
-  <string name="barcode_scanner_error">Desculpe, scanner de código de barras não instalado</string>
   <string name="cancel">Cancelar</string>
   <string name="cancel_loading_form">Cancelar</string>
   <string name="cancel_location">Cancelar</string>

--- a/collect_app/src/main/res/values-ro/strings.xml
+++ b/collect_app/src/main/res/values-ro/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Fișierul audio nu a fost specificat.</string>
   <string name="audio_file_invalid">Fișierul: %s nu este un fișier audio valid.</string>
   <string name="backup">înapoi către \necranul \nanterior</string>
-  <string name="barcode_scanner_error">Ne pare rău, scanner-ul de coduri de bare nu este instalat!</string>
   <string name="cancel">Anulează</string>
   <string name="cancel_loading_form">Anulează</string>
   <string name="cancel_location">Anulează</string>

--- a/collect_app/src/main/res/values-ru/strings.xml
+++ b/collect_app/src/main/res/values-ru/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Аудио-файл не был выбран.</string>
   <string name="audio_file_invalid">Файл: %s не является аудио-файлом.</string>
   <string name="backup">Вернуться \nк предыдущему\nвопросу</string>
-  <string name="barcode_scanner_error">Сканер штрих-кодов не установлен!</string>
   <string name="cancel">Отмена</string>
   <string name="cancel_loading_form">Отмена</string>
   <string name="cancel_location">Отмена</string>

--- a/collect_app/src/main/res/values-sq/strings.xml
+++ b/collect_app/src/main/res/values-sq/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Audio file e specifikuar nuk gjendet</string>
   <string name="audio_file_invalid">File: %s nuk është një audio file funksionale</string>
   <string name="backup">Rikthehu tek \nprevious\nprompt</string>
-  <string name="barcode_scanner_error">Kujdes, skanuesi i barkodeve nuk është i instaluar</string>
   <string name="cancel">Anullo</string>
   <string name="cancel_loading_form">Anullo</string>
   <string name="cancel_location">Anullo</string>

--- a/collect_app/src/main/res/values-sv-rSE/strings.xml
+++ b/collect_app/src/main/res/values-sv-rSE/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Ingen ljudfil har valts</string>
   <string name="audio_file_invalid">Filen: %s är inte en giltig ljudfil</string>
   <string name="backup">gå bakåt till\nföregående\ninmatningsrad</string>
-  <string name="barcode_scanner_error">Tyvärr, streckkodsläsare är inte installerad!</string>
   <string name="cancel">Avbryt</string>
   <string name="cancel_loading_form">Avbryt</string>
   <string name="cancel_location">Avbryt</string>

--- a/collect_app/src/main/res/values-sw-rKE/strings.xml
+++ b/collect_app/src/main/res/values-sw-rKE/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Urefu</string>
   <string name="audio_file_error">hakuna faili ya sauti bayana</string>
   <string name="audio_file_invalid">faili: %s sio faili halali ya sauti</string>
-  <string name="barcode_scanner_error">Samahani, Barcode Scanner haipo</string>
   <string name="cancel">Tamatisha</string>
   <string name="cancel_loading_form">Tamatisha</string>
   <string name="cancel_location">Tamatisha</string>

--- a/collect_app/src/main/res/values-sw/strings.xml
+++ b/collect_app/src/main/res/values-sw/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Muinuko</string>
   <string name="audio_file_error">Hakuna faili ya sauti iliyochaguliwa.</string>
   <string name="audio_file_invalid">Faili: %s si ya sauti.</string>
-  <string name="barcode_scanner_error">Pole, Barcode Skena haikuwekwa!</string>
   <string name="cancel">Sitisha</string>
   <string name="cancel_loading_form">Sitisha</string>
   <string name="cancel_location">Sitisha</string>

--- a/collect_app/src/main/res/values-th-rTH/strings.xml
+++ b/collect_app/src/main/res/values-th-rTH/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">ยังไม่ได้เลือกไฟล์เสียง</string>
   <string name="audio_file_invalid">ไฟล์ %s ไม่ใช่ไฟล์เสียง</string>
   <string name="backup">ย้อนกลับไป\nที่คำถาม\nก่อนหน้านี้</string>
-  <string name="barcode_scanner_error">ขออภัย, โปรแกรมอ่านบาร์โคดยังไม่ได้ติดตั้ง!</string>
   <string name="cancel">ยกเลิก</string>
   <string name="cancel_loading_form">ยกเลิก</string>
   <string name="cancel_location">ยกเลิก</string>

--- a/collect_app/src/main/res/values-tl-rPH/strings.xml
+++ b/collect_app/src/main/res/values-tl-rPH/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Taas</string>
   <string name="audio_file_error">Walang talaksang-tunog na tinukoy.</string>
   <string name="audio_file_invalid">Talaksa: %s ay hindi wastong talaksang-tunog.</string>
-  <string name="barcode_scanner_error">Paumanhin, ang Barcode Scanner ay hindi naka-kanâ!</string>
   <string name="cancel">Urong</string>
   <string name="cancel_loading_form">Urong</string>
   <string name="cancel_location">Urong</string>

--- a/collect_app/src/main/res/values-tl/strings.xml
+++ b/collect_app/src/main/res/values-tl/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Taas</string>
   <string name="audio_file_error">Walang talaksang-tunog na tinukoy.</string>
   <string name="audio_file_invalid">Talaksa: %s ay hindi wastong talaksang-tunog.</string>
-  <string name="barcode_scanner_error">Paumanhin, ang Barcode Scanner ay hindi naka-kanâ!</string>
   <string name="cancel">Urong</string>
   <string name="cancel_loading_form">Urong</string>
   <string name="cancel_location">Urong</string>

--- a/collect_app/src/main/res/values-tr/strings.xml
+++ b/collect_app/src/main/res/values-tr/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">Meridyen</string>
   <string name="audio_file_error">Ses dosyası belirlenmedi.</string>
   <string name="audio_file_invalid">%s dosyasi geçerli bir ses dosyasi degildir!</string>
-  <string name="barcode_scanner_error">Barkod okuyucu tanimlanamadi!</string>
   <string name="cancel">Vazgeç</string>
   <string name="cancel_loading_form">Vazgeç</string>
   <string name="cancel_location">Vazgeç</string>

--- a/collect_app/src/main/res/values-uk/strings.xml
+++ b/collect_app/src/main/res/values-uk/strings.xml
@@ -14,7 +14,6 @@
   <string name="audio_file_error">Не вказано жодного аудіофайлу</string>
   <string name="audio_file_invalid">Файл: %s не є аудіофайлом</string>
   <string name="backup">назад до\nпопереднього\nпитання</string>
-  <string name="barcode_scanner_error">Вибачте, сканер штрихкодів не встановлено!</string>
   <string name="cancel">Скасувати</string>
   <string name="cancel_loading_form">Скасувати</string>
   <string name="cancel_location">Скасувати</string>

--- a/collect_app/src/main/res/values-ur-rPK/strings.xml
+++ b/collect_app/src/main/res/values-ur-rPK/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">اّواز کے فائل کی تفصیل نہیں ہے</string>
   <string name="audio_file_invalid">فائل: ‎%s‏ قابل توثیق اّواز کی فائل نہیں ہے</string>
   <string name="backup">پیچھے کیلئے ؟  پچھلا ؟ پرامپٹ</string>
-  <string name="barcode_scanner_error">معافی, بار کوڈ سکینر نصب نہیں ہے</string>
   <string name="cancel">منسوخ</string>
   <string name="cancel_loading_form">منسوخ</string>
   <string name="cancel_location">منسوخ</string>

--- a/collect_app/src/main/res/values-ur/strings.xml
+++ b/collect_app/src/main/res/values-ur/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">اّواز کے فائل کی تفصیل نہیں ہے</string>
   <string name="audio_file_invalid">فائل: ‎%s‏ قابل توثیق اّواز کی فائل نہیں ہے</string>
   <string name="backup">پیچھے کیلئے ؟  پچھلا ؟ پرامپٹ</string>
-  <string name="barcode_scanner_error">معافی, بار کوڈ سکینر نصب نہیں ہے</string>
   <string name="cancel">منسوخ</string>
   <string name="cancel_loading_form">منسوخ</string>
   <string name="cancel_location">منسوخ</string>

--- a/collect_app/src/main/res/values-vi/strings.xml
+++ b/collect_app/src/main/res/values-vi/strings.xml
@@ -13,7 +13,6 @@
   <string name="audio_file_error">Không có file âm thanh nào được xác định.</string>
   <string name="audio_file_invalid">File: %s không phải là file âm thanh hợp lệ.</string>
   <string name="backup">quay về \nprevious\nprompt</string>
-  <string name="barcode_scanner_error">Xin lỗi, máy quét mã vạch không được cài dặt!</string>
   <string name="cancel">Huỷ</string>
   <string name="cancel_loading_form">Huỷ</string>
   <string name="cancel_location">Huỷ</string>

--- a/collect_app/src/main/res/values-zh/strings.xml
+++ b/collect_app/src/main/res/values-zh/strings.xml
@@ -11,7 +11,6 @@
   <string name="altitude">海拔</string>
   <string name="audio_file_error">缺少音频文件.</string>
   <string name="audio_file_invalid">文件: %s 不是有效的音频文件.</string>
-  <string name="barcode_scanner_error">条码扫描器未安装!</string>
   <string name="cancel">取消</string>
   <string name="cancel_loading_form">取消</string>
   <string name="cancel_location">取消</string>

--- a/collect_app/src/main/res/values-zu/strings.xml
+++ b/collect_app/src/main/res/values-zu/strings.xml
@@ -10,7 +10,6 @@
   <string name="audio_file_error">Akukho msindo otholakalayo</string>
   <string name="audio_file_invalid">Msindo: %s Ifayela ayiwona umsindo ozwakala kahle</string>
   <string name="backup">buyela\nemuva</string>
-  <string name="barcode_scanner_error">Uxolo ibhakhodi skena ayifakiwe</string>
   <string name="cancel">Khansela</string>
   <string name="cancel_loading_form">Khansela</string>
   <string name="cancel_location">Khansela</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -26,7 +26,6 @@
 <string name="audio_file_error">No audio file was specified.</string>
 <string name="audio_file_invalid">File: %s is not a valid audio file.</string>
 <string name="backup">backward to\nprevious\nprompt</string>
-<string name="barcode_scanner_error">Sorry, Barcode Scanner is not installed!</string>
 <string name="cancel">Cancel</string>
 <string name="cancel_loading_form">Cancel</string>
 <string name="cancel_location">Cancel</string>


### PR DESCRIPTION
Pull request for issue 1021. Uses embedded zxing lib in BarcodeWidget instead of launching intent for an external Barcode scanning app.