### PR TITLE
Increase the buffer size for FileUtils.getMd5Hash. 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -141,7 +141,7 @@ public class FileUtils {
 
             final InputStream is = new FileInputStream(file);
 
-            while(true) {
+            while (true) {
                 int result = is.read(buffer, 0, bufSize);
                 if (result == -1) {
                     break;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -127,42 +127,29 @@ public class FileUtils {
         }
     }
 
+    static int bufSize = 16 * 1024; // May be set by unit test
+
     public static String getMd5Hash(File file) {
         try {
-            // CTS (6/15/2010) : stream file through digest instead of handing it the byte[]
             MessageDigest md = MessageDigest.getInstance("MD5");
-            int chunkSize = 256;
+            final byte[] buffer = new byte[bufSize];
 
-            byte[] chunk = new byte[chunkSize];
-
-            // Get the size of the file
-            long llength = file.length();
-
-            if (llength > Integer.MAX_VALUE) {
+            if (file.length() > Integer.MAX_VALUE) {
                 Timber.e("File %s is too large", file.getName());
                 return null;
             }
 
-            int length = (int) llength;
+            final InputStream is = new FileInputStream(file);
 
-            InputStream is = null;
-            is = new FileInputStream(file);
-
-            int l = 0;
-            for (l = 0; l + chunkSize < length; l += chunkSize) {
-                is.read(chunk, 0, chunkSize);
-                md.update(chunk, 0, chunkSize);
+            while(true) {
+                int result = is.read(buffer, 0, bufSize);
+                if (result == -1) {
+                    break;
+                }
+                md.update(buffer, 0, result);
             }
 
-            int remaining = length - l;
-            if (remaining > 0) {
-                is.read(chunk, 0, remaining);
-                md.update(chunk, 0, remaining);
-            }
-            byte[] messageDigest = md.digest();
-
-            BigInteger number = new BigInteger(1, messageDigest);
-            String md5 = number.toString(16);
+            String md5 = new BigInteger(1, md.digest()).toString(16);
             while (md5.length() < 32) {
                 md5 = "0" + md5;
             }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -1,0 +1,28 @@
+package org.odk.collect.android.utilities;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class FileUtilsTest {
+    @Test public void md5HashIsCorrect() throws NoSuchAlgorithmException, IOException {
+        String contents = "Hello, world";
+        File tempFile = File.createTempFile("hello", "txt");
+        tempFile.deleteOnExit();
+        FileWriter fw = new FileWriter(tempFile);
+        fw.write(contents);
+        fw.close();
+        for (int bufSize : Arrays.asList(1, contents.length() - 1, contents.length(), 64 * 1024)) {
+            FileUtils.bufSize = bufSize;
+            String md5Hash = FileUtils.getMd5Hash(tempFile);
+            String expectedResult = "bc6e6f16b8a077ef5fbc8d59d0b931b9";  // From md5 command-line utility
+            assertEquals(expectedResult, md5Hash);
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -20,9 +20,8 @@ public class FileUtilsTest {
         fw.close();
         for (int bufSize : Arrays.asList(1, contents.length() - 1, contents.length(), 64 * 1024)) {
             FileUtils.bufSize = bufSize;
-            String md5Hash = FileUtils.getMd5Hash(tempFile);
             String expectedResult = "bc6e6f16b8a077ef5fbc8d59d0b931b9";  // From md5 command-line utility
-            assertEquals(expectedResult, md5Hash);
+            assertEquals(expectedResult, FileUtils.getMd5Hash(tempFile));
         }
     }
 }


### PR DESCRIPTION
Reading and hashing 256 bytes at a time causes a small performance problem. 16K is working well. Clean up the code, especially removing duplication. Add a test that exercises boundary cases with the buffer.

#### What has been done to verify that this works as intended?
An excellent test

#### Why is this the best possible solution? Were any other approaches considered?
We could go higher with the buffer size if we know we have the memory.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.