### PR TITLE
Log form processing timings; Improve related code quality

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2557,13 +2557,16 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 }
             }
 
-            // if somehow we end up with a bad language, set it to the default
+            long start = System.currentTimeMillis();
+            Timber.i("calling formController.setLanguage");
             try {
                 formController.setLanguage(newLanguage);
             } catch (Exception e) {
+                // if somehow we end up with a bad language, set it to the default
                 Timber.e("Ended up with a bad language. %s", newLanguage);
                 formController.setLanguage(defaultLanguage);
             }
+            Timber.i("Done in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
         }
 
         boolean pendingActivityResult = task.hasPendingActivityResult();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -116,80 +116,31 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
 
     /**
      * Initialize {@link FormEntryController} with {@link FormDef} from binary or
-     * from XML. If given an instance, it will be used to fill the {@link FormDef}
-     * .
+     * from XML. If given an instance, it will be used to fill the {@link FormDef}.
      */
     @Override
     protected FECWrapper doInBackground(String... path) {
-        FormDef fd = null;
-        FileInputStream fis = null;
         errorMsg = null;
 
-        String formPath = path[0];
+        final String formPath = path[0];
+        final File formXml = new File(formPath);
 
-        File formXml = new File(formPath);
-        String formHash = FileUtils.getMd5Hash(formXml);
-        File formBin = new File(Collect.CACHE_PATH + File.separator + formHash + ".formdef");
+        final FormDef formDef = createFormDefFromCacheOrXml(formPath, formXml);
 
-        publishProgress(
-                Collect.getInstance().getString(R.string.survey_loading_reading_form_message));
-
-
-        //    FormDef.setDefaultEventNotifier(new EventNotifier() {
-        //
-        //      @Override
-        //      public void publishEvent(Event event) {
-        //        Log.d("FormDef", event.asLogLine());
-        //      }
-        //    });
-
-        if (formBin.exists()) {
-            // if we have binary, deserialize binary
-            Timber.i("Attempting to load %s from cached file: %s",
-                    formXml.getName(), formBin.getAbsolutePath());
-            fd = deserializeFormDef(formBin);
-            if (fd == null) {
-                // some error occured with deserialization. Remove the file, and make a
-                // new .formdef
-                // from xml
-                Timber.w("Deserialization FAILED!  Deleting cache file: %s",
-                        formBin.getAbsolutePath());
-                formBin.delete();
-            }
-        }
-        if (fd == null) {
-            // no binary, read from xml
-            try {
-                Timber.i("Attempting to load from: %s", formXml.getAbsolutePath());
-                fis = new FileInputStream(formXml);
-                fd = XFormUtils.getFormFromInputStream(fis);
-                if (fd == null) {
-                    errorMsg = "Error reading XForm file";
-                } else {
-                    serializeFormDef(fd, formPath);
-                }
-            } catch (Exception e) {
-                Timber.e(e);
-                errorMsg = e.getMessage();
-            } finally {
-                IOUtils.closeQuietly(fis);
-            }
-        }
-
-        if (errorMsg != null || fd == null) {
+        if (errorMsg != null || formDef == null) {
             return null;
         }
 
         // set paths to /sdcard/odk/forms/formfilename-media/
-        String formFileName = formXml.getName().substring(0, formXml.getName().lastIndexOf("."));
-        File formMediaDir = new File(formXml.getParent(), formFileName + "-media");
+        final String formFileName = formXml.getName().substring(0, formXml.getName().lastIndexOf("."));
+        final File formMediaDir = new File(formXml.getParent(), formFileName + "-media");
 
         externalDataManager = new ExternalDataManagerImpl(formMediaDir);
 
         // add external data function handlers
         ExternalDataHandler externalDataHandlerPull = new ExternalDataHandlerPull(
                 externalDataManager);
-        fd.getEvaluationContext().addFunctionHandler(externalDataHandlerPull);
+        formDef.getEvaluationContext().addFunctionHandler(externalDataHandlerPull);
 
         try {
             loadExternalData(formMediaDir);
@@ -205,51 +156,16 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
 
         // create FormEntryController from formdef
-        FormEntryModel fem = new FormEntryModel(fd);
-        FormEntryController fec = new FormEntryController(fem);
+        final FormEntryModel fem = new FormEntryModel(formDef);
+        final FormEntryController fec = new FormEntryController(fem);
 
         boolean usedSavepoint = false;
 
         try {
-            // import existing data into formdef
-            if (instancePath != null) {
-                File instance = new File(instancePath);
-                File shadowInstance = SaveToDiskTask.savepointFile(instance);
-                if (shadowInstance.exists() && (shadowInstance.lastModified()
-                        > instance.lastModified())) {
-                    // the savepoint is newer than the saved value of the instance.
-                    // use it.
-                    usedSavepoint = true;
-                    instance = shadowInstance;
-                    Timber.w("Loading instance from shadow file: %s", shadowInstance.getAbsolutePath());
-                }
-                if (instance.exists()) {
-                    // This order is important. Import data, then initialize.
-                    try {
-                        importData(instance, fec);
-                        fd.initialize(false, new InstanceInitializationFactory());
-                    } catch (RuntimeException e) {
-                        Timber.e(e);
-
-                        // SCTO-633
-                        if (usedSavepoint
-                                && !(e.getCause() instanceof XPathTypeMismatchException)) {
-                            // this means that the .save file is corrupted or 0-sized, so
-                            // don't use it.
-                            usedSavepoint = false;
-                            instancePath = null;
-                            fd.initialize(true, new InstanceInitializationFactory());
-                        } else {
-                            // this means that the saved instance is corrupted.
-                            throw e;
-                        }
-                    }
-                } else {
-                    fd.initialize(true, new InstanceInitializationFactory());
-                }
-            } else {
-                fd.initialize(true, new InstanceInitializationFactory());
-            }
+            Timber.i("Importing existing data");
+            final long start = System.currentTimeMillis();
+            usedSavepoint = importExistingData(formDef, fec);
+            Timber.i("Imported in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
         } catch (RuntimeException e) {
             Timber.e(e);
             if (e.getCause() instanceof XPathTypeMismatchException) {
@@ -270,22 +186,110 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         // Remove previous forms
         ReferenceManager.instance().clearSession();
 
+        processItemSets(formMediaDir);
+
+        // This should get moved to the Application Class
+        if (ReferenceManager.instance().getFactories().length == 0) {
+            // this is /sdcard/odk
+            ReferenceManager.instance().addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
+        }
+
+        // Set jr://... to point to /sdcard/odk/forms/filename-media/
+        ReferenceManager.instance().addSessionRootTranslator(
+                new RootTranslator("jr://images/", "jr://file/forms/" + formFileName + "-media/"));
+        ReferenceManager.instance().addSessionRootTranslator(
+                new RootTranslator("jr://image/", "jr://file/forms/" + formFileName + "-media/"));
+        ReferenceManager.instance().addSessionRootTranslator(
+                new RootTranslator("jr://audio/", "jr://file/forms/" + formFileName + "-media/"));
+        ReferenceManager.instance().addSessionRootTranslator(
+                new RootTranslator("jr://video/", "jr://file/forms/" + formFileName + "-media/"));
+
+        final FormController fc = new FormController(formMediaDir, fec, instancePath == null ? null
+                : new File(instancePath));
+        if (xpath != null) {
+            // we are resuming after having terminated -- set index to this
+            // position...
+            FormIndex idx = fc.getIndexFromXPath(xpath);
+            fc.jumpToIndex(idx);
+        }
+        if (waitingXPath != null) {
+            FormIndex idx = fc.getIndexFromXPath(waitingXPath);
+            fc.setIndexWaitingForData(idx);
+        }
+        data = new FECWrapper(fc, usedSavepoint);
+        return data;
+    }
+
+    private FormDef createFormDefFromCacheOrXml(String formPath, File formXml) {
+        final String formHash = FileUtils.getMd5Hash(formXml);
+
+        publishProgress(
+                Collect.getInstance().getString(R.string.survey_loading_reading_form_message));
+
+        final File cachedForm = new File(Collect.CACHE_PATH + File.separator + formHash + ".formdef");
+        if (cachedForm.exists()) {
+            Timber.i("Attempting to load %s from cached file: %s.",
+                    formXml.getName(), cachedForm.getAbsolutePath());
+            final long start = System.currentTimeMillis();
+            final FormDef deserializedFormDef = deserializeFormDef(cachedForm);
+            if (deserializedFormDef != null) {
+                Timber.i("Loaded in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
+
+                return deserializedFormDef;
+            }
+
+            // An error occurred with deserialization. Remove the file, and make a
+            // new .formdef from xml.
+            Timber.w("Deserialization FAILED! Deleting cache file: %s",
+                    cachedForm.getAbsolutePath());
+            cachedForm.delete();
+        }
+
+        FileInputStream fis = null;
+        // no binary, read from xml
+        try {
+            Timber.i("Attempting to load from: %s", formXml.getAbsolutePath());
+            final long start = System.currentTimeMillis();
+            fis = new FileInputStream(formXml);
+            FormDef formDefFromXml = XFormUtils.getFormFromInputStream(fis);
+            if (formDefFromXml == null) {
+                errorMsg = "Error reading XForm file";
+            } else {
+                Timber.i("Loaded in %.3f seconds. Now saving to cache.",
+                        (System.currentTimeMillis() - start) / 1000F);
+                final long start2 = System.currentTimeMillis();
+                serializeFormDef(formDefFromXml, formPath);
+                Timber.i("Saved to cache in %.3f seconds.",
+                        (System.currentTimeMillis() - start2) / 1000F);
+                return formDefFromXml;
+            }
+        } catch (Exception e) {
+            Timber.e(e);
+            errorMsg = e.getMessage();
+        } finally {
+            IOUtils.closeQuietly(fis);
+        }
+
+        return null;
+    }
+
+    private void processItemSets(File formMediaDir) {
         // for itemsets.csv, we only check to see if the itemset file has been
         // updated
-        File csv = new File(formMediaDir.getAbsolutePath() + "/" + ITEMSETS_CSV);
+        final File csv = new File(formMediaDir.getAbsolutePath() + "/" + ITEMSETS_CSV);
         String csvmd5 = null;
         if (csv.exists()) {
             csvmd5 = FileUtils.getMd5Hash(csv);
             boolean readFile = false;
-            ItemsetDbAdapter ida = new ItemsetDbAdapter();
+            final ItemsetDbAdapter ida = new ItemsetDbAdapter();
             ida.open();
             // get the database entry (if exists) for this itemsets.csv, based
             // on the path
-            Cursor c = ida.getItemsets(csv.getAbsolutePath());
+            final Cursor c = ida.getItemsets(csv.getAbsolutePath());
             if (c != null) {
                 if (c.getCount() == 1) {
                     c.moveToFirst(); // should be only one, ever, if any
-                    String oldmd5 = c.getString(c.getColumnIndex("hash"));
+                    final String oldmd5 = c.getString(c.getColumnIndex("hash"));
                     if (oldmd5.equals(csvmd5)) {
                         // they're equal, do nothing
                     } else {
@@ -306,45 +310,50 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
                 readCSV(csv, csvmd5, ItemsetDbAdapter.getMd5FromString(csv.getAbsolutePath()));
             }
         }
+    }
 
-        // This should get moved to the Application Class
-        if (ReferenceManager.instance().getFactories().length == 0) {
-            // this is /sdcard/odk
-            ReferenceManager.instance().addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
+    private boolean importExistingData(FormDef formDef, FormEntryController fec) {
+        final InstanceInitializationFactory instanceInit = new InstanceInitializationFactory();
+        boolean usedSavepoint = false;
+        if (instancePath != null) {
+            File instance = new File(instancePath);
+            final File shadowInstance = SaveToDiskTask.savepointFile(instance);
+            if (shadowInstance.exists() && (shadowInstance.lastModified()
+                    > instance.lastModified())) {
+                // the savepoint is newer than the saved value of the instance.
+                // use it.
+                usedSavepoint = true;
+                instance = shadowInstance;
+                Timber.w("Loading instance from shadow file: %s", shadowInstance.getAbsolutePath());
+            }
+            if (instance.exists()) {
+                // This order is important. Import data, then initialize.
+                try {
+                    importData(instance, fec);
+                    formDef.initialize(false, instanceInit);
+                } catch (RuntimeException e) {
+                    Timber.e(e);
+
+                    // SCTO-633
+                    if (usedSavepoint
+                            && !(e.getCause() instanceof XPathTypeMismatchException)) {
+                        // this means that the .save file is corrupted or 0-sized, so
+                        // don't use it.
+                        usedSavepoint = false;
+                        instancePath = null;
+                        formDef.initialize(true, instanceInit);
+                    } else {
+                        // this means that the saved instance is corrupted.
+                        throw e;
+                    }
+                }
+            } else {
+                formDef.initialize(true, instanceInit);
+            }
+        } else {
+            formDef.initialize(true, instanceInit);
         }
-
-        // Set jr://... to point to /sdcard/odk/forms/filename-media/
-        ReferenceManager.instance().addSessionRootTranslator(
-                new RootTranslator("jr://images/", "jr://file/forms/" + formFileName + "-media/"));
-        ReferenceManager.instance().addSessionRootTranslator(
-                new RootTranslator("jr://image/", "jr://file/forms/" + formFileName + "-media/"));
-        ReferenceManager.instance().addSessionRootTranslator(
-                new RootTranslator("jr://audio/", "jr://file/forms/" + formFileName + "-media/"));
-        ReferenceManager.instance().addSessionRootTranslator(
-                new RootTranslator("jr://video/", "jr://file/forms/" + formFileName + "-media/"));
-
-        // clean up vars
-        fis = null;
-        fd = null;
-        formBin = null;
-        formXml = null;
-        formPath = null;
-
-        FormController fc = new FormController(formMediaDir, fec, instancePath == null ? null
-                : new File(instancePath));
-        if (xpath != null) {
-            // we are resuming after having terminated -- set index to this
-            // position...
-            FormIndex idx = fc.getIndexFromXPath(xpath);
-            fc.jumpToIndex(idx);
-        }
-        if (waitingXPath != null) {
-            FormIndex idx = fc.getIndexFromXPath(waitingXPath);
-            fc.setIndexWaitingForData(idx);
-        }
-        data = new FECWrapper(fc, usedSavepoint);
-        return data;
-
+        return usedSavepoint;
     }
 
     @SuppressWarnings("unchecked")
@@ -412,7 +421,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
     }
 
-    public boolean importData(File instanceFile, FormEntryController fec) {
+    private boolean importData(File instanceFile, FormEntryController fec) {
         publishProgress(
                 Collect.getInstance().getString(R.string.survey_loading_reading_data_message));
 


### PR DESCRIPTION
Now we can more easily see where time is spent in Collect, with large forms. A few areas stick out:

- Serializing the form takes a long time. Maybe replacing the custom serialization will help.
- We are doing an extra parse to check for a bad submission URL (@shobhitagarwal1612). Perhaps we can eliminate this.
- There is a section in JavaRosa that performs terribly with many translation text elements: `PrefixTree`. I think it is trying to save RAM by collapsing common string prefixes. A comment inside suggests we can eliminate it.

```
22:33:14.689 I/DownloadFormsTask: Started downloading to /storage/emulated/0/odk/.cache/Nigeria Wards.xml-1261948924.tempDownload from http://192.168.1.221/formXml?formId=wards
22:33:15.890 W/DownloadFormsTask: Copied /storage/emulated/0/odk/.cache/Nigeria Wards.xml-1261948924.tempDownload over /storage/emulated/0/odk/forms/Nigeria Wards.xml
22:33:15.901 W/FileUtils: /storage/emulated/0/odk/.cache/Nigeria Wards.xml-1261948924.tempDownload has been deleted.
22:33:16.020 I/DownloadFormsTask: No Manifest for: Nigeria Wards
22:33:16.020 I/DownloadFormsTask: Starting an extra parse to check for a bad submission URL. /storage/emulated/0/odk/forms/Nigeria Wards.xml
22:33:34.749 I/FileUtils: XML file /storage/emulated/0/odk/forms/Nigeria Wards.xml does not have a submission element
22:33:34.750 I/DownloadFormsTask: Parse finished in 18.729 seconds.
22:33:34.762 W/DownloadFormsTask: Parsing document /storage/emulated/0/odk/forms/Nigeria Wards.xml
22:33:53.283 I/FileUtils: XML file /storage/emulated/0/odk/forms/Nigeria Wards.xml does not have a submission element
22:33:53.284 I/DownloadFormsTask: Parse finished in 18.521 seconds.
22:33:53.453 W/DownloadFormsTask: Form uri = content://org.odk.collect.android.provider.odk.forms/forms/1, isNew = true
22:34:01.454 I/FormEntryActivity: Creating PROGRESS_DIALOG
22:34:01.589 I/FormLoaderTask: Attempting to load from: /storage/emulated/0/odk/forms/Nigeria Wards.xml
22:34:01.598 I/System.out: Parsing form...
22:34:20.597 I/System.out: Title: "Nigeria Wards"
22:34:48.510 I/FormLoaderTask: Loaded in 46.921 seconds. Now saving to cache.
22:38:29.446 I/FormLoaderTask: Saved to cache in 220.936 seconds.
22:38:29.477 I/FormLoaderTask: Importing existing data
22:50:31.151 I/FormLoaderTask: Imported in 721.674 seconds.
Continuing, later, with a smaller form
23:09:02.889 I/FormEntryActivity: calling formController.setLanguage
23:09:22.660 E/FormEntryActivity: Ended up with a bad language. null
23:12:49.023 I/FormEntryActivity: Done in 226.799 seconds.
```

The code improvements are mostly Extract Method refactorings to improve readability, and making variables `final` where that reduces reader cognitive load or prevents certain types of potential errors.

Closes #

#### What has been done to verify that this works as intended?
I have manually tested all affected form processing activities.

#### Why is this the best possible solution? Were any other approaches considered?
The goal here was to identify slow spots and make them easily visible to others. This does it well.

#### Are there any risks to merging this code? If so, what are they?
Only the usual ones.

#### Do we need any specific form for testing your changes? If so, please attach one.
No