### PR TITLE
Fixes Circle CI build

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilder.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilder.java
@@ -56,6 +56,7 @@ public class CustomSQLiteQueryBuilder {
         return this;
     }
 
+    @SuppressWarnings("PMD.ConsecutiveLiteralAppends")
     public CustomSQLiteQueryBuilder columnsForInsert(String... columns) {
         query.append("(");
         columnsForSelect(columns);

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -137,6 +137,7 @@
         <exclude name="ExcessivePublicCount" />
         <exclude name="ExcessiveClassLength" />
         <exclude name="NcssMethodCount" />
+    </rule>
     <rule ref="rulesets/java/unusedcode.xml">
         <exclude name="UnusedFormalParameter" />
     </rule>


### PR DESCRIPTION
The build was failing as PMD was detecting `ConsecutiveLiteralAppends` for line 60 in CustomSQLiteQueryBuilder.java. 

The warning generated is false as PMD didn't take into consideration that the variable `query` might also get modified in the function call. So, I have suppressed this warning. This PR also adds a missing `<rule>` ending tag 

#### What has been done to verify that this works as intended?
No bug detected by PMD

#### Why is this the best possible solution? Were any other approaches considered?
Suppressing the warning looked like a simple and safe approach. 

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No