### PR TITLE
Explicitly excludes each rule in PMD ruleset

### DIFF
--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -34,13 +34,37 @@
     </rule>
     <rule ref="rulesets/java/logging-java.xml"/>
     <rule ref="rulesets/java/braces.xml"/>
-    <!--<rule ref="rulesets/java/strings.xml"/>
-    <rule ref="rulesets/java/basic.xml"/>
+    <rule ref="rulesets/java/strings.xml">
+        <exclude name="AvoidDuplicateLiterals" />
+        <exclude name="InefficientEmptyStringCheck" />
+        <exclude name="UseIndexOfChar" />
+        <exclude name="AppendCharacterWithChar" />
+        <exclude name="InefficientStringBuffering" />
+        <exclude name="ConsecutiveAppendsShouldReuse" />
+        <exclude name="UseEqualsToCompareStrings" />
+        <exclude name="ConsecutiveLiteralAppends" />
+        <exclude name="InsufficientStringBufferDeclaration" />
+        <exclude name="UselessStringValueOf" />
+        <exclude name="AvoidStringBufferField" />
+    </rule>
+    <rule ref="rulesets/java/basic.xml">
+        <exclude name="BigIntegerInstantiation" />
+        <exclude name="DontUseFloatTypeForLoopIndices" />
+        <exclude name="CollapsibleIfStatements" />
+        <exclude name="SimplifiedTernary" />
+        <exclude name="AvoidBranchingStatementAsLastInLoop" />
+        <exclude name="ReturnFromFinallyBlock" />
+    </rule>
     <rule ref="rulesets/java/naming.xml">
         <exclude name="AbstractNaming"/>
         <exclude name="LongVariable"/>
         <exclude name="ShortMethodName"/>
         <exclude name="ShortVariable"/>
         <exclude name="VariableNamingConventions"/>
-    </rule>-->
+        <exclude name="AvoidFieldNameMatchingMethodName"/>
+        <exclude name="ShortClassName"/>
+        <exclude name="MethodNamingConventions"/>
+        <exclude name="AvoidFieldNameMatchingTypeName"/>
+        <exclude name="BooleanGetMethodName"/>
+    </rule>
 </ruleset>


### PR DESCRIPTION
This PR excludes the rules detected by PMD explicitly

#### Why is this the best possible solution? Were any other approaches considered?
This is the better approach as we can fix each of them separately in separate PRs

#### Are there any risks to merging this code? If so, what are they?
It only excludes the rules from `pmd-ruleset.xml` so it's pretty safe to be merged

After merging this, we can add an issue to keep a track of all the remaining issues