### PR TITLE
BUG strange behaviour with buttons instead of swiping

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1388,16 +1388,15 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      * Disables the back button if it is first question....
      */
     private void adjustBackNavigationButtonVisibility() {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = Collect.getInstance().getFormController();
         try {
+            FormIndex originalFormIndex = formController.getFormIndex();
             boolean firstQuestion = formController.stepToPreviousScreenEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM;
             backButton.setEnabled(!firstQuestion);
-            formController.stepToNextScreenEvent();
-            if (formController.getEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
+            if (formController.stepToNextScreenEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                 backButton.setEnabled(true);
-                formController.stepToNextScreenEvent();
             }
+            formController.jumpToIndex(originalFormIndex);
         } catch (JavaRosaException e) {
             backButton.setEnabled(true);
             Timber.e(e);


### PR DESCRIPTION
Closes #1464 

#### What has been done to verify that this works as intended?
I've tested attached forms from #1464 

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that if we call `stepToPreviousScreenEvent() ` like here https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1464?expand=1#diff-03ff45091550285dd88b56927010c457R1394 we go back skipping all repeat groups if they are empty. If we have two repeat groups one after another we skip both and then we tried to go forward only once (like we skipped only one repeat group but we could skip 2,3,4 etc) https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1464?expand=1#diff-03ff45091550285dd88b56927010c457L1399. Now we just [jump to an original index](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1464?expand=1#diff-03ff45091550285dd88b56927010c457R1399) so it should work in all cases.

#### Are there any risks to merging this code? If so, what are they?
I think it's safe but we need @mmarciniak90 to test it too of course :)
