### PR TITLE
Caused by java.lang.NullPointerException: Attempt to get length of null array

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
@@ -312,34 +312,38 @@ public class InstanceServerUploader extends InstanceUploader {
 
         // add media files
         List<File> files = new ArrayList<File>();
-        for (File f : allFiles) {
-            String fileName = f.getName();
+        if (allFiles != null) {
+            for (File f : allFiles) {
+                String fileName = f.getName();
 
-            if (fileName.startsWith(".")) {
-                continue; // ignore invisible files
-            } else if (fileName.equals(instanceFile.getName())) {
-                continue; // the xml file has already been added
-            } else if (fileName.equals(submissionFile.getName())) {
-                continue; // the xml file has already been added
+                if (fileName.startsWith(".")) {
+                    continue; // ignore invisible files
+                } else if (fileName.equals(instanceFile.getName())) {
+                    continue; // the xml file has already been added
+                } else if (fileName.equals(submissionFile.getName())) {
+                    continue; // the xml file has already been added
+                }
+
+                String extension = getFileExtension(fileName);
+
+                if (openRosaServer) {
+                    files.add(f);
+                } else if (extension.equals("jpg")) { // legacy 0.9x
+                    files.add(f);
+                } else if (extension.equals("3gpp")) { // legacy 0.9x
+                    files.add(f);
+                } else if (extension.equals("3gp")) { // legacy 0.9x
+                    files.add(f);
+                } else if (extension.equals("mp4")) { // legacy 0.9x
+                    files.add(f);
+                } else if (extension.equals("osm")) { // legacy 0.9x
+                    files.add(f);
+                } else {
+                    Timber.w("unrecognized file type %s", f.getName());
+                }
             }
-
-            String extension = getFileExtension(fileName);
-
-            if (openRosaServer) {
-                files.add(f);
-            } else if (extension.equals("jpg")) { // legacy 0.9x
-                files.add(f);
-            } else if (extension.equals("3gpp")) { // legacy 0.9x
-                files.add(f);
-            } else if (extension.equals("3gp")) { // legacy 0.9x
-                files.add(f);
-            } else if (extension.equals("mp4")) { // legacy 0.9x
-                files.add(f);
-            } else if (extension.equals("osm")) { // legacy 0.9x
-                files.add(f);
-            } else {
-                Timber.w("unrecognized file type %s", f.getName());
-            }
+        } else {
+            return false;
         }
 
         boolean first = true;


### PR DESCRIPTION
Closes #1593 

#### What has been done to verify that this works as intended?
I wasn't able to reproduce the issue but I hardcoded a null value and tested this fix.
If the problem takes place the form is kept and we can try to send it again.

#### Why is this the best possible solution? Were any other approaches considered?
`listFiles()` might return null so we should add a null check.
`Returns null if this abstract pathname does not denote a directory, or if an I/O error occurs.
`https://docs.oracle.com/javase/6/docs/api/java/io/File.html#listFiles%28%29

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.