### PR TITLE
Fixes Circle CI build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ test:
         - ./gradlew findbugs -Pandroid.useDexArchive=false
         - ./gradlew lint -Pandroid.useDexArchive=false
         - ./gradlew checkstyle -Pandroid.useDexArchive=false
-        - ./gradlew build jacocoTestReport testDebugUnitTest -Pandroid.useDexArchive=false
+        - ./gradlew jacocoTestDebugUnitTestReport -Pandroid.useDexArchive=false
         
         # Instrumented tests take time, so only run them on master
         # SD card needed for circleci-android22 image


### PR DESCRIPTION
`jacocoTestReport` runs multiple gradle tasks including `pmd`, `check-style` and `find-bugs`. Also, the unitTest were getting run in release mode.

#### What has been done to verify that this works as intended?
Build is passing on CircleCI as well as locally

#### Why is this the best possible solution? Were any other approaches considered?
`jacocoTestDebugUnitTestReportonly ` executes only the unitTest task in debug mode.

#### Are there any risks to merging this code? If so, what are they?
No