### PR TITLE
Ignore HardwareIds lint

### DIFF
--- a/collect_app/lint.xml
+++ b/collect_app/lint.xml
@@ -31,4 +31,5 @@
     <issue id="IconLocation" severity="error" />
   
     <issue id="ContentDescription" severity="ignore" />
+    <issue id="HardwareIds" severity="ignore" />
 </lint>


### PR DESCRIPTION
It's related to https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java

The explanation of this lint says: "Using these device identifiers is not recommended other than for high value fraud prevention and advanced telephony use-cases." 

In our case we need that and there is no other solution so we can just ignore this lint.