### PR TITLE
Record altitude and accuracy in Google Maps geotrace points

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -335,6 +335,9 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
             polylineOptions.add(point);
             MarkerOptions markerOptions = new MarkerOptions().position(point).draggable(true);
             Marker marker = map.addMarker(markerOptions);
+            String alt = sp[2].replace(" ", "");
+            String acc = sp[3].replace(" ", "");
+            marker.setSnippet(alt + ";" + acc);
             markerArray.add(marker);
         }
         polyline = map.addPolyline(polylineOptions);
@@ -382,9 +385,10 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
         for (int i = 0; i < markerArray.size(); i++) {
             String lat = Double.toString(markerArray.get(i).getPosition().latitude);
             String lng = Double.toString(markerArray.get(i).getPosition().longitude);
-            String alt = "0.0";
-            String acu = "0.0";
-            tempString = tempString + lat + " " + lng + " " + alt + " " + acu + ";";
+            String altAcc = markerArray.get(i).getSnippet();
+            String alt = altAcc.substring(0, altAcc.indexOf(';'));
+            String accu = altAcc.substring(altAcc.indexOf(';') + 1, altAcc.length());
+            tempString = tempString + lat + " " + lng + " " + alt + " " + accu + ";";
         }
         return tempString;
     }
@@ -584,6 +588,7 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
         LatLng latLng = new LatLng(curLocation.getLatitude(), curLocation.getLongitude());
         MarkerOptions markerOptions = new MarkerOptions().position(latLng).draggable(true);
         Marker marker = map.addMarker(markerOptions);
+        marker.setSnippet(curLocation.getAltitude() + ";" + curLocation.getAccuracy());
         markerArray.add(marker);
         if (polyline == null) {
             polylineOptions.add(latLng);
@@ -642,6 +647,7 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     @Override
     public void onMarkerDragEnd(Marker marker) {
         update_polyline();
+        marker.setSnippet("0.0;0.0");
     }
 
     private void showPolygonErrorDialog() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceOsmMapActivity.java
@@ -735,9 +735,8 @@ public class GeoTraceOsmMapActivity extends Activity implements IRegisterReceive
         @Override
         public void onMarkerDrag(Marker marker) {
             update_polygon();
-
+            marker.setSubDescription("0.0");
         }
-
     };
 
     private void showClearDialog() {


### PR DESCRIPTION
Closes #1459 

#### What has been done to verify that this works as intended?
Tested scenarios:
If you add a point the altitude and accuracy should be recorded too. Sometimes the altitude might be 0 since it's not available in some places (I guess) but it's not our bug.
If you move the point manually the altitude should be set to 0 since we are not able to read this value easily for other locations (than our current location), the accuracy should be 0 too in that case since it should be super accurate itself when someone set the position of points manually.

It should work in the same way for both GoogleMaps and OSM.

#### Why is this the best possible solution? Were any other approaches considered?
Maybe the code is not beautiful since I used `setSnippet` method to record values but there is no better solution. The Marker class is final so I can't extend it and doesn't contain any field to keep those values.

#### Are there any risks to merging this code? If so, what are they?
No, it's safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use AllWidgetsForm