### PR TITLE
Issue #1154 Force to show Menu item, Fix #1154

### DIFF
--- a/collect_app/src/main/res/menu/form_menu.xml
+++ b/collect_app/src/main/res/menu/form_menu.xml
@@ -8,20 +8,24 @@
   OR CONDITIONS OF ANY KIND, either express or implied. See the License for
   the specific language governing permissions and limitations under the License.
 -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
+<menu xmlns:tools="http://schemas.android.com/tools"
+      xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <!-- tools:ignore="AlwaysShowAction" due to #1154 on small screen action is more important
+    than title-->
     <item
         android:id="@+id/menu_save"
         android:icon="@drawable/ic_menu_save"
         android:title="@string/save_all_answers"
-        app:showAsAction="ifRoom"/>
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction"/>
 
     <item
         android:id="@+id/menu_goto"
         android:icon="@drawable/ic_menu_goto"
         android:title="@string/view_hierarchy"
-        app:showAsAction="ifRoom"/>
+        app:showAsAction="always"/>
 
     <item
         android:id="@+id/menu_languages"


### PR DESCRIPTION
Closes #1154 

#### What has been done to verify that this works as intended?
Tested on emulator 320x480: mdpi API 19, it was reproducible. 

#### Why is this the best possible solution? Were any other approaches considered?
It's the best solution if Action has more priority than title text, because it leaves less space for title
Other approach was to remove Application Icon logo on the left to the title, since it not in any modern android app, but it wasn't solving the issue.

#### Are there any risks to merging this code? If so, what are they?
No risk, Lint error suppression was added for tools:ignore="AlwaysShowAction" because it's a conscious decision to give priority to frequently used action button over title, that is available on previous screen.
