### PR TITLE
Match subtext test to display name test.

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
@@ -117,10 +117,10 @@ public class FormsDaoTest {
         assertEquals(6, forms.size());
 
         assertEquals("Widgets", forms.get(0).getDisplayName());
-        assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(1).getDisplaySubtext());
+        assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(0).getDisplaySubtext());
 
         assertEquals("sample", forms.get(1).getDisplayName());
-        assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(0).getDisplaySubtext());
+        assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(1).getDisplaySubtext());
 
         assertEquals("Miramare", forms.get(2).getDisplayName());
         assertEquals("Added on Wed, Feb 22, 2017 at 17:55", forms.get(2).getDisplaySubtext());


### PR DESCRIPTION
I noticed after merging @danielrees18's latest pull request that the order of the display subtext checks was confusing.

#### What has been done to verify that this works as intended?
Ran tests and verified that they pass.

#### Why is this the best possible solution? Were any other approaches considered?
None other possible.

#### Are there any risks to merging this code? If so, what are they?
This is a test-only change so no risk!