### PR TITLE
Added downgrade method for forms and instances databases

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilderTestCase.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilderTestCase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.application.Collect;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class CustomSQLiteQueryBuilderTestCase {
+
+    private static final String DATABASE_PATH = Collect.METADATA_PATH + "/test.db";
+    private static final String TEST_TABLE_NAME = "testTable";
+    private static final String TEST_TABLE_NAME_2 = "testTable2";
+
+    private String[] tableColumns = new String[] {"_id", "col1", "col2", "col3"};
+
+    private SQLiteDatabase sqLiteDatabase;
+
+    @Before
+    public void setUp() {
+        sqLiteDatabase = SQLiteDatabase.openOrCreateDatabase(DATABASE_PATH, null, null);
+        dropTable(TEST_TABLE_NAME);
+        dropTable(TEST_TABLE_NAME_2);
+    }
+
+    @Test
+    public void dropTableTest() {
+        createTestTable();
+        assertTrue(tableExists(TEST_TABLE_NAME));
+        CustomSQLiteQueryBuilder
+                .begin(sqLiteDatabase)
+                .dropIfExists(TEST_TABLE_NAME)
+                .end();
+        assertFalse(tableExists(TEST_TABLE_NAME));
+    }
+
+    @Test
+    public void renameTableTest() {
+        createTestTable();
+        insertExampleData(TEST_TABLE_NAME);
+        assertTrue(tableExists(TEST_TABLE_NAME));
+        assertFalse(tableExists(TEST_TABLE_NAME_2));
+        checkValues(TEST_TABLE_NAME);
+        CustomSQLiteQueryBuilder
+                .begin(sqLiteDatabase)
+                .renameTable(TEST_TABLE_NAME)
+                .to(TEST_TABLE_NAME_2)
+                .end();
+        assertFalse(tableExists(TEST_TABLE_NAME));
+        assertTrue(tableExists(TEST_TABLE_NAME_2));
+        checkValues(TEST_TABLE_NAME_2);
+    }
+
+    @Test
+    public void copyTableTest() {
+        createTestTable();
+        insertExampleData(TEST_TABLE_NAME);
+        assertTrue(tableExists(TEST_TABLE_NAME));
+        assertFalse(tableExists(TEST_TABLE_NAME_2));
+        checkValues(TEST_TABLE_NAME);
+
+        CustomSQLiteQueryBuilder
+                .begin(sqLiteDatabase)
+                .renameTable(TEST_TABLE_NAME)
+                .to(TEST_TABLE_NAME_2)
+                .end();
+
+        assertFalse(tableExists(TEST_TABLE_NAME));
+        assertTrue(tableExists(TEST_TABLE_NAME_2));
+        checkValues(TEST_TABLE_NAME_2);
+
+        createTestTable();
+
+        CustomSQLiteQueryBuilder
+                .begin(sqLiteDatabase)
+                .insertInto(TEST_TABLE_NAME)
+                .columnsForInsert(tableColumns)
+                .select()
+                .columnsForSelect(tableColumns)
+                .from(TEST_TABLE_NAME_2)
+                .end();
+
+        checkValues(TEST_TABLE_NAME);
+
+        CustomSQLiteQueryBuilder
+                .begin(sqLiteDatabase)
+                .dropIfExists(TEST_TABLE_NAME_2)
+                .end();
+
+        assertTrue(tableExists(TEST_TABLE_NAME));
+        assertFalse(tableExists(TEST_TABLE_NAME_2));
+    }
+
+    private void dropTable(String tableName) {
+        CustomSQLiteQueryBuilder
+                .begin(sqLiteDatabase)
+                .dropIfExists(tableName)
+                .end();
+        assertFalse(tableExists(tableName));
+    }
+
+    private void checkValues(String tableName) {
+        Cursor cursor = sqLiteDatabase.rawQuery("SELECT * FROM " + tableName, null);
+        int index = 1;
+        if (cursor != null) {
+            try {
+                while (cursor.moveToNext()) {
+                    assertEquals(String.valueOf(index), cursor.getString(cursor.getColumnIndex("_id")));
+                    assertEquals("col" + index + "x1Value", cursor.getString(cursor.getColumnIndex("col1")));
+                    assertEquals("col" + index + "x2Value", cursor.getString(cursor.getColumnIndex("col2")));
+                    assertEquals("col" + index + "x3Value", cursor.getString(cursor.getColumnIndex("col3")));
+
+                    index++;
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+    }
+
+    private void createTestTable() {
+        sqLiteDatabase.execSQL("CREATE TABLE " + TEST_TABLE_NAME + " ("
+                + "_id" + " integer primary key, "
+                + "col1" + " text not null, "
+                + "col2" + " text, "
+                + "col3" + " text);");
+    }
+
+    private void insertExampleData(String tableName) {
+        sqLiteDatabase.execSQL("INSERT INTO " + tableName + " VALUES "
+                + "(1, 'col1x1Value', 'col1x2Value', 'col1x3Value'), "
+                + "(2, 'col2x1Value', 'col2x2Value', 'col2x3Value'), "
+                + "(3, 'col3x1Value', 'col3x2Value', 'col3x3Value');");
+    }
+
+    private boolean tableExists(String tableName) {
+        boolean isExist = false;
+        Cursor cursor = sqLiteDatabase.rawQuery("select DISTINCT tbl_name from sqlite_master where tbl_name = '" + tableName + "'", null);
+        if (cursor != null) {
+            if (cursor.getCount() > 0) {
+                isExist = true;
+            }
+            cursor.close();
+        }
+        return isExist;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
@@ -23,6 +23,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.DatabaseContext;
 import org.odk.collect.android.provider.FormsProviderAPI;
+import org.odk.collect.android.utilities.SQLiteQueryBuilder;
 
 import timber.log.Timber;
 
@@ -45,29 +46,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        onCreateNamed(db, FORMS_TABLE_NAME);
-    }
-
-    private void onCreateNamed(SQLiteDatabase db, String tableName) {
-        db.execSQL("CREATE TABLE " + tableName + " (" + FormsProviderAPI.FormsColumns._ID
-                + " integer primary key, " + FormsProviderAPI.FormsColumns.DISPLAY_NAME
-                + " text not null, " + FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT
-                + " text not null, " + FormsProviderAPI.FormsColumns.DESCRIPTION
-                + " text, "
-                + FormsProviderAPI.FormsColumns.JR_FORM_ID
-                + " text not null, "
-                + FormsProviderAPI.FormsColumns.JR_VERSION
-                + " text, "
-                + FormsProviderAPI.FormsColumns.MD5_HASH
-                + " text not null, "
-                + FormsProviderAPI.FormsColumns.DATE
-                + " integer not null, " // milliseconds
-                + FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH + " text not null, "
-                + FormsProviderAPI.FormsColumns.FORM_FILE_PATH + " text not null, "
-                + FormsProviderAPI.FormsColumns.LANGUAGE + " text, "
-                + FormsProviderAPI.FormsColumns.SUBMISSION_URI + " text, "
-                + FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY + " text, "
-                + FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH + " text not null);");
+        createFormsTable(db, FORMS_TABLE_NAME);
     }
 
     @SuppressWarnings({"checkstyle:FallThrough"})
@@ -94,6 +73,28 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
         }
     }
 
+    @Override
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        boolean success = true;
+        try {
+            SQLiteQueryBuilder
+                    .begin(db)
+                    .dropIfExists(FORMS_TABLE_NAME)
+                    .end();
+
+            createFormsTable(db, FORMS_TABLE_NAME);
+        } catch (SQLiteException e) {
+            Timber.e(e);
+            success = false;
+        }
+
+        if (success) {
+            Timber.i("Downgrading database completed with success.");
+        } else {
+            Timber.i("Downgrading database from version " + oldVersion + " to " + newVersion + " failed.");
+        }
+    }
+
     private boolean upgradeToVersion2(SQLiteDatabase db) {
         boolean success = true;
         try {
@@ -112,7 +113,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
             // adding BASE64_RSA_PUBLIC_KEY and changing type and name of
             // integer MODEL_VERSION to text VERSION
             db.execSQL("DROP TABLE IF EXISTS " + TEMP_FORMS_TABLE_NAME);
-            onCreateNamed(db, TEMP_FORMS_TABLE_NAME);
+            createFormsTable(db, TEMP_FORMS_TABLE_NAME);
             db.execSQL("INSERT INTO "
                     + TEMP_FORMS_TABLE_NAME
                     + " ("
@@ -179,7 +180,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
 
             // risky failures here...
             db.execSQL("DROP TABLE IF EXISTS " + FORMS_TABLE_NAME);
-            onCreateNamed(db, FORMS_TABLE_NAME);
+            createFormsTable(db, FORMS_TABLE_NAME);
             db.execSQL("INSERT INTO "
                     + FORMS_TABLE_NAME
                     + " ("
@@ -232,5 +233,27 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
         }
 
         return success;
+    }
+
+    private void createFormsTable(SQLiteDatabase db, String tableName) {
+        db.execSQL("CREATE TABLE " + tableName + " (" + FormsProviderAPI.FormsColumns._ID
+                + " integer primary key, " + FormsProviderAPI.FormsColumns.DISPLAY_NAME
+                + " text not null, " + FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT
+                + " text not null, " + FormsProviderAPI.FormsColumns.DESCRIPTION
+                + " text, "
+                + FormsProviderAPI.FormsColumns.JR_FORM_ID
+                + " text not null, "
+                + FormsProviderAPI.FormsColumns.JR_VERSION
+                + " text, "
+                + FormsProviderAPI.FormsColumns.MD5_HASH
+                + " text not null, "
+                + FormsProviderAPI.FormsColumns.DATE
+                + " integer not null, " // milliseconds
+                + FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH + " text not null, "
+                + FormsProviderAPI.FormsColumns.FORM_FILE_PATH + " text not null, "
+                + FormsProviderAPI.FormsColumns.LANGUAGE + " text, "
+                + FormsProviderAPI.FormsColumns.SUBMISSION_URI + " text, "
+                + FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY + " text, "
+                + FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH + " text not null);");
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
@@ -23,7 +23,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.DatabaseContext;
 import org.odk.collect.android.provider.FormsProviderAPI;
-import org.odk.collect.android.utilities.SQLiteQueryBuilder;
+import org.odk.collect.android.utilities.CustomSQLiteQueryBuilder;
 
 import timber.log.Timber;
 
@@ -77,7 +77,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
     public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
         boolean success = true;
         try {
-            SQLiteQueryBuilder
+            CustomSQLiteQueryBuilder
                     .begin(db)
                     .dropIfExists(FORMS_TABLE_NAME)
                     .end();

--- a/collect_app/src/main/java/org/odk/collect/android/database/helpers/InstancesDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/helpers/InstancesDatabaseHelper.java
@@ -24,7 +24,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.DatabaseContext;
 import org.odk.collect.android.provider.InstanceProviderAPI;
-import org.odk.collect.android.utilities.SQLiteQueryBuilder;
+import org.odk.collect.android.utilities.CustomSQLiteQueryBuilder;
 
 import timber.log.Timber;
 
@@ -158,7 +158,7 @@ public class InstancesDatabaseHelper extends SQLiteOpenHelper {
         String temporaryTable = INSTANCES_TABLE_NAME + "_tmp";
 
         try {
-            SQLiteQueryBuilder
+            CustomSQLiteQueryBuilder
                     .begin(db)
                     .renameTable(INSTANCES_TABLE_NAME)
                     .to(temporaryTable)
@@ -167,7 +167,7 @@ public class InstancesDatabaseHelper extends SQLiteOpenHelper {
             createInstancesTable(db);
 
             // Try to avoid renaming columns in the future since restoring data after downgrade might not work
-            SQLiteQueryBuilder
+            CustomSQLiteQueryBuilder
                     .begin(db)
                     .insertInto(INSTANCES_TABLE_NAME)
                     .columnsForInsert(instancesTableColumns)
@@ -176,7 +176,7 @@ public class InstancesDatabaseHelper extends SQLiteOpenHelper {
                     .from(temporaryTable)
                     .end();
 
-            SQLiteQueryBuilder
+            CustomSQLiteQueryBuilder
                     .begin(db)
                     .dropIfExists(temporaryTable)
                     .end();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilder.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilder.java
@@ -19,7 +19,7 @@ package org.odk.collect.android.utilities;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 
-public class SQLiteQueryBuilder {
+public class CustomSQLiteQueryBuilder {
     private static final String SPACE = " ";
     private static final String SEMICOLON = ";";
 
@@ -27,13 +27,23 @@ public class SQLiteQueryBuilder {
 
     private StringBuilder query;
 
-    private SQLiteQueryBuilder(SQLiteDatabase db) {
+    // Only for tests
+    CustomSQLiteQueryBuilder() {
+        this(null);
+    }
+
+    // Only for tests
+    public StringBuilder getQuery() {
+        return query;
+    }
+
+    private CustomSQLiteQueryBuilder(SQLiteDatabase db) {
         this.db = db;
         query = new StringBuilder();
     }
 
-    public static SQLiteQueryBuilder begin(SQLiteDatabase db) {
-        return new SQLiteQueryBuilder(db);
+    public static CustomSQLiteQueryBuilder begin(SQLiteDatabase db) {
+        return new CustomSQLiteQueryBuilder(db);
     }
 
     public void end() throws SQLiteException {
@@ -41,19 +51,19 @@ public class SQLiteQueryBuilder {
         db.execSQL(query.toString());
     }
 
-    public SQLiteQueryBuilder select() {
+    public CustomSQLiteQueryBuilder select() {
         query.append("SELECT").append(SPACE);
         return this;
     }
 
-    public SQLiteQueryBuilder columnsForInsert(String... columns) {
+    public CustomSQLiteQueryBuilder columnsForInsert(String... columns) {
         query.append("(");
         columnsForSelect(columns);
         query.append(")").append(SPACE);
         return this;
     }
 
-    public SQLiteQueryBuilder columnsForSelect(String... columns) {
+    public CustomSQLiteQueryBuilder columnsForSelect(String... columns) {
         for (String column : columns) {
             query.append(column).append(",");
         }
@@ -62,58 +72,28 @@ public class SQLiteQueryBuilder {
         return this;
     }
 
-    public SQLiteQueryBuilder from(String table) {
+    public CustomSQLiteQueryBuilder from(String table) {
         query.append("FROM").append(SPACE).append(table).append(SPACE);
         return this;
     }
 
-    public SQLiteQueryBuilder renameTable(String table) {
+    public CustomSQLiteQueryBuilder renameTable(String table) {
         query.append("ALTER TABLE").append(SPACE).append(table).append(SPACE).append("RENAME TO").append(SPACE);
         return this;
     }
 
-    public SQLiteQueryBuilder dropIfExists(String table) {
-        query.append("DROP TABLE IF EXISTS").append(SPACE).append(table).append(SPACE);
-        return this;
-    }
-
-    public SQLiteQueryBuilder to(String table) {
+    public CustomSQLiteQueryBuilder to(String table) {
         query.append(table);
         return this;
     }
 
-    public SQLiteQueryBuilder insertInto(String table) {
+    public CustomSQLiteQueryBuilder dropIfExists(String table) {
+        query.append("DROP TABLE IF EXISTS").append(SPACE).append(table).append(SPACE);
+        return this;
+    }
+
+    public CustomSQLiteQueryBuilder insertInto(String table) {
         query.append("INSERT INTO").append(SPACE).append(table);
-        return this;
-    }
-
-    public SQLiteQueryBuilder alter() {
-        query.append("ALTER").append(SPACE);
-        return this;
-    }
-
-    public SQLiteQueryBuilder table(final String table) {
-        query.append("TABLE").append(SPACE).append(table).append(SPACE);
-        return this;
-    }
-
-    public SQLiteQueryBuilder defaultValue(final Object defaultValue) {
-        query.append("DEFAULT").append(SPACE).append(defaultValue).append(SPACE);
-        return this;
-    }
-
-    public SQLiteQueryBuilder where() {
-        query.append("WHERE").append(SPACE);
-        return this;
-    }
-
-    public SQLiteQueryBuilder column(final String column) {
-        query.append(column).append(SPACE);
-        return this;
-    }
-
-    public SQLiteQueryBuilder isNull() {
-        query.append("IS NULL").append(SPACE);
         return this;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/SQLiteQueryBuilder.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/SQLiteQueryBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
+
+public class SQLiteQueryBuilder {
+    private static final String SPACE = " ";
+    private static final String SEMICOLON = ";";
+
+    private final SQLiteDatabase db;
+
+    private StringBuilder query;
+
+    private SQLiteQueryBuilder(SQLiteDatabase db) {
+        this.db = db;
+        query = new StringBuilder();
+    }
+
+    public static SQLiteQueryBuilder begin(SQLiteDatabase db) {
+        return new SQLiteQueryBuilder(db);
+    }
+
+    public void end() throws SQLiteException {
+        query.append(SEMICOLON);
+        db.execSQL(query.toString());
+    }
+
+    public SQLiteQueryBuilder select() {
+        query.append("SELECT").append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder columnsForInsert(String... columns) {
+        query.append("(");
+        columnsForSelect(columns);
+        query.append(")").append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder columnsForSelect(String... columns) {
+        for (String column : columns) {
+            query.append(column).append(",");
+        }
+        int lastCommaIndex = query.lastIndexOf(",");
+        query.deleteCharAt(lastCommaIndex).append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder from(String table) {
+        query.append("FROM").append(SPACE).append(table).append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder renameTable(String table) {
+        query.append("ALTER TABLE").append(SPACE).append(table).append(SPACE).append("RENAME TO").append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder dropIfExists(String table) {
+        query.append("DROP TABLE IF EXISTS").append(SPACE).append(table).append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder to(String table) {
+        query.append(table);
+        return this;
+    }
+
+    public SQLiteQueryBuilder insertInto(String table) {
+        query.append("INSERT INTO").append(SPACE).append(table);
+        return this;
+    }
+
+    public SQLiteQueryBuilder alter() {
+        query.append("ALTER").append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder table(final String table) {
+        query.append("TABLE").append(SPACE).append(table).append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder defaultValue(final Object defaultValue) {
+        query.append("DEFAULT").append(SPACE).append(defaultValue).append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder where() {
+        query.append("WHERE").append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder column(final String column) {
+        query.append(column).append(SPACE);
+        return this;
+    }
+
+    public SQLiteQueryBuilder isNull() {
+        query.append("IS NULL").append(SPACE);
+        return this;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilderTestCase.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilderTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CustomSQLiteQueryBuilderTestCase {
+
+    private String[] columns = new String[] {"_id", "col1", "col2", "col3"};
+
+    @Test
+    public void selectTest() {
+        assertEquals("SELECT ", new CustomSQLiteQueryBuilder().select().getQuery().toString());
+    }
+
+    @Test
+    public void columnsForInsertTest() {
+        assertEquals("(_id,col1,col2,col3 ) ", new CustomSQLiteQueryBuilder().columnsForInsert(columns).getQuery().toString());
+    }
+
+    @Test
+    public void columnsForSelectTest() {
+        assertEquals("_id,col1,col2,col3 ", new CustomSQLiteQueryBuilder().columnsForSelect(columns).getQuery().toString());
+    }
+
+    @Test
+    public void fromTest() {
+        assertEquals("FROM testTableName ", new CustomSQLiteQueryBuilder().from("testTableName").getQuery().toString());
+    }
+
+    @Test
+    public void renameTableTest() {
+        assertEquals("ALTER TABLE testTableName RENAME TO ", new CustomSQLiteQueryBuilder().renameTable("testTableName").getQuery().toString());
+    }
+
+    @Test
+    public void toTest() {
+        assertEquals("testTableName", new CustomSQLiteQueryBuilder().to("testTableName").getQuery().toString());
+    }
+
+
+    @Test
+    public void dropIfExistsTest() {
+        assertEquals("DROP TABLE IF EXISTS testTableName ", new CustomSQLiteQueryBuilder().dropIfExists("testTableName").getQuery().toString());
+    }
+
+    @Test
+    public void insertIntoTest() {
+        assertEquals("INSERT INTO testTableName", new CustomSQLiteQueryBuilder().insertInto("testTableName").getQuery().toString());
+    }
+}


### PR DESCRIPTION
Closes #1452 

I decided to implement onDowngrade methods for forms and instances databases since these databases will be likely extended in the future so we really need that.

#### What has been done to verify that this works as intended?
I've tested upgrade/downgrade forms and instances databases using this scenario:
1. I installed this version 
2. Then I created new branch and added new columns for both tables.
3. I installed that version (upgrade went well)
4. I returned to this original branch and installed it again (downgrade went well)

**I was able to keep all data and have original tables in both cases.**  

#### Why is this the best possible solution? Were any other approaches considered?
Overall downgrading hasn't been supported in Android since 4.x? (I'm not sure about the version - it's not important). If you try to install an older app when you have a newer version of it you are asked to uninstall your current newer version first. Then all data is cleared (databases too) and that's why in most cases the problem with downgrading doesn't exist in other apps. In ODK Collect we store databases using external storage and we want to keep all data even if someone tries to downgrade (what might be dangerous - there were some related issues).

There is no a perfect way to restore old database and keep all data. 
When it comes to forms database I decided just to drop existed table and created new one (appropriate for new version). Then the database is auto filled using scanning forms functionality and it works well. Easy!
https://github.com/opendatakit/collect/pull/1453/files#diff-0c930d81466089bfec86df65dbef3a4eR80

When it comes to instances database it's not as easy as before because in instances table we have data like status for example (which can't be properly restored using scanning instances functionality). That's why I decided to recreate this table (like it was in the previous cases) but also read all data from original (old) table and try to insert to the new one. 
https://github.com/opendatakit/collect/pull/1453/files#diff-c6a9cd678a1a4f071894e0b4efe6cd92R161
This approach works well (I tested it) in described above scenario (if you only add/remove columns) but it's not possible to read/insert data if columns are renamed for example (so we should try to avoid such an operations). In the worst case if you rename any column and try to downgrade insert doesn't work and all data will be restored using scanning instances functionality.

To sum up: It should be a perfect solution when it comes to `forms.db` as we can restore all data scanning for forms. For `instnces.db` it should be also perfect solution assuming we don't implement changes like renaming columns (adding/removing columns is ok) in the worst case all data will be restored using scanning functionality too.

#### Are there any risks to merging this code? If so, what are they?
I think it's safe.
