### PR TITLE
Use StringBuilder instead of StringBuffer

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ReplaceCallback.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ReplaceCallback.java
@@ -54,7 +54,7 @@ public class ReplaceCallback {
      */
     public static String replace(String regex, String subject, int limit,
             AtomicInteger count, Callback callback) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Matcher matcher = Pattern.compile(regex).matcher(subject);
         int i;
         for (i = 0; (limit < 0 || i < limit) && matcher.find(); i++) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -48,7 +48,7 @@ public class TextUtils {
 
             String stylesText = attributes.replaceAll("style=[\"'](.*?)[\"']", "$1");
             String[] styles = stylesText.trim().split(";");
-            StringBuffer stylesOutput = new StringBuffer();
+            StringBuilder stylesOutput = new StringBuilder();
 
             for (String style : styles) {
                 String[] stylesAttributes = style.trim().split(":");


### PR DESCRIPTION
StringBuffer is synchronized, so for performance reasons StringBuilder should be
used in preference unless thread safety is required.
See https://docs.oracle.com/javase/7/docs/api/java/lang/StringBuffer.html