### PR TITLE
Ignore case when sorting Blank Forms list

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
@@ -110,17 +110,17 @@ public class FormsDaoTest {
         assertEquals("sample", forms.get(5).getDisplayName());
         assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(5).getDisplaySubtext());
 
-        String sortOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " DESC";
+        String sortOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE DESC";
 
         cursor = formsDao.getFormsCursor(null, null, null, sortOrder);
         forms = formsDao.getFormsFromCursor(cursor);
         assertEquals(6, forms.size());
 
-        assertEquals("sample", forms.get(0).getDisplayName());
-        assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(0).getDisplaySubtext());
-
-        assertEquals("Widgets", forms.get(1).getDisplayName());
+        assertEquals("Widgets", forms.get(0).getDisplayName());
         assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(1).getDisplaySubtext());
+
+        assertEquals("sample", forms.get(1).getDisplayName());
+        assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(0).getDisplaySubtext());
 
         assertEquals("Miramare", forms.get(2).getDisplayName());
         assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(2).getDisplaySubtext());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -42,7 +42,6 @@ import org.odk.collect.android.listeners.FormDownloaderListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.preferences.PreferencesActivity;
-import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.tasks.DownloadFormsTask;
@@ -465,7 +464,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         Collections.sort(filteredFormList, new Comparator<HashMap<String, String>>() {
             @Override
             public int compare(HashMap<String, String> lhs, HashMap<String, String> rhs) {
-                if (getSortingOrder().equals(FormsProviderAPI.FormsColumns.DISPLAY_NAME + " ASC")) {
+                if (getSortingOrder().equals(SORT_BY_NAME_ASC)) {
                     return lhs.get(FORMNAME).compareToIgnoreCase(rhs.get(FORMNAME));
                 } else {
                     return rhs.get(FORMNAME).compareToIgnoreCase(lhs.get(FORMNAME));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormListActivity.java
@@ -10,13 +10,13 @@ import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrde
 
 abstract class FormListActivity extends AppListActivity {
     protected String getSortingOrder() {
-        String sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " ASC";
+        String sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE ASC";
         switch (getSelectedSortingOrder()) {
             case BY_NAME_ASC:
-                sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " ASC";
+                sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE ASC";
                 break;
             case BY_NAME_DESC:
-                sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " DESC";
+                sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE DESC";
                 break;
             case BY_DATE_ASC:
                 sortingOrder = FormsProviderAPI.FormsColumns.DATE + " ASC";

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormListActivity.java
@@ -9,20 +9,28 @@ import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrde
 import static org.odk.collect.android.utilities.ApplicationConstants.SortingOrder.BY_NAME_DESC;
 
 abstract class FormListActivity extends AppListActivity {
+
+    protected static final String SORT_BY_NAME_ASC
+            = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE ASC";
+    protected static final String SORT_BY_NAME_DESC
+            = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE DESC";
+    protected static final String SORT_BY_DATE_ASC = FormsProviderAPI.FormsColumns.DATE + " ASC";
+    protected static final String SORT_BY_DATE_DESC = FormsProviderAPI.FormsColumns.DATE + " ASC";
+
     protected String getSortingOrder() {
-        String sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE ASC";
+        String sortingOrder = SORT_BY_NAME_ASC;
         switch (getSelectedSortingOrder()) {
             case BY_NAME_ASC:
-                sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE ASC";
+                sortingOrder = SORT_BY_NAME_ASC;
                 break;
             case BY_NAME_DESC:
-                sortingOrder = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " COLLATE NOCASE DESC";
+                sortingOrder = SORT_BY_NAME_DESC;
                 break;
             case BY_DATE_ASC:
-                sortingOrder = FormsProviderAPI.FormsColumns.DATE + " ASC";
+                sortingOrder = SORT_BY_DATE_ASC;
                 break;
             case BY_DATE_DESC:
-                sortingOrder = FormsProviderAPI.FormsColumns.DATE + " DESC";
+                sortingOrder = SORT_BY_DATE_DESC;
                 break;
         }
         return sortingOrder;


### PR DESCRIPTION
Closes #1264 

#### What has been done to verify that this works as intended?
I have verified the behavior by running on a device and adjusting the sorting to make sure that lowercase letters are sorted in alphabetical order with uppercase letters. I have also modified a test to use the `COLLATE NOCASE` SQL option to test this behavior as well

#### Why is this the best possible solution? Were any other approaches considered?

`COLLAGE NOCASE` is a built in SQL command which converts uppercase ASCII characters to lowercase prior to executing a compare. This is the least intrusive change to the codebase to achieve the desired result. More can be read about `COLLATE` in the [SQLite documentation](https://sqlite.org/datatype3.html#collating_sequences)

#### Are there any risks to merging this code? If so, what are they?

There are no risks.


I did a bit of refactoring as well by assigning the `sortingOrder` options to static variables which can be easily compared against in other places in the product, such as `FormDownloadList:467`.
