### PR TITLE
Default values in settings are restored if user update to version with #1623

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -66,7 +66,6 @@ import timber.log.Timber;
 import static org.odk.collect.android.logic.PropertyManager.PROPMGR_USERNAME;
 import static org.odk.collect.android.logic.PropertyManager.SCHEME_USERNAME;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_USERNAME;
-import static org.odk.collect.android.preferences.PreferenceKeys.SHOULD_LOAD_DEFAULT_VALUES;
 
 /**
  * The Open Data Kit Collect application.
@@ -287,15 +286,6 @@ public class Collect extends Application {
         setupLeakCanary();
     }
 
-    // Default values should be loaded after a fresh installation or first app run after upgrading to the version in which the flag was introduced
-    private boolean shouldLoadDefaultValues() {
-        boolean firstAppRun = GeneralSharedPreferences.getInstance().getBoolean(SHOULD_LOAD_DEFAULT_VALUES, true);
-        if (firstAppRun) {
-            GeneralSharedPreferences.getInstance().save(SHOULD_LOAD_DEFAULT_VALUES, false);
-        }
-        return firstAppRun;
-    }
-
     private void setupLeakCanary() {
         if (LeakCanary.isInAnalyzerProcess(this)) {
             // This process is dedicated to LeakCanary for heap analysis.
@@ -358,7 +348,7 @@ public class Collect extends Application {
     }
 
     private void loadDefaultValuesIfNeeded() {
-        if (shouldLoadDefaultValues()) {
+        if (GeneralSharedPreferences.getInstance().getAll().isEmpty()) {
             GeneralSharedPreferences.getInstance().loadDefaultValues();
             AdminSharedPreferences.getInstance().loadDefaultValues();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -55,7 +55,6 @@ public final class PreferenceKeys {
     // other keys
     public static final String KEY_LAST_VERSION             = "lastVersion";
     public static final String KEY_FIRST_RUN                = "firstRun";
-    public static final String SHOULD_LOAD_DEFAULT_VALUES   = "shouldLoadDefaultValues";
     /** Whether any existing username and email values have been migrated to form metadata */
     static final String KEY_METADATA_MIGRATED               = "metadata_migrated";
     static final String KEY_AUTOSEND_WIFI                   = "autosend_wifi";
@@ -112,7 +111,6 @@ public final class PreferenceKeys {
     static final Collection<String> KEYS_WE_SHOULD_NOT_RESET = Arrays.asList(
             KEY_LAST_VERSION,
             KEY_FIRST_RUN,
-            SHOULD_LOAD_DEFAULT_VALUES,
             KEY_METADATA_MIGRATED,
             KEY_AUTOSEND_WIFI,
             KEY_AUTOSEND_NETWORK


### PR DESCRIPTION
Closes #1660 

#### What has been done to verify that this works as intended?
I've tested updates with saved settings.

#### Why is this the best possible solution? Were any other approaches considered?
Now I load default values only if shared preferences are empty (fresh installation).

#### Are there any risks to merging this code? If so, what are they?
I think it's safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.