### PR TITLE
Update available translations

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -22,10 +22,10 @@ public class ApplicationConstants {
     public static final int SQLITE_MAX_VARIABLE_NUMBER = 999;
 
     public static final String[] TRANSLATIONS_AVAILABLE = {"af", "am", "ar", "bn",
-            "ca", "cs", "de", "en", "es", "es_SV", "et", "fa", "fi", "fr", "ha",
-            "hi", "hi_IN", "hu", "in", "it", "ja", "ka", "km", "lo_LA", "lt", "mg",
+            "ca", "cs", "de", "en", "es", "et", "fa", "fi", "fr", "ha",
+            "hi", "hu", "in", "it", "ja", "ka", "km", "lo_LA", "lt", "mg", "mr",
             "my", "nb", "ne_NP", "nl", "no", "pl", "ps", "pt", "ro", "ru", "so",
-            "sq", "sw", "sw_KE", "ta", "th_TH", "tl", "tl_PH", "tr", "uk", "ur",
+            "sq", "sw", "sw_KE", "ta", "th_TH", "tl", "tr", "uk", "ur",
             "ur_PK", "vi", "zh", "zu"};
 
     public abstract static class BundleKeys {


### PR DESCRIPTION
The array of available languages got out of sync with what is actually available. In particular, `mr` (Marathi / मराठी) was recently added.

This should go in a patch release.