### PR TITLE
Decimal widget display text

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
@@ -25,6 +25,8 @@ import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
 
@@ -82,8 +84,11 @@ public class DecimalWidget extends StringWidget {
             String string = nf.format(d);
             d = Double.parseDouble(string.replace(',', '.'));
             //answer.setText(d.toString());
-            answer.setText(String.format(Locale.ENGLISH, "%f", d));
-            Selection.setSelection(answer.getText(), answer.getText().toString().length());
+            //answer.setText(String.format(Locale.ENGLISH, "%f", d));
+
+            answer.setText(string);
+
+            Selection.setSelection(answer.getText(), string.length());
         }
 
         // disable if read only

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
@@ -25,8 +25,6 @@ import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
 
@@ -72,23 +70,19 @@ public class DecimalWidget extends StringWidget {
         fa[0] = new InputFilter.LengthFilter(15);
         answer.setFilters(fa);
 
-        NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
-        nf.setMaximumFractionDigits(15);
-        nf.setMaximumIntegerDigits(15);
-        nf.setGroupingUsed(false);
-
         Double d = getDoubleAnswerValue();
 
         if (d != null) {
-            // truncate to 15 digits max...
-            String string = nf.format(d);
-            d = Double.parseDouble(string.replace(',', '.'));
-            //answer.setText(d.toString());
-            //answer.setText(String.format(Locale.ENGLISH, "%f", d));
+            // truncate to 15 digits max in US locale
+            NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
+            nf.setMaximumFractionDigits(15);
+            nf.setMaximumIntegerDigits(15);
+            nf.setGroupingUsed(false);
 
-            answer.setText(string);
+            String formattedValue = nf.format(d);
+            answer.setText(formattedValue);
 
-            Selection.setSelection(answer.getText(), string.length());
+            Selection.setSelection(answer.getText(), answer.getText().length());
         }
 
         // disable if read only

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.text.InputFilter;
 import android.text.InputType;
+import android.text.Selection;
 import android.text.method.DigitsKeyListener;
 
 import org.javarosa.core.model.data.DecimalData;
@@ -72,20 +73,19 @@ public class ExDecimalWidget extends ExStringWidget {
         fa[0] = new InputFilter.LengthFilter(15);
         answer.setFilters(fa);
 
-        // apparently an attempt at rounding to no more than 15 digit precision???
-        NumberFormat nf = NumberFormat.getNumberInstance();
-        nf.setMaximumFractionDigits(15);
-        nf.setMaximumIntegerDigits(15);
-        nf.setGroupingUsed(false);
-
         Double d = getDoubleAnswerValue();
 
         if (d != null) {
-            // truncate to 15 digits max...
-            String string = nf.format(d);
-            d = Double.parseDouble(string.replace(',', '.')); // in case , is decimal pt
-            //answer.setText(d.toString());
-            answer.setText(String.format(Locale.ENGLISH, "%f", d));
+            // truncate to 15 digits max in US locale
+            NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
+            nf.setMaximumFractionDigits(15);
+            nf.setMaximumIntegerDigits(15);
+            nf.setGroupingUsed(false);
+
+            String formattedValue = nf.format(d);
+            answer.setText(formattedValue);
+
+            Selection.setSelection(answer.getText(), answer.getText().length());
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -66,7 +66,9 @@ public class DecimalWidgetTest {
     @Test
     // Fails when double is turned to string using String.format(Locale.US, "%f", d)
     // because default precision for %f is 6
-    public void decimalValueShouldMaintainPrecision() {
+    // NOTE: in the case of a decimal value with trailing 0s, it's probably not possible to maintain
+    // that precision. For example, 9.00 becomes 9
+    public void decimalValueShouldNotAddPrecision() {
         Double twoDecimalDouble = 9.99;
         String twoDecimalString = "9.99";
         when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -1,0 +1,163 @@
+package org.odk.collect.android.widgets;
+
+import org.javarosa.core.model.IFormElement;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.odk.collect.android.BuildConfig;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
+public class DecimalWidgetTest {
+    @Mock
+    FormEntryPrompt formEntryPrompt;
+
+    @Mock
+    IAnswerData answerData;
+
+    @Mock
+    IFormElement element;
+
+    @Mock
+    QuestionDef question;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        when(formEntryPrompt.getLongText()).thenReturn("A decimal question");
+
+        when(formEntryPrompt.getFormElement()).thenReturn(element);
+        when(element.getAdditionalAttribute(null, "playColor")).thenReturn(null);
+
+        when(formEntryPrompt.getQuestion()).thenReturn(question);
+        when(question.getAdditionalAttribute(null, "rows")).thenReturn(null);
+    }
+
+    @Test
+    // Fails when double is turned to string with toString or String.format(Locale.US, "%f", d))
+    public void integerValueShouldDisplayNoDecimalPoint() {
+        Double integerDouble = 0.;
+        String integerString = "0";
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(integerDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(), is(equalTo(integerString)));
+    }
+
+    @Test
+    // Fails when double is turned to string using String.format(Locale.US, "%f", d)
+    // because default precision for %f is 6
+    public void decimalValueShouldMaintainPrecision() {
+        Double twoDecimalDouble = 9.99;
+        String twoDecimalString = "9.99";
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(twoDecimalDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(), is(equalTo(twoDecimalString)));
+    }
+
+    @Test
+    // Fails when double is turned to string with toString or String.format(Locale.US, "%f", d)
+    public void negativeIntegerShouldDisplayNegativeWithNoDecimalPoint() {
+        Double negativeIntegerDouble = -999.;
+        String negativeIntegerString = "-999";
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(negativeIntegerDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(), is(equalTo(negativeIntegerString)));
+    }
+
+    @Test
+    // Fails when double is turned to string with toString because of scientific notation
+    // https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
+    public void fifteenDigitValueShouldDisplayAllDigits() {
+        Double fifteenDigitDouble = 999999999999999.;
+        String fifteenDigitString = "999999999999999";
+        assertTrue(fifteenDigitString.length() == 15);
+
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(fifteenDigitDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(), is(equalTo(fifteenDigitString)));
+    }
+
+    @Test
+    // Fails when double is turned to string with toString because of scientific notation
+    // https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
+    public void fifteenDigitNegativeValueShouldDisplayAllDigits() {
+        Double fifteenDigitNegativeDouble = -99999999999999.;
+        String fifteenDigitNegativeString = "-99999999999999";
+        assertTrue(fifteenDigitNegativeString.length() == 15);
+
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(fifteenDigitNegativeDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(),
+                is(equalTo(fifteenDigitNegativeString)));
+    }
+
+    @Test
+    // Fails when double is turned to string using String.format(Locale.US, "%f", d) because default
+    // precision for %f is 6
+    public void fifteenDigitDecimalValueShouldDisplayAllDigits() {
+        Double fifteenDigitDecimalDouble = 0.9999999999999;
+        String fifteenDigitDecimalString = "0.9999999999999";
+        assertTrue(fifteenDigitDecimalString.length() == 15);
+
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(fifteenDigitDecimalDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(),
+                is(equalTo(fifteenDigitDecimalString)));
+    }
+
+    @Test
+    // This should never be possible because the EditText has a limit on it
+    public void digitsAboveLimitOfFifteenShouldBeTruncatedFromLeft() {
+        Double eighteenDigitDouble = 9999999999999994.;
+        String fifteenDigitString = "999999999999994";
+        assertTrue(fifteenDigitString.length() == 15);
+
+        when(formEntryPrompt.getAnswerValue()).thenReturn(answerData);
+        when(answerData.getValue()).thenReturn(eighteenDigitDouble);
+
+        DecimalWidget decimalWidget = new DecimalWidget(RuntimeEnvironment.application,
+                formEntryPrompt, false);
+
+        assertThat(decimalWidget.answer.getText().toString(), is(equalTo(fifteenDigitString)));
+    }
+}


### PR DESCRIPTION
Fixes #1282.

We need to be really careful with these core widgets so I thought this would be a good place to add some tests. It's really important that the display value is right because it is eventually parsed to replace the backing value.

I structured the tests such that the current implementation wouldn't need to be changed. The formatting happens in the widget constructor and so I used a mocked `IAnswerData` to get things going. I think this exercises the code paths I want but it does feel heavyweight. I'd be very interested in some feedback on whether these are reasonable tests and whether there would be a better way to structure them. @grzesiek2010 @srsudar @alxndrsn 

One thing that I did change is to remove the call on `replace(',', '.')`. Because that came after a call on `format` with a formatter set to `Locale.US`, I didn't think it was possible to get a comma as a decimal marker. I can't see any way to produce or save a comma decimal marker even in a locale where it would be correct. Perhaps it's something we should allow in a future PR.

The tests clearly show the issue from #1282 (revert `DecimalWidget` to the version from `master`) and the problems with #1284.

Did I illustrate all the cases?