### PR TITLE
Remove audit setting

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TimerLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TimerLogger.java
@@ -172,7 +172,7 @@ public class TimerLogger {
          */
         boolean loggingEnabledInForm = formController.getSubmissionMetadata().audit;
         boolean loggingEnabledInPref = sharedPreferences.getBoolean(
-                AdminKeys.KEY_TIMER_LOG_ENABLED, false);
+                AdminKeys.KEY_TIMER_LOG_ENABLED, true);
         timerEnabled = loggingEnabledInForm && loggingEnabledInPref;
 
         if (timerEnabled) {

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -507,9 +507,6 @@
     <string name="server_settings_title">Server</string>
     <string name="type">Type</string>
     <string name="form_entry">Uncheck to hide from Form Entry</string>
-    <string name="audit">Audit</string>
-    <string name="timer_log">Record time in questions</string>
-    <string name="timer_log_summary">Record time spent answering each question</string>
     <string name="use_device_language">Use device language</string>
     <string name="not_supported_offline_layer_format">Selected offline layer file uses the PBF format which is not supported!</string>
 </resources>

--- a/collect_app/src/main/res/xml/form_management_preferences.xml
+++ b/collect_app/src/main/res/xml/form_management_preferences.xml
@@ -20,17 +20,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="@string/audit"
-        android:title="@string/audit" >
-        <CheckBoxPreference
-            android:id="@+id/timer_log"
-            android:defaultValue="true"
-            android:key="timer_log"
-            android:summary="@string/timer_log_summary"
-            android:title="@string/timer_log" />
-    </PreferenceCategory>
-
-    <PreferenceCategory
         android:key="form_filling"
         android:title="@string/form_filling_category">
         <CheckBoxPreference

--- a/collect_app/src/main/res/xml/preferences.xml
+++ b/collect_app/src/main/res/xml/preferences.xml
@@ -89,17 +89,6 @@
         </PreferenceCategory>
 
         <PreferenceCategory
-            android:key="@string/audit"
-            android:title="@string/audit" >
-            <CheckBoxPreference
-                android:id="@+id/timer_log"
-                android:defaultValue="true"
-                android:key="timer_log"
-                android:summary="@string/timer_log_summary"
-                android:title="@string/timer_log" />
-        </PreferenceCategory>
-
-        <PreferenceCategory
             android:key="form_filling"
             android:title="@string/form_filling_category">
             <CheckBoxPreference

--- a/collect_app/src/main/res/xml/user_settings_access_preferences.xml
+++ b/collect_app/src/main/res/xml/user_settings_access_preferences.xml
@@ -76,10 +76,5 @@
             android:defaultValue="true"
             android:key="analytics"
             android:title="@string/analytics" />
-        <CheckBoxPreference
-            android:id="@+id/timer_log"
-            android:defaultValue="true"
-            android:key="change_timer_log"
-            android:title="@string/timer_log" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
When doing a last verification before putting out the 1.8.0 release, I realized that the audit setting is confusing since we won't be announcing the feature yet. I propose that we start by removing it from the interface as I have done in this pull request. We can then discuss whether it needs to be added back in (#1204).

See commit messages for more details.

I have verified that:
- the setting is no longer visible in general settings / form management
- the show/hide setting is no longer visible in admin settings / user settings
- the audit still works when specified by the form