### PR TITLE
Replace deprecated API usage in ReferenceManager (#1405)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -268,7 +268,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
 
         // Remove previous forms
-        ReferenceManager._().clearSession();
+        ReferenceManager.instance().clearSession();
 
         // for itemsets.csv, we only check to see if the itemset file has been
         // updated
@@ -308,19 +308,19 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
 
         // This should get moved to the Application Class
-        if (ReferenceManager._().getFactories().length == 0) {
+        if (ReferenceManager.instance().getFactories().length == 0) {
             // this is /sdcard/odk
-            ReferenceManager._().addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
+            ReferenceManager.instance().addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
         }
 
         // Set jr://... to point to /sdcard/odk/forms/filename-media/
-        ReferenceManager._().addSessionRootTranslator(
+        ReferenceManager.instance().addSessionRootTranslator(
                 new RootTranslator("jr://images/", "jr://file/forms/" + formFileName + "-media/"));
-        ReferenceManager._().addSessionRootTranslator(
+        ReferenceManager.instance().addSessionRootTranslator(
                 new RootTranslator("jr://image/", "jr://file/forms/" + formFileName + "-media/"));
-        ReferenceManager._().addSessionRootTranslator(
+        ReferenceManager.instance().addSessionRootTranslator(
                 new RootTranslator("jr://audio/", "jr://file/forms/" + formFileName + "-media/"));
-        ReferenceManager._().addSessionRootTranslator(
+        ReferenceManager.instance().addSessionRootTranslator(
                 new RootTranslator("jr://video/", "jr://file/forms/" + formFileName + "-media/"));
 
         // clean up vars

--- a/collect_app/src/main/java/org/odk/collect/android/views/AudioButton.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/AudioButton.java
@@ -72,7 +72,7 @@ public class AudioButton extends AppCompatImageButton {
 
             String audioFilename = "";
             try {
-                audioFilename = ReferenceManager._().DeriveReference(uri).getLocalURI();
+                audioFilename = ReferenceManager.instance().DeriveReference(uri).getLocalURI();
             } catch (InvalidReferenceException e) {
                 Timber.e(e);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -124,7 +124,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
             String videoFilename = "";
             try {
                 videoFilename =
-                        ReferenceManager._().DeriveReference(videoURI).getLocalURI();
+                        ReferenceManager.instance().DeriveReference(videoURI).getLocalURI();
             } catch (InvalidReferenceException e) {
                 Timber.e(e, "Invalid reference exception due to %s ", e.getMessage());
             }
@@ -217,7 +217,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
         final int imageId = ViewIds.generateViewId();
         if (imageURI != null) {
             try {
-                String imageFilename = ReferenceManager._().DeriveReference(imageURI).getLocalURI();
+                String imageFilename = ReferenceManager.instance().DeriveReference(imageURI).getLocalURI();
                 final File imageFile = new File(imageFilename);
                 if (imageFile.exists()) {
                     DisplayMetrics metrics = context.getResources().getDisplayMetrics();
@@ -233,7 +233,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
 
                         if (bigImageURI != null) {
                             imageView.setOnClickListener(new OnClickListener() {
-                                String bigImageFilename = ReferenceManager._()
+                                String bigImageFilename = ReferenceManager.instance()
                                         .DeriveReference(bigImageURI).getLocalURI();
                                 File bigImage = new File(bigImageFilename);
 


### PR DESCRIPTION
Closes #1405 

#### What has been done to verify that this works as intended?
All the test are still running, application is compiling

#### Why is this the best possible solution? Were any other approaches considered?
Replace all the ReferenceManager._() calls with instance()

#### Are there any risks to merging this code? If so, what are they?
No, as far as I know.

IDE feature that was used: Run inspection -> Deprecated API Usage". After making changes and re-running inspection warnings related to ReferenceManager are no longer present.
