### PR TITLE
Fixed screen orientation in DrawActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.activities;
 
 import android.app.Activity;
 import android.content.DialogInterface;
+import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.net.Uri;
@@ -64,6 +65,7 @@ public class DrawActivity extends AppCompatActivity {
     public static final String OPTION_ANNOTATE = "annotate";
     public static final String OPTION_DRAW = "draw";
     public static final String REF_IMAGE = "refImage";
+    public static final String SCREEN_ORIENTATION = "screenOrientation";
     public static final String EXTRA_OUTPUT = android.provider.MediaStore.EXTRA_OUTPUT;
     public static final String SAVEPOINT_IMAGE = "savepointImage"; // during
     // restore
@@ -149,6 +151,9 @@ public class DrawActivity extends AppCompatActivity {
             savepointImage.delete();
             output = new File(Collect.TMPFILE_PATH);
         } else {
+            if (extras.getInt(SCREEN_ORIENTATION) == 1) {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+            }
             loadOption = extras.getString(OPTION);
             if (loadOption == null) {
                 loadOption = OPTION_DRAW;
@@ -199,7 +204,7 @@ public class DrawActivity extends AppCompatActivity {
         }
 
         drawView = (DrawView) findViewById(R.id.drawView);
-        drawView.setupView(this, OPTION_SIGNATURE.equals(loadOption), savepointImage);
+        drawView.setupView(OPTION_SIGNATURE.equals(loadOption));
     }
 
     private void saveAndClose() {

--- a/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
@@ -54,9 +54,8 @@ public class DrawView extends View {
         super(context, attrs);
     }
 
-    public void setupView(Context c, boolean isSignature, File f) {
+    public void setupView(boolean isSignature) {
         this.isSignature = isSignature;
-        backgroundBitmapFile = f;
 
         bitmapPaint = new Paint(Paint.DITHER_FLAG);
         currentPath = new Path();
@@ -88,20 +87,9 @@ public class DrawView extends View {
 
     public void resetImage(int w, int h) {
         if (backgroundBitmapFile.exists()) {
-            // Because this activity is used in a fixed landscape mode only, sometimes resetImage()
-            // is called upon with flipped w/h (before orientation changes have been applied)
-            if (w > h) {
-                int temp = w;
-                w = h;
-                h = temp;
-            }
-            
             bitmap = FileUtils.getBitmapAccuratelyScaledToDisplay(
-                    backgroundBitmapFile, w, h).copy(
+                    backgroundBitmapFile, h, w).copy(
                     Bitmap.Config.ARGB_8888, true);
-            // bitmap =
-            // Bitmap.createScaledBitmap(BitmapFactory.decodeFile(backgroundBitmapFile.getPath()),
-            // w, h, true);
             canvas = new Canvas(bitmap);
         } else {
             bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -71,6 +71,8 @@ public class AnnotateWidget extends QuestionWidget implements BaseImageWidget {
 
     private TextView errorTextView;
 
+    private int screenOrientation;
+
     public AnnotateWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
 
@@ -196,6 +198,8 @@ public class AnnotateWidget extends QuestionWidget implements BaseImageWidget {
                         screenHeight, screenWidth);
                 if (bmp == null) {
                     errorTextView.setVisibility(View.VISIBLE);
+                } else if (bmp.getHeight() > bmp.getWidth()) {
+                    screenOrientation = 1; // portrait
                 }
             }
             imageView = getAnswerImageView(bmp);
@@ -222,8 +226,8 @@ public class AnnotateWidget extends QuestionWidget implements BaseImageWidget {
             File f = new File(getInstanceFolder() + File.separator + binaryName);
             i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(f));
         }
-        i.putExtra(DrawActivity.EXTRA_OUTPUT,
-                Uri.fromFile(new File(Collect.TMPFILE_PATH)));
+        i.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
+        i.putExtra(DrawActivity.SCREEN_ORIENTATION, screenOrientation);
 
         try {
             waitForData();


### PR DESCRIPTION
Closes #1558 

#### What has been done to verify that this works as intended?
I've tested implemented changes on various devices (including theDrawWidget and the SignatureWIdget since they use the same DrawActivity)

#### Why is this the best possible solution? Were any other approaches considered?
We have been using landscape mode for all images. But now we rotate images properly (#1541) so we can use portrait mode if needed what is even better.

v1.10.2:
![screenshot_2017-10-26-10-46-32](https://user-images.githubusercontent.com/3276264/32043450-10318348-ba3b-11e7-9376-6d216350564a.png)

v1.11.0 beta:
![screenshot_2017-10-26-10-43-58](https://user-images.githubusercontent.com/3276264/32043471-1c862a72-ba3b-11e7-935e-e07957ec4805.png)

The Current branch:
![screenshot_2017-10-26-10-40-46](https://user-images.githubusercontent.com/3276264/32043441-0b769cd0-ba3b-11e7-86bb-77b30773ccf7.png)
![screenshot_2017-10-26-10-41-25](https://user-images.githubusercontent.com/3276264/32043442-0b90d1e0-ba3b-11e7-9492-fcf51dc9c868.png)


**So my changes fix the bug in v1.11.0 and even improves the approach visible in v1.10.2.**

#### Are there any risks to merging this code? If so, what are they?
It should be tested on different devices (I've used 4) but generally, it looks safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use AllWidgetsForm.