### PR TITLE
Clicking an image used as a choice does not select that option

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -235,12 +235,12 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                         imageView.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View v) {
-                                Collect.getInstance().getActivityLogger().logInstanceAction(
+                                if (bigImageURI != null) {
+                                    Collect.getInstance().getActivityLogger().logInstanceAction(
                                         this, "onClick",
                                         "showImagePromptBigImage" + MediaLayout.this.selectionDesignator,
                                         MediaLayout.this.index);
-
-                                if (bigImageURI != null) {
+                                    
                                     try {
                                         File bigImage = new File(ReferenceManager
                                                 .instance()

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -168,7 +168,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
         RelativeLayout.LayoutParams imageParams =
-                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+                new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT,
                         LayoutParams.WRAP_CONTENT);
         RelativeLayout.LayoutParams videoParams =
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
@@ -232,32 +232,41 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                         imageView.setImageBitmap(b);
                         imageView.setId(imageId);
 
-                        if (bigImageURI != null) {
-                            imageView.setOnClickListener(new OnClickListener() {
-                                String bigImageFilename = ReferenceManager.instance()
-                                        .DeriveReference(bigImageURI).getLocalURI();
-                                File bigImage = new File(bigImageFilename);
+                        imageView.setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                Collect.getInstance().getActivityLogger().logInstanceAction(
+                                        this, "onClick",
+                                        "showImagePromptBigImage" + MediaLayout.this.selectionDesignator,
+                                        MediaLayout.this.index);
 
-
-                                @Override
-                                public void onClick(View v) {
-                                    Collect.getInstance().getActivityLogger().logInstanceAction(
-                                            this, "onClick",
-                                            "showImagePromptBigImage" + MediaLayout.this.selectionDesignator,
-                                            MediaLayout.this.index);
-
-                                    Intent i = new Intent("android.intent.action.VIEW");
-                                    i.setDataAndType(Uri.fromFile(bigImage), "image/*");
+                                if (bigImageURI != null) {
                                     try {
+                                        File bigImage = new File(ReferenceManager
+                                                .instance()
+                                                .DeriveReference(bigImageURI)
+                                                .getLocalURI());
+
+                                        Intent i = new Intent("android.intent.action.VIEW");
+                                        i.setDataAndType(Uri.fromFile(bigImage), "image/*");
                                         getContext().startActivity(i);
+                                    } catch (InvalidReferenceException e) {
+                                        Timber.e(e, "Invalid image reference due to %s ", e.getMessage());
                                     } catch (ActivityNotFoundException e) {
                                         Timber.d(e, "No Activity found to handle due to %s", e.getMessage());
                                         ToastUtils.showShortToast(getContext().getString(R.string.activity_not_found,
-                                                        "view image"));
+                                                "view image"));
+                                    }
+                                } else {
+                                    if (viewText instanceof RadioButton) {
+                                        ((RadioButton) viewText).setChecked(true);
+                                    } else if (viewText instanceof CheckBox) {
+                                        CheckBox checkbox = (CheckBox) viewText;
+                                        checkbox.setChecked(!checkbox.isChecked());
                                     }
                                 }
-                            });
-                        }
+                            }
+                        });
                     } else {
                         // Loading the image failed, so it's likely a bad file.
                         errorMsg = getContext().getString(R.string.file_invalid, imageFile);


### PR DESCRIPTION
Closes #1510 

#### What has been done to verify that this works as intended?
I've tested attached form which contains Select One Question and Select Multiple Question (both witch images)

#### Why is this the best possible solution? Were any other approaches considered?
In this case there is only one solution - checking/unchecking buttons after clicking on images too.

#### Are there any risks to merging this code? If so, what are they?
I've changed this line https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1510?expand=1#diff-8a96509b41b463c22daa03b8c26a6637L171 in order to be able to click on the empty space after image too. I tested it and everything is ok but it would be good to check it on various devices to be sure images are in the same places as before and they look like before.

#### Do we need any specific form for testing your changes? If so, please attach one.
Yes. Here you go: 
[form.zip](https://github.com/opendatakit/collect/files/1358733/form.zip)

Just to clarify. We should be able to select an answer by clicking on an image only if `big-image` attribute is not specified, otherwise if you click on that image you should be able to see it in gallery (full screen). Attached form contains that case.

