### PR TITLE
Replaced Boolean objects with primitive boolean

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -310,7 +310,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         String startingXPath = null;
         String waitingXPath = null;
         String instancePath = null;
-        Boolean newForm = true;
+        boolean newForm = true;
         autoSaved = false;
         if (savedInstanceState != null) {
             if (savedInstanceState.containsKey(KEY_FORMPATH)) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -230,7 +230,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private boolean shownAlertDialogIsGroupRepeat;
 
     // used to limit forward/backward swipes to one per question
-    private boolean beenSwiped = false;
+    private boolean beenSwiped;
 
     private final Object saveDialogLock = new Object();
     private int viewCount = 0;
@@ -249,7 +249,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     }
 
     private SharedPreferences adminPreferences;
-    private boolean showNavigationButtons = false;
+    private boolean showNavigationButtons;
 
     private FormsDao formsDao;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -95,11 +95,11 @@ public class GeoPointMapActivity extends FragmentActivity implements OnMarkerDra
 
     private boolean setClear = false;
     private boolean captureLocation = false;
-    private Boolean foundFirstLocation = false;
-    private Boolean readOnly = false;
-    private Boolean draggable = false;
-    private Boolean intentDraggable = false;
-    private Boolean locationFromIntent = false;
+    private boolean foundFirstLocation = false;
+    private boolean readOnly = false;
+    private boolean draggable = false;
+    private boolean intentDraggable = false;
+    private boolean locationFromIntent = false;
 
     private boolean isMapReady = false;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -77,7 +77,7 @@ public class GeoPointMapActivity extends FragmentActivity implements OnMarkerDra
     private Location location;
     private ImageButton reloadLocation;
 
-    private boolean isDragged = false;
+    private boolean isDragged;
     private ImageButton showLocation;
 
     private int locationCount = 0;
@@ -93,15 +93,15 @@ public class GeoPointMapActivity extends FragmentActivity implements OnMarkerDra
     private Button zoomPointButton;
     private Button zoomLocationButton;
 
-    private boolean setClear = false;
-    private boolean captureLocation = false;
-    private boolean foundFirstLocation = false;
-    private boolean readOnly = false;
-    private boolean draggable = false;
-    private boolean intentDraggable = false;
-    private boolean locationFromIntent = false;
+    private boolean setClear;
+    private boolean captureLocation;
+    private boolean foundFirstLocation;
+    private boolean readOnly;
+    private boolean draggable;
+    private boolean intentDraggable;
+    private boolean locationFromIntent;
 
-    private boolean isMapReady = false;
+    private boolean isMapReady;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -77,9 +77,9 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
     private Location location;
     private ImageButton reloadLocationButton;
 
-    private boolean captureLocation = false;
-    private boolean setClear = false;
-    private boolean isDragged = false;
+    private boolean captureLocation;
+    private boolean setClear;
+    private boolean isDragged;
     private ImageButton showLocationButton;
 
     private int locationCount = 0;
@@ -94,12 +94,12 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
 
     public MyLocationNewOverlay myLocationOverlay;
 
-    private boolean readOnly = false;
-    private boolean draggable = false;
-    private boolean intentDraggable = false;
-    private boolean locationFromIntent = false;
+    private boolean readOnly;
+    private boolean draggable;
+    private boolean intentDraggable;
+    private boolean locationFromIntent;
     private int locationCountNum = 0;
-    private boolean foundFirstLocation = false;
+    private boolean foundFirstLocation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -94,12 +94,12 @@ public class GeoPointOsmMapActivity extends FragmentActivity implements Location
 
     public MyLocationNewOverlay myLocationOverlay;
 
-    private Boolean readOnly = false;
-    private Boolean draggable = false;
-    private Boolean intentDraggable = false;
-    private Boolean locationFromIntent = false;
+    private boolean readOnly = false;
+    private boolean draggable = false;
+    private boolean intentDraggable = false;
+    private boolean locationFromIntent = false;
     private int locationCountNum = 0;
-    private Boolean foundFirstLocation = false;
+    private boolean foundFirstLocation = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -80,7 +80,7 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
     private View zoomDialogView;
     private Button zoomPointButton;
     private Button zoomLocationButton;
-    private boolean foundFirstLocation = false;
+    private boolean foundFirstLocation;
 
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -80,7 +80,7 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
     private View zoomDialogView;
     private Button zoomPointButton;
     private Button zoomLocationButton;
-    private Boolean foundFirstLocation = false;
+    private boolean foundFirstLocation = false;
 
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
@@ -69,10 +69,10 @@ public class GeoShapeOsmMapActivity extends Activity implements IRegisterReceive
     private MapEventsOverlay overlayEvents;
     private boolean clearButtonTest = false;
     private ImageButton clearButton;
-    public Boolean gpsStatus = true;
+    public boolean gpsStatus = true;
     private ImageButton locationButton;
     public MyLocationNewOverlay myLocationOverlay;
-    public Boolean dataLoaded = false;
+    public boolean dataLoaded = false;
 
     private MapHelper helper;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeOsmMapActivity.java
@@ -67,12 +67,12 @@ public class GeoShapeOsmMapActivity extends Activity implements IRegisterReceive
     public static final int stroke_width = 5;
     public String finalReturnString;
     private MapEventsOverlay overlayEvents;
-    private boolean clearButtonTest = false;
+    private boolean clearButtonTest;
     private ImageButton clearButton;
     public boolean gpsStatus = true;
     private ImageButton locationButton;
     public MyLocationNewOverlay myLocationOverlay;
-    public boolean dataLoaded = false;
+    public boolean dataLoaded;
 
     private MapHelper helper;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -85,9 +85,9 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     public AlertDialog.Builder dialogBuilder;
     private View polygonPolylineView;
     private AlertDialog alertDialog;
-    private boolean beenPaused = false;
+    private boolean beenPaused;
     private Integer traceMode = 1; // 0 manual, 1 is automatic
-    private boolean playCheck = false;
+    private boolean playCheck;
     private Spinner timeUnits;
     private Spinner timeDelay;
 
@@ -108,8 +108,8 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     private Button zoomPointButton;
     private Button zoomLocationButton;
 
-    private boolean firstLocationFound = false;
-    private boolean modeActive = false;
+    private boolean firstLocationFound;
+    private boolean modeActive;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -85,9 +85,9 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     public AlertDialog.Builder dialogBuilder;
     private View polygonPolylineView;
     private AlertDialog alertDialog;
-    private Boolean beenPaused = false;
+    private boolean beenPaused = false;
     private Integer traceMode = 1; // 0 manual, 1 is automatic
-    private Boolean playCheck = false;
+    private boolean playCheck = false;
     private Spinner timeUnits;
     private Spinner timeDelay;
 
@@ -108,8 +108,8 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     private Button zoomPointButton;
     private Button zoomLocationButton;
 
-    private Boolean firstLocationFound = false;
-    private Boolean modeActive = false;
+    private boolean firstLocationFound = false;
+    private boolean modeActive = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -797,7 +797,7 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
 
     }
 
-    public void setModeActive(Boolean modeActive) {
+    public void setModeActive(boolean modeActive) {
         this.modeActive = modeActive;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -67,7 +67,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private ScheduledFuture schedulerHandler;
     public int zoomLevel = 3;
     public boolean gpsStatus = true;
-    private boolean playCheck = false;
+    private boolean playCheck;
     private MapView mapView;
     public MyLocationNewOverlay myLocationOverlay;
     private ImageButton locationButton;
@@ -97,7 +97,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private View zoomDialogView;
     private Button zoomPointButton;
     private Button zoomLocationButton;
-    private boolean modeActive = false;
+    private boolean modeActive;
 
     private LocationClient locationClient;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -66,8 +66,8 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture schedulerHandler;
     public int zoomLevel = 3;
-    public Boolean gpsStatus = true;
-    private Boolean playCheck = false;
+    public boolean gpsStatus = true;
+    private boolean playCheck = false;
     private MapView mapView;
     public MyLocationNewOverlay myLocationOverlay;
     private ImageButton locationButton;
@@ -88,7 +88,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private Integer traceMode; // 0 manual, 1 is automatic
     private Spinner timeUnits;
     private Spinner timeDelay;
-    private Boolean beenPaused;
+    private boolean beenPaused;
     private MapHelper helper;
 
     private AlertDialog zoomDialog;
@@ -97,7 +97,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
     private View zoomDialogView;
     private Button zoomPointButton;
     private Button zoomLocationButton;
-    private Boolean modeActive = false;
+    private boolean modeActive = false;
 
     private LocationClient locationClient;
 
@@ -875,7 +875,7 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
         disableMyLocation();
     }
 
-    public void setModeActive(Boolean modeActive) {
+    public void setModeActive(boolean modeActive) {
         this.modeActive = modeActive;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -478,7 +478,7 @@ public class FormController {
      * @return ANSWER_OK and leave index unchanged or change index to bad value and return error
      * type.
      */
-    public int validateAnswers(Boolean markCompleted) throws JavaRosaException {
+    public int validateAnswers(boolean markCompleted) throws JavaRosaException {
         ValidateOutcome outcome = getFormDef().validate(markCompleted);
         if (outcome != null) {
             this.jumpToIndex(outcome.failedPrompt);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -50,8 +50,8 @@ import timber.log.Timber;
 public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
 
     private FormSavedListener savedListener;
-    private Boolean save;
-    private Boolean markCompleted;
+    private boolean save;
+    private boolean markCompleted;
     private Uri uri;
     private String instanceName;
 
@@ -63,7 +63,7 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
     public static final int ENCRYPTION_ERROR = 505;
 
 
-    public SaveToDiskTask(Uri uri, Boolean saveAndExit, Boolean markCompleted, String updatedName) {
+    public SaveToDiskTask(Uri uri, boolean saveAndExit, boolean markCompleted, String updatedName) {
         this.uri = uri;
         save = saveAndExit;
         this.markCompleted = markCompleted;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
@@ -23,7 +23,7 @@ import timber.log.Timber;
 public class ResponseMessageParser {
     private HttpEntity httpEntity;
     private static final String MESSAGE_XML_TAG = "message";
-    public Boolean isValid = false;
+    public boolean isValid = false;
     public String messageResponse;
 
     public ResponseMessageParser(HttpEntity httpEntity) {
@@ -38,7 +38,7 @@ public class ResponseMessageParser {
         return httpEntity;
     }
 
-    public Boolean isValid() {
+    public boolean isValid() {
         return this.isValid;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
@@ -23,7 +23,7 @@ import timber.log.Timber;
 public class ResponseMessageParser {
     private HttpEntity httpEntity;
     private static final String MESSAGE_XML_TAG = "message";
-    public boolean isValid = false;
+    public boolean isValid;
     public String messageResponse;
 
     public ResponseMessageParser(HttpEntity httpEntity) {


### PR DESCRIPTION
Replaced `Boolean` objects with primitive booleans where instantiating Objects were not necessary. Booleans are more expensive to create, have 3 states and therefore increase the risk of NullPointerException

#### What has been done to verify that this works as intended?
ran lint, checkstyle and PMD

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
It's safe
