### PR TITLE
handles return value from methods

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -140,7 +140,7 @@ public class DrawActivity extends AppCompatActivity {
             loadOption = OPTION_DRAW;
             refImage = null;
             savepointImage = new File(Collect.TMPDRAWFILE_PATH);
-            savepointImage.delete();
+            FileUtils.deleteAndReport(savepointImage);
             output = new File(Collect.TMPFILE_PATH);
         } else {
             loadOption = extras.getString(OPTION);
@@ -161,7 +161,7 @@ public class DrawActivity extends AppCompatActivity {
                 }
             } else {
                 savepointImage = new File(Collect.TMPDRAWFILE_PATH);
-                savepointImage.delete();
+                FileUtils.deleteAndReport(savepointImage);
                 if (refImage != null && refImage.exists()) {
                     FileUtils.copyFile(refImage, savepointImage);
                 }
@@ -240,7 +240,7 @@ public class DrawActivity extends AppCompatActivity {
     }
 
     private void reset() {
-        savepointImage.delete();
+        FileUtils.deleteAndReport(savepointImage);
         if (!OPTION_SIGNATURE.equals(loadOption) && refImage != null
                 && refImage.exists()) {
             FileUtils.copyFile(refImage, savepointImage);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -761,7 +761,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 saveAudioVideoAnswer(mediaUri);
                 String filePath = MediaUtils.getDataColumn(this, mediaUri, null, null);
                 if (filePath != null) {
-                    new File(filePath).delete();
+                    FileUtils.deleteAndReport(new File(filePath));
                 }
                 try {
                     getContentResolver().delete(mediaUri, null, null);
@@ -2070,7 +2070,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         File temp = SaveToDiskTask.savepointFile(formController
                 .getInstancePath());
         if (temp.exists()) {
-            temp.delete();
+            FileUtils.deleteAndReport(temp);
         }
 
         boolean erase = false;
@@ -2109,9 +2109,9 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             if (f.exists() && f.isDirectory()) {
                 for (File del : f.listFiles()) {
                     Timber.i("Deleting file: %s", del.getAbsolutePath());
-                    del.delete();
+                    FileUtils.deleteAndReport(del);
                 }
-                f.delete();
+                FileUtils.deleteAndReport(f);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -55,6 +55,7 @@ import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
+import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.PlayServicesUtil;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.SharedPreferencesUtils;
@@ -235,11 +236,11 @@ public class MainMenuActivity extends AppCompatActivity {
             boolean success = sharedPrefs.loadSharedPreferencesFromJSONFile(j);
             if (success) {
                 ToastUtils.showLongToast(R.string.settings_successfully_loaded_file_notification);
-                j.delete();
+                FileUtils.deleteAndReport(j);
 
                 // Delete settings file to prevent overwrite of settings from JSON file on next startup
                 if (f.exists()) {
-                    f.delete();
+                    FileUtils.deleteAndReport(f);
                 }
             } else {
                 ToastUtils.showLongToast(R.string.corrupt_settings_file_notification);
@@ -248,7 +249,7 @@ public class MainMenuActivity extends AppCompatActivity {
             boolean success = loadSharedPreferencesFromFile(f);
             if (success) {
                 ToastUtils.showLongToast(R.string.settings_successfully_loaded_file_notification);
-                f.delete();
+                FileUtils.deleteAndReport(f);
             } else {
                 ToastUtils.showLongToast(R.string.corrupt_settings_file_notification);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/database/ActivityLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/ActivityLogger.java
@@ -48,7 +48,10 @@ public final class ActivityLogger {
 
         DatabaseHelper() {
             super(new DatabaseContext(Collect.LOG_PATH), DATABASE_NAME, null, DATABASE_VERSION);
-            new File(Collect.LOG_PATH).mkdirs();
+            boolean success = new File(Collect.LOG_PATH).mkdirs();
+            if (!success) {
+                Timber.e("Failed to create the %s directories", Collect.LOG_PATH);
+            }
         }
 
         @Override

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FileReference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FileReference.java
@@ -5,6 +5,7 @@
 package org.odk.collect.android.logic;
 
 import org.javarosa.core.reference.Reference;
+import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -64,8 +65,7 @@ public class FileReference implements Reference {
 
     @Override
     public void remove() {
-        // TODO bad practice to ignore return values
-        new File(getInternalURI()).delete();
+        FileUtils.deleteAndReport(new File(getInternalURI()));
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -245,10 +245,10 @@ public class FormsProvider extends ContentProvider {
                     // should make this recursive if we get worried about
                     // the media directory containing directories
                     Timber.i("attempting to delete file: %s", f.getAbsolutePath());
-                    f.delete();
+                    FileUtils.deleteAndReport(f);
                 }
             }
-            file.delete();
+            FileUtils.deleteAndReport(file);
             Timber.i("attempting to delete file: %s", file.getAbsolutePath());
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -31,6 +31,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.helpers.InstancesDatabaseHelper;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -205,10 +206,10 @@ public class InstanceProvider extends ContentProvider {
                 for (File f : files) {
                     // should make this recursive if we get worried about
                     // the media directory containing directories
-                    f.delete();
+                    FileUtils.deleteAndReport(f);
                 }
             }
-            directory.delete();
+            FileUtils.deleteAndReport(directory);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -157,8 +157,12 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                         errors.append(e.getMessage()).append("\r\n");
                         File badFile = new File(formDefFile.getParentFile(),
                                 formDefFile.getName() + ".bad");
-                        badFile.delete();
-                        formDefFile.renameTo(badFile);
+                        FileUtils.deleteAndReport(badFile);
+                        boolean success = formDefFile.renameTo(badFile);
+                        if (!success) {
+                            //TODO: proper course of action for the fail case
+                            Timber.e("Failed to rename file %s", formDefFile.getAbsoluteFile().toString());
+                        }
                         continue;
                     }
 
@@ -195,8 +199,11 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                         errors.append(e.getMessage()).append("\r\n");
                         File badFile = new File(formDefFile.getParentFile(),
                                 formDefFile.getName() + ".bad");
-                        badFile.delete();
-                        formDefFile.renameTo(badFile);
+                        FileUtils.deleteAndReport(badFile);
+                        boolean success = formDefFile.renameTo(badFile);
+                        if (!success) {
+                            Timber.e("Failed to rename file: %s" , formDefFile.getAbsoluteFile().toString());
+                        }
                         continue;
                     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -154,7 +154,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
                 // from xml
                 Timber.w("Deserialization FAILED!  Deleting cache file: %s",
                         formBin.getAbsolutePath());
-                formBin.delete();
+                FileUtils.deleteAndReport(formBin);
             }
         }
         if (fd == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/EncryptionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/EncryptionUtils.java
@@ -495,7 +495,7 @@ public class EncryptionUtils {
                 continue; // MacOSX garbage
             }
             if (f.getName().endsWith(".enc")) {
-                f.delete(); // try to delete this (leftover junk)
+                FileUtils.deleteAndReport(f); // try to delete this (leftover junk)
             } else {
                 filesToProcess.add(f);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -137,7 +137,7 @@ public class MediaUtils {
         }
         File f = new File(imageFile);
         if (f.exists()) {
-            f.delete();
+            FileUtils.deleteAndReport(f);
         }
         return count;
     }
@@ -252,7 +252,7 @@ public class MediaUtils {
         }
         File f = new File(audioFile);
         if (f.exists()) {
-            f.delete();
+            FileUtils.deleteAndReport(f);
         }
         return count;
     }
@@ -367,7 +367,7 @@ public class MediaUtils {
         }
         File f = new File(videoFile);
         if (f.exists()) {
-            f.delete();
+            FileUtils.deleteAndReport(f);
         }
         return count;
     }


### PR DESCRIPTION
replaced File.delete() with FileUtils.deleteAndReport().
It's a bad practice to ignore return values and this commit fixes this issue in the code base.
`UtilFiles.deleteAndReport()` gives a file a second chance to delete by calling `File.deleteOnExit()` and report the result. 
Also this commit will log the return value of File.renameTo() and File.mkdirs() if they fail

#### What has been done to verify that this works as intended?
ran all tests and also simulated on the Android Emulator.

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
It's safe
