### PR TITLE
Update build tools

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,16 +14,16 @@ dependencies:
         # Cache Android SDK to avoid unnecessary downloads
         # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
         - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
-        - if ! $(grep -q "Revision=25.0.3" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
-        - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
+        - if ! $(grep -q "Revision=26" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/build-tools/26.0.1 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-26.0.1"; fi
         - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
-        - if ! $(grep -q "Revision=45.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-        - if ! $(grep -q "Revision=44.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
+        - if ! $(grep -q "Revision=47.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+        - if ! $(grep -q "Revision=57.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
 
     cache_directories:
         - /usr/local/android-sdk-linux/tools
         - /usr/local/android-sdk-linux/platform-tools
-        - /usr/local/android-sdk-linux/build-tools/25.0.2
+        - /usr/local/android-sdk-linux/build-tools/26.0.1
         - /usr/local/android-sdk-linux/platforms/android-25
         - /usr/local/android-sdk-linux/extras/android/m2repository
         - /usr/local/android-sdk-linux/extras/google/m2repository

--- a/circle.yml
+++ b/circle.yml
@@ -15,15 +15,15 @@ dependencies:
         # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
         - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
         - if ! $(grep -q "Revision=26" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
-        - if [ ! -e /usr/local/android-sdk-linux/build-tools/26.0.1 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-26.0.1"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
         - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
         - if ! $(grep -q "Revision=47.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-        - if ! $(grep -q "Revision=57.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
+        - if ! $(grep -q "Revision=58.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi
 
     cache_directories:
         - /usr/local/android-sdk-linux/tools
         - /usr/local/android-sdk-linux/platform-tools
-        - /usr/local/android-sdk-linux/build-tools/26.0.1
+        - /usr/local/android-sdk-linux/build-tools/25.0.2
         - /usr/local/android-sdk-linux/platforms/android-25
         - /usr/local/android-sdk-linux/extras/android/m2repository
         - /usr/local/android-sdk-linux/extras/google/m2repository

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
         # https://discuss.circleci.com/t/android-sdk-support-library-24/5247/5
         - if ! $(grep -q "Revision=25.2.5" /usr/local/android-sdk-linux/tools/source.properties); then echo y | android update sdk --no-ui --all --filter "tools"; fi
         - if ! $(grep -q "Revision=26" /usr/local/android-sdk-linux/platform-tools/source.properties); then echo y | android update sdk --no-ui --all --filter "platform-tools"; fi
-        - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
+        - if [ ! -e /usr/local/android-sdk-linux/build-tools/26.0.1 ]; then echo y | android update sdk --no-ui --all --filter "build-tools-26.0.1"; fi
         - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter "android-25"; fi
         - if ! $(grep -q "Revision=47.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
         - if ! $(grep -q "Revision=58.0.0" /usr/local/android-sdk-linux/extras/google/m2repository/source.properties); then echo y | android update sdk --no-ui --all --filter "extra-google-m2repository"; fi

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -63,7 +63,7 @@ if (secretsFile.exists()) {
 
 android {
     compileSdkVersion(25)
-    buildToolsVersion('25.0.2')
+    buildToolsVersion('26.0.1')
 
     defaultConfig {
         applicationId('org.odk.collect.android')


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Ran my branch on CircleCI and confirmed that the build-tools that the version checks don't re-download SDK components. Also confirmed via SSH that 26.0.1 is installed on the servers.

#### Why is this the best possible solution? Were any other approaches considered?
In general, we should use the latest versions of things.

#### Are there any risks to merging this code? If so, what are they?
Not really. We should merge right after a release to give ourselves time to recover. Please squash the commit history.