### PR TITLE
Close external data databases when discarding changes.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2023,6 +2023,10 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 } else {
                     Collect.getInstance().getActivityLogger()
                             .logInstanceAction(this, "createQuitDialog", "discardAndExit");
+
+                    // close all open databases of external data.
+                    Collect.getInstance().getExternalDataManager().close();
+
                     FormController formController = Collect.getInstance().getFormController();
                     if (formController != null) {
                         formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_EXIT, 0, null, false, true);


### PR DESCRIPTION
Maintains behavior from before exit dialog update as discussed [here](https://github.com/opendatakit/collect/pull/1360/files/15533b17ffd672e5a93af4589d09524399fdf6d2#r136136632)

#### What has been done to verify that this works as intended?
Load the [sample preloading form](https://opendatakit.org/downloads/download-info/sample-preloading-form/), exit without saving.

#### Why is this the best possible solution? Were any other approaches considered?
I don't know that this is strictly necessary and I don't know how to confirm whether or not it is. I can imagine that deleting an unclosed database file could occasionally cause problems, though, so I think adding it back in is the safest approach.

#### Are there any risks to merging this code? If so, what are they?
I don't believe so. The `close` method starts with a `null` check so worst case it has no effect at all.