### PR TITLE
Read-only fields with text or numbers should not display an underline and should use black text

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.text.Editable;
 import android.text.Selection;
 import android.text.TextWatcher;
@@ -102,7 +103,9 @@ public class StringWidget extends QuestionWidget {
         }
 
         if (readOnly) {
+            answer.setBackground(null);
             answer.setEnabled(false);
+            answer.setTextColor(Color.BLACK);
             answer.setFocusable(false);
         }
 


### PR DESCRIPTION
This PR is in reference to resolve #1268 
Form for testing:
[widgets.txt](https://github.com/opendatakit/collect/files/1164740/widgets.txt)
