### PR TITLE
move timerLogger object into formController. Fix #1234.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1947,7 +1947,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                                                     "createQuitDialog",
                                                     "discardAndExit");
                                     FormController formController = Collect.getInstance().getFormController();
-                                    if(formController != null) {
+                                    if (formController != null) {
                                         formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_EXIT, 0, null, false, true);
                                     }
                                     removeTempInstance();
@@ -1966,7 +1966,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                                 Collect.getInstance().getExternalDataManager().close();
 
                                 FormController formController = Collect.getInstance().getFormController();
-                                if(formController != null) {
+                                if (formController != null) {
                                     formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_EXIT, 0, null, false, true);
                                 }
                                 removeTempInstance();
@@ -2447,7 +2447,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     public void onAnimationEnd(Animation animation) {
         Timber.i("onAnimationEnd %s",
                 ((animation == inAnimation) ? "in"
-                : ((animation == outAnimation) ? "out" : "other")));
+                        : ((animation == outAnimation) ? "out" : "other")));
         if (inAnimation == animation) {
             animationCompletionSet |= 1;
         } else if (outAnimation == animation) {
@@ -2466,7 +2466,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         // Added by AnimationListener interface.
         Timber.i("onAnimationRepeat %s",
                 ((animation == inAnimation) ? "in"
-                : ((animation == outAnimation) ? "out" : "other")));
+                        : ((animation == outAnimation) ? "out" : "other")));
     }
 
     @Override
@@ -2474,7 +2474,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         // Added by AnimationListener interface.
         Timber.i("onAnimationStart %s",
                 ((animation == inAnimation) ? "in"
-                : ((animation == outAnimation) ? "out" : "other")));
+                        : ((animation == outAnimation) ? "out" : "other")));
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -44,6 +44,7 @@ import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.AgingCredentialsProvider;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.PRNGFixes;
+import org.odk.collect.android.utilities.TimerLogger;
 import org.opendatakit.httpclientandroidlib.client.CookieStore;
 import org.opendatakit.httpclientandroidlib.client.CredentialsProvider;
 import org.opendatakit.httpclientandroidlib.client.protocol.HttpClientContext;

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -44,7 +44,6 @@ import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.AgingCredentialsProvider;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.PRNGFixes;
-import org.odk.collect.android.utilities.TimerLogger;
 import org.opendatakit.httpclientandroidlib.client.CookieStore;
 import org.opendatakit.httpclientandroidlib.client.CredentialsProvider;
 import org.opendatakit.httpclientandroidlib.client.protocol.HttpClientContext;

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -41,6 +41,7 @@ import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.odk.collect.android.exception.JavaRosaException;
+import org.odk.collect.android.utilities.TimerLogger;
 import org.odk.collect.android.views.ODKView;
 
 import java.io.File;
@@ -76,6 +77,11 @@ public class FormController {
      * Non OpenRosa metadata tag names
      */
     private static final String AUDIT = "audit";
+
+    /*
+     * Store the timerLogger object with the form controller state
+     */
+    private TimerLogger timerLogger;
 
     /**
      * OpenRosa metadata of a form instance.
@@ -188,6 +194,14 @@ public class FormController {
 
     public FormIndex getIndexWaitingForData() {
         return indexWaitingForData;
+    }
+
+    public TimerLogger getTimerLogger() {
+        return timerLogger;
+    }
+
+    public void setTimerLogger(TimerLogger logger) {
+        timerLogger = logger;
     }
 
     /**


### PR DESCRIPTION
The timer logger state was being lost after a screen rotation.  However the formController state is restored from the Collect object.  This change put the reference to the timer logger object in the formController so that it is restored at the same time.