### PR TITLE
converted non-short-circuiting operations to short-circuiting ones

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -366,7 +366,7 @@ public class GeoPointMapActivity extends FragmentActivity implements OnMarkerDra
     }
 
     private void overlayMyLocationLayers() {
-        if (draggable & !readOnly) {
+        if (draggable && !readOnly) {
             map.setOnMarkerDragListener(this);
             map.setOnMapLongClickListener(this);
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -338,7 +338,7 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
 
     private void overlayMyLocationLayers() {
         map.getOverlays().add(myLocationOverlay);
-        if (draggable & !readOnly) {
+        if (draggable && !readOnly) {
             if (marker != null) {
                 marker.setOnMarkerDragListener(this);
                 marker.setDraggable(true);


### PR DESCRIPTION
This code seems to be using non-short-circuit which causes both sides of the expression to be evaluated. the result can be inferred by only evaluating one side when using short-circuit operations.
Merging this code would not impact or change any other behaviour in the application.
