### PR TITLE
intent-filter inside InstanceChooserList activity

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -139,7 +139,6 @@ the specific language governing permissions and limitations under the License.
         <activity
             android:name=".activities.InstanceChooserList"
             android:label="@string/app_name">
-
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
@@ -149,7 +148,6 @@ the specific language governing permissions and limitations under the License.
                 <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
             </intent-filter>
         </activity>
-     
         <activity
             android:name=".activities.FormChooserList"
             android:label="@string/app_name">

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -138,17 +138,18 @@ the specific language governing permissions and limitations under the License.
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:name=".activities.InstanceChooserList"
-            android:label="@string/app_name" />
+            android:label="@string/app_name">
 
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW" />
-            <action android:name="android.intent.action.EDIT" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
 
-            <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.DEFAULT" />
 
-            <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
-        </intent-filter>
-
+                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
+            </intent-filter>
+        </activity>
+     
         <activity
             android:name=".activities.FormChooserList"
             android:label="@string/app_name">


### PR DESCRIPTION
This contrib put `intent-filter` inside  `InstanceChooserList` activity, fixing "Permission Denial" error when working with this ODK Collect intent.
