### PR TITLE
Mocks ExPrinter intent.

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/AllFormsWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/AllFormsWidgetTest.java
@@ -276,7 +276,8 @@ public class AllFormsWidgetTest {
 
     public void testExPrinterWidget() {
         onView(withText("Initiate Printing")).perform(click());
-
+        
+        intending(hasAction("org.opendatakit.sensors.ZebraPrinter"));
         intended(hasAction("org.opendatakit.sensors.ZebraPrinter"));
 
         // There is also a BroadcastIntent that sends the data but we don't


### PR DESCRIPTION
Github automatically closed the other one while fixing the history.

Works on #1586 
