### PR TITLE
Avoid crash if external data manager is null.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -83,6 +83,7 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.exception.GDriveConnectionException;
 import org.odk.collect.android.exception.JavaRosaException;
+import org.odk.collect.android.external.ExternalDataManager;
 import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.listeners.FormLoaderListener;
@@ -2025,7 +2026,10 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                             .logInstanceAction(this, "createQuitDialog", "discardAndExit");
 
                     // close all open databases of external data.
-                    Collect.getInstance().getExternalDataManager().close();
+                    ExternalDataManager manager = Collect.getInstance().getExternalDataManager();
+                    if (manager != null) {
+                        manager.close();
+                    }
 
                     FormController formController = Collect.getInstance().getFormController();
                     if (formController != null) {


### PR DESCRIPTION
Closes #1431

#### What has been done to verify that this works as intended?
I wasn't able to reproduce the crash but I can confirm that exiting without saving continues to work as expected.

#### Why is this the best possible solution? Were any other approaches considered?
I think it would be worth doing a more thorough review of how `ExternalDataManager` is used and when it should be closed. For now, this null check prevents the immediate crash so I think we should merge it.

#### Are there any risks to merging this code? If so, what are they?
None.
