### PR TITLE
Bearing widget not working

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -162,10 +162,10 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
         boolean isMagneticFieldSensorAvailable = false;
 
         SensorManager sensorManager = (SensorManager) getContext().getSystemService(Context.SENSOR_SERVICE);
-        if (sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null){
+        if (sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null) {
             isAccelerometerSensorAvailable = true;
         }
-        if (sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null){
+        if (sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null) {
             isMagneticFieldSensorAvailable = true;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -171,7 +171,7 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
 
         if (!isAccelerometerSensorAvailable || ! isMagneticFieldSensorAvailable) {
             getBearingButton.setEnabled(false);
-            ToastUtils.showLongToast(R.string.lack_of_sensors);
+            ToastUtils.showLongToast(R.string.bearing_lack_of_sensors);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -18,6 +18,8 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.hardware.Sensor;
+import android.hardware.SensorManager;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
@@ -32,6 +34,7 @@ import org.odk.collect.android.activities.BearingActivity;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.utilities.ToastUtils;
 
 /**
  * BearingWidget is the widget that allows the user to get a compass heading.
@@ -81,6 +84,8 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
                         FormEntryActivity.BEARING_CAPTURE);
             }
         });
+
+        checkForRequiredSensors();
 
         LinearLayout answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.VERTICAL);
@@ -150,5 +155,23 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
         super.cancelLongPress();
         getBearingButton.cancelLongPress();
         answerDisplay.cancelLongPress();
+    }
+
+    private void checkForRequiredSensors() {
+        boolean isAccelerometerSensorAvailable = false;
+        boolean isMagneticFieldSensorAvailable = false;
+
+        SensorManager sensorManager = (SensorManager) getContext().getSystemService(Context.SENSOR_SERVICE);
+        if (sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) != null){
+            isAccelerometerSensorAvailable = true;
+        }
+        if (sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD) != null){
+            isMagneticFieldSensorAvailable = true;
+        }
+
+        if (!isAccelerometerSensorAvailable || ! isMagneticFieldSensorAvailable) {
+            getBearingButton.setEnabled(false);
+            ToastUtils.showLongToast(R.string.lack_of_sensors);
+        }
     }
 }

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -516,5 +516,5 @@
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
-    <string name="lack_of_sensors">Yor device does not support at least one of required sensors: accelerometer, magnetic field.</string>
+    <string name="bearing_lack_of_sensors">Bearing cannot be collected: device is missing accelerometer, magnetic field sensor or both.</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -516,4 +516,5 @@
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
+    <string name="lack_of_sensors">Yor device does not support at least one of required sensors: accelerometer, magnetic field.</string>
 </resources>


### PR DESCRIPTION
Closes #1458 

#### What has been done to verify that this works as intended?
I tested one of devices mentioned by @mmarciniak90 https://github.com/opendatakit/collect/issues/1458#issuecomment-329782930 it was Samsung J1 with Android 4.4
and the reason why it doesn't work on some devices is pretty simple - device you use must support accelerometer and magnetic field sensors. 
In my case tested device doesn't have magnetic field sensor. 
To be sure I'm right I tested a few apps from play store and I also listed all sensors from tested device:

> 0 = {Sensor@830041129792} "{Sensor name="K2HH Accelerometer Sensor", vendor="STM", version=1, type=1, maxRange=19.6133, resolution=0.038307227, power=0.13, minDelay=10000}"
1 = {Sensor@830041118856} "{Sensor name="CM36672 Proximity Sensor", vendor="Capella Microsystems, Inc.", version=1, type=8, maxRange=8.0, resolution=8.0, power=0.75, minDelay=0}"
2 = {Sensor@830041100848} "{Sensor name="Screen Orientation Sensor", vendor="Samsung Electronics", version=1, type=65558, maxRange=255.0, resolution=0.0, power=0.0, minDelay=0}"

for comparison here is a list from my Samsung Galaxy S4:
> 0 = {Sensor@22020} "{Sensor name="K330 3-axis Accelerometer", vendor="STMicroelectronics", version=1, type=1, maxRange=19.6133, resolution=5.985504E-4, power=0.25, minDelay=10000}"
1 = {Sensor@22021} "{Sensor name="YAS532 Magnetic Sensor", vendor="Yamaha Corporation", version=1, type=2, maxRange=1200.0, resolution=0.06, power=6.0, minDelay=10000}"
2 = {Sensor@22022} "{Sensor name="K330 Gyroscope sensor", vendor="STMicroelectronics", version=1, type=4, maxRange=8.726646, resolution=3.0543262E-4, power=6.1, minDelay=10000}"
3 = {Sensor@22023} "{Sensor name="Barometer Sensor", vendor="STMicroelectronics", version=1, type=6, maxRange=1013.25, resolution=1.0, power=1.0, minDelay=180000}"
4 = {Sensor@22024} "{Sensor name="MAX88920 Proximity Sensor", vendor="MAXIM, Inc.", version=1, type=8, maxRange=8.0, resolution=8.0, power=0.75, minDelay=0}"
5 = {Sensor@22025} "{Sensor name="CM3323 RGB Sensor", vendor="Capella Microsystems, Inc.", version=1, type=5, maxRange=60000.0, resolution=1.0, power=0.75, minDelay=10000}"
6 = {Sensor@22026} "{Sensor name="SHTC1 relative humidity sensor", vendor="Sensirion", version=1, type=12, maxRange=100.0, resolution=0.04, power=0.3, minDelay=1000000}"
7 = {Sensor@22027} "{Sensor name="SHTC1 ambient temperature sensor", vendor="Sensirion", version=1, type=13, maxRange=165.0, resolution=0.01, power=0.3, minDelay=1000000}"
8 = {Sensor@22028} "{Sensor name="YAS532 Magnetic Sensor UnCalibrated", vendor="Yamaha Corporation", version=1, type=14, maxRange=1200.0, resolution=0.06, power=6.0, minDelay=10000}"
9 = {Sensor@22029} "{Sensor name="SAMSUNG Significant Motion Sensor", vendor="Samsung Inc.", version=1, type=17, maxRange=1.0, resolution=1.0, power=0.3, minDelay=-1}"
10 = {Sensor@22030} "{Sensor name="SAMSUNG Step Detector Sensor", vendor="Samsung Inc.", version=1, type=18, maxRange=1.0, resolution=1.0, power=0.3, minDelay=0}"
11 = {Sensor@22031} "{Sensor name="SAMSUNG Step Counter Sensor", vendor="Samsung Inc.", version=1, type=19, maxRange=100000.0, resolution=1.0, power=0.3, minDelay=0}"
12 = {Sensor@22032} "{Sensor name="UnCalibrated Gyroscope sensor", vendor="Samsung Inc", version=1, type=16, maxRange=8.726646, resolution=3.0543262E-4, power=6.1, minDelay=10000}"
13 = {Sensor@22033} "{Sensor name="Screen Orientation Sensor", vendor="Samsung Electronics", version=3, type=65558, maxRange=255.0, resolution=255.0, power=0.25, minDelay=0}"
14 = {Sensor@22034} "{Sensor name="Rotation Vector Sensor", vendor="AOSP", version=3, type=11, maxRange=1.0, resolution=5.9604645E-8, power=12.35, minDelay=10000}"
15 = {Sensor@22035} "{Sensor name="Gravity Sensor", vendor="AOSP", version=3, type=9, maxRange=19.6133, resolution=5.985504E-4, power=12.35, minDelay=10000}"
16 = {Sensor@22036} "{Sensor name="Linear Acceleration Sensor", vendor="AOSP", version=3, type=10, maxRange=19.6133, resolution=5.985504E-4, power=12.35, minDelay=10000}"
17 = {Sensor@22037} "{Sensor name="Orientation Sensor", vendor="AOSP", version=1, type=3, maxRange=360.0, resolution=0.00390625, power=12.35, minDelay=10000}"

#### Why is this the best possible solution? Were any other approaches considered?
Showing a toast is everything we can do in that case.

#### Are there any risks to merging this code? If so, what are they?
It's safe