### PR TITLE
Fixed blocked swiping

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -194,7 +194,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private static final int SAVING_IMAGE_DIALOG = 3;
 
     private boolean autoSaved;
-    private boolean doSwipe;
+    private boolean doSwipe = true;
 
     // Random ID
     private static final int DELETE_REPEAT = 654321;


### PR DESCRIPTION
There was a bug in my implementation of `RangeWidget`. It causes blocking possibility to swipe as implemented `doSwipe` is `false` by default.