### PR TITLE
Upgrading the gradle from 3.0 to 4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.trickyandroid:jacoco-everywhere:0.2.1'
         classpath 'com.google.gms:google-services:3.0.0'
     }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -63,7 +63,6 @@ if (secretsFile.exists()) {
 
 android {
     compileSdkVersion(25)
-    buildToolsVersion('26.0.1')
 
     defaultConfig {
         applicationId('org.odk.collect.android')
@@ -115,10 +114,13 @@ android {
     }
 
     // https://stackoverflow.com/a/27119543/152938
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def file = output.outputFile
-            output.outputFile = new File(file.parent, file.name.replace("_app","").replace(".apk", "-" + defaultConfig.versionName + ".apk"))
+    android.applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            def outputFile = output.outputFile
+            if (outputFile != null) {
+                def fileName = outputFile.name.replace("_app","").replace(".apk", "-" + defaultConfig.versionName + ".apk")
+                outputFileName = fileName
+            }
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 03 09:12:28 EST 2017
+#Tue Nov 28 15:28:00 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Closes #1651 

#### What has been done to verify that this works as intended?

Upgraded the gradle from 3.0 to 4.1, removed the buildToolsVersion('26.0.1') from build.gradle and changed the ApplicationVariant in build.gradle

#### Why is this the best possible solution? Were any other approaches considered?

This is one solution I found, it is working fine.

#### Are there any risks to merging this code? If so, what are they?

So far I know, there is no risk.

#### Do we need any specific form for testing your changes? If so, please attach one.

No