### PR TITLE
Refactors Shared Preferences

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTestCase.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTestCase.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.preferences.AdminKeys;
+import org.odk.collect.android.preferences.AdminSharedPreferences;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI;
@@ -41,9 +43,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 @RunWith(AndroidJUnit4.class)
 public class ResetAppStateTestCase {
@@ -127,22 +129,18 @@ public class ResetAppStateTestCase {
     private void setupTestSettings() throws IOException {
         String username = "usernameTest";
         String password = "passwordTest";
-        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(Collect.getInstance());
-        settings
-                .edit()
-                .putString(PreferenceKeys.KEY_USERNAME, username)
-                .putString(PreferenceKeys.KEY_PASSWORD, password)
-                .apply();
 
-        assertEquals(username, settings.getString(PreferenceKeys.KEY_USERNAME, null));
-        assertEquals(password, settings.getString(PreferenceKeys.KEY_PASSWORD, null));
+        GeneralSharedPreferences generalSettings = new GeneralSharedPreferences(Collect.getInstance().getBaseContext());
+        generalSettings.save(PreferenceKeys.KEY_USERNAME, username);
+        generalSettings.save(PreferenceKeys.KEY_PASSWORD, password);
 
-        settings
-                .edit()
-                .putBoolean(AdminKeys.KEY_VIEW_SENT, false)
-                .apply();
+        assertEquals(username, generalSettings.get(PreferenceKeys.KEY_USERNAME));
+        assertEquals(password, generalSettings.get(PreferenceKeys.KEY_PASSWORD));
 
-        assertEquals(false, settings.getBoolean(AdminKeys.KEY_VIEW_SENT, false));
+        AdminSharedPreferences adminSettings = new AdminSharedPreferences(Collect.getInstance().getBaseContext());
+        adminSettings.save(AdminKeys.KEY_VIEW_SENT, false);
+
+        assertEquals(false, adminSettings.getBoolean(AdminKeys.KEY_VIEW_SENT, false));
 
         assertTrue(new File(Collect.SETTINGS).exists() || new File(Collect.SETTINGS).mkdir());
         assertTrue(new File(Collect.SETTINGS + "/collect.settings").createNewFile());

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/MockedServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/MockedServerTest.java
@@ -36,7 +36,7 @@ public abstract class MockedServerTest {
     }
 
     private static void configAppFor(MockWebServer server) {
-        GeneralSharedPreferences preferences = Collect.getInstance().getGeneralPrefs();
+        GeneralSharedPreferences preferences = new GeneralSharedPreferences(Collect.getInstance().getBaseContext());
 
         String serverUrl = server.url("/").toString();
         preferences.save(PreferenceKeys.KEY_SERVER_URL, serverUrl);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/MockedServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/MockedServerTest.java
@@ -1,15 +1,13 @@
 package org.odk.collect.android.test;
 
-import android.content.SharedPreferences.Editor;
-import android.preference.PreferenceManager;
-
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.Before;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -19,9 +17,34 @@ import static org.odk.collect.android.test.TestUtils.backupPreferences;
 import static org.odk.collect.android.test.TestUtils.restorePreferences;
 
 public abstract class MockedServerTest {
+    protected MockWebServer server;
     private Map<String, ?> prefsBackup;
 
-    protected MockWebServer server;
+    protected static String join(String... strings) {
+        StringBuilder bob = new StringBuilder();
+        for (String s : strings) {
+            bob.append(s).append('\n');
+        }
+        return bob.toString();
+    }
+
+    private static MockWebServer mockWebServer() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        configAppFor(server);
+        return server;
+    }
+
+    private static void configAppFor(MockWebServer server) {
+        GeneralSharedPreferences preferences = Collect.getInstance().getGeneralPrefs();
+
+        String serverUrl = server.url("/").toString();
+        preferences.save(PreferenceKeys.KEY_SERVER_URL, serverUrl);
+
+        if (preferences.get(PreferenceKeys.KEY_SERVER_URL).equals(serverUrl)) {
+            throw new RuntimeException("Failed to set up SharedPreferences for MockWebServer");
+        }
+    }
 
     @Before
     public void http_setUp() throws Exception {
@@ -64,28 +87,5 @@ public abstract class MockedServerTest {
 
     protected RecordedRequest nextRequest() throws Exception {
         return server.takeRequest(1, TimeUnit.MILLISECONDS);
-    }
-
-   protected static String join(String... strings) {
-        StringBuilder bob = new StringBuilder();
-        for (String s : strings) {
-            bob.append(s).append('\n');
-        }
-        return bob.toString();
-    }
-
-    private static MockWebServer mockWebServer() throws Exception {
-        MockWebServer server = new MockWebServer();
-        server.start();
-        configAppFor(server);
-        return server;
-    }
-
-    private static void configAppFor(MockWebServer server) {
-        Editor prefs = PreferenceManager.getDefaultSharedPreferences(Collect.getInstance().getBaseContext()).edit();
-        prefs.putString(PreferenceKeys.KEY_SERVER_URL, server.url("/").toString());
-        if (!prefs.commit()) {
-            throw new RuntimeException("Failed to set up SharedPreferences for MockWebServer");
-        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/TestUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/TestUtils.java
@@ -2,7 +2,10 @@ package org.odk.collect.android.test;
 
 import android.content.SharedPreferences;
 import android.os.Environment;
-import android.preference.PreferenceManager;
+
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.io.Closeable;
 import java.io.File;
@@ -10,44 +13,24 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
-
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 
 public final class TestUtils {
-    private TestUtils() {}
+    private TestUtils() {
+    }
 
     public static Map<String, ?> backupPreferences() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(Collect.getInstance().getBaseContext());
+        SharedPreferences prefs = (SharedPreferences) new GeneralSharedPreferences(Collect.getInstance().getBaseContext());
         return Collections.unmodifiableMap(prefs.getAll());
     }
 
     public static void restorePreferences(Map<String, ?> backup) {
-        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(Collect.getInstance().getBaseContext()).edit();
-
-        editor.clear();
+        GeneralSharedPreferences preferences = new GeneralSharedPreferences(Collect.getInstance().getBaseContext());
+        preferences.clearAll();
 
         for (Map.Entry<String, ?> e : backup.entrySet()) {
             Object v = e.getValue();
-            if (v instanceof Boolean) {
-                editor.putBoolean(e.getKey(), (Boolean) v);
-            } else if (v instanceof Float) {
-                editor.putFloat(e.getKey(), (Float) v);
-            } else if (v instanceof Integer) {
-                editor.putInt(e.getKey(), (Integer) v);
-            } else if (v instanceof Long) {
-                editor.putLong(e.getKey(), (Long) v);
-            } else if (v instanceof String) {
-                editor.putString(e.getKey(), (String) v);
-            } else if (v instanceof Set) {
-                editor.putStringSet(e.getKey(), (Set<String>) v);
-            } else {
-                throw new RuntimeException("Unhandled preference value type: " + v);
-            }
+            preferences.save(e.getKey(), v);
         }
-
-        editor.apply();
     }
 
     public static File createTempFile(String content) throws Exception {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -35,9 +35,9 @@ import android.widget.SimpleCursorAdapter;
 import android.widget.TextView;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.listeners.DiskSyncListener;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
@@ -196,7 +196,7 @@ public class InstanceUploaderList extends InstanceListActivity
     }
 
     private void uploadSelectedFiles() {
-        String server = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_PROTOCOL);
+        String server = (String) Collect.getInstance().getGeneralPrefs().get(PreferenceKeys.KEY_PROTOCOL);
         long[] instanceIds = listView.getCheckedItemIds();
         if (server.equalsIgnoreCase(getString(R.string.protocol_google_sheets))) {
             // if it's Sheets, start the Sheets uploader

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -646,7 +646,7 @@ public class MainMenuActivity extends AppCompatActivity {
                 }
             }
             prefEdit.apply();
-            AuthDialogUtility.setWebCredentialsFromPreferences(this);
+            AuthDialogUtility.setWebCredentialsFromPreferences();
 
             // second object is admin options
             Editor adminEdit = getSharedPreferences(AdminPreferencesActivity.ADMIN_PREFERENCES,

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -269,11 +269,11 @@ public class Collect extends Application {
         activityLogger = new ActivityLogger(
                 mgr.getSingularProperty(PropertyManager.PROPMGR_DEVICE_ID));
 
-        generalSharedPreferences = new GeneralSharedPreferences(this);
+        generalSharedPreferences = new GeneralSharedPreferences(getBaseContext());
 
-        adminSharedPreferences = new AdminSharedPreferences(this);
+        adminSharedPreferences = new AdminSharedPreferences(getBaseContext());
 
-        AuthDialogUtility.setWebCredentialsFromPreferences(this);
+        AuthDialogUtility.setWebCredentialsFromPreferences();
         if (BuildConfig.DEBUG) {
             Timber.plant(new Timber.DebugTree());
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -168,11 +168,11 @@ public class Collect extends Application {
         return activityLogger;
     }
 
-    public GeneralSharedPreferences getGeneralSharedPreferences() {
+    public GeneralSharedPreferences getGeneralPrefs() {
         return generalSharedPreferences;
     }
 
-    public AdminSharedPreferences getAdminSharedPreferences() {
+    public AdminSharedPreferences getAdminPrefs() {
         return adminSharedPreferences;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -258,20 +258,18 @@ public class Collect extends Application {
         new LocaleHelper().updateLocale(this);
         singleton = this;
 
+        generalSharedPreferences = new GeneralSharedPreferences(getBaseContext());
+        adminSharedPreferences = new AdminSharedPreferences(getBaseContext());
+
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
-        FormMetadataMigrator.migrate(PreferenceManager.getDefaultSharedPreferences(this));
+        FormMetadataMigrator.migrate((SharedPreferences) generalSharedPreferences);
         AutoSendPreferenceMigrator.migrate();
 
         PropertyManager mgr = new PropertyManager(this);
 
         FormController.initializeJavaRosa(mgr);
 
-        activityLogger = new ActivityLogger(
-                mgr.getSingularProperty(PropertyManager.PROPMGR_DEVICE_ID));
-
-        generalSharedPreferences = new GeneralSharedPreferences(getBaseContext());
-
-        adminSharedPreferences = new AdminSharedPreferences(getBaseContext());
+        activityLogger = new ActivityLogger(mgr.getSingularProperty(PropertyManager.PROPMGR_DEVICE_ID));
 
         AuthDialogUtility.setWebCredentialsFromPreferences();
         if (BuildConfig.DEBUG) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -38,8 +38,10 @@ import org.odk.collect.android.database.ActivityLogger;
 import org.odk.collect.android.external.ExternalDataManager;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.AutoSendPreferenceMigrator;
 import org.odk.collect.android.preferences.FormMetadataMigrator;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.AgingCredentialsProvider;
 import org.odk.collect.android.utilities.AuthDialogUtility;
@@ -77,6 +79,7 @@ public class Collect extends Application {
     public static final String DEFAULT_FONTSIZE = "21";
     public static final String OFFLINE_LAYERS = ODK_ROOT + File.separator + "layers";
     public static final String SETTINGS = ODK_ROOT + File.separator + "settings";
+    public static String defaultSysLanguage;
     private static Collect singleton = null;
 
     static {
@@ -93,7 +96,8 @@ public class Collect extends Application {
     private ExternalDataManager externalDataManager;
     private Tracker tracker;
 
-    public static String defaultSysLanguage;
+    private GeneralSharedPreferences generalSharedPreferences;
+    private AdminSharedPreferences adminSharedPreferences;
 
     public static Collect getInstance() {
         return singleton;
@@ -162,6 +166,14 @@ public class Collect extends Application {
 
     public ActivityLogger getActivityLogger() {
         return activityLogger;
+    }
+
+    public GeneralSharedPreferences getGeneralSharedPreferences() {
+        return generalSharedPreferences;
+    }
+
+    public AdminSharedPreferences getAdminSharedPreferences() {
+        return adminSharedPreferences;
     }
 
     public FormController getFormController() {
@@ -256,6 +268,10 @@ public class Collect extends Application {
 
         activityLogger = new ActivityLogger(
                 mgr.getSingularProperty(PropertyManager.PROPMGR_DEVICE_ID));
+
+        generalSharedPreferences = new GeneralSharedPreferences(this);
+
+        adminSharedPreferences = new AdminSharedPreferences(this);
 
         AuthDialogUtility.setWebCredentialsFromPreferences(this);
         if (BuildConfig.DEBUG) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
@@ -23,7 +23,7 @@ import static org.odk.collect.android.preferences.AdminPreferencesFragment.ADMIN
 
 public class AdminSharedPreferences {
 
-    private android.content.SharedPreferences sharedPreferences;
+    private SharedPreferences sharedPreferences;
 
     public AdminSharedPreferences(Context context) {
         sharedPreferences = context.getSharedPreferences(ADMIN_PREFERENCES, 0);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
@@ -15,28 +15,19 @@
 package org.odk.collect.android.preferences;
 
 
-import org.odk.collect.android.application.Collect;
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import static org.odk.collect.android.preferences.AdminKeys.KEY_ADMIN_PW;
 import static org.odk.collect.android.preferences.AdminPreferencesFragment.ADMIN_PREFERENCES;
 
 public class AdminSharedPreferences {
 
-    private static AdminSharedPreferences instance = null;
     private android.content.SharedPreferences sharedPreferences;
-    private android.content.SharedPreferences.Editor editor;
 
-    private AdminSharedPreferences() {
-        sharedPreferences = Collect.getInstance().getSharedPreferences(ADMIN_PREFERENCES, 0);
+    public AdminSharedPreferences(Context context) {
+        sharedPreferences = context.getSharedPreferences(ADMIN_PREFERENCES, 0);
     }
-
-    public static synchronized AdminSharedPreferences getInstance() {
-        if (instance == null) {
-            instance = new AdminSharedPreferences();
-        }
-        return instance;
-    }
-
 
     public Object get(String key) {
         if (key.equals(KEY_ADMIN_PW)) {
@@ -46,7 +37,7 @@ public class AdminSharedPreferences {
         }
     }
 
-    public Object getDefault(String key) {
+    private Object getDefault(String key) {
         if (key.equals(KEY_ADMIN_PW)) {
             return "";
         } else {
@@ -60,7 +51,7 @@ public class AdminSharedPreferences {
     }
 
     public void save(String key, Object value) {
-        editor = sharedPreferences.edit();
+        SharedPreferences.Editor editor = sharedPreferences.edit();
         if (value == null || value == "" || value instanceof String) {
             editor.putString(key, (String) value);
         } else if (value instanceof Boolean) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
@@ -37,7 +37,7 @@ public class AdminSharedPreferences {
         }
     }
 
-    private Object getDefault(String key) {
+    public Object getDefault(String key) {
         if (key.equals(KEY_ADMIN_PW)) {
             return "";
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminSharedPreferences.java
@@ -66,4 +66,7 @@ public class AdminSharedPreferences {
         editor.apply();
     }
 
+    public boolean getBoolean(String key, boolean value) {
+        return sharedPreferences.getBoolean(key, value);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AutoSendPreferenceMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AutoSendPreferenceMigrator.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.preferences;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.odk.collect.android.application.Collect;
 
 import java.util.Map;
 
@@ -16,8 +17,8 @@ public class AutoSendPreferenceMigrator {
 
     public static void migrate() {
 
-        boolean autoSendWifi = GeneralSharedPreferences.getInstance().getBoolean(KEY_AUTOSEND_WIFI, false);
-        boolean autoSendNetwork = GeneralSharedPreferences.getInstance().getBoolean(KEY_AUTOSEND_NETWORK, false);
+        boolean autoSendWifi = Collect.getInstance().getGeneralPrefs().getBoolean(KEY_AUTOSEND_WIFI, false);
+        boolean autoSendNetwork = Collect.getInstance().getGeneralPrefs().getBoolean(KEY_AUTOSEND_NETWORK, false);
 
         migrate(autoSendWifi, autoSendNetwork);
     }
@@ -61,7 +62,7 @@ public class AutoSendPreferenceMigrator {
     }
 
     private static void migrate(boolean autoSendWifi, boolean autoSendNetwork) {
-        String autoSend = (String) GeneralSharedPreferences.getInstance().get(KEY_AUTOSEND);
+        String autoSend = (String) Collect.getInstance().getGeneralPrefs().get(KEY_AUTOSEND);
 
         if (autoSendNetwork && autoSendWifi) {
             autoSend = "wifi_and_cellular";
@@ -72,6 +73,6 @@ public class AutoSendPreferenceMigrator {
         }
 
         //save to shared preferences
-        GeneralSharedPreferences.getInstance().save(KEY_AUTOSEND, autoSend);
+        Collect.getInstance().getGeneralPrefs().save(KEY_AUTOSEND, autoSend);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/DisabledPreferencesRemover.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/DisabledPreferencesRemover.java
@@ -20,6 +20,8 @@ import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
 
+import org.odk.collect.android.application.Collect;
+
 import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
@@ -42,7 +44,7 @@ class DisabledPreferencesRemover {
      */
     void remove(AdminAndGeneralKeys... keyPairs) {
         for (AdminAndGeneralKeys agKeys : keyPairs) {
-            boolean prefAllowed = (boolean) AdminSharedPreferences.getInstance().get(agKeys.adminKey);
+            boolean prefAllowed = (boolean) Collect.getInstance().getAdminPrefs().get(agKeys.adminKey);
 
             if (!prefAllowed) {
                 Preference preference = pf.findPreference(agKeys.generalKey);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
@@ -19,6 +19,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import java.util.Set;
+
 import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.GENERAL_KEYS;
@@ -26,6 +28,7 @@ import static org.odk.collect.android.preferences.PreferenceKeys.GENERAL_KEYS;
 public class GeneralSharedPreferences {
 
     private android.content.SharedPreferences sharedPreferences;
+    private SharedPreferences.Editor editor;
 
     public GeneralSharedPreferences(Context context) {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -60,8 +63,13 @@ public class GeneralSharedPreferences {
         save(key, defaultValue);
     }
 
+    public void clearAll() {
+        editor.clear();
+        editor.apply();
+    }
+
     public void save(String key, Object value) {
-        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor = sharedPreferences.edit();
         if (value == null || value == "" || value instanceof String) {
             editor.putString(key, (String) value);
         } else if (value instanceof Boolean) {
@@ -72,6 +80,10 @@ public class GeneralSharedPreferences {
             editor.putInt(key, (Integer) value);
         } else if (value instanceof Float) {
             editor.putFloat(key, (Float) value);
+        } else if (value instanceof Set) {
+            editor.putStringSet(key, (Set<String>) value);
+        } else {
+            throw new RuntimeException("Unhandled preference value type: " + value);
         }
         editor.apply();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
@@ -27,7 +27,7 @@ import static org.odk.collect.android.preferences.PreferenceKeys.GENERAL_KEYS;
 
 public class GeneralSharedPreferences {
 
-    private android.content.SharedPreferences sharedPreferences;
+    private SharedPreferences sharedPreferences;
     private SharedPreferences.Editor editor;
 
     public GeneralSharedPreferences(Context context) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
@@ -15,9 +15,9 @@
 package org.odk.collect.android.preferences;
 
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-
-import org.odk.collect.android.application.Collect;
 
 import timber.log.Timber;
 
@@ -25,19 +25,10 @@ import static org.odk.collect.android.preferences.PreferenceKeys.GENERAL_KEYS;
 
 public class GeneralSharedPreferences {
 
-    private static GeneralSharedPreferences instance = null;
     private android.content.SharedPreferences sharedPreferences;
-    private android.content.SharedPreferences.Editor editor;
 
-    private GeneralSharedPreferences() {
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(Collect.getInstance());
-    }
-
-    public static synchronized GeneralSharedPreferences getInstance() {
-        if (instance == null) {
-            instance = new GeneralSharedPreferences();
-        }
-        return instance;
+    public GeneralSharedPreferences(Context context) {
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
     }
 
     public Object get(String key) {
@@ -70,7 +61,7 @@ public class GeneralSharedPreferences {
     }
 
     public void save(String key, Object value) {
-        editor = sharedPreferences.edit();
+        SharedPreferences.Editor editor = sharedPreferences.edit();
         if (value == null || value == "" || value instanceof String) {
             editor.putString(key, (String) value);
         } else if (value instanceof Boolean) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -23,6 +23,7 @@ import android.view.ViewGroup;
 
 import org.javarosa.core.services.IPropertyManager;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.logic.PropertyManager;
 
@@ -35,13 +36,9 @@ import java.util.List;
 public class PreferencesActivity extends PreferenceActivity {
     public static final String INTENT_KEY_ADMIN_MODE = "adminMode";
 
-    private AdminSharedPreferences sharedPreferences;
-
     @Override
     public void onBuildHeaders(List<Header> target) {
         super.onBuildHeaders(target);
-
-        sharedPreferences = AdminSharedPreferences.getInstance();
 
         final boolean adminMode = getIntent().getBooleanExtra(INTENT_KEY_ADMIN_MODE, false);
 
@@ -82,7 +79,7 @@ public class PreferencesActivity extends PreferenceActivity {
 
     private boolean hasAtleastOneSettingEnabled(Collection<String> keys) {
         for (String key : keys) {
-            boolean value = (boolean) sharedPreferences.get(key);
+            boolean value = (boolean) Collect.getInstance().getAdminPrefs().get(key);
             if (value) {
                 return true;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -203,7 +203,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
         super.onPause();
 
         if (credentialsHaveChanged) {
-            AuthDialogUtility.setWebCredentialsFromPreferences(getActivity().getBaseContext());
+            AuthDialogUtility.setWebCredentialsFromPreferences();
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -331,15 +331,15 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
     }
 
     private void clearCachedCrendentials() {
-        String server = (String) GeneralSharedPreferences
-                .getInstance().get(PreferenceKeys.KEY_SERVER_URL);
+        String server = (String) Collect.getInstance()
+                .getGeneralPrefs().get(PreferenceKeys.KEY_SERVER_URL);
         Uri u = Uri.parse(server);
         WebUtils.clearHostCredentials(u.getHost());
         Collect.getInstance().getCookieStore().clear();
     }
 
     protected void setDefaultAggregatePaths() {
-        GeneralSharedPreferences sharedPreferences = GeneralSharedPreferences.getInstance();
+        GeneralSharedPreferences sharedPreferences = Collect.getInstance().getGeneralPrefs();
         sharedPreferences.reset(KEY_FORMLIST_URL);
         sharedPreferences.reset(KEY_SUBMISSION_URL);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
@@ -74,7 +74,7 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
 
     private boolean isFormAutoSendOptionEnabled(NetworkInfo currentNetworkInfo) {
         // make sure autosend is enabled on the given connected interface
-        String autosend = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_AUTOSEND);
+        String autosend = (String) Collect.getInstance().getGeneralPrefs().get(PreferenceKeys.KEY_AUTOSEND);
         boolean sendwifi = autosend.equals("wifi_only");
         boolean sendnetwork = autosend.equals("cellular_only");
         if (autosend.equals("wifi_and_cellular")) {
@@ -122,7 +122,7 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
                     Collect.getInstance(), Collections.singleton(DriveScopes.DRIVE))
                     .setBackOff(new ExponentialBackOff());
 
-            GeneralSharedPreferences settings = GeneralSharedPreferences.getInstance();
+            GeneralSharedPreferences settings = Collect.getInstance().getGeneralPrefs();
 
             String protocol = (String) settings.get(PreferenceKeys.KEY_PROTOCOL);
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploader.java
@@ -91,7 +91,7 @@ public abstract class InstanceUploader extends AsyncTask<Long, Integer, Instance
                                 List<Long> toDelete = new ArrayList<>();
                                 results.moveToPosition(-1);
 
-                                boolean isFormAutoDeleteOptionEnabled = (boolean) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_DELETE_AFTER_SEND);
+                                boolean isFormAutoDeleteOptionEnabled = (boolean) Collect.getInstance().getGeneralPrefs().get(PreferenceKeys.KEY_DELETE_AFTER_SEND);
                                 while (results.moveToNext()) {
                                     if (isFormAutoDeleteOptionEnabled) {
                                         toDelete.add(results.getLong(results.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID)));

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploader.java
@@ -24,7 +24,6 @@ import android.os.AsyncTask;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.utilities.ApplicationConstants;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
@@ -36,8 +36,33 @@ import org.odk.collect.android.preferences.PreferenceKeys;
 public class AuthDialogUtility {
     private static final String TAG = "AuthDialogUtility";
 
+    public static void setWebCredentialsFromPreferences() {
+
+        String username = getUserName();
+        String password = getPassword();
+
+        if (username == null || username.isEmpty()) {
+            return;
+        }
+
+        String host = Uri.parse(getServer()).getHost();
+        WebUtils.addCredentials(username, password, host);
+    }
+
+    private static String getServer() {
+        return (String) Collect.getInstance().getGeneralPrefs().get(PreferenceKeys.KEY_SERVER_URL);
+    }
+
+    private static String getPassword() {
+        return (String) Collect.getInstance().getGeneralPrefs().get(PreferenceKeys.KEY_PASSWORD);
+    }
+
+    private static String getUserName() {
+        return (String) Collect.getInstance().getGeneralPrefs().get(PreferenceKeys.KEY_USERNAME);
+    }
+
     public AlertDialog createDialog(final Context context,
-            final AuthDialogUtilityResultListener resultListener) {
+                                    final AuthDialogUtilityResultListener resultListener) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
         final View dialogView = LayoutInflater.from(context)
@@ -47,11 +72,11 @@ public class AuthDialogUtility {
         final EditText password = (EditText) dialogView.findViewById(R.id.password_edit);
 
         final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
-        username.setText(getUserName(settings));
-        password.setText(getPassword(settings));
+        username.setText(getUserName());
+        password.setText(getPassword());
 
         builder.setTitle(context.getString(R.string.server_requires_auth));
-        builder.setMessage(context.getString(R.string.server_auth_credentials, getServer(settings, context)));
+        builder.setMessage(context.getString(R.string.server_auth_credentials, getServer()));
         builder.setView(dialogView);
         builder.setPositiveButton(context.getString(R.string.ok), new DialogInterface.OnClickListener() {
             @Override
@@ -61,8 +86,8 @@ public class AuthDialogUtility {
                 String userNameValue = username.getText().toString();
                 String passwordValue = password.getText().toString();
 
-                saveCredentials(settings, userNameValue, passwordValue);
-                setWebCredentialsFromPreferences(context);
+                saveCredentials(userNameValue, passwordValue);
+                setWebCredentialsFromPreferences();
 
                 resultListener.updatedCredentials();
             }
@@ -82,39 +107,9 @@ public class AuthDialogUtility {
         return builder.create();
     }
 
-    public static void setWebCredentialsFromPreferences(Context context) {
-        final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
-
-        String username = getUserName(settings);
-        String password = getPassword(settings);
-
-        if (username == null || username.isEmpty()) {
-            return;
-        }
-
-        String host = Uri.parse(getServer(settings, context)).getHost();
-        WebUtils.addCredentials(username, password, host);
-    }
-
-    private static String getServer(SharedPreferences settings, Context context) {
-        return settings.getString(PreferenceKeys.KEY_SERVER_URL,
-                context.getString(R.string.default_server_url));
-    }
-
-    private static String getPassword(SharedPreferences settings) {
-        return settings.getString(PreferenceKeys.KEY_PASSWORD, null);
-    }
-
-    private static String getUserName(SharedPreferences settings) {
-        return settings.getString(PreferenceKeys.KEY_USERNAME, null);
-    }
-
-    private void saveCredentials(SharedPreferences settings, String userName, String password) {
-        settings
-                .edit()
-                .putString(PreferenceKeys.KEY_USERNAME, userName)
-                .putString(PreferenceKeys.KEY_PASSWORD, password)
-                .apply();
+    private void saveCredentials(String userName, String password) {
+        Collect.getInstance().getGeneralPrefs().save(PreferenceKeys.KEY_USERNAME, userName);
+        Collect.getInstance().getGeneralPrefs().save(PreferenceKeys.KEY_PASSWORD, password);
     }
 
     public interface AuthDialogUtilityResultListener {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/SharedPreferencesUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/SharedPreferencesUtils.java
@@ -20,9 +20,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.AutoSendPreferenceMigrator;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -59,7 +57,7 @@ public class SharedPreferencesUtils {
 
         //checking for admin password
         if (keys.contains(KEY_ADMIN_PW)) {
-            String password = (String) AdminSharedPreferences.getInstance().get(KEY_ADMIN_PW);
+            String password = (String) Collect.getInstance().getGeneralPrefs().get(KEY_ADMIN_PW);
             if (!password.equals("")) {
                 adminPrefs.put(KEY_ADMIN_PW, password);
             }
@@ -68,7 +66,7 @@ public class SharedPreferencesUtils {
 
         for (String key : keys) {
             Object defaultValue = GENERAL_KEYS.get(key);
-            Object value = GeneralSharedPreferences.getInstance().get(key);
+            Object value = Collect.getInstance().getGeneralPrefs().get(key);
 
             if (value == null) {
                 value = "";
@@ -85,8 +83,8 @@ public class SharedPreferencesUtils {
 
         for (String key : ALL_KEYS) {
 
-            Object defaultValue = AdminSharedPreferences.getInstance().getDefault(key);
-            Object value = AdminSharedPreferences.getInstance().get(key);
+            Object defaultValue = Collect.getInstance().getAdminPrefs().getDefault(key);
+            Object value = Collect.getInstance().getAdminPrefs().get(key);
             if (defaultValue != value) {
                 adminPrefs.put(key, value);
             }
@@ -105,9 +103,9 @@ public class SharedPreferencesUtils {
 
             if (generalPrefsJson.has(key)) {
                 Object value = generalPrefsJson.get(key);
-                GeneralSharedPreferences.getInstance().save(key, value);
+                Collect.getInstance().getAdminPrefs().save(key, value);
             } else {
-                GeneralSharedPreferences.getInstance().reset(key);
+                Collect.getInstance().getAdminPrefs().reset(key);
             }
         }
 
@@ -115,9 +113,9 @@ public class SharedPreferencesUtils {
 
             if (adminPrefsJson.has(key)) {
                 Object value = adminPrefsJson.get(key);
-                AdminSharedPreferences.getInstance().save(key, value);
+                Collect.getInstance().getAdminPrefs().save(key, value);
             } else {
-                AdminSharedPreferences.getInstance().reset(key);
+                Collect.getInstance().getAdminPrefs().reset(key);
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/SharedPreferencesUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/SharedPreferencesUtils.java
@@ -119,7 +119,7 @@ public class SharedPreferencesUtils {
             }
         }
 
-        AuthDialogUtility.setWebCredentialsFromPreferences(context);
+        AuthDialogUtility.setWebCredentialsFromPreferences();
         AutoSendPreferenceMigrator.migrate(generalPrefsJson);
 
         //settings import confirmation toast

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/UrlUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/UrlUtils.java
@@ -20,7 +20,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.exception.BadUrlException;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
@@ -53,7 +52,7 @@ public class UrlUtils {
                     // if we didn't find one in the content provider,
                     // try to get from settings
                     if (urlString == null) {
-                        urlString = (String) GeneralSharedPreferences.getInstance()
+                        urlString = (String) Collect.getInstance().getGeneralPrefs()
                                 .get(PreferenceKeys.KEY_GOOGLE_SHEETS_URL);
                     }
                 }
@@ -85,6 +84,4 @@ public class UrlUtils {
             return spreadsheetId;
         }
     }
-
-
 }


### PR DESCRIPTION
- Removes the singleton pattern from `AdminSharedPreferences` and `GeneralSharedPreferences`

- Adds getter methods in `Collect` class to get their instances. 

- Refactors existing usages

- Modifies test cases to use these classes

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?