### PR TITLE
Attempt to invoke virtual method 'android.net.Uri android.content.Intent.getData()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -586,8 +586,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode,
-                                    final Intent intent) {
+    protected void onActivityResult(int requestCode, int resultCode, final Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
         FormController formController = Collect.getInstance()
                 .getFormController();
@@ -609,6 +608,11 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             if (requestCode != HIERARCHY_ACTIVITY) {
                 ((ODKView) currentView).cancelWaitingForBinaryData();
             }
+            return;
+        }
+
+        if (intent == null) {
+            Timber.i("The intent has a null value for requestCode: " + requestCode);
             return;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -612,7 +612,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         }
 
         if (intent == null) {
-            Timber.i("The intent has a null value for requestCode: " + requestCode);
+            Timber.w("The intent has a null value for requestCode: " + requestCode);
             return;
         }
 


### PR DESCRIPTION
Closes #1364 

#### What has been done to verify that this works as intended?
I'm not able to reproduce the issue but I believe it's possible since our users might use lots of different camera apps etc.

#### Why is this the best possible solution? Were any other approaches considered?
I can't see any better solution, if the intent has a null value we can't do anything we can just handle that case.

#### Are there any risks to merging this code? If so, what are they?
It's completely safe.