### PR TITLE
Add project specific secrets and instructions for building releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ local.properties
 
 # gradle env props
 gradle.properties
+secrets.properties
 
 # built application files
 *.apk

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Per-commit debug builds can be found on [CircleCI](https://circleci.com/gh/opend
 
 Current and previous production builds can be found on the [ODK website](https://opendatakit.org/downloads/download-info/odk-collect-apk).
 
+## Creating signed releases
+Create a `secrets.properties` file in the `collect_app` folder with the following:
+```
+// collect_app/secrets.properties
+RELEASE_STORE_FILE=/path/to/collect.keystore
+RELEASE_STORE_PASSWORD=secure-store-password
+RELEASE_KEY_ALIAS=key-alias
+RELEASE_KEY_PASSWORD=secure-alias-password
+```
+Run `./gradlew assembleRelease` and, if successful, a signed release will be at `collect_app/build/outputs/apk`. 
+
+You can also use Android Studio by going to `Build` menu, `Generate Signed APK...`, and generate signed releases that way.
 
 ## Troubleshooting
 #### Error when running Robolectric tests from Android Studio on macOS: `build/intermediates/bundles/debug/AndroidManifest.xml (No such file or directory)`

--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ Per-commit debug builds can be found on [CircleCI](https://circleci.com/gh/opend
 
 Current and previous production builds can be found on the [ODK website](https://opendatakit.org/downloads/download-info/odk-collect-apk).
 
-## Creating signed releases
-Create a `secrets.properties` file in the `collect_app` folder with the following:
+## Creating signed releases for Google Play Store
+Project maintainers have the keys to upload signed releases to the Play Store. 
+
+Maintainers have a `secrets.properties` file in the `collect_app` folder with the following:
 ```
 // collect_app/secrets.properties
 RELEASE_STORE_FILE=/path/to/collect.keystore
@@ -95,9 +97,7 @@ RELEASE_STORE_PASSWORD=secure-store-password
 RELEASE_KEY_ALIAS=key-alias
 RELEASE_KEY_PASSWORD=secure-alias-password
 ```
-Run `./gradlew assembleRelease` and, if successful, a signed release will be at `collect_app/build/outputs/apk`. 
-
-You can also use Android Studio by going to `Build` menu, `Generate Signed APK...`, and generate signed releases that way.
+To generate official signed releases, you'll need the keystore file, the keystore passwords, a configured `secrets.properties` file, and then run `./gradlew assembleRelease`. If successful, a signed release will be at `collect_app/build/outputs/apk`.
 
 ## Troubleshooting
 #### Error when running Robolectric tests from Android Studio on macOS: `build/intermediates/bundles/debug/AndroidManifest.xml (No such file or directory)`

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -55,6 +55,12 @@ def getVersionName = { ->
     }
 }
 
+def secretsFile = file('secrets.properties')
+def secrets = new Properties()
+if(secretsFile.exists()) {
+    secrets.load(new FileInputStream(secretsFile))
+}
+
 android {
     compileSdkVersion(25)
     buildToolsVersion('25.0.2')
@@ -69,8 +75,22 @@ android {
         multiDexEnabled true
     }
 
+    signingConfigs {
+        release {
+            if (secrets.getProperty('RELEASE_STORE_FILE')) {
+                storeFile file(secrets.getProperty('RELEASE_STORE_FILE'))
+                storePassword secrets.getProperty('RELEASE_STORE_PASSWORD')
+                keyAlias secrets.getProperty('RELEASE_KEY_ALIAS')
+                keyPassword secrets.getProperty('RELEASE_KEY_PASSWORD')
+            }
+       }
+    }
+
     buildTypes {
         release {
+            if (secrets.getProperty('RELEASE_STORE_FILE')) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
@@ -78,6 +98,14 @@ android {
             debuggable(true)
             // Allows AndroidTest JaCoCo reports to be generated
             testCoverageEnabled(true)
+        }
+    }
+
+    // https://stackoverflow.com/a/27119543/152938
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def file = output.outputFile
+            output.outputFile = new File(file.parent, file.name.replace("_app","").replace(".apk", "-" + defaultConfig.versionName + ".apk"))
         }
     }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -57,7 +57,7 @@ def getVersionName = { ->
 
 def secretsFile = file('secrets.properties')
 def secrets = new Properties()
-if(secretsFile.exists()) {
+if (secretsFile.exists()) {
     secrets.load(new FileInputStream(secretsFile))
 }
 


### PR DESCRIPTION
* Added project-specific secrets.properties with config required to build releases.
* Changed build.gradle so passphrase can be fetched from a file. If secrets file doesn't exist, release builds are unsigned.
* Changed build.gradle so APK name has version details
* Added instructions to increase bus factor
* Confirmed working by trying builds with and without secrets.properties file