### PR TITLE
Add support for read-only groups

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1062,7 +1062,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 .getFormController();
 
         menu.add(0, v.getId(), 0, getString(R.string.clear_answer));
-        if (formController.indexContainsRepeatableGroup()) {
+        if (formController.indexContainsRepeatableGroup() && formController.isGroupRemovable()) {
             menu.add(0, DELETE_REPEAT, 0, getString(R.string.delete_repeat));
         }
         menu.setHeaderTitle(getString(R.string.edit_prompt));

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -1177,4 +1177,14 @@ public class FormController {
         return new InstanceMetadata(instanceId, instanceName);
     }
 
+    public boolean isGroupRemovable() {
+        boolean result = true;
+        FormIndex currentIndex = getFormIndex();
+        IFormElement element = formEntryController.getModel().getForm().getChild(currentIndex);
+        if (element instanceof GroupDef) {
+            GroupDef gd = (GroupDef) element;
+            result = !"false()".equals(gd.getAdditionalAttribute(null, "removable"));
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
This PR is in reference to resolve #185

Test form:
[group.txt](https://github.com/opendatakit/collect/files/1091180/group.txt)

This solution completely disable "Remove group" option. there is a second case in the issue as well:

> last loop delete only allowed 

but we can solve it in a separate pr adding another attribute.

@lognaturel 
What do you think about this solution?