### PR TITLE
Force 9-digit commit hash to match filename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,12 @@ jobs:
                   fi
           - run:
               name: Run integration tests
+              # if the file fails to copy, it's likely because --abbrev=9 doesn't match the
+              # real hash length anymore.
               command: |
                   if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" && "$CIRCLE_BRANCH" == "master" ]]; then \
                     echo "y" | sudo gcloud firebase test android run \
-                    --app collect_app/build/outputs/apk/collect-debug-$(git describe --tags --dirty --always).apk \
+                    --app collect_app/build/outputs/apk/collect-debug-$(git describe --tags --dirty --always --abbrev=9).apk \
                     --test collect_app/build/outputs/apk/collect_app-debug-androidTest.apk \
                     --device model=Nexus5,version=21,locale=en,orientation=portrait \
                     --results-bucket opendatakit-collect-test-results; \


### PR DESCRIPTION
Fixes broken build

#### What has been done to verify that this works as intended?
I've verified the `git describe --tags --dirty --always --abbrev=9` command locally. I've verified that the problem with the build is that the length of the git hash is different between the apk filename and the filename generated for copy.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only solution I can think of right now.

#### Are there any risks to merging this code? If so, what are they?
If I understand correctly, `git describe` uses the minimum hash length for disambiguation. Eventually more than 9 characters may be needed and then the build will fail again. I included a comment to help us remember why in that case.

#### Do we need any specific form for testing your changes? If so, please attach one.