### PR TITLE
Use existed suppressFlingGesture() method in RangeWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -193,7 +193,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private static final int SAVING_IMAGE_DIALOG = 3;
 
     private boolean autoSaved;
-    private boolean doSwipe = true;
 
     // Random ID
     private static final int DELETE_REPEAT = 654321;
@@ -2814,7 +2813,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 PreferenceKeys.KEY_NAVIGATION,
                 PreferenceKeys.NAVIGATION_SWIPE);
 
-        if (navigation.contains(PreferenceKeys.NAVIGATION_SWIPE) && doSwipe) {
+        if (navigation.contains(PreferenceKeys.NAVIGATION_SWIPE)) {
             // Looks for user swipes. If the user has swiped, move to the
             // appropriate screen.
 
@@ -2949,9 +2948,5 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         public EmptyView(Context context) {
             super(context);
         }
-    }
-
-    public void allowSwiping(boolean doSwipe) {
-        this.doSwipe = doSwipe;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
@@ -60,6 +60,7 @@ public abstract class RangeWidget extends QuestionWidget {
     private View view;
 
     private boolean isPickerAppearance;
+    private boolean suppressFlingGesture;
 
     private Button pickerButton;
     private TextView answerTextView;
@@ -96,6 +97,11 @@ public abstract class RangeWidget extends QuestionWidget {
             pickerButton.setOnLongClickListener(l);
             answerTextView.setOnLongClickListener(l);
         }
+    }
+
+    @Override
+    public boolean suppressFlingGesture(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+        return suppressFlingGesture;
     }
 
     private void setUpLayoutElements() {
@@ -160,12 +166,12 @@ public abstract class RangeWidget extends QuestionWidget {
         seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-                ((FormEntryActivity) getContext()).allowSwiping(true);
+                suppressFlingGesture = false;
             }
 
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) {
-                ((FormEntryActivity) getContext()).allowSwiping(false);
+                suppressFlingGesture = true;
             }
 
             @Override


### PR DESCRIPTION
Closes #1370 

#### What has been done to verify that this works as intended?
I've tested swiping in RangeWidget to confirm it works as expected.

#### Why is this the best possible solution? Were any other approaches considered?
Using existed method our code is clear and we don't need additional changes in FormEntryActivity class.

#### Are there any risks to merging this code? If so, what are they?
No, it's safe.
