### PR TITLE
Only check if widget is waiting for data if it is a binary widget.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -862,7 +862,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private QuestionWidget getWidgetWaitingForBinaryData() {
         QuestionWidget questionWidget = null;
         for (QuestionWidget qw :  ((ODKView) currentView).getWidgets()) {
-            if (((IBinaryWidget) qw).isWaitingForBinaryData()) {
+            if (qw instanceof IBinaryWidget && ((IBinaryWidget) qw).isWaitingForBinaryData()) {
                 questionWidget = qw;
             }
         }


### PR DESCRIPTION
Closes #1411 

#### What has been done to verify that this works as intended?
Reproduced the crash with [field-list-binary.xml.txt](https://github.com/opendatakit/collect/files/1275279/field-list-binary.xml.txt) and verified it doesn't crash with the fix.

#### Why is this the best possible solution? Were any other approaches considered?
It's a straightforward fix that avoids widgets that are not binary widgets. I can't think of any other approach.

#### Are there any risks to merging this code? If so, what are they?
None I can identify.