### PR TITLE
Add an option to set an image size in settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -125,6 +125,7 @@ import timber.log.Timber;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_IMAGE_SIZE;
 import static org.odk.collect.android.utilities.ApplicationConstants.XML_OPENROSA_NAMESPACE;
 
 
@@ -844,9 +845,16 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     }
 
     private void scaleDownImageIfNeeded(String path) {
+        Integer maxPixels;
+
         QuestionWidget questionWidget = getWidgetWaitingForBinaryData();
         if (questionWidget != null) {
-            Integer maxPixels = getMaxPixelsForImageIfDefined(questionWidget);
+            maxPixels = getMaxPixelsFromFormIfDefined(questionWidget);
+
+            if (maxPixels == null) {
+                maxPixels = getMaxPixelsFromSettings();
+            }
+
             if (maxPixels != null) {
                 scaleDownImage(path, maxPixels);
             }
@@ -864,7 +872,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         return questionWidget;
     }
 
-    private Integer getMaxPixelsForImageIfDefined(QuestionWidget questionWidget) {
+    private Integer getMaxPixelsFromFormIfDefined(QuestionWidget questionWidget) {
         Integer maxPixels = null;
         for (TreeElement attrs : questionWidget.getPrompt().getBindAttributes()) {
             if ("max-pixels".equals(attrs.getName()) && XML_OPENROSA_NAMESPACE.equals(attrs.getNamespace())) {
@@ -873,6 +881,24 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 } catch (NumberFormatException e) {
                     Timber.i(e);
                 }
+            }
+        }
+        return maxPixels;
+    }
+
+    private Integer getMaxPixelsFromSettings() {
+        Integer maxPixels = null;
+        String imageSizeMode = (String) GeneralSharedPreferences.getInstance().get(KEY_IMAGE_SIZE);
+        String[] imageEntryValues = getResources().getStringArray(R.array.image_size_entry_values);
+        if (!imageSizeMode.equals(imageEntryValues[0])) {
+            if (imageSizeMode.equals(imageEntryValues[1])) {
+                maxPixels = 640;
+            } else if (imageSizeMode.equals(imageEntryValues[2])) {
+                maxPixels = 1024;
+            } else if (imageSizeMode.equals(imageEntryValues[3])) {
+                maxPixels = 2048;
+            } else if (imageSizeMode.equals(imageEntryValues[4])) {
+                maxPixels = 4096;
             }
         }
         return maxPixels;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -898,7 +898,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             } else if (imageSizeMode.equals(imageEntryValues[3])) {
                 maxPixels = 2048;
             } else if (imageSizeMode.equals(imageEntryValues[4])) {
-                maxPixels = 4096;
+                maxPixels = 3072;
             }
         }
         return maxPixels;

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
@@ -42,6 +42,7 @@ public final class AdminKeys {
     public static final String KEY_CHANGE_FONT_SIZE            = "change_font_size";
     public static final String KEY_DEFAULT_TO_FINALIZED        = "default_to_finalized";
     public static final String KEY_HIGH_RESOLUTION             = "high_resolution";
+    public static final String KEY_IMAGE_SIZE                  = "image_size";
     public static final String KEY_SHOW_SPLASH_SCREEN          = "show_splash_screen";
     public static final String KEY_DELETE_AFTER_SEND           = "delete_after_send";
     public static final String KEY_INSTANCE_FORM_SYNC          = "instance_form_sync";
@@ -73,6 +74,7 @@ public final class AdminKeys {
             ag(KEY_APP_LANGUAGE,               PreferenceKeys.KEY_APP_LANGUAGE),
             ag(KEY_DEFAULT_TO_FINALIZED,       PreferenceKeys.KEY_COMPLETED_DEFAULT),
             ag(KEY_HIGH_RESOLUTION,            PreferenceKeys.KEY_HIGH_RESOLUTION),
+            ag(KEY_IMAGE_SIZE,                 PreferenceKeys.KEY_IMAGE_SIZE),
             ag(KEY_SHOW_SPLASH_SCREEN,         PreferenceKeys.KEY_SHOW_SPLASH),
             ag(KEY_SHOW_SPLASH_SCREEN,         PreferenceKeys.KEY_SPLASH_PATH),
             ag(KEY_DELETE_AFTER_SEND,          PreferenceKeys.KEY_DELETE_AFTER_SEND),
@@ -121,6 +123,7 @@ public final class AdminKeys {
             KEY_DEFAULT_TO_FINALIZED,
             KEY_CONSTRAINT_BEHAVIOR,
             KEY_HIGH_RESOLUTION,
+            KEY_IMAGE_SIZE,
             KEY_INSTANCE_FORM_SYNC,
             KEY_TIMER_LOG_ENABLED
     );

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -24,6 +24,7 @@ import org.odk.collect.android.R;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_CONSTRAINT_BEHAVIOR;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_IMAGE_SIZE;
 
 public class FormManagementPreferences extends BasePreferenceFragment {
 
@@ -34,6 +35,7 @@ public class FormManagementPreferences extends BasePreferenceFragment {
 
         initConstraintBehaviorPref();
         initAutoSendPrefs();
+        initImageSizePrefs();
     }
 
     @Override
@@ -80,6 +82,25 @@ public class FormManagementPreferences extends BasePreferenceFragment {
 
         autosend.setSummary(autosend.getEntry());
         autosend.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+                String entry = (String) ((ListPreference) preference).getEntries()[index];
+                preference.setSummary(entry);
+                return true;
+            }
+        });
+    }
+
+    private void initImageSizePrefs() {
+        final ListPreference imageSize = (ListPreference) findPreference(KEY_IMAGE_SIZE);
+
+        if (imageSize == null) {
+            return;
+        }
+
+        imageSize.setSummary(imageSize.getEntry());
+        imageSize.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -51,6 +51,7 @@ public final class PreferenceKeys {
     public static final String KEY_COMPLETED_DEFAULT        = "default_completed";
 
     public static final String KEY_HIGH_RESOLUTION          = "high_resolution";
+    public static final String KEY_IMAGE_SIZE               = "image_size";
 
     public static final String KEY_AUTOSEND                 = "autosend";
     public static final String KEY_AUTOSEND_WIFI            = "autosend_wifi";
@@ -93,6 +94,7 @@ public final class PreferenceKeys {
         hashMap.put(KEY_SUBMISSION_URL,             Collect.getInstance().getString(R.string.default_odk_submission));
         hashMap.put(KEY_NAVIGATION,                 "swipe");
         hashMap.put(KEY_CONSTRAINT_BEHAVIOR,        "on_swipe");
+        hashMap.put(KEY_IMAGE_SIZE,                 "original_image_size");
         hashMap.put(KEY_COMPLETED_DEFAULT,          true);
         hashMap.put(KEY_MAP_SDK,                    "google_maps");
         hashMap.put(KEY_MAP_BASEMAP,                "streets");

--- a/collect_app/src/main/res/values/arrays.xml
+++ b/collect_app/src/main/res/values/arrays.xml
@@ -52,6 +52,20 @@ the specific language governing permissions and limitations under the License. -
         <item>@string/constraint_behavior_on_swipe</item>
         <item>@string/constraint_behavior_on_finalize</item>
     </string-array>
+    <string-array name="image_size_entry_values" translatable="false">
+        <item>original_image_size</item>
+        <item>very_small</item>
+        <item>small</item>
+        <item>medium</item>
+        <item>large</item>
+    </string-array>
+    <string-array name="image_size_entries">
+        <item>@string/original_image_size</item>
+        <item>@string/very_small</item>
+        <item>@string/small</item>
+        <item>@string/medium</item>
+        <item>@string/large</item>
+    </string-array>
     <string-array name="map_sdk_selector_entries">
         <item>@string/google_maps_sdk</item>
         <item>@string/openstreetmap_sdk</item>

--- a/collect_app/src/main/res/values/arrays.xml
+++ b/collect_app/src/main/res/values/arrays.xml
@@ -60,11 +60,11 @@ the specific language governing permissions and limitations under the License. -
         <item>large</item>
     </string-array>
     <string-array name="image_size_entries">
-        <item>@string/original_image_size</item>
-        <item>@string/very_small</item>
-        <item>@string/small</item>
-        <item>@string/medium</item>
-        <item>@string/large</item>
+        <item>@string/image_size_original</item>
+        <item>@string/image_size_very_small</item>
+        <item>@string/image_size_small</item>
+        <item>@string/image_size_medium</item>
+        <item>@string/image_size_large</item>
     </string-array>
     <string-array name="map_sdk_selector_entries">
         <item>@string/google_maps_sdk</item>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -517,7 +517,7 @@
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
-    <string name="large">Large (4096px)</string>
+    <string name="large">Large (3072px)</string>
     <string name="medium">Medium (2048px)</string>
     <string name="small">Small (1024px)</string>
     <string name="very_small">Very small (640px)</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -497,6 +497,7 @@
     <string name="form_submission_category">Form submission</string>
     <string name="form_filling_category">Form filling</string>
     <string name="high_resolution_title">High res video</string>
+    <string name="image_size_title">Image size</string>
     <string name="form_import_category">Form import</string>
     <string name="user_and_device_identity_title">User and device identity</string>
     <string name="constraint_behavior_title">Constraint processing</string>
@@ -516,4 +517,10 @@
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
+    <string name="large">Large (4096px)</string>
+    <string name="medium">Medium (2048px)</string>
+    <string name="small">Small (1024px)</string>
+    <string name="very_small">Very small (640px)</string>
+    <string name="original_image_size">Original size from camera (default)</string>
+    <string name="image_size_dialog_title">Maximum pixels of the long edge of the image</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -517,11 +517,11 @@
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
-    <string name="large">Large (3072px)</string>
-    <string name="medium">Medium (2048px)</string>
-    <string name="small">Small (1024px)</string>
-    <string name="very_small">Very small (640px)</string>
-    <string name="original_image_size">Original size from camera (default)</string>
+    <string name="image_size_large">Large (3072px)</string>
+    <string name="image_size_medium">Medium (2048px)</string>
+    <string name="image_size_small">Small (1024px)</string>
+    <string name="image_size_very_small">Very small (640px)</string>
+    <string name="image_size_original">Original size from camera (default)</string>
     <string name="image_size_dialog_title">Maximum pixels of the long edge of the image</string>
     <string name="bearing_lack_of_sensors">Bearing cannot be collected: device is missing accelerometer, magnetic field sensor or both.</string>
 </resources>

--- a/collect_app/src/main/res/xml/form_management_preferences.xml
+++ b/collect_app/src/main/res/xml/form_management_preferences.xml
@@ -37,6 +37,13 @@
             android:key="high_resolution"
             android:summary="@string/high_resolution_summary"
             android:title="@string/high_resolution_title" />
+        <ListPreference
+            android:defaultValue="original_image_size"
+            android:dialogTitle="@string/image_size_dialog_title"
+            android:entries="@array/image_size_entries"
+            android:entryValues="@array/image_size_entry_values"
+            android:key="image_size"
+            android:title="@string/image_size_title" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/collect_app/src/main/res/xml/user_settings_access_preferences.xml
+++ b/collect_app/src/main/res/xml/user_settings_access_preferences.xml
@@ -47,6 +47,10 @@
             android:title="@string/high_resolution_title" />
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="image_size"
+            android:title="@string/image_size_title" />
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="show_splash_screen"
             android:title="@string/show_splash_title" />
         <CheckBoxPreference


### PR DESCRIPTION
Closes #1217 

#### What has been done to verify that this works as intended?
1. I've tested the attached form (all possible options).
2. I've tested saving/reading settings using QR code and settings file.
3. I've tested hiding this option in admin settings.

#### Why is this the best possible solution? Were any other approaches considered?
This approach seems to be the only one right. It's clear and uses the code added before for #1210 

#### Are there any risks to merging this code? If so, what are they?
I can't imagine any other scenario apart from those I mentioned above. If @mmarciniak90 tests the same too and confirm it works as expected it should be safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
Yes. We can use this form:
[AllWidgets.txt](https://github.com/opendatakit/collect/files/1362416/AllWidgets.txt)

where `orx:max-pixels` is specified only for one question with image widget.