### PR TITLE
Prevents secondary instances from getting parsed as column name in InstanceGoogleSheetsUploader

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -808,7 +808,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                          *  and represents the data structure of the record that will be created
                          *  and submitted with the form.
                          *  Additional instances are called <secondary instances>.
-                         *  So breaking the loop after discovering the <primary instance> so that
+                         *  So, we are breaking the loop after discovering the <primary instance> so that
                          *  <secondary instances> don't get counted as field columns.
                          *
                          *  For more info read [this](https://opendatakit.github.io/xforms-spec/#instance)

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -788,7 +788,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                         depth++;
                         lastpush = depth;
                     }
-                    if (parser.getName().equals("instance") && parser.getAttributeCount() == 0) {
+                    if (parser.getName().equals("instance") && isMainInstance(parser)) {
                         getPaths = true;
                     }
                     break;
@@ -818,6 +818,16 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             }
             event = parser.next();
         }
+    }
+
+    /**
+     * Primary instances do not have any attribute
+     * whereas secondary instances must have an "id" attribute
+     * <p>
+     * https://github.com/opendatakit/collect/issues/1444
+     */
+    private boolean isMainInstance(XmlPullParser parser) {
+        return parser.getAttributeCount() == 0;
     }
 
     private void processInstanceXML(File instanceFile,

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -68,7 +68,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-
 import java.util.regex.Pattern;
 
 import timber.log.Timber;
@@ -789,7 +788,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                         depth++;
                         lastpush = depth;
                     }
-                    if (parser.getName().equals("instance")) {
+                    if (parser.getName().equals("instance") && parser.getAttributeCount() == 0) {
                         getPaths = true;
                     }
                     break;


### PR DESCRIPTION
Closes #1444 

#### What has been done to verify that this works as intended?
Successfully uploaded to google sheets using this form
[CARITASNPJ.xlsx](https://github.com/opendatakit/collect/files/1305312/CARITASNPJ.xlsx)

#### Why is this the best possible solution? Were any other approaches considered?
This approach restricts the secondary instances from getting added as column names on the basis of the number of attributes. Since primary instances have 0 attributes and secondary instances have 1 attribute "id" so it looked like a solution to this problem but I am not sure if this is the best approach.

#### Are there any risks to merging this code? If so, what are they?
I have very minimal knowledge of how and when secondary instances are created as I was not able to generate other form having secondary instances. @yanokwa @grzesiek2010 Can you please share your wisdom here? 