### PR TITLE
Report crashes only for the collect release

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -95,6 +95,7 @@ android {
             }
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            resValue("bool", "FIREBASE_CRASH_ENABLED", "false")
         }
         // Release build for the original ODK Collect app
         odkCollectRelease {
@@ -103,11 +104,13 @@ android {
             }
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            resValue("bool", "FIREBASE_CRASH_ENABLED", "true")
         }
         debug {
             debuggable(true)
             // Allows AndroidTest JaCoCo reports to be generated
             testCoverageEnabled(true)
+            resValue("bool", "FIREBASE_CRASH_ENABLED", "false")
         }
     }
 

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -291,6 +291,10 @@ the specific language governing permissions and limitations under the License.
             android:value="@integer/google_play_services_version"
             tools:replace="android:value" />  <!-- integer/google_play_services_version -->
 
+        <meta-data
+            android:name="firebase_crash_collection_enabled"
+            android:value="@bool/FIREBASE_CRASH_ENABLED"/>
+
         <uses-library
             android:name="com.google.android.maps"
             android:required="false" />

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -277,7 +277,7 @@ public class Collect extends Application {
         if (BuildConfig.BUILD_TYPE.equals("odkCollectRelease")) {
             Timber.plant(new CrashReportingTree());
         } else {
-            Timber.plant(new NotLoggingTree());
+            Timber.plant(new Timber.DebugTree());
         }
 
         setupLeakCanary();
@@ -315,12 +315,6 @@ public class Collect extends Application {
             tracker = analytics.newTracker(R.xml.global_tracker);
         }
         return tracker;
-    }
-
-    private class NotLoggingTree extends Timber.Tree {
-        @Override
-        protected void log(int priority, String tag, String message, Throwable t) {
-        }
     }
 
     private static class CrashReportingTree extends Timber.Tree {


### PR DESCRIPTION
Closes #1472 

**What has been done to verify that this works as intended?**
It's a fix for #1554 that solution was wrong since all crashes have been reported automatically anyway.

**Why is this the best possible solution? Were any other approaches considered?**
Now I use new method `setCrashCollectionEnabled` which is available in v11

**Are there any risks to merging this code? If so, what are they?**
No.

**Do we need any specific form for testing your changes? If so, please attach one.**
No