### PR TITLE
Import Outcome from InstanceUploader base class.

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.dto.Instance;
 import org.odk.collect.android.provider.InstanceProviderAPI;
-import org.odk.collect.android.tasks.InstanceServerUploader.Outcome;
+import org.odk.collect.android.tasks.InstanceUploader.Outcome;
 import org.odk.collect.android.test.MockedServerTest;
 
 import okhttp3.mockwebserver.RecordedRequest;


### PR DESCRIPTION
The connected tests only run on master so we missed this one when the base class name changed!