### PR TITLE
Use JavaRosa 2.5.1.

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     compile group: 'joda-time', name: 'joda-time', version: '2.9.7'
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
-    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.0'
+    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.1'
     compile group: 'org.osmdroid', name: 'osmdroid-android', version: '5.6.4'
     compile group: 'org.slf4j', name: 'slf4j-android', version: '1.6.1-RC1'
     compile group: 'pub.devrel', name: 'easypermissions', version: '0.2.1'


### PR DESCRIPTION
JavaRosa update to fix opendatakit/javarosa#180

#### What has been done to verify that this works as intended?
Verified that I could reproduce the crash on v1.10.1 then followed the same steps on this branch. Confirmed that there is no stack trace.

#### Why is this the best possible solution? Were any other approaches considered?
It's a one-line change on the JR side supported by tests.

#### Are there any risks to merging this code? If so, what are they?
None. One-line change.