### PR TITLE
Replaced == with .equals() in String comparasion

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -310,7 +310,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         String startingXPath = null;
         String waitingXPath = null;
         String instancePath = null;
-        Boolean newForm = true;
+        boolean newForm = true;
         autoSaved = false;
         if (savedInstanceState != null) {
             if (savedInstanceState.containsKey(KEY_FORMPATH)) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -366,7 +366,7 @@ public class GeoPointMapActivity extends FragmentActivity implements OnMarkerDra
     }
 
     private void overlayMyLocationLayers() {
-        if (draggable & !readOnly) {
+        if (draggable && !readOnly) {
             map.setOnMarkerDragListener(this);
             map.setOnMapLongClickListener(this);
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -95,11 +95,11 @@ public class GeoPointMapActivity extends FragmentActivity implements OnMarkerDra
 
     private boolean setClear = false;
     private boolean captureLocation = false;
-    private Boolean foundFirstLocation = false;
-    private Boolean readOnly = false;
-    private Boolean draggable = false;
-    private Boolean intentDraggable = false;
-    private Boolean locationFromIntent = false;
+    private boolean foundFirstLocation = false;
+    private boolean readOnly = false;
+    private boolean draggable = false;
+    private boolean intentDraggable = false;
+    private boolean locationFromIntent = false;
 
     private boolean isMapReady = false;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -338,7 +338,7 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
 
     private void overlayMyLocationLayers() {
         map.getOverlays().add(myLocationOverlay);
-        if (draggable & !readOnly) {
+        if (draggable && !readOnly) {
             if (marker != null) {
                 marker.setOnMarkerDragListener(this);
                 marker.setDraggable(true);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -94,12 +94,12 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
 
     public MyLocationNewOverlay myLocationOverlay;
 
-    private Boolean readOnly = false;
-    private Boolean draggable = false;
-    private Boolean intentDraggable = false;
-    private Boolean locationFromIntent = false;
+    private boolean readOnly = false;
+    private boolean draggable = false;
+    private boolean intentDraggable = false;
+    private boolean locationFromIntent = false;
     private int locationCountNum = 0;
-    private Boolean foundFirstLocation = false;
+    private boolean foundFirstLocation = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -80,7 +80,7 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
     private View zoomDialogView;
     private Button zoomPointButton;
     private Button zoomLocationButton;
-    private Boolean foundFirstLocation = false;
+    private boolean foundFirstLocation = false;
 
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
@@ -69,10 +69,10 @@ public class GeoShapeOsmMapActivity extends Activity implements IRegisterReceive
     private MapEventsOverlay overlayEvents;
     private boolean clearButtonTest = false;
     private ImageButton clearButton;
-    public Boolean gpsStatus = true;
+    public boolean gpsStatus = true;
     private ImageButton locationButton;
     public MyLocationNewOverlay myLocationOverlay;
-    public Boolean dataLoaded = false;
+    public boolean dataLoaded = false;
 
     private MapHelper helper;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -85,9 +85,9 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     public AlertDialog.Builder dialogBuilder;
     private View polygonPolylineView;
     private AlertDialog alertDialog;
-    private Boolean beenPaused = false;
+    private boolean beenPaused = false;
     private Integer traceMode = 1; // 0 manual, 1 is automatic
-    private Boolean playCheck = false;
+    private boolean playCheck = false;
     private Spinner timeUnits;
     private Spinner timeDelay;
 
@@ -108,8 +108,8 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     private Button zoomPointButton;
     private Button zoomLocationButton;
 
-    private Boolean firstLocationFound = false;
-    private Boolean modeActive = false;
+    private boolean firstLocationFound = false;
+    private boolean modeActive = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -505,7 +505,7 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
         String units = timeUnits.getSelectedItem().toString();
         Long timeDelay;
         TimeUnit timeUnitsValue;
-        if (units == getString(R.string.minutes)) {
+        if (units.equals(getString(R.string.minutes))) {
             timeDelay = Long.parseLong(delay) * (60);
             timeUnitsValue = TimeUnit.SECONDS;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -619,7 +619,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
         String units = timeUnits.getSelectedItem().toString();
         Long timeDelay;
         TimeUnit timeUnitsValue;
-        if (units == getString(R.string.minutes)) {
+        if (units.equals(getString(R.string.minutes))) {
             timeDelay = Long.parseLong(delay) * (60); //Convert minutes to seconds
             timeUnitsValue = TimeUnit.SECONDS;
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -66,8 +66,8 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture schedulerHandler;
     public int zoomLevel = 3;
-    public Boolean gpsStatus = true;
-    private Boolean playCheck = false;
+    public boolean gpsStatus = true;
+    private boolean playCheck = false;
     private MapView mapView;
     public MyLocationNewOverlay myLocationOverlay;
     private ImageButton locationButton;
@@ -88,7 +88,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private Integer traceMode; // 0 manual, 1 is automatic
     private Spinner timeUnits;
     private Spinner timeDelay;
-    private Boolean beenPaused;
+    private boolean beenPaused;
     private MapHelper helper;
 
     private AlertDialog zoomDialog;
@@ -97,7 +97,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private View zoomDialogView;
     private Button zoomPointButton;
     private Button zoomLocationButton;
-    private Boolean modeActive = false;
+    private boolean modeActive = false;
 
     private LocationClient locationClient;
 
@@ -875,7 +875,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
         disableMyLocation();
     }
 
-    public void setModeActive(Boolean modeActive) {
+    public void setModeActive(boolean modeActive) {
         this.modeActive = modeActive;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -50,8 +50,8 @@ import timber.log.Timber;
 public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
 
     private FormSavedListener savedListener;
-    private Boolean save;
-    private Boolean markCompleted;
+    private boolean save;
+    private boolean markCompleted;
     private Uri uri;
     private String instanceName;
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
@@ -23,7 +23,7 @@ import timber.log.Timber;
 public class ResponseMessageParser {
     private HttpEntity httpEntity;
     private static final String MESSAGE_XML_TAG = "message";
-    public Boolean isValid = false;
+    public boolean isValid = false;
     public String messageResponse;
 
     public ResponseMessageParser(HttpEntity httpEntity) {


### PR DESCRIPTION
replace == and != with .equals when comparing Java Strings. == tests for reference equality whereas .equals() tests for value equality. this code may lead to bugs, especially when "new String("   ")" used instead of String literals.

Here is the String .equals() method:
public boolean equals(Object anObject) {
        if (this == anObject) {
            return true;
        }
        if (anObject instanceof String) {
            String anotherString = (String) anObject;
            int n = count;
            if (n == anotherString.count) {
                int i = 0;
                while (n-- != 0) {
                    if (charAt(i) != anotherString.charAt(i))
                            return false;
                    i++;
                }
                return true;
            }
        }
        return false;
    }