### PR TITLE
Adds pmd rule BooleanGetMethodName

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2707,7 +2707,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             case SaveToDiskTask.SAVED_AND_EXIT:
                 ToastUtils.showShortToast(R.string.data_saved_ok);
                 formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_SAVE, 0, null, false, false);
-                if (saveResult.getComplete()) {
+                if (saveResult.isComplete()) {
                     formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_EXIT, 0, null, false, false);
                     formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_FINALIZE, 0, null, false, true);     // Force writing of audit since we are exiting
                 } else {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveResult.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveResult.java
@@ -33,7 +33,7 @@ public class SaveResult {
         return saveResult;
     }
 
-    public boolean getComplete() {
+    public boolean isComplete() {
         return complete;
     }
 

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -63,6 +63,5 @@
         <exclude name="ShortClassName"/>
         <exclude name="MethodNamingConventions"/>
         <exclude name="AvoidFieldNameMatchingTypeName"/>
-        <exclude name="BooleanGetMethodName"/>
     </rule>
 </ruleset>


### PR DESCRIPTION
Adds pmd naming rule BooleanGetMethodName.
This rule suggests that any method `getX()` returning a boolean should be renamed `isX()`  