### PR TITLE
Add an option in admin settings to prevent from uninstalling the app

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -276,6 +276,14 @@ the specific language governing permissions and limitations under the License.
                 <action android:name="com.google.android.gms.analytics.ANALYTICS_DISPATCH" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name="android.app.admin.DeviceAdminReceiver"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data android:name="android.app.device_admin" android:resource="@xml/device_admin"/>
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
         <service
             android:name="com.google.android.gms.analytics.AnalyticsService"
             android:enabled="true"

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
@@ -35,6 +35,7 @@ public final class AdminKeys {
     // server
     static final String KEY_CHANGE_ADMIN_PASSWORD               = "admin_password";
     static final String KEY_IMPORT_SETTINGS                     = "import_settings";
+    static final String KEY_PREVENT_UNINSTALLING                = "prevent_uninstalling";
     public static final String KEY_CHANGE_SERVER               = "change_server";
     public static final String KEY_CHANGE_FORM_METADATA        = "change_form_metadata";
 

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -516,4 +516,7 @@
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
+    <string name="prevent_uninstalling">Prevent uninstalling</string>
+    <string name="enabled">Enabled</string>
+    <string name="disabled">Disabled</string>
 </resources>

--- a/collect_app/src/main/res/xml/admin_preferences.xml
+++ b/collect_app/src/main/res/xml/admin_preferences.xml
@@ -29,6 +29,10 @@
         android:key="import_settings"
         android:title="@string/import_settings" />
 
+    <Preference
+        android:key="prevent_uninstalling"
+        android:title="@string/prevent_uninstalling" />
+
     <PreferenceCategory android:title="@string/user_access_control">
 
         <PreferenceScreen

--- a/collect_app/src/main/res/xml/device_admin.xml
+++ b/collect_app/src/main/res/xml/device_admin.xml
@@ -1,0 +1,1 @@
+<device-admin></device-admin>


### PR DESCRIPTION
Closes #1428 

#### What has been done to verify that this works as intended?
I've tested enabling/disabling implemented option.

#### Why is this the best possible solution? Were any other approaches considered?
It's not a perfect solution because we still can deactivate device administrator in device settings but I believe it should be enough for lots of our enumerators who are not really familiar with new technology.

There is no better solution and since it wasn't a big effort to implement it I decided to do that to show you how it works @lognaturel it's your decisions what's next. As I said it might be useful but it's not perfect so sneaky users might disable it in a device settings.

#### Are there any risks to merging this code? If so, what are they?
I can't find any.
