### PR TITLE
Fixed orientation of DrawWidget

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -126,6 +126,7 @@ the specific language governing permissions and limitations under the License.
             android:taskAffinity="" />
         <activity
             android:name=".activities.DrawActivity"
+            android:screenOrientation="landscape"
             android:label="@string/app_name" />
         <activity
             android:name=".activities.OpenSourceLicensesActivity"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -18,7 +18,6 @@ package org.odk.collect.android.activities;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
-import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -183,12 +182,9 @@ public class DrawActivity extends AppCompatActivity {
         // output -- where the output should be written
 
         if (OPTION_SIGNATURE.equals(loadOption)) {
-            // set landscape
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
             alertTitleString = getString(R.string.quit_application,
                     getString(R.string.sign_button));
         } else if (OPTION_ANNOTATE.equals(loadOption)) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
             alertTitleString = getString(R.string.quit_application,
                     getString(R.string.markup_image));
         } else {


### PR DESCRIPTION
There are three widgets that use [DrawActivity](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java):

- [AnnotateWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java)
- [SignatureWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java)
- [DrawWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java)

The first two uses only landscape mode. I think we should be consistent and do the same with DrawWidget additionally that change fixes the problem with small image when we open saved image (DrawWidget).