### PR TITLE
The app crashes when I try to take a picture using the SelfieWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -239,7 +239,7 @@ public class Camera2Fragment extends Fragment
         @Override
         public void onImageAvailable(ImageReader reader) {
             try {
-                backgroundHandler.post(new ImageSaver(reader.acquireNextImage(), getActivity()));
+                backgroundHandler.post(new ImageSaver(reader.acquireNextImage()));
             } catch (IllegalStateException e) {
                 Timber.e(e);
             }
@@ -802,6 +802,8 @@ public class Camera2Fragment extends Fragment
                                                @NonNull CaptureRequest request,
                                                @NonNull TotalCaptureResult result) {
                     unlockFocus();
+                    activity.setResult(Activity.RESULT_OK);
+                    activity.finish();
                 }
             };
 
@@ -874,11 +876,8 @@ public class Camera2Fragment extends Fragment
          */
         private final Image image;
 
-        private Activity activity;
-
-        public ImageSaver(Image image, Activity activity) {
+        ImageSaver(Image image) {
             this.image = image;
-            this.activity = activity;
         }
 
         @Override
@@ -897,9 +896,6 @@ public class Camera2Fragment extends Fragment
             } catch (IOException e) {
                 Timber.e(e);
             }
-
-            activity.setResult(Activity.RESULT_OK);
-            activity.finish();
         }
     }
 


### PR DESCRIPTION
Closes #1551 

#### What has been done to verify that this works as intended?
I've tested mentioned Samsung Galaxy S7

#### Why is this the best possible solution? Were any other approaches considered?
it was a race condition problem and some fast devices called `activity.finish()` before the `unlockFocus()` method.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use AllWIdgetsForm