### PR TITLE
Require gradle check task run.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 Closes #
 
+#### Did you run the `check` gradle task and make sure there were no errors? (if the answer is no, the PR will be rejected unless it is a work in progress!)
+
 #### What has been done to verify that this works as intended?
 
 #### Why is this the best possible solution? Were any other approaches considered?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To contribute code to ODK Collect, you will need to open a [pull request](https:
 
         git push
         
-1. Once you have completed your code changes, verify that you have followed the [style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#style-guidelines). Additionally, [lint](https://developer.android.com/studio/write/lint.html) is run for each new build so please run `gradle lint` and fix any errors before issuing a pull request.
+1. Once you have completed your code changes, verify that you have followed the [style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#style-guidelines). Please run `gradle check` to run all static analysis and tests. Make sure to fix any errors before issuing a pull request.
 
 1. When your changes are ready to be added to the core ODK Collect project, [open a pull request](https://help.github.com/articles/creating-a-pull-request/). Make sure to set the base fork to `opendatakit/collect`. Describe your changes in the comment, refer to any relevant issues using [keywords for closing issues](https://help.github.com/articles/closing-issues-via-commit-messages/) and tag any person you think might need to know about the changes.
 
@@ -38,7 +38,7 @@ To contribute code to ODK Collect, you will need to open a [pull request](https:
 
 1. Keep your pull request focused on one narrow goal. This could mean addressing an issue with multiple, smaller pull requests. Small pull requests are easier to review and less likely to introduce bugs. If you would like to make stylistic changes to the code, create a separate pull request.
 
-1. Run `./gradlew lint` and `./gradlew checkstyle` and fix any errors.
+1. Run the gradle `check` task and fix any errors. You can run it at the command line with `./gradlew check` or in Android Studio by selecting it from the menu shown by View > Tool Windows > Gradle.
 
 1. Write clear code. Use descriptive names and create meaningful abstractions (methods, classes).
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Ran `./gradlew check` and verified that it does run every check we need.

#### Why is this the best possible solution? Were any other approaches considered?
This simplifies what contributors need to do to verify their build is passing. I also considered adding the checks to the build task but I thought that could get really annoying and slow.

#### Are there any risks to merging this code? If so, what are they?
The PR template is getting a bit long but since this is a y/n question I think it's ok.

#### Do we need any specific form for testing your changes? If so, please attach one.