### PR TITLE
SurveyCTO contribution: Fixed application crash when loading offline map tiles.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/spatial/OsmMBTileSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/spatial/OsmMBTileSource.java
@@ -82,7 +82,7 @@ public class OsmMBTileSource extends BitmapTileSourceBase {
         SQLiteDatabase db = SQLiteDatabase.openDatabase(file.getAbsolutePath(), null, flags);
 
         // Get the tile size
-        Cursor cursor = db.rawQuery("SELECT tile_data FROM images LIMIT 0,1",
+        Cursor cursor = db.rawQuery("SELECT tile_data FROM tiles LIMIT 0,1",
                 new String[]{});
 
         if (cursor.getCount() != 0) {


### PR DESCRIPTION
@lognaturel reported a crash in #1045. We have fixed it on our branch and we should share that fix here.