### PR TITLE
Adds a new dependency of leak canary for the custom buildType

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -203,6 +203,7 @@ dependencies {
     debugCompile group: 'com.squareup.leakcanary', name: 'leakcanary-android', version: '1.5.4'
     // No-Op version of LeakCanary for release builds: no notifications, no analysis, nothing
     releaseCompile group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
+    odkCollectReleaseCompile group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
 
     // Testing-only dependencies
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
Closes #

#### What has been done to verify that this works as intended?
Tried running `./gradlew lint`  successfully

#### Why is this the best possible solution? Were any other approaches considered?
Since we have a custom build type, so that needs to be added too as a dependency in the `build.gradle`

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No