### PR TITLE
Update javarosa to 2.5.0-SNAPSHOT.

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     compile group: 'joda-time', name: 'joda-time', version: '2.9.7'
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
-    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.4.0'
+    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.0-SNAPSHOT'
     compile group: 'org.osmdroid', name: 'osmdroid-android', version: '5.6.4'
     compile group: 'org.slf4j', name: 'slf4j-android', version: '1.6.1-RC1'
     compile group: 'pub.devrel', name: 'easypermissions', version: '0.2.1'


### PR DESCRIPTION
No issue filed because this is a routine update. JavaRosa 2.5.0 includes major structural changes to add support for external secondary instances (opendatakit/javarosa#16) so it would be good to spend some time verifying the snapshot before the release.

#### What has been done to verify that this works as intended?
Ran the build on a real device, went through eIMCI form, saved, edited saved form. All tests on the JavaRosa side pass.

#### Why is this the best possible solution? Were any other approaches considered?
I think now is the right time to get the snapshot in so that we can get some stress testing in.

#### Are there any risks to merging this code? If so, what are they?
There may be some subtle issues with form parsing although that is unlikely. Merging now increases our chances of catching them before there's a release.