### PR TITLE
1478 fix padding left & right, to support API 16 Android 4.1

### DIFF
--- a/collect_app/src/main/res/layout/item_view_option.xml
+++ b/collect_app/src/main/res/layout/item_view_option.xml
@@ -8,6 +8,8 @@
           android:minHeight="@dimen/touch_target_size"
           android:paddingEnd="@dimen/padding_extra_large"
           android:paddingStart="@dimen/padding_extra_large"
+          android:paddingLeft="@dimen/padding_extra_large"
+          android:paddingRight="@dimen/padding_extra_large"
           android:textColor="@color/primaryTextColor"
           android:textSize="@dimen/text_size_small"
           tools:drawableLeft="@drawable/ic_save_grey_32dp"


### PR DESCRIPTION
Closes #1478 
Could someone test it on API 16 before merging please.

#### What has been done to verify that this works as intended?
I couldn't launch app on Emulator API 16 'cause of issue with Emulator SD card emulation, but according to stackoverflow paddingStart was added in API 17
#### Why is this the best possible solution? Were any other approaches considered?
That is the proper use of Padding on old versions.
#### Are there any risks to merging this code? If so, what are they?
It might not work for some magic reason on some mysterious devices, with very little chance.