### PR TITLE
Fix timezone difference problem (Issue #70)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
@@ -11,12 +11,9 @@ import java.util.Locale;
 
 public class DateTimeUtils {
 
-    private static final boolean JELLY_BEAN_MR2_OR_NEWER =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
-
     public static String getDateTimeBasedOnUserLocale(Date date, String appearance, boolean containsTime) {
         final DateFormat dateFormatter;
-        if (JELLY_BEAN_MR2_OR_NEWER) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             String format = android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), getDateTimePattern(containsTime, appearance));
             dateFormatter = new SimpleDateFormat(format, Locale.getDefault());
         } else {
@@ -42,7 +39,7 @@ public class DateTimeUtils {
 
     public static String getTimeBasedOnUserLocale(Date date) {
         final DateFormat dateFormatter;
-        if (JELLY_BEAN_MR2_OR_NEWER) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             String format = android.text.format.DateFormat.getBestDateTimePattern(
                     Locale.getDefault(), "HHmm");
             dateFormatter = new SimpleDateFormat(format, Locale.getDefault());

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
@@ -2,6 +2,8 @@ package org.odk.collect.android.utilities;
 
 import android.os.Build;
 
+import org.joda.time.DateTime;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -9,9 +11,12 @@ import java.util.Locale;
 
 public class DateTimeUtils {
 
+    private static final boolean JELLY_BEAN_MR2_OR_NEWER =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+
     public static String getDateTimeBasedOnUserLocale(Date date, String appearance, boolean containsTime) {
-        DateFormat dateFormatter;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        final DateFormat dateFormatter;
+        if (JELLY_BEAN_MR2_OR_NEWER) {
             String format = android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), getDateTimePattern(containsTime, appearance));
             dateFormatter = new SimpleDateFormat(format, Locale.getDefault());
         } else {
@@ -33,5 +38,28 @@ public class DateTimeUtils {
             datePattern = "yyyyMMM";
         }
         return datePattern;
+    }
+
+    public static String getTimeBasedOnUserLocale(Date date) {
+        final DateFormat dateFormatter;
+        if (JELLY_BEAN_MR2_OR_NEWER) {
+            String format = android.text.format.DateFormat.getBestDateTimePattern(
+                    Locale.getDefault(), "HHmm");
+            dateFormatter = new SimpleDateFormat(format, Locale.getDefault());
+        } else {
+            dateFormatter = DateFormat.getTimeInstance(DateFormat.DEFAULT, Locale.getDefault());
+        }
+        return dateFormatter.format(date);
+    }
+
+    /**
+     * Adjusts Dates to have correct values in the current timezone.
+     * @param date the Date to be adjusted
+     * @return the adjusted date, as a DateTime object
+     */
+    public static DateTime correctForTimezoneOffsetDifference(Date date) {
+        // We can tolerate the getTimezoneOffset deprecation until rewriting with Java 8 Date/Time
+        int timezoneOffsetDiff = date.getTimezoneOffset() - (new Date()).getTimezoneOffset();
+        return new DateTime(date.getTime()).plusMinutes(timezoneOffsetDiff);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -19,21 +19,27 @@ package org.odk.collect.android.utilities;
 import org.javarosa.core.model.data.DateData;
 import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.TimeData;
 import org.javarosa.form.api.FormEntryPrompt;
 
 import java.util.Date;
 
+import static org.odk.collect.android.utilities.DateTimeUtils.correctForTimezoneOffsetDifference;
+
 public class FormEntryPromptUtils {
 
     public static String getAnswerText(FormEntryPrompt fep) {
-        IAnswerData data = fep.getAnswerValue();
-        String text;
+        final IAnswerData data = fep.getAnswerValue();
+        final String text;
         if (data instanceof DateTimeData) {
             text = DateTimeUtils.getDateTimeBasedOnUserLocale((Date) data.getValue(),
                     fep.getQuestion().getAppearanceAttr(), true);
         } else if (data instanceof DateData) {
             text = DateTimeUtils.getDateTimeBasedOnUserLocale((Date) data.getValue(),
                     fep.getQuestion().getAppearanceAttr(), false);
+        } else if (data instanceof TimeData) {
+            Date date = correctForTimezoneOffsetDifference((Date) data.getValue()).toDate();
+            text = DateTimeUtils.getTimeBasedOnUserLocale(date);
         } else {
             text = fep.getAnswerText();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -44,6 +44,8 @@ import java.util.Date;
 
 import timber.log.Timber;
 
+import static org.odk.collect.android.utilities.DateTimeUtils.correctForTimezoneOffsetDifference;
+
 /**
  * Displays a TimePicker widget.
  *
@@ -167,7 +169,8 @@ public class TimeWidget extends QuestionWidget {
         if (formEntryPrompt.getAnswerValue() == null) {
             clearAnswer();
         } else {
-            DateTime dt = new DateTime(((Date) formEntryPrompt.getAnswerValue().getValue()).getTime());
+            Date date = (Date) formEntryPrompt.getAnswerValue().getValue();
+            DateTime dt = correctForTimezoneOffsetDifference(date);
             hourOfDay = dt.getHourOfDay();
             minuteOfHour = dt.getMinuteOfHour();
             setTimeLabel();


### PR DESCRIPTION
I like this approach because it doesn’t require JavaRosa changes. (The date parsing and formatting in JavaRosa should be carefully handled as a separate project at some future point.) It simply adjusts java.util.Date objects to match the current timezone, so that when the hour value is naïvely plucked from them it is correct.

I’ll work on automated tests for this, unless I hear that we don’t want to go this way. @lognaturel, @grzesiek2010, your thoughts?