### PR TITLE
Adds a null check while adding about fragment

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AboutPreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AboutPreferencesActivity.java
@@ -25,9 +25,11 @@ public class AboutPreferencesActivity extends PreferenceActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        getFragmentManager()
-                .beginTransaction()
-                .replace(android.R.id.content, new AboutPreferencesFragment())
-                .commit();
+        if (savedInstanceState == null) {
+            getFragmentManager()
+                    .beginTransaction()
+                    .replace(android.R.id.content, new AboutPreferencesFragment())
+                    .commit();
+        }
     }
 }


### PR DESCRIPTION
Closes #1402 

#### What has been done to verify that this works as intended?
Tested on a physical device: Android 7.0

#### Why is this the best possible solution? Were any other approaches considered?
Whenever the screen is rotated, **onCreate** will execute and will replace the current fragment with another new Fragment. So, I have added a null check before committing a new fragment.

#### Are there any risks to merging this code? If so, what are they?
No
