### PR TITLE
Adding Codecov for Test Coverage to CircleCI yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build status](https://circleci.com/gh/opendatakit/collect.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/opendatakit/collect)
 [![Slack status](http://slack.opendatakit.org/badge.svg)](http://slack.opendatakit.org)
+[![codecov.io](https://codecov.io/github/opendatakit/collect/branch/master/graph/badge.svg)](https://codecov.io/github/opendatakit/collect)
 
 ODK Collect is an Android app for filling out forms. It is designed to be used in resource-constrained environments with challenges such as unreliable connectivity or power infrastructure. ODK Collect is part of Open Data Kit (ODK), a free and open-source set of tools which help organizations author, field, and manage mobile data collection solutions. Learn more about the Open Data Kit project and its history [here](https://opendatakit.org/about/) and read about example ODK deployments [here](https://opendatakit.org/about/deployments/).
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![Platform](https://img.shields.io/badge/platform-Android-blue.svg)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build status](https://circleci.com/gh/opendatakit/collect.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/opendatakit/collect)
-[![Slack status](http://slack.opendatakit.org/badge.svg)](http://slack.opendatakit.org)
 [![codecov.io](https://codecov.io/github/opendatakit/collect/branch/master/graph/badge.svg)](https://codecov.io/github/opendatakit/collect)
+[![Slack status](http://slack.opendatakit.org/badge.svg)](http://slack.opendatakit.org)
 
 ODK Collect is an Android app for filling out forms. It is designed to be used in resource-constrained environments with challenges such as unreliable connectivity or power infrastructure. ODK Collect is part of Open Data Kit (ODK), a free and open-source set of tools which help organizations author, field, and manage mobile data collection solutions. Learn more about the Open Data Kit project and its history [here](https://opendatakit.org/about/) and read about example ODK deployments [here](https://opendatakit.org/about/deployments/).
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -65,3 +65,4 @@ test:
 
         - if [ $CIRCLE_BRANCH = 'master' ]; then cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS; fi
         - if [ $CIRCLE_BRANCH = 'master' ]; then cp -r collect_app/build/reports/androidTests/connected $CIRCLE_TEST_REPORTS/androidTests; fi
+        - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ test:
         - ./gradlew findbugs -Pandroid.useDexArchive=false
         - ./gradlew lint -Pandroid.useDexArchive=false
         - ./gradlew checkstyle -Pandroid.useDexArchive=false
-        - ./gradlew testDebugUnitTest -Pandroid.useDexArchive=false
+        - ./gradlew build jacocoTestReport testDebugUnitTest -Pandroid.useDexArchive=false
         
         # Instrumented tests take time, so only run them on master
         # SD card needed for circleci-android22 image

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'jacoco-android'
 apply from: '../config/quality.gradle'
 
 import com.android.ddmlib.DdmPreferences


### PR DESCRIPTION
Integrates [CodeCov](https://codecov.io/) to [CircleCI](https://circleci.com) as a part of automatic building process 

#### What has been done to verify that this works as intended?
Successfully implemented it on the [forked](https://github.com/shobhitagarwal1612/collect) repo

#### Why is this the best possible solution? Were any other approaches considered?
Codecov was decided as a better option as discussed on the [forum](https://forum.opendatakit.org/t/adding-code-coverage-tool/9786)

#### Are there any risks to merging this code? If so, what are they?
Maybe. We can also include a local yaml for customizing more settings. [more info](https://github.com/codecov/support/wiki/Codecov-Yaml)

![screenshot](https://forum.opendatakit.org/uploads/default/original/2X/a/a03722b48e153b9864cb24c35f5405705d8c4c3c.png)


