### PR TITLE
Allow to create lint-result.xml file

### DIFF
--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -85,7 +85,7 @@ task pmd(type: Pmd) {
 android {
     lintOptions {
         abortOnError true
-        xmlReport false
+        xmlReport true
         htmlReport true
         lintConfig file("$configDir/lint/lint.xml")
         htmlOutput file("$reportsDir/lint/lint-result.html")


### PR DESCRIPTION
Closes #1377 

#### What has been done to verify that this works as intended?
I've ran `./gradlew lint` command to confirm that file is created

#### Are there any risks to merging this code? If so, what are they?
No, it's safe.
