### PR TITLE
Null checks for TimerSaveTask

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
@@ -43,7 +43,11 @@ public class TimerSaveTask extends AsyncTask<TimerLogger.Event, Void, Void> {
             Timber.e(e);
         } finally {
             try {
-                fw.close();
+                if (fw != null) {
+                    fw.close();
+                } else {
+                    Timber.e("Attempt to close null FileWriter for TimerLogger.");
+                }
             } catch (Exception e) {
                 Timber.e(e);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
@@ -2,6 +2,7 @@
 package org.odk.collect.android.tasks;
 
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 
 import org.odk.collect.android.utilities.TimerLogger;
 
@@ -15,7 +16,7 @@ import timber.log.Timber;
  * Background task for appending a timer event to the timer log
  */
 public class TimerSaveTask extends AsyncTask<TimerLogger.Event, Void, Void> {
-    private File file;
+    private @NonNull File file;
     private static final String TIMING_CSV_HEADER = "event, node, start, end";
 
     public TimerSaveTask(File file) {
@@ -27,20 +28,16 @@ public class TimerSaveTask extends AsyncTask<TimerLogger.Event, Void, Void> {
 
         FileWriter fw = null;
         try {
-            if (file != null) {
-                boolean newFile = !file.exists();
-                fw = new FileWriter(file, true);
-                if (newFile) {
-                    fw.write(TIMING_CSV_HEADER + "\n");
+            boolean newFile = !file.exists();
+            fw = new FileWriter(file, true);
+            if (newFile) {
+                fw.write(TIMING_CSV_HEADER + "\n");
+            }
+            if (params.length > 0) {
+                for (TimerLogger.Event ev : params) {
+                    fw.write(ev.toString() + "\n");
+                    Timber.i("Log audit Event: %s", ev.toString());
                 }
-                if (params.length > 0) {
-                    for (TimerLogger.Event ev : params) {
-                        fw.write(ev.toString() + "\n");
-                        Timber.i("Log audit Event: %s", ev.toString());
-                    }
-                }
-            } else {
-                Timber.e("Attempt to build FileWriter on null TimerLogger file.");
             }
         } catch (IOException e) {
             Timber.e(e);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
@@ -15,7 +15,7 @@ import timber.log.Timber;
  * Background task for appending a timer event to the timer log
  */
 public class TimerSaveTask extends AsyncTask<TimerLogger.Event, Void, Void> {
-    private static File file;
+    private File file;
     private static final String TIMING_CSV_HEADER = "event, node, start, end";
 
     public TimerSaveTask(File file) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
@@ -27,17 +27,21 @@ public class TimerSaveTask extends AsyncTask<TimerLogger.Event, Void, Void> {
 
         FileWriter fw = null;
         try {
-            boolean newFile = !file.exists();
-            fw = new FileWriter(file, true);
-            if (newFile) {
-                fw.write(TIMING_CSV_HEADER + "\n");
-            }
-            if (params.length > 0) {
-                //for (int i = 0; i < params.length; i++) {
-                for (TimerLogger.Event ev : params) {
-                    fw.write(ev.toString() + "\n");
-                    Timber.i("Log audit Event: %s", ev.toString());
+            if (file != null) {
+                boolean newFile = !file.exists();
+                fw = new FileWriter(file, true);
+                if (newFile) {
+                    fw.write(TIMING_CSV_HEADER + "\n");
                 }
+                if (params.length > 0) {
+                    //for (int i = 0; i < params.length; i++) {
+                    for (TimerLogger.Event ev : params) {
+                        fw.write(ev.toString() + "\n");
+                        Timber.i("Log audit Event: %s", ev.toString());
+                    }
+                }
+            } else {
+                Timber.e("Attempt to build FileWriter on null TimerLogger file.");
             }
         } catch (IOException e) {
             Timber.e(e);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/TimerSaveTask.java
@@ -34,7 +34,6 @@ public class TimerSaveTask extends AsyncTask<TimerLogger.Event, Void, Void> {
                     fw.write(TIMING_CSV_HEADER + "\n");
                 }
                 if (params.length > 0) {
-                    //for (int i = 0; i < params.length; i++) {
                     for (TimerLogger.Event ev : params) {
                         fw.write(ev.toString() + "\n");
                         Timber.i("Log audit Event: %s", ev.toString());

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TimerLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TimerLogger.java
@@ -282,7 +282,11 @@ public class TimerLogger {
         if (saveTask == null || saveTask.getStatus() == AsyncTask.Status.FINISHED) {
 
             Event[] eventArray = events.toArray(new Event[events.size()]);
-            saveTask = new TimerSaveTask(timerlogFile).execute(eventArray);
+            if (timerlogFile != null) {
+                saveTask = new TimerSaveTask(timerlogFile).execute(eventArray);
+            } else {
+                Timber.e("timerlogFile null when attempting to write events.");
+            }
             events = new ArrayList<>();
 
         } else {


### PR DESCRIPTION
Addresses part of #1340.

Defensive `null` checks for `TimerSaveTask`. Ideally these cases would never happen but it's better to log them and know if they do than to hard crash.

Previous to this change, `master` crashes on trying to open a form with an audit tag. Changes have been verified with [audit-test-orx.txt](https://github.com/opendatakit/collect/files/1218755/audit-test-orx.txt) to guard against crashes and log unexpected state.

@nap2000 @grzesiek2010 @jknightco please review.