### PR TITLE
Fixed Samsung devices

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -26,6 +26,7 @@ import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.view.accessibility.AccessibilityManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -45,6 +46,8 @@ import java.lang.reflect.Field;
 import java.util.Date;
 
 import timber.log.Timber;
+
+import static android.content.Context.ACCESSIBILITY_SERVICE;
 
 /**
  * Displays a DatePicker widget. DateWidget handles leap years and does not allow dates that do not
@@ -191,11 +194,12 @@ public class DateWidget extends QuestionWidget {
 
     private int getTheme() {
         int theme = 0;
+        // https://github.com/opendatakit/collect/issues/1424
         // https://github.com/opendatakit/collect/issues/1367
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (!isBrokenSamsungDevice() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             theme = android.R.style.Theme_Material_Light_Dialog;
         }
-        if (!showCalendar) {
+        if (!showCalendar || (isBrokenSamsungDevice() && isTalkBackActive())) {
             theme = android.R.style.Theme_Holo_Light_Dialog;
         }
 
@@ -225,6 +229,18 @@ public class DateWidget extends QuestionWidget {
             setDateLabel();
             datePickerDialog.updateDate(dt.getYear(), dt.getMonthOfYear() - 1, dt.getDayOfMonth());
         }
+    }
+
+    // https://stackoverflow.com/questions/28618405/datepicker-crashes-on-my-device-when-clicked-with-personal-app
+    private boolean isBrokenSamsungDevice() {
+        return (Build.MANUFACTURER.equalsIgnoreCase("samsung")
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1);
+    }
+
+    // https://stackoverflow.com/a/34853067/5479029
+    private boolean isTalkBackActive() {
+        return ((AccessibilityManager) getContext().getSystemService(ACCESSIBILITY_SERVICE)).isTouchExplorationEnabled();
     }
 
     public boolean isDayHidden() {
@@ -261,10 +277,12 @@ public class DateWidget extends QuestionWidget {
 
     private class CustomDatePickerDialog extends DatePickerDialog {
         private String dialogTitle = getContext().getString(R.string.select_date);
+        private int theme;
 
         CustomDatePickerDialog(Context context, int theme, OnDateSetListener listener, int year, int month, int dayOfMonth) {
             super(context, theme, listener, year, month, dayOfMonth);
-            if (!showCalendar) {
+            this.theme = theme;
+            if (theme == android.R.style.Theme_Holo_Light_Dialog) {
                 setTitle(dialogTitle);
                 fixSpinner(context, year, month, dayOfMonth);
                 getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
@@ -273,7 +291,7 @@ public class DateWidget extends QuestionWidget {
         }
 
         public void setTitle(CharSequence title) {
-            if (!showCalendar) {
+            if (theme == android.R.style.Theme_Holo_Light_Dialog) {
                 super.setTitle(dialogTitle);
             }
         }


### PR DESCRIPTION
Closes #1424

#### Why is this the best possible solution? Were any other approaches considered?
As I said in the issue description it was visible on Collect 1.9.0 and Collect 1.9.1 but now there are many more instances so I'm pretty sure it's related to https://github.com/opendatakit/collect/pull/1399/files#diff-71ee66035a9814fa3226aa0ab0ddfd23R196 and I wasn't reproduce the issue. That's why I added [this](https://github.com/opendatakit/collect/pull/1425/files#diff-71ee66035a9814fa3226aa0ab0ddfd23R199) so now it works as before (using default dialog theme) for Samsungs API 21 and 22.

But I was able to reproduce this issue using TalkBack option and french language as described [here](https://stackoverflow.com/a/34853067/5479029)  and that's why I added https://github.com/opendatakit/collect/pull/1425/files#diff-71ee66035a9814fa3226aa0ab0ddfd23R202

I doubt someone uses TalkBack with ODK Collect as it's really hard but maybe someone has tried and that's why we can see similar crashes on 1.9.0 and 1.9.1.

#### Are there any risks to merging this code? If so, what are they?
It looks safe.
