### PR TITLE
Changed verbosity level

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -128,8 +128,7 @@ public class DownloadFormsTask extends
                     Timber.i("No Manifest for: %s", fd.formName);
                 }
             } catch (TaskCancelledException e) {
-                Timber.e(e);
-
+                Timber.i(e);
                 cleanUp(fileResult, e.getFile(), tempMediaPath);
 
                 // do not download additional forms.
@@ -182,8 +181,7 @@ public class DownloadFormsTask extends
 
                     cleanUp(fileResult, null, tempMediaPath);
                 } catch (TaskCancelledException e) {
-                    Timber.e(e);
-
+                    Timber.i(e);
                     cleanUp(fileResult, e.getFile(), tempMediaPath);
                 }
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -174,7 +174,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             try {
                 spreadsheetId = UrlUtils.getSpreadsheetID(id);
             } catch (BadUrlException e) {
-                Timber.e(e);
+                Timber.i(e);
                 outcome.results.put(id, e.getMessage());
                 return false;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
@@ -234,7 +234,7 @@ public class InstanceServerUploader extends InstanceUploader {
             } catch (ClientProtocolException | ConnectTimeoutException | UnknownHostException | SocketTimeoutException | HttpHostConnectException e) {
                 if (e instanceof ClientProtocolException) {
                     outcome.results.put(id, fail + "Client Protocol Exception");
-                    Timber.e(e, "Client Protocol Exception");
+                    Timber.i(e, "Client Protocol Exception");
                 } else if (e instanceof ConnectTimeoutException) {
                     outcome.results.put(id, fail + "Connection Timeout");
                     Timber.i(e, "Connection Timeout");
@@ -243,10 +243,10 @@ public class InstanceServerUploader extends InstanceUploader {
                     Timber.i(e, "Network Connection Failed");
                 } else if (e instanceof SocketTimeoutException) {
                     outcome.results.put(id, fail + "Connection Timeout");
-                    Timber.e(e, "Connection timeout");
+                    Timber.i(e, "Connection timeout");
                 } else {
                     outcome.results.put(id, fail + "Network Connection Refused");
-                    Timber.e(e, "Network Connection Refused");
+                    Timber.i(e, "Network Connection Refused");
                 }
                 cv.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMISSION_FAILED);
                 Collect.getInstance().getContentResolver().update(toUpdate, cv, null, null);
@@ -434,11 +434,7 @@ public class InstanceServerUploader extends InstanceUploader {
                     return true;
                 }
             } catch (IOException e) {
-                if (e instanceof UnknownHostException || e instanceof ConnectTimeoutException) {
-                    Timber.i(e);
-                } else {
-                    Timber.e(e);
-                }
+                Timber.i(e);
                 String msg = e.getMessage();
                 if (msg == null) {
                     msg = e.toString();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
@@ -35,6 +35,7 @@ import org.opendatakit.httpclientandroidlib.Header;
 import org.opendatakit.httpclientandroidlib.HttpEntity;
 import org.opendatakit.httpclientandroidlib.HttpResponse;
 import org.opendatakit.httpclientandroidlib.HttpStatus;
+import org.opendatakit.httpclientandroidlib.NoHttpResponseException;
 import org.opendatakit.httpclientandroidlib.client.ClientProtocolException;
 import org.opendatakit.httpclientandroidlib.client.HttpClient;
 import org.opendatakit.httpclientandroidlib.client.methods.HttpHead;
@@ -50,6 +51,7 @@ import org.opendatakit.httpclientandroidlib.protocol.HttpContext;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -231,7 +233,7 @@ public class InstanceServerUploader extends InstanceUploader {
                         return true;
                     }
                 }
-            } catch (ClientProtocolException | ConnectTimeoutException | UnknownHostException | SocketTimeoutException | HttpHostConnectException e) {
+            } catch (ClientProtocolException | ConnectTimeoutException | UnknownHostException | SocketTimeoutException | NoHttpResponseException | SocketException e) {
                 if (e instanceof ClientProtocolException) {
                     outcome.results.put(id, fail + "Client Protocol Exception");
                     Timber.i(e, "Client Protocol Exception");
@@ -434,7 +436,13 @@ public class InstanceServerUploader extends InstanceUploader {
                     return true;
                 }
             } catch (IOException e) {
-                Timber.i(e);
+                if (e instanceof UnknownHostException || e instanceof HttpHostConnectException
+                        || e instanceof SocketException || e instanceof NoHttpResponseException
+                        || e instanceof SocketTimeoutException || e instanceof ConnectTimeoutException) {
+                    Timber.i(e);
+                } else {
+                    Timber.e(e);
+                }
                 String msg = e.getMessage();
                 if (msg == null) {
                     msg = e.toString();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebUtils.java
@@ -54,7 +54,9 @@ import org.xmlpull.v1.XmlPullParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
@@ -310,12 +312,12 @@ public final class WebUtils {
      */
     public static DocumentFetchResult getXmlDocument(String urlString,
             HttpContext localContext, HttpClient httpclient) {
-        URI u = null;
+        URI u;
         try {
             URL url = new URL(urlString);
             u = url.toURI();
-        } catch (Exception e) {
-            Timber.e(e, "Error converting URL %s to uri", urlString);
+        } catch (URISyntaxException | MalformedURLException e) {
+            Timber.i(e, "Error converting URL %s to uri", urlString);
             return new DocumentFetchResult(e.getLocalizedMessage()
                     // + app.getString(R.string.while_accessing) + urlString);
                     + ("while accessing") + urlString, 0);
@@ -334,7 +336,7 @@ public final class WebUtils {
         HttpGet req = WebUtils.createOpenRosaHttpGet(u);
         req.addHeader(WebUtils.ACCEPT_ENCODING_HEADER, WebUtils.GZIP_CONTENT_ENCODING);
 
-        HttpResponse response = null;
+        HttpResponse response;
         try {
             response = httpclient.execute(req, localContext);
             int statusCode = response.getStatusLine().getStatusCode();


### PR DESCRIPTION
@lognaturel in this pr https://github.com/opendatakit/collect/pull/1229 I changed the verbosity level only for `UnknownHostException` and `ConnectTimeoutException` but now I can see that there are lots of different exceptions that we can also treat in the same way:
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/fde4eabe?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/80aefc7f?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/52083462?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/2263bad0?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/1b08b207?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/3b7b3a90?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356
https://console.firebase.google.com/project/api-project-322300403941/monitoring/app/android:org.odk.collect.android/cluster/e18e797d?reportTypes=REPORT_TYPE_UNSPECIFIED&duration=2592000000&appVersions=2356