### PR TITLE
Not supported by calendar-mode DatePicker Bug

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -191,6 +191,10 @@ public class DateWidget extends QuestionWidget {
 
     private int getTheme() {
         int theme = 0;
+        // https://github.com/opendatakit/collect/issues/1367
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            theme = android.R.style.Theme_Material_Light_Dialog;
+        }
         if (!showCalendar) {
             theme = android.R.style.Theme_Holo_Light_Dialog;
         }
@@ -256,13 +260,11 @@ public class DateWidget extends QuestionWidget {
     }
 
     private class CustomDatePickerDialog extends DatePickerDialog {
-        int theme;
         private String dialogTitle = getContext().getString(R.string.select_date);
 
         CustomDatePickerDialog(Context context, int theme, OnDateSetListener listener, int year, int month, int dayOfMonth) {
             super(context, theme, listener, year, month, dayOfMonth);
-            this.theme = theme;
-            if (theme != 0) {
+            if (!showCalendar) {
                 setTitle(dialogTitle);
                 fixSpinner(context, year, month, dayOfMonth);
                 getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
@@ -271,7 +273,7 @@ public class DateWidget extends QuestionWidget {
         }
 
         public void setTitle(CharSequence title) {
-            if (theme != 0) {
+            if (!showCalendar) {
                 super.setTitle(dialogTitle);
             }
         }


### PR DESCRIPTION
Closes #1367 

#### What has been done to verify that this works as intended?
I've tested this fix using:
**Devices:**
Samsung Galaxy S4 Android 5.0.1
Huawei Y560 5.1.1
Sony Xperia Z3 6.0.1
Samsung Galaxy S7 Android 7.0

**AVD:**
API 21
API 22
API 23
API 24
API 25

#### Why is this the best possible solution? Were any other approaches considered?
I've also tested other possible themes like: `ThemeOverlay_Material_Dialog` or `Theme_DeviceDefault_Light_Dialog` but only the one used works properly on all devices I've tested.

#### Are there any risks to merging this code? If so, what are they?
Who knows.... (I bet it's ok but can't be sure) the previous solution assumed that the default [theme is 0 ](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java#L193) as it's a default value if we don't set it (look https://developer.android.com/reference/android/app/DatePickerDialog.html).

To be honest using 0 value on API 23, 24, 25 the calendar view works on my devices but looks different (uses other color than other devices) so it may point there is something wrong with this default theme and as we now know from #1367 it doesn't work at all on some devices. Using this solution the color is the same on all devices and as @russbiggs confirmed it fixes his issue.

So please everyone who has 5 minutes test this solution on your device and add a note below.
