### PR TITLE
Fixed problem with timeLogger

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2516,6 +2516,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         t.cancel(true);
         t.destroy();
         Collect.getInstance().setFormController(formController);
+        setTimerLogger(formController);
         supportInvalidateOptionsMenu();
 
         Collect.getInstance().setExternalDataManager(task.getExternalDataManager());
@@ -2594,13 +2595,11 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 formController.setInstancePath(instanceFile);
             }
 
-            setTimerLogger(formController);
             formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_START, 0, null, false, true);
         } else {
             Intent reqIntent = getIntent();
             boolean showFirst = reqIntent.getBooleanExtra("start", false);
 
-            setTimerLogger(formController);
             formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_RESUME, 0, null, false, true);
 
             if (!showFirst) {


### PR DESCRIPTION
This PR is in reference to resolve #1313  and #1314

I wasn't able to reproduce the issue but I think we should call https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1314?diff=unified&expand=1&name=COLLECT-1314#diff-03ff45091550285dd88b56927010c457R2519 earlier just like now.  

I think the crash might take place when https://github.com/opendatakit/collect/pull/1322/files#diff-03ff45091550285dd88b56927010c457R2554 is true because then we do return and don't call setTimerLogger(formController); (I can confirm it takes place id I implement this change in the code manually)