### PR TITLE
Replaces HardCopying of arrays with System.arraycopy() 

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -171,6 +171,7 @@ dependencies {
     }
 
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
     compile (group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.1') {

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -171,7 +171,6 @@ dependencies {
     }
 
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
     compile (group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.1') {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -42,6 +42,7 @@ import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccoun
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.services.drive.DriveScopes;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
@@ -111,12 +112,7 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
         Intent intent = getIntent();
         selectedInstanceIDs = intent.getLongArrayExtra(FormEntryActivity.KEY_INSTANCES);
 
-        instancesToSend = new Long[(selectedInstanceIDs == null) ? 0 : selectedInstanceIDs.length];
-        if (selectedInstanceIDs != null) {
-            for (int i = 0; i < selectedInstanceIDs.length; ++i) {
-                instancesToSend[i] = selectedInstanceIDs[i];
-            }
-        }
+        instancesToSend = ArrayUtils.toObject(selectedInstanceIDs);
 
         // at this point, we don't expect this to be empty...
         if (instancesToSend.length == 0) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -42,7 +42,6 @@ import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccoun
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.services.drive.DriveScopes;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
@@ -50,6 +49,7 @@ import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceGoogleSheetsUploader;
+import org.odk.collect.android.utilities.ArrayUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
 import java.util.Collections;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
@@ -107,12 +108,8 @@ public class InstanceUploaderActivity extends AppCompatActivity implements Insta
             selectedInstanceIDs = intent.getLongArrayExtra(FormEntryActivity.KEY_INSTANCES);
         }
 
-        instancesToSend = new Long[(selectedInstanceIDs == null) ? 0 : selectedInstanceIDs.length];
-        if (selectedInstanceIDs != null) {
-            for (int i = 0; i < selectedInstanceIDs.length; ++i) {
-                instancesToSend[i] = selectedInstanceIDs[i];
-            }
-        }
+        instancesToSend = selectedInstanceIDs == null ? ArrayUtils.EMPTY_LONG_OBJECT_ARRAY
+                : ArrayUtils.toObject(selectedInstanceIDs);
 
         // at this point, we don't expect this to be empty...
         if (instancesToSend.length == 0) {
@@ -161,12 +158,7 @@ public class InstanceUploaderActivity extends AppCompatActivity implements Insta
         outState.putString(ALERT_MSG, alertMsg);
         outState.putBoolean(ALERT_SHOWING, alertShowing);
         outState.putString(AUTH_URI, url);
-
-        long[] toSend = new long[instancesToSend.length];
-        for (int i = 0; i < instancesToSend.length; ++i) {
-            toSend[i] = instancesToSend[i];
-        }
-        outState.putLongArray(TO_SEND, toSend);
+        outState.putLongArray(TO_SEND, ArrayUtils.toPrimitive(instancesToSend));
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -25,7 +25,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
@@ -33,6 +32,7 @@ import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceServerUploader;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.ArrayUtils;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 
 import java.util.ArrayList;
@@ -108,8 +108,7 @@ public class InstanceUploaderActivity extends AppCompatActivity implements Insta
             selectedInstanceIDs = intent.getLongArrayExtra(FormEntryActivity.KEY_INSTANCES);
         }
 
-        instancesToSend = selectedInstanceIDs == null ? ArrayUtils.EMPTY_LONG_OBJECT_ARRAY
-                : ArrayUtils.toObject(selectedInstanceIDs);
+        instancesToSend = ArrayUtils.toObject(selectedInstanceIDs);
 
         // at this point, we don't expect this to be empty...
         if (instancesToSend.length == 0) {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
@@ -213,21 +213,15 @@ abstract class AppListFragment extends ListFragment {
     }
 
     /**
-     * Returns the IDs of the checked items, using the ListView of this activity.
+     * Returns the IDs of the checked items, as an array of Long
      */
-    protected long[] getCheckedIds() {
-        return getCheckedIds(getListView());
-    }
-
-    /**
-     * Returns the IDs of the checked items, using the ListView provided
-     */
-    protected long[] getCheckedIds(ListView lv) {
+    protected Long[] getCheckedIdObjects() {
         // This method could be simplified by using getCheckedItemIds, if one ensured that
         // IDs were “stable” (see the getCheckedItemIds doc).
+        ListView lv = getListView();
         int itemCount = lv.getCount();
         int checkedItemCount = lv.getCheckedItemCount();
-        long[] checkedIds = new long[checkedItemCount];
+        Long[] checkedIds = new Long[checkedItemCount];
         int resultIndex = 0;
         for (int posIdx = 0; posIdx < itemCount; posIdx++) {
             if (lv.isItemChecked(posIdx)) {
@@ -236,18 +230,6 @@ abstract class AppListFragment extends ListFragment {
             }
         }
         return checkedIds;
-    }
-
-    /**
-     * Returns the IDs of the checked items, as an array of Long
-     */
-    protected Long[] getCheckedIdObjects() {
-        long[] checkedIds = getCheckedIds();
-        Long[] checkedIdObjects = new Long[checkedIds.length];
-        for (int i = 0; i < checkedIds.length; i++) {
-            checkedIdObjects[i] = checkedIds[i];
-        }
-        return checkedIdObjects;
     }
 
     protected int getCheckedCount() {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -981,9 +981,7 @@ public class FormController {
 
         FormEntryCaption[] v = getCaptionHierarchy();
         FormEntryCaption[] groups = new FormEntryCaption[v.length - lastquestion];
-        for (int i = 0; i < v.length - lastquestion; i++) {
-            groups[i] = v[i];
-        }
+        System.arraycopy(v, 0, groups, 0, v.length - lastquestion);
         return groups;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ArrayUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ArrayUtils.java
@@ -1,0 +1,52 @@
+package org.odk.collect.android.utilities;
+
+
+public class ArrayUtils {
+
+    /**
+     * An empty immutable {@code Long} array.
+     */
+    private static final Long[] EMPTY_LONG_OBJECT_ARRAY = new Long[0];
+
+    /**
+     * An empty immutable {@code long} array.
+     */
+    private static final long[] EMPTY_LONG_ARRAY = new long[0];
+
+
+    /**
+     * <p>Converts an array of primitive longs to objects.</p>
+     *
+     * @param array a {@code long} array
+     * @return a {@code Long} array
+     */
+    @SuppressWarnings("PMD.AvoidArrayLoops")
+    public static Long[] toObject(long[] array) {
+        if (array == null || array.length == 0) {
+            return EMPTY_LONG_OBJECT_ARRAY;
+        }
+        final Long[] result = new Long[array.length];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = array[i];
+        }
+        return result;
+    }
+
+    /**
+     * <p>Converts an array of object Longs to primitives.</p>
+     *
+     * @param array a {@code Long} array
+     * @return a {@code long} array
+     */
+    @SuppressWarnings("PMD.AvoidArrayLoops")
+    public static long[] toPrimitive(Long[] array) {
+        if (array == null || array.length == 0) {
+            return EMPTY_LONG_ARRAY;
+        }
+        final long[] result = new long[array.length];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = array[i];
+        }
+        return result;
+    }
+}

--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -104,7 +104,6 @@
         <exclude name="PrematureDeclaration" />
         <exclude name="UseStringBufferForStringAppends" />
         <exclude name="SimplifyStartsWith" />
-        <exclude name="AvoidArrayLoops" />
         <exclude name="UnnecessaryWrapperObjectCreation" />
     </rule>
     <rule ref="rulesets/java/strictexception.xml">


### PR DESCRIPTION
`System.arraycopy()` uses JNI (Java Native Interface) to copy an array (or parts of it), so it is blazingly fast (for more info read [here](http://www.javaspecialists.co.za/archive/Issue124.html))

Also, the conversion of primitive array to object array and vice versa has been replaced with methods of `ArrayUtils` utility class from `commons-lang3` package

#### What has been done to verify that this works as intended?
This is just refactoring and does not modify the behavior in any possible way. 

#### Why is this the best possible solution? Were any other approaches considered?
Replaces the code with the standard library method calls

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No