### PR TITLE
Keep the support lib.

### DIFF
--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -5,5 +5,6 @@
 -dontwarn org.xmlpull.v1.**
 
 -keep class org.javarosa.**
+-keep class android.support.v7.widget.** { *; }
 
 -dontobfuscate


### PR DESCRIPTION
Closes #1393 

#### What has been done to verify that this works as intended?
This will need to be verified with a signed build.

#### Why is this the best possible solution? Were any other approaches considered?
Other options include disabling proguard but that is pretty extreme. This should keep the necessary libraries.

`{ *; }` is a wildcard that keeps all members and methods.

#### Are there any risks to merging this code? If so, what are they?
It could be the wrong thing to keep but then we'd just have to try again.
