### PR TITLE
Fix code coverage report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,15 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'
+        classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
         classpath 'com.google.gms:google-services:3.0.0'
+    }
+    configurations.all {
+        resolutionStrategy {
+            // use old jacoco so Robolectric test coverage is included in reports
+            // track https://github.com/paveldudka/JacocoEverywhere/issues/14 for a less hacky solution
+            force 'org.jacoco:org.jacoco.core:0.7.2.201409121644'
+        }
     }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ test:
         # SD card needed for circleci-android22 image
         # https://circleci.com/docs/1.0/android/
         - mksdcard -l e 128M sdcard.img
-        - emulator -avd circleci-android22 -sdcard sdcard.img -no-window:
+        - emulator -memory 256 -avd circleci-android22 -sdcard sdcard.img -no-window:
             background: true
             parallel: true
         - circle-android wait-for-boot

--- a/circle.yml
+++ b/circle.yml
@@ -59,8 +59,6 @@ test:
         - find . -type f -regex ".*/collect_app/build/reports/pmd/pmd*.*" -exec cp {} $CIRCLE_TEST_REPORTS/pmd/ \;
 
         - mkdir -p $CIRCLE_TEST_REPORTS/tests
-        - find . -type f -regex ".*/collect_app/build/test-results/.*.xml" -exec cp {} $CIRCLE_TEST_REPORTS/tests/ \;
+        - find . -type f -regex ".*/collect_app/build/reports/coverage/debug/report.xml" -exec cp {} $CIRCLE_TEST_REPORTS/tests/ \;
 
-        - if [ $CIRCLE_BRANCH = 'master' ]; then cp -r collect_app/build/outputs/apk $CIRCLE_ARTIFACTS; fi
-        - if [ $CIRCLE_BRANCH = 'master' ]; then cp -r collect_app/build/reports/androidTests/connected $CIRCLE_TEST_REPORTS/androidTests; fi
         - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -36,17 +36,15 @@ test:
         - ./gradlew findbugs -Pandroid.useDexArchive=false
         - ./gradlew lint -Pandroid.useDexArchive=false
         - ./gradlew checkstyle -Pandroid.useDexArchive=false
-        - ./gradlew jacocoTestDebugUnitTestReport -Pandroid.useDexArchive=false
-        
-        # Instrumented tests take time, so only run them on master
+
         # SD card needed for circleci-android22 image
         # https://circleci.com/docs/1.0/android/
-        - if [ $CIRCLE_BRANCH = 'master' ]; then mksdcard -l e 128M sdcard.img; fi
-        - if [ $CIRCLE_BRANCH = 'master' ]; then emulator -avd circleci-android22 -sdcard sdcard.img -no-window; fi:
+        - mksdcard -l e 128M sdcard.img
+        - emulator -avd circleci-android22 -sdcard sdcard.img -no-window:
             background: true
             parallel: true
-        - if [ $CIRCLE_BRANCH = 'master' ]; then circle-android wait-for-boot; fi
-        - if [ $CIRCLE_BRANCH = 'master' ]; then ./gradlew connectedCheck -Pandroid.useDexArchive=false; fi
+        - circle-android wait-for-boot
+        - ./gradlew connectedCheck -Pandroid.useDexArchive=false
 
     post:
         - cp -r collect_app/build/reports/checkstyle $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
         # Out of memory errors in Android builds
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
         # https://docs.gradle.org/current/userguide/build_environment.html
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2560M -XX:+HeapDumpOnOutOfMemoryError"'
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048M -XX:+HeapDumpOnOutOfMemoryError -XX:MaxPermSize=512m"'
 
 dependencies:
     pre:

--- a/circle.yml
+++ b/circle.yml
@@ -59,6 +59,6 @@ test:
         - find . -type f -regex ".*/collect_app/build/reports/pmd/pmd*.*" -exec cp {} $CIRCLE_TEST_REPORTS/pmd/ \;
 
         - mkdir -p $CIRCLE_TEST_REPORTS/tests
-        - find . -type f -regex ".*/collect_app/build/reports/coverage/debug/report.xml" -exec cp {} $CIRCLE_TEST_REPORTS/tests/ \;
+        - find . -type f -regex ".*/collect_app/build/reports/coverage/debug/report*.*" -exec cp {} $CIRCLE_TEST_REPORTS/tests/ \;
 
         - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,16 @@
 machine:
     environment:
+        # Disable emulator audio
+        QEMU_AUDIO_DRV: none
+
         # Set memory limits for the JVM
         # https://circleci.com/docs/oom/#setting-memory-limits-for-the-jvm
-        _JAVA_OPTIONS: "-Xms512m -Xmx2048m"
+        _JAVA_OPTIONS: "-Xms256m -Xmx1280m -XX:MaxPermSize=350m"
 
         # Out of memory errors in Android builds
         # https://circleci.com/docs/oom/#out-of-memory-errors-in-android-builds
         # https://docs.gradle.org/current/userguide/build_environment.html
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048M -XX:+HeapDumpOnOutOfMemoryError -XX:MaxPermSize=512m"'
+        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1536m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
     pre:

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'jacoco-android'
 apply from: '../config/quality.gradle'
 
 import com.android.ddmlib.DdmPreferences

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -94,24 +94,3 @@ android {
         xmlOutput file("$reportsDir/lint/lint-result.xml")
     }
 }
-
-connectedCheck.doLast {
-    // Add CLI report for Jacoco coverage
-    def slurper = new XmlSlurper()
-    slurper.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
-    slurper.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-
-    def report = slurper.parse("../collect_app/build/reports/coverage/debug/report.xml")
-
-    println "------ Code Coverage ------"
-    report.package.each { p ->
-        println "--> ${p.@name.toString().replaceAll('/', '.')}"
-        p.counter.each { c ->
-            def covered = c.@covered.toString() as int
-            def missed = c.@missed.toString() as int
-            def percent = ((100 * covered) / (covered + missed))
-            println String.format('    %-16s %.1f ', c.@type, percent) + '%'
-        }
-        println "----------------------------------"
-    }
-}

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -101,7 +101,7 @@ connectedCheck.doLast {
     slurper.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
     slurper.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
-    def report = slurper.parse("./build/reports/coverage/debug/report.xml")
+    def report = slurper.parse("../collect_app/build/reports/coverage/debug/report.xml")
 
     println "------ Code Coverage ------"
     report.package.each { p ->

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -2,6 +2,8 @@ apply plugin: 'checkstyle'
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
 
+apply plugin: 'jacoco-everywhere'
+
 /*
  * Copyright 2015 Vincent Brison.
  *
@@ -90,5 +92,26 @@ android {
         lintConfig file("$configDir/lint/lint.xml")
         htmlOutput file("$reportsDir/lint/lint-result.html")
         xmlOutput file("$reportsDir/lint/lint-result.xml")
+    }
+}
+
+connectedCheck.doLast {
+    // Add CLI report for Jacoco coverage
+    def slurper = new XmlSlurper()
+    slurper.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+    slurper.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+    def report = slurper.parse("./build/reports/coverage/debug/report.xml")
+
+    println "------ Code Coverage ------"
+    report.package.each { p ->
+        println "--> ${p.@name.toString().replaceAll('/', '.')}"
+        p.counter.each { c ->
+            def covered = c.@covered.toString() as int
+            def missed = c.@missed.toString() as int
+            def percent = ((100 * covered) / (covered + missed))
+            println String.format('    %-16s %.1f ', c.@type, percent) + '%'
+        }
+        println "----------------------------------"
     }
 }


### PR DESCRIPTION
Closes #1473

- Replaces `jacoco-android` with `jacoco-everywhere` (difference, `jacoco-everywhere` runs unit tests and instrumentation tests by running gradle task `connectedCheck`)

- Runs instrumentation tests on all branches

- Reduces the memory allocation of avd to 256 MB, adds `Max Perm Size` to 512 and modifies -`Xmx2560M` to `Xmx1536m` in order to prevent 4G limit of Circle CI container

- Merges the unit tests and instrumentation tests report into one as they are generated together

#### What has been done to verify that this works as intended?
Code coverage has increased to 14.12% (+13.34%)
https://codecov.io/github/shobhitagarwal1612/collect/commit/a1f0fbd067d0bcd435e5192a296f3351a7a1dc9f

#### Why is this the best possible solution? Were any other approaches considered?
It's the only solution which worked successfully

#### Are there any risks to merging this code? If so, what are they?
Now the instrumentation tests are run on all branches and not on just `master` branch. This had to be done as `jacoco-everywhere` builds unit tests report & instrumentation tests report by using a single gradle task `connectedCheck`. 
