### PR TITLE
Only save search view state if it exists.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
@@ -49,6 +49,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 
+import timber.log.Timber;
+
 import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrder.BY_NAME_ASC;
 
 abstract class AppListActivity extends AppCompatActivity {
@@ -142,10 +144,12 @@ abstract class AppListActivity extends AppCompatActivity {
         super.onSaveInstanceState(outState);
         outState.putSerializable(SELECTED_INSTANCES, selectedInstances);
         outState.putBoolean(IS_BOTTOM_DIALOG_SHOWN, bottomSheetDialog.isShowing());
-        
+
         if (searchView != null) {
             outState.putBoolean(IS_SEARCH_BOX_SHOWN, !searchView.isIconified());
             outState.putString(SEARCH_TEXT, String.valueOf(searchView.getQuery()));
+        } else {
+            Timber.e("Unexpected null search view (issue #1412)");
         }
 
         if (bottomSheetDialog.isShowing()) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
@@ -141,9 +141,12 @@ abstract class AppListActivity extends AppCompatActivity {
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(SELECTED_INSTANCES, selectedInstances);
-        outState.putBoolean(IS_SEARCH_BOX_SHOWN, !searchView.isIconified());
         outState.putBoolean(IS_BOTTOM_DIALOG_SHOWN, bottomSheetDialog.isShowing());
-        outState.putString(SEARCH_TEXT, String.valueOf(searchView.getQuery()));
+        
+        if (searchView != null) {
+            outState.putBoolean(IS_SEARCH_BOX_SHOWN, !searchView.isIconified());
+            outState.putString(SEARCH_TEXT, String.valueOf(searchView.getQuery()));
+        }
 
         if (bottomSheetDialog.isShowing()) {
             bottomSheetDialog.dismiss();


### PR DESCRIPTION
Closes #1412 

#### What has been done to verify that this works as intended?
I don't have a device or emulator with a hardware button at the moment so I haven't been able to check that the fix works. I did verify that there is no crash on a device without a hardware button. I have also verified that the `Bundle` get methods behave well when fetching values for keys that don't exist. That is, `getBoolean` returns `false`, etc.

#### Why is this the best possible solution? Were any other approaches considered?
This isn't a permanent solution -- it still needs to be decided how the interface should work in the case of a hardware menu button. It should avoid crashes and provide more time to restructure the code as needed.

@shobhitagarwal1612 I'm particularly interested in your opinion since you are more familiar with this code and have an emulator with a hardware button.

#### Are there any risks to merging this code? If so, what are they?
None, it's only a null check.