### PR TITLE
Construct audit logger in getter to avoid NullPointerExceptions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2517,7 +2517,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         t.cancel(true);
         t.destroy();
         Collect.getInstance().setFormController(formController);
-        setTimerLogger(formController);
         supportInvalidateOptionsMenu();
 
         Collect.getInstance().setExternalDataManager(task.getExternalDataManager());
@@ -2712,20 +2711,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         this.stepMessage = stepMessage;
         if (progressDialog != null) {
             progressDialog.setMessage(getString(R.string.please_wait) + "\n\n" + stepMessage);
-        }
-    }
-
-    /*
-     * Create the timer logger object
-     */
-    private void setTimerLogger(FormController formController) {
-
-        if (formController.getTimerLogger() == null) {
-
-            // Create a new timerLogger object if there is no saved timer logger
-            formController.setTimerLogger(new TimerLogger(formController.getInstancePath(),
-                    PreferenceManager.getDefaultSharedPreferences(this),
-                    formController));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -204,7 +204,7 @@ public class FormController {
         return timerLogger;
     }
 
-    public void setTimerLogger(TimerLogger logger) {
+    private void setTimerLogger(TimerLogger logger) {
         timerLogger = logger;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -15,6 +15,8 @@
 package org.odk.collect.android.logic;
 
 
+import android.preference.PreferenceManager;
+
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -196,6 +198,9 @@ public class FormController {
     }
 
     public TimerLogger getTimerLogger() {
+        if (timerLogger == null) {
+            setTimerLogger(new TimerLogger(getInstancePath(), this));
+        }
         return timerLogger;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -14,9 +14,6 @@
 
 package org.odk.collect.android.logic;
 
-
-import android.preference.PreferenceManager;
-
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TimerLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TimerLogger.java
@@ -1,14 +1,12 @@
 
 package org.odk.collect.android.utilities;
 
-import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.SystemClock;
 
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.form.api.FormEntryController;
 import org.odk.collect.android.logic.FormController;
-import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.tasks.TimerSaveTask;
 
 import java.io.File;
@@ -162,18 +160,13 @@ public class TimerLogger {
     private boolean timerEnabled = false;              // Set true of the timer logger is enabled
 
 
-    public TimerLogger(File instanceFile, SharedPreferences sharedPreferences, FormController formController) {
+    public TimerLogger(File instanceFile, FormController formController) {
 
         /*
-         * The timer logger is enabled if:
-         *  1) The meta section of the form contains a logging entry
+         * The timer logger is enabled if the meta section of the form contains a logging entry
          *      <orx:audit />
-         *  2) And logging has been enabled in the device preferences
          */
-        boolean loggingEnabledInForm = formController.getSubmissionMetadata().audit;
-        boolean loggingEnabledInPref = sharedPreferences.getBoolean(
-                AdminKeys.KEY_TIMER_LOG_ENABLED, true);
-        timerEnabled = loggingEnabledInForm && loggingEnabledInPref;
+        timerEnabled = formController.getSubmissionMetadata().audit;
 
         if (timerEnabled) {
             filename = "audit.csv";


### PR DESCRIPTION
Closes #1340.

From discussion in #1322 [here](https://github.com/opendatakit/collect/pull/1322#issuecomment-321614431).

The reason there was a setter for the timer logger in the activity is because there used to be a setting controlling the audit. There isn't currently though it will probably be brought back for energy conservation once location logging is added (and also see #1204). For now, I think removing it makes sense.

I have verified that the audit is still captured with the form [audit-test-orx.txt](https://github.com/opendatakit/collect/files/1215828/audit-test-orx.txt).

@nap2000, @grzesiek2010 and @jknightco could you please review and see if you think this is the right way to go?