### PR TITLE
Moves RequestCodes to ApplicationConstants

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -125,6 +125,7 @@ import timber.log.Timber;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 import static org.odk.collect.android.utilities.ApplicationConstants.XML_OPENROSA_NAMESPACE;
 
 
@@ -151,29 +152,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private static final boolean DO_NOT_EXIT = false;
     private static final boolean EVALUATE_CONSTRAINTS = true;
     private static final boolean DO_NOT_EVALUATE_CONSTRAINTS = false;
-
-    // Request codes for returning data from specified intent.
-    public static final int IMAGE_CAPTURE = 1;
-    public static final int BARCODE_CAPTURE = 2;
-    public static final int AUDIO_CAPTURE = 3;
-    public static final int VIDEO_CAPTURE = 4;
-    public static final int LOCATION_CAPTURE = 5;
-    public static final int HIERARCHY_ACTIVITY = 6;
-    public static final int IMAGE_CHOOSER = 7;
-    public static final int AUDIO_CHOOSER = 8;
-    public static final int VIDEO_CHOOSER = 9;
-    public static final int EX_STRING_CAPTURE = 10;
-    public static final int EX_INT_CAPTURE = 11;
-    public static final int EX_DECIMAL_CAPTURE = 12;
-    public static final int DRAW_IMAGE = 13;
-    public static final int SIGNATURE_CAPTURE = 14;
-    public static final int ANNOTATE_IMAGE = 15;
-    public static final int ALIGNED_IMAGE = 16;
-    public static final int BEARING_CAPTURE = 17;
-    public static final int EX_GROUP_CAPTURE = 18;
-    public static final int OSM_CAPTURE = 19;
-    public static final int GEOSHAPE_CAPTURE = 20;
-    public static final int GEOTRACE_CAPTURE = 21;
 
     // Extra returned from gp activity
     public static final String LOCATION_RESULT = "LOCATION_RESULT";
@@ -619,16 +597,16 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
         if (resultCode == RESULT_CANCELED) {
             // request was canceled...
-            if (requestCode != HIERARCHY_ACTIVITY) {
+            if (requestCode != RequestCodes.HIERARCHY_ACTIVITY) {
                 ((ODKView) currentView).cancelWaitingForBinaryData();
             }
             return;
         }
 
         // intent is needed for all requestCodes except of DRAW_IMAGE, ANNOTATE_IMAGE, SIGNATURE_CAPTURE, IMAGE_CAPTURE and HIERARCHY_ACTIVITY
-        if (intent == null && requestCode != DRAW_IMAGE && requestCode != ANNOTATE_IMAGE
-                && requestCode != SIGNATURE_CAPTURE && requestCode != IMAGE_CAPTURE
-                && requestCode != HIERARCHY_ACTIVITY) {
+        if (intent == null && requestCode != RequestCodes.DRAW_IMAGE && requestCode != RequestCodes.ANNOTATE_IMAGE
+                && requestCode != RequestCodes.SIGNATURE_CAPTURE && requestCode != RequestCodes.IMAGE_CAPTURE
+                && requestCode != RequestCodes.HIERARCHY_ACTIVITY) {
             Timber.w("The intent has a null value for requestCode: " + requestCode);
             ToastUtils.showLongToast(getString(R.string.null_intent_value));
             return;
@@ -652,14 +630,14 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
         switch (requestCode) {
 
-            case OSM_CAPTURE:
+            case RequestCodes.OSM_CAPTURE:
                 String osmFileName = intent.getStringExtra("OSM_FILE_NAME");
                 ((ODKView) currentView).setBinaryData(osmFileName);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case EX_STRING_CAPTURE:
-            case EX_INT_CAPTURE:
-            case EX_DECIMAL_CAPTURE:
+            case RequestCodes.EX_STRING_CAPTURE:
+            case RequestCodes.EX_INT_CAPTURE:
+            case RequestCodes.EX_DECIMAL_CAPTURE:
                 String key = "value";
                 boolean exists = intent.getExtras().containsKey(key);
                 if (exists) {
@@ -668,7 +646,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                     saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 }
                 break;
-            case EX_GROUP_CAPTURE:
+            case RequestCodes.EX_GROUP_CAPTURE:
                 try {
                     Bundle extras = intent.getExtras();
                     ((ODKView) currentView).setDataForFields(extras);
@@ -677,10 +655,10 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                     createErrorDialog(e.getCause().getMessage(), DO_NOT_EXIT);
                 }
                 break;
-            case DRAW_IMAGE:
-            case ANNOTATE_IMAGE:
-            case SIGNATURE_CAPTURE:
-            case IMAGE_CAPTURE:
+            case RequestCodes.DRAW_IMAGE:
+            case RequestCodes.ANNOTATE_IMAGE:
+            case RequestCodes.SIGNATURE_CAPTURE:
+            case RequestCodes.IMAGE_CAPTURE:
                 /*
                  * We saved the image to the tempfile_path, but we really want it to
                  * be in: /sdcard/odk/instances/[current instnace]/something.jpg so
@@ -707,7 +685,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 ((ODKView) currentView).setBinaryData(nf);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case ALIGNED_IMAGE:
+            case RequestCodes.ALIGNED_IMAGE:
                 /*
                  * We saved the image to the tempfile_path; the app returns the full
                  * path to the saved file in the EXTRA_OUTPUT extra. Take that file
@@ -730,7 +708,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 ((ODKView) currentView).setBinaryData(nf);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case IMAGE_CHOOSER:
+            case RequestCodes.IMAGE_CHOOSER:
                 /*
                  * We have a saved image somewhere, but we really want it to be in:
                  * /sdcard/odk/instances/[current instnace]/something.jpg so we move
@@ -749,8 +727,8 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 new Thread(runnable).start();
 
                 break;
-            case AUDIO_CAPTURE:
-            case VIDEO_CAPTURE:
+            case RequestCodes.AUDIO_CAPTURE:
+            case RequestCodes.VIDEO_CAPTURE:
                 Uri mediaUri = intent.getData();
                 saveAudioVideoAnswer(mediaUri);
                 String filePath = MediaUtils.getDataColumn(this, mediaUri, null, null);
@@ -765,32 +743,31 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 break;
 
 
-            case AUDIO_CHOOSER:
-            case VIDEO_CHOOSER:
+            case RequestCodes.AUDIO_CHOOSER:
+            case RequestCodes.VIDEO_CHOOSER:
                 saveAudioVideoAnswer(intent.getData());
                 break;
-            case LOCATION_CAPTURE:
+            case RequestCodes.LOCATION_CAPTURE:
                 String sl = intent.getStringExtra(LOCATION_RESULT);
                 ((ODKView) currentView).setBinaryData(sl);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case GEOSHAPE_CAPTURE:
-                //String ls = intent.getStringExtra(GEOSHAPE_RESULTS);
+            case RequestCodes.GEOSHAPE_CAPTURE:
                 String gshr = intent.getStringExtra(GEOSHAPE_RESULTS);
                 ((ODKView) currentView).setBinaryData(gshr);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case GEOTRACE_CAPTURE:
+            case RequestCodes.GEOTRACE_CAPTURE:
                 String traceExtra = intent.getStringExtra(GEOTRACE_RESULTS);
                 ((ODKView) currentView).setBinaryData(traceExtra);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case BEARING_CAPTURE:
+            case RequestCodes.BEARING_CAPTURE:
                 String bearing = intent.getStringExtra(BEARING_RESULT);
                 ((ODKView) currentView).setBinaryData(bearing);
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
-            case HIERARCHY_ACTIVITY:
+            case RequestCodes.HIERARCHY_ACTIVITY:
                 // We may have jumped to a new index in hierarchy activity, so
                 // refresh
                 break;
@@ -1014,7 +991,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
                 Intent i = new Intent(this, FormHierarchyActivity.class);
                 i.putExtra(ApplicationConstants.BundleKeys.FORM_MODE, ApplicationConstants.FormModes.EDIT_SAVED);
-                startActivityForResult(i, HIERARCHY_ACTIVITY);
+                startActivityForResult(i, RequestCodes.HIERARCHY_ACTIVITY);
                 return true;
             case R.id.menu_preferences:
                 Collect.getInstance()

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -63,4 +63,28 @@ public class ApplicationConstants {
         public static final int BY_STATUS_ASC = 4;
         public static final int BY_STATUS_DESC = 5;
     }
+
+    public abstract static class RequestCodes {
+        public static final int IMAGE_CAPTURE = 1;
+        // public static final int BARCODE_CAPTURE = 2;
+        public static final int AUDIO_CAPTURE = 3;
+        public static final int VIDEO_CAPTURE = 4;
+        public static final int LOCATION_CAPTURE = 5;
+        public static final int HIERARCHY_ACTIVITY = 6;
+        public static final int IMAGE_CHOOSER = 7;
+        public static final int AUDIO_CHOOSER = 8;
+        public static final int VIDEO_CHOOSER = 9;
+        public static final int EX_STRING_CAPTURE = 10;
+        public static final int EX_INT_CAPTURE = 11;
+        public static final int EX_DECIMAL_CAPTURE = 12;
+        public static final int DRAW_IMAGE = 13;
+        public static final int SIGNATURE_CAPTURE = 14;
+        public static final int ANNOTATE_IMAGE = 15;
+        public static final int ALIGNED_IMAGE = 16;
+        public static final int BEARING_CAPTURE = 17;
+        public static final int EX_GROUP_CAPTURE = 18;
+        public static final int OSM_CAPTURE = 19;
+        public static final int GEOSHAPE_CAPTURE = 20;
+        public static final int GEOTRACE_CAPTURE = 21;
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -41,7 +41,6 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.ExternalParamsException;
 import org.odk.collect.android.exception.JavaRosaException;
@@ -61,6 +60,8 @@ import java.util.Map;
 import java.util.Set;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.EX_GROUP_CAPTURE;
 
 /**
  * This class is
@@ -157,8 +158,7 @@ public class ODKView extends ScrollView implements OnLongClickListener {
                                 }
                             }
 
-                            ((Activity) getContext()).startActivityForResult(i,
-                                    FormEntryActivity.EX_GROUP_CAPTURE);
+                            ((Activity) getContext()).startActivityForResult(i, EX_GROUP_CAPTURE);
                         } catch (ExternalParamsException e) {
                             Timber.e(e, "ExternalParamsException");
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -38,7 +38,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.utilities.FileUtils;
@@ -48,6 +47,9 @@ import org.odk.collect.android.utilities.ViewIds;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.ALIGNED_IMAGE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CHOOSER;
 
 /**
  * Widget that allows user to invoke the aligned-image camera to take pictures and add them to the
@@ -142,8 +144,7 @@ public class AlignedImageWidget extends QuestionWidget implements FileWidget {
                 try {
                     formController.setIndexWaitingForData(
                             formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.ALIGNED_IMAGE);
+                    ((Activity) getContext()).startActivityForResult(i, ALIGNED_IMAGE);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             getContext().getString(R.string.activity_not_found,
@@ -169,8 +170,7 @@ public class AlignedImageWidget extends QuestionWidget implements FileWidget {
                 try {
                     formController
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CHOOSER);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CHOOSER);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             getContext().getString(R.string.activity_not_found, "choose image"),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -38,7 +38,6 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -47,6 +46,10 @@ import org.odk.collect.android.utilities.ViewIds;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.ANNOTATE_IMAGE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CAPTURE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CHOOSER;
 
 /**
  * Image widget that supports annotations on the image.
@@ -108,8 +111,7 @@ public class AnnotateWidget extends QuestionWidget implements FileWidget {
                 try {
                     Collect.getInstance().getFormController()
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CAPTURE);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CAPTURE);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),
@@ -139,8 +141,7 @@ public class AnnotateWidget extends QuestionWidget implements FileWidget {
                 try {
                     Collect.getInstance().getFormController()
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CHOOSER);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CHOOSER);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),
@@ -243,8 +244,7 @@ public class AnnotateWidget extends QuestionWidget implements FileWidget {
         try {
             Collect.getInstance().getFormController()
                     .setIndexWaitingForData(formEntryPrompt.getIndex());
-            ((Activity) getContext()).startActivityForResult(i,
-                    FormEntryActivity.ANNOTATE_IMAGE);
+            ((Activity) getContext()).startActivityForResult(i, ANNOTATE_IMAGE);
         } catch (ActivityNotFoundException e) {
             Toast.makeText(
                     getContext(),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -33,7 +33,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.utilities.FileUtil;
@@ -42,6 +41,9 @@ import org.odk.collect.android.utilities.MediaUtil;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.AUDIO_CAPTURE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.AUDIO_CHOOSER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -103,8 +105,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
                 try {
                     formController
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.AUDIO_CAPTURE);
+                    ((Activity) getContext()).startActivityForResult(i, AUDIO_CAPTURE);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),
@@ -132,8 +133,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
                 try {
                     formController
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.AUDIO_CHOOSER);
+                    ((Activity) getContext()).startActivityForResult(i, AUDIO_CHOOSER);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -29,9 +29,10 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.BearingActivity;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.BEARING_CAPTURE;
 
 /**
  * BearingWidget is the widget that allows the user to get a compass heading.
@@ -77,8 +78,7 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
                     formController.setIndexWaitingForData(formEntryPrompt.getIndex());
                 }
 
-                ((Activity) getContext()).startActivityForResult(i,
-                        FormEntryActivity.BEARING_CAPTURE);
+                ((Activity) getContext()).startActivityForResult(i, BEARING_CAPTURE);
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
@@ -38,7 +38,6 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -47,6 +46,8 @@ import org.odk.collect.android.utilities.ViewIds;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.DRAW_IMAGE;
 
 /**
  * Free drawing widget.
@@ -157,8 +158,7 @@ public class DrawWidget extends QuestionWidget implements FileWidget {
         try {
             Collect.getInstance().getFormController()
                     .setIndexWaitingForData(formEntryPrompt.getIndex());
-            ((Activity) getContext()).startActivityForResult(i,
-                    FormEntryActivity.DRAW_IMAGE);
+            ((Activity) getContext()).startActivityForResult(i, DRAW_IMAGE);
         } catch (ActivityNotFoundException e) {
             Toast.makeText(
                     getContext(),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -26,12 +26,13 @@ import android.text.method.DigitsKeyListener;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalAppsUtils;
 
 import java.text.NumberFormat;
 import java.util.Locale;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.EX_DECIMAL_CAPTURE;
 
 
 /**
@@ -94,8 +95,7 @@ public class ExDecimalWidget extends ExStringWidget {
         i.putExtra("value", getDoubleAnswerValue());
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "launchIntent",
                 i.getAction(), formEntryPrompt.getIndex());
-        ((Activity) getContext()).startActivityForResult(i,
-                FormEntryActivity.EX_DECIMAL_CAPTURE);
+        ((Activity) getContext()).startActivityForResult(i, EX_DECIMAL_CAPTURE);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
@@ -25,11 +25,12 @@ import android.text.method.DigitsKeyListener;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalAppsUtils;
 
 import java.util.Locale;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.EX_INT_CAPTURE;
 
 /**
  * Launch an external app to supply an integer value. If the app
@@ -82,8 +83,7 @@ public class ExIntegerWidget extends ExStringWidget {
         i.putExtra("value", getIntegerAnswerValue());
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "launchIntent",
                 i.getAction(), formEntryPrompt.getIndex());
-        ((Activity) getContext()).startActivityForResult(i,
-                FormEntryActivity.EX_INT_CAPTURE);
+        ((Activity) getContext()).startActivityForResult(i, EX_INT_CAPTURE);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -49,6 +49,8 @@ import java.util.Map;
 
 import timber.log.Timber;
 
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.EX_STRING_CAPTURE;
+
 /**
  * <p>Launch an external app to supply a string value. If the app
  * does not launch, enable the text area for regular data entry.</p>
@@ -200,8 +202,7 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
         i.putExtra("value", formEntryPrompt.getAnswerText());
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "launchIntent",
                 i.getAction(), formEntryPrompt.getIndex());
-        ((Activity) getContext()).startActivityForResult(i,
-                FormEntryActivity.EX_STRING_CAPTURE);
+        ((Activity) getContext()).startActivityForResult(i, EX_STRING_CAPTURE);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -33,7 +33,6 @@ import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.GeoPointActivity;
 import org.odk.collect.android.activities.GeoPointMapActivity;
 import org.odk.collect.android.activities.GeoPointOsmMapActivity;
@@ -43,6 +42,8 @@ import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.PlayServicesUtil;
 
 import java.text.DecimalFormat;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.LOCATION_CAPTURE;
 
 /**
  * GeoPointWidget is the widget that allows the user to get GPS readings.
@@ -150,8 +151,7 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
                     formController.setIndexWaitingForData(formEntryPrompt.getIndex());
                 }
 
-                ((Activity) getContext()).startActivityForResult(i,
-                        FormEntryActivity.LOCATION_CAPTURE);
+                ((Activity) getContext()).startActivityForResult(i, LOCATION_CAPTURE);
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -30,13 +30,14 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.GeoShapeGoogleMapActivity;
 import org.odk.collect.android.activities.GeoShapeOsmMapActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.PlayServicesUtil;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.GEOSHAPE_CAPTURE;
 
 /**
  * GeoShapeWidget is the widget that allows the user to get Collect multiple GPS points.
@@ -112,7 +113,7 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
         if (s.length() != 0) {
             i.putExtra(SHAPE_LOCATION, s);
         }
-        ((Activity) getContext()).startActivityForResult(i, FormEntryActivity.GEOSHAPE_CAPTURE);
+        ((Activity) getContext()).startActivityForResult(i, GEOSHAPE_CAPTURE);
     }
 
     private void updateButtonLabelsAndVisibility(boolean dataAvailable) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -31,13 +31,14 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.GeoTraceGoogleMapActivity;
 import org.odk.collect.android.activities.GeoTraceOsmMapActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.PlayServicesUtil;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.GEOTRACE_CAPTURE;
 
 /**
  * GeoShapeTrace is the widget that allows the user to get Collect multiple GPS points based on the
@@ -121,7 +122,7 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
         if (s.length() != 0) {
             i.putExtra(TRACE_LOCATION, s);
         }
-        ((Activity) getContext()).startActivityForResult(i, FormEntryActivity.GEOTRACE_CAPTURE);
+        ((Activity) getContext()).startActivityForResult(i, GEOTRACE_CAPTURE);
     }
 
     private void updateButtonLabelsAndVisibility(boolean dataAvailable) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -40,7 +40,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.ViewIds;
@@ -49,6 +48,9 @@ import java.io.File;
 import java.util.Date;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CAPTURE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CHOOSER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -112,8 +114,7 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
                 try {
                     Collect.getInstance().getFormController()
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CAPTURE);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CAPTURE);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),
@@ -143,8 +144,7 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
                 try {
                     Collect.getInstance().getFormController()
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CHOOSER);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CHOOSER);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -39,7 +39,6 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CaptureSelfieActivity;
 import org.odk.collect.android.activities.CaptureSelfieActivityNewApi;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -48,6 +47,9 @@ import org.odk.collect.android.utilities.ViewIds;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CAPTURE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.IMAGE_CHOOSER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the form.
@@ -112,8 +114,7 @@ public class ImageWidget extends QuestionWidget implements FileWidget {
                 try {
                     Collect.getInstance().getFormController().setIndexWaitingForData(
                             formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CAPTURE);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CAPTURE);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             getContext().getString(R.string.activity_not_found, "image capture"),
@@ -138,8 +139,7 @@ public class ImageWidget extends QuestionWidget implements FileWidget {
                 try {
                     Collect.getInstance().getFormController()
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.IMAGE_CHOOSER);
+                    ((Activity) getContext()).startActivityForResult(i, IMAGE_CHOOSER);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(getContext(),
                             getContext().getString(R.string.activity_not_found, "choose image"),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -24,7 +24,6 @@ import org.javarosa.core.model.osm.OSMTag;
 import org.javarosa.core.model.osm.OSMTagItem;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.utilities.ViewIds;
@@ -34,6 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.OSM_CAPTURE;
 
 /**
  * Widget that allows the user to launch OpenMapKit to get an OSM Feature with a
@@ -208,8 +209,7 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
                 formController.setIndexWaitingForData(
                         formEntryPrompt.getIndex());
                 // launch
-                ((Activity) ctx).startActivityForResult(launchIntent,
-                        FormEntryActivity.OSM_CAPTURE);
+                ((Activity) ctx).startActivityForResult(launchIntent, OSM_CAPTURE);
             } else {
                 errorTextView.setVisibility(View.VISIBLE);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
@@ -37,7 +37,6 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -46,6 +45,8 @@ import org.odk.collect.android.utilities.ViewIds;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.SIGNATURE_CAPTURE;
 
 /**
  * Signature widget.
@@ -152,8 +153,7 @@ public class SignatureWidget extends QuestionWidget implements FileWidget {
 
         try {
             Collect.getInstance().getFormController().setIndexWaitingForData(formEntryPrompt.getIndex());
-            ((Activity) getContext()).startActivityForResult(i,
-                    FormEntryActivity.SIGNATURE_CAPTURE);
+            ((Activity) getContext()).startActivityForResult(i, SIGNATURE_CAPTURE);
         } catch (ActivityNotFoundException e) {
             Toast.makeText(getContext(),
                     getContext().getString(R.string.activity_not_found, "signature capture"),

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -37,7 +37,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.PreferenceKeys;
@@ -52,6 +51,8 @@ import java.util.Locale;
 import timber.log.Timber;
 
 import static android.os.Build.MODEL;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.VIDEO_CAPTURE;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.VIDEO_CHOOSER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -140,8 +141,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
                 try {
                     formController
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.VIDEO_CAPTURE);
+                    ((Activity) getContext()).startActivityForResult(i, VIDEO_CAPTURE);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),
@@ -172,8 +172,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
                 try {
                     formController
                             .setIndexWaitingForData(formEntryPrompt.getIndex());
-                    ((Activity) getContext()).startActivityForResult(i,
-                            FormEntryActivity.VIDEO_CHOOSER);
+                    ((Activity) getContext()).startActivityForResult(i, VIDEO_CHOOSER);
                 } catch (ActivityNotFoundException e) {
                     Toast.makeText(
                             getContext(),


### PR DESCRIPTION
Just a minor refactor. The main purpose for doing this is to reduce the size of the FormEntryActivity. 

#### What has been done to verify that this works as intended?
Pure code refactor, does not alter the behavior in any way

#### Why is this the best possible solution? Were any other approaches considered?
Since RequestCode for the various widgets is accessed in multiple classes, not just in FormEntryActivty. So moving them to application constants seemed like a good option. 

#### Are there any risks to merging this code? If so, what are they?
No