### PR TITLE
Use Javarosa 2.6.0 snapshot

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -173,7 +173,7 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
-    compile (group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.5.1') {
+    compile (group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.6.0-SNAPSHOT') {
         exclude module: 'joda-time'
     }
     compile group: 'org.osmdroid', name: 'osmdroid-android', version: '5.6.4'


### PR DESCRIPTION
Updates Javarosa so we can start exercising some big recent changes:
- https://github.com/opendatakit/javarosa/pull/192 -- significant performance improvements on first load of forms. 
- https://github.com/opendatakit/javarosa/pull/189 -- update to how times are parsed when using time widget

**Risks**
This makes changes to how forms are loaded and there is some chance it breaks behavior there. @mdudzinski is working on some automated tests on the JR side. @mmarciniak90 please try crazy things to try to break it! 😉