### PR TITLE
Forks shouldn't report to Firebase Crash

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -88,7 +88,16 @@ android {
     }
 
     buildTypes {
+        // Release build for all forks
         release {
+            if (secrets.getProperty('RELEASE_STORE_FILE')) {
+                signingConfig signingConfigs.release
+            }
+            minifyEnabled(true)
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+        }
+        // Release build for the original ODK Collect app
+        odkCollectRelease {
             if (secrets.getProperty('RELEASE_STORE_FILE')) {
                 signingConfig signingConfigs.release
             }

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -273,10 +273,10 @@ public class Collect extends Application {
                 mgr.getSingularProperty(PropertyManager.PROPMGR_DEVICE_ID));
 
         AuthDialogUtility.setWebCredentialsFromPreferences();
-        if (BuildConfig.DEBUG) {
-            Timber.plant(new NotLoggingTree());
-        } else {
+        if (BuildConfig.BUILD_TYPE.equals("odkCollectRelease")) {
             Timber.plant(new CrashReportingTree());
+        } else {
+            Timber.plant(new NotLoggingTree());
         }
     }
 
@@ -308,7 +308,7 @@ public class Collect extends Application {
 
     private class NotLoggingTree extends Timber.Tree {
         @Override
-        protected void log(int priority, String tag, String message, Throwable throwable) {
+        protected void log(int priority, String tag, String message, Throwable t) {
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -274,7 +274,7 @@ public class Collect extends Application {
 
         AuthDialogUtility.setWebCredentialsFromPreferences();
         if (BuildConfig.DEBUG) {
-            Timber.plant(new Timber.DebugTree());
+            Timber.plant(new NotLoggingTree());
         } else {
             Timber.plant(new CrashReportingTree());
         }
@@ -304,6 +304,12 @@ public class Collect extends Application {
             tracker = analytics.newTracker(R.xml.global_tracker);
         }
         return tracker;
+    }
+
+    private class NotLoggingTree extends Timber.Tree {
+        @Override
+        protected void log(int priority, String tag, String message, Throwable throwable) {
+        }
     }
 
     private static class CrashReportingTree extends Timber.Tree {


### PR DESCRIPTION
Closes #1472 

I'm afraid there is no perfect solution. Blocking debug builds is pretty easy using `NotLoggingTree` but it's a bit more difficult when it comes to the release build. Maybe we can add another release build only for us as I did, but it's not perfect too since everyone can use it despite the comment that it's only for us.

