### PR TITLE
Fixed java.lang.RuntimeException

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1241,15 +1241,14 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                             (groups.length > 0 ? groups[groups.length - 1].getLongText() : "[top]"),
                             (prompts.length > 0 ? prompts[0].getQuestionText() : "[no question]"));
                 } catch (RuntimeException e) {
-                    Timber.e(e);
+                    Timber.i(e);
                     // this is badness to avoid a crash.
                     try {
                         event = formController.stepToNextScreenEvent();
-                        createErrorDialog(e.getMessage(), DO_NOT_EXIT);
+                        createErrorDialog(e.getMessage(), EXIT);
                     } catch (JavaRosaException e1) {
-                        Timber.e(e1);
-                        createErrorDialog(e.getMessage() + "\n\n" + e1.getCause().getMessage(),
-                                DO_NOT_EXIT);
+                        Timber.i(e1);
+                        createErrorDialog(e.getMessage() + "\n\n" + e1.getCause().getMessage(), EXIT);
                     }
                     return createView(event, advancingPage);
                 }


### PR DESCRIPTION
This PR is in reference to resolve #1331

If there is something wrong with a form we display a dialog. I think we should close that form after that to avoid any strange problems like this one.
In order to do that we should use EXIT flag instead of DO_NOT_EXIT.