### PR TITLE
configuration of the applicationID avoid fork crach report from user crach report

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -66,7 +66,7 @@ android {
     buildToolsVersion('26.0.1')
 
     defaultConfig {
-        applicationId('org.odk.collect.android')
+        applicationId('org.odk.collect.android.debug')
         minSdkVersion(16)
         targetSdkVersion(22)
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()

--- a/collect_app/google-services.json
+++ b/collect_app/google-services.json
@@ -8,7 +8,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:322300403941:android:5e1d7c3c296329e8",
         "android_client_info": {
-          "package_name": "org.odk.collect.android"
+          "package_name": "org.odk.collect.android.debug"
         }
       },
       "oauth_client": [],


### PR DESCRIPTION
to separate the loges between developer (fork) and the users (Released)
#### What has been done to verify that this works as intended?
changing the application Id explicitly will prevent release builds of forks from logging.
#### Why is this the best possible solution? Were any other approaches considered?
this is the best solution because it's not harm the package name which need reconstruct the architecture of the application also code still as it is.
#### Are there any risks to merging this code? If so, what are they?
risky is not exist, because the code still as it is
