### PR TITLE
Removed the icon from the toolbar

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FileManagerTabs.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FileManagerTabs.java
@@ -14,7 +14,6 @@
 
 package org.odk.collect.android.activities;
 
-import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -67,13 +66,6 @@ public class FileManagerTabs extends AppCompatActivity {
         slidingTabLayout.setFontColor(android.R.color.white);
         slidingTabLayout.setBackgroundColor(Color.DKGRAY);
         slidingTabLayout.setViewPager(viewPager);
-    }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setNavigationIcon(R.drawable.notes);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
@@ -23,7 +23,6 @@ import android.support.v4.app.ListFragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
-import android.support.v7.widget.Toolbar;
 import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -206,13 +205,6 @@ abstract class AppListFragment extends ListFragment {
         if (drawerToggle != null) {
             drawerToggle.syncState();
         }
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        Toolbar toolbar = (Toolbar) getActivity().findViewById(R.id.toolbar);
-        toolbar.setNavigationIcon(R.drawable.notes);
     }
 
     private void setupDrawer(View rootView) {

--- a/collect_app/src/main/res/layout/toolbar.xml
+++ b/collect_app/src/main/res/layout/toolbar.xml
@@ -9,5 +9,4 @@
     app:contentInsetEnd="0dp"
     app:contentInsetStart="0dp"
     app:contentInsetStartWithNavigation="0dp"
-    app:navigationIcon="@drawable/notes"
     app:theme="@style/ThemeOverlay.AppCompat.ActionBar" />


### PR DESCRIPTION
@lognaturel 
My proposal is to remove the icon from toolbar as there is no enough space especially now when we display "three dots".
Before:
![screenshot_2017-07-10-14-26-49](https://user-images.githubusercontent.com/3276264/28018082-2a03cb96-657c-11e7-9cce-3670ea822250.png)

Now:
![screenshot_2017-07-10-14-28-00](https://user-images.githubusercontent.com/3276264/28018087-2ef6b2d0-657c-11e7-8ccc-cac22ed25f5b.png)
