### PR TITLE
Setting to prevent backwards movement can be bypassed

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -23,7 +23,6 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.tasks.SaveToDiskTask;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -87,7 +87,7 @@ public class FormIndexSavepointTest {
         assertFormIndex(originalFormIndex, readFormIndex);
     }
 
-    private static void assertFormIndex(FormIndex expected, FormIndex actual) {
+    private void assertFormIndex(FormIndex expected, FormIndex actual) {
         assertEquals(expected, actual);
         assertEquals(expected.getReference(), actual.getReference());
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -16,78 +16,69 @@
 
 package org.odk.collect.android.utilities;
 
-import android.support.test.runner.AndroidJUnit4;
-
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.TreeReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.tasks.SaveFormIndexTask;
 import org.odk.collect.android.tasks.SaveToDiskTask;
 
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(MockitoJUnitRunner.class)
 public class FormIndexSavepointTest {
 
     private File instancePath;
+    @Mock
+    private FormController formController;
 
     @Before
     public void setUp() {
         instancePath = new File(Collect.INSTANCES_PATH + File.separator + "test.xml");
-        FormController formController = mock(FormController.class);
         when(formController.getInstancePath()).thenReturn(instancePath);
         Collect.getInstance().setFormController(formController);
     }
 
     @Test
-    public void testBeginningOfForm() {
+    public void saveAndReadFormIndexTest1() {
         FormIndex originalFormIndex = FormIndex.createBeginningOfFormIndex();
         File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
-        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
+        SaveFormIndexTask.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
-        assertFormIndex(originalFormIndex, readFormIndex);
+        FormIndex readFormIndex = SaveFormIndexTask.loadFormIndexFromFile();
+        assertFormIndexesEqual(originalFormIndex, readFormIndex);
     }
 
     @Test
-    public void testEndOfForm() {
-        FormIndex originalFormIndex = FormIndex.createEndOfFormIndex();
-        File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
-        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
-
-        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
-        assertFormIndex(originalFormIndex, readFormIndex);
-    }
-
-    @Test
-    public void testNullReference() {
+    public void saveAndReadFormIndexTest2() {
         FormIndex originalFormIndex = new FormIndex(1, 2, null);
         File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
-        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
+        SaveFormIndexTask.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
-        assertFormIndex(originalFormIndex, readFormIndex);
+        FormIndex readFormIndex = SaveFormIndexTask.loadFormIndexFromFile();
+        assertFormIndexesEqual(originalFormIndex, readFormIndex);
     }
 
     @Test
-    public void testNonNullReference() {
+    public void saveAndReadFormIndexTest3() {
         TreeReference treeReference = TreeReference.rootRef();
         FormIndex originalFormIndex = new FormIndex(1, 2, treeReference);
         File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
-        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
+        SaveFormIndexTask.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
-        assertFormIndex(originalFormIndex, readFormIndex);
+        FormIndex readFormIndex = SaveFormIndexTask.loadFormIndexFromFile();
+        assertFormIndexesEqual(originalFormIndex, readFormIndex);
     }
 
-    private void assertFormIndex(FormIndex expected, FormIndex actual) {
+    private void assertFormIndexesEqual(FormIndex expected, FormIndex actual) {
         assertEquals(expected, actual);
         assertEquals(expected.getReference(), actual.getReference());
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.instance.TreeReference;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.tasks.SaveToDiskTask;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class FormIndexSavepointTest {
+
+    private File instancePath;
+
+    @Before
+    public void setUp() {
+        instancePath = new File(Collect.INSTANCES_PATH + File.separator + "test.xml");
+        FormController formController = mock(FormController.class);
+        when(formController.getInstancePath()).thenReturn(instancePath);
+        Collect.getInstance().setFormController(formController);
+    }
+
+    @Test
+    public void testBeginningOfForm() {
+        FormIndex originalFormIndex = FormIndex.createBeginningOfFormIndex();
+        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
+        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+
+        FormIndex readFormIndex = FileUtils.loadFormIndex();
+
+        assertFormIndex(originalFormIndex, readFormIndex);
+    }
+
+    @Test
+    public void testEndOfForm() {
+        FormIndex originalFormIndex = FormIndex.createEndOfFormIndex();
+        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
+        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+
+        FormIndex readFormIndex = FileUtils.loadFormIndex();
+
+        assertFormIndex(originalFormIndex, readFormIndex);
+    }
+
+    @Test
+    public void testNullReference() {
+        FormIndex originalFormIndex = new FormIndex(1, 2, null);
+        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
+        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+
+        FormIndex readFormIndex = FileUtils.loadFormIndex();
+
+        assertFormIndex(originalFormIndex, readFormIndex);
+    }
+
+    @Test
+    public void testNonNullReference() {
+        TreeReference treeReference = TreeReference.rootRef();
+        FormIndex originalFormIndex = new FormIndex(1, 2, treeReference);
+        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
+        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+
+        FormIndex readFormIndex = FileUtils.loadFormIndex();
+
+        assertFormIndex(originalFormIndex, readFormIndex);
+    }
+
+    private static void assertFormIndex(FormIndex expected, FormIndex actual) {
+        assertEquals(expected, actual);
+        assertEquals(expected.getReference(), actual.getReference());
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -49,33 +49,30 @@ public class FormIndexSavepointTest {
     @Test
     public void testBeginningOfForm() {
         FormIndex originalFormIndex = FormIndex.createBeginningOfFormIndex();
-        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
-        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndex();
-
+        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
         assertFormIndex(originalFormIndex, readFormIndex);
     }
 
     @Test
     public void testEndOfForm() {
         FormIndex originalFormIndex = FormIndex.createEndOfFormIndex();
-        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
-        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndex();
-
+        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
         assertFormIndex(originalFormIndex, readFormIndex);
     }
 
     @Test
     public void testNullReference() {
         FormIndex originalFormIndex = new FormIndex(1, 2, null);
-        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
-        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndex();
-
+        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
         assertFormIndex(originalFormIndex, readFormIndex);
     }
 
@@ -83,11 +80,10 @@ public class FormIndexSavepointTest {
     public void testNonNullReference() {
         TreeReference treeReference = TreeReference.rootRef();
         FormIndex originalFormIndex = new FormIndex(1, 2, treeReference);
-        File tempIndex = SaveToDiskTask.savepointIndexFile(instancePath);
-        SaveToDiskTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
-        FormIndex readFormIndex = FileUtils.loadFormIndex();
-
+        FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
         assertFormIndex(originalFormIndex, readFormIndex);
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -49,7 +49,7 @@ public class FormIndexSavepointTest {
     @Test
     public void testBeginningOfForm() {
         FormIndex originalFormIndex = FormIndex.createBeginningOfFormIndex();
-        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
         FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
         FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
@@ -59,7 +59,7 @@ public class FormIndexSavepointTest {
     @Test
     public void testEndOfForm() {
         FormIndex originalFormIndex = FormIndex.createEndOfFormIndex();
-        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
         FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
         FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
@@ -69,7 +69,7 @@ public class FormIndexSavepointTest {
     @Test
     public void testNullReference() {
         FormIndex originalFormIndex = new FormIndex(1, 2, null);
-        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
         FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
         FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();
@@ -80,7 +80,7 @@ public class FormIndexSavepointTest {
     public void testNonNullReference() {
         TreeReference treeReference = TreeReference.rootRef();
         FormIndex originalFormIndex = new FormIndex(1, 2, treeReference);
-        File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(instancePath);
+        File tempIndex = SaveToDiskTask.getFormIndexFile(instancePath.getName());
         FileUtils.exportFormIndexToFile(originalFormIndex, tempIndex);
 
         FormIndex readFormIndex = FileUtils.loadFormIndexFromFile();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2065,15 +2065,10 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         FormController formController = Collect.getInstance().getFormController();
 
         // attempt to remove any scratch file
-        File temp = SaveToDiskTask.savepointFile(formController.getInstancePath());
-        if (temp.exists()) {
-            temp.delete();
-        }
-
-        File tempIndexFile = SaveToDiskTask.savepointFormIndexIndexFile(formController.getInstancePath());
-        if (tempIndexFile.exists()) {
-            tempIndexFile.delete();
-        }
+        File tempInstanceFile = SaveToDiskTask.getSavepointFile(formController.getInstancePath().getName());
+        File tempIndexFile = SaveToDiskTask.getFormIndexFile(formController.getInstancePath().getName());
+        FileUtils.deleteAndReport(tempInstanceFile);
+        FileUtils.deleteAndReport(tempIndexFile);
 
         boolean erase;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2070,7 +2070,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             temp.delete();
         }
 
-        File tempIndexFile = SaveToDiskTask.savepointIndexFile(formController.getInstancePath());
+        File tempIndexFile = SaveToDiskTask.savepointFormIndexIndexFile(formController.getInstancePath());
         if (tempIndexFile.exists()) {
             tempIndexFile.delete();
         }
@@ -2643,7 +2643,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 // we've just loaded a saved form, so start in the hierarchy view
 
                 if (!allowMovingBackwards) {
-                    FormIndex formIndex = FileUtils.loadFormIndex();
+                    FormIndex formIndex = FileUtils.loadFormIndexFromFile();
                     if (formIndex != null) {
                         formController.jumpToIndex(formIndex);
                         refreshCurrentView();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -119,8 +119,6 @@ import org.odk.collect.android.widgets.StringWidget;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.ObjectInputStream;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.HashMap;

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -317,7 +317,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         boolean usedSavepoint = false;
         if (instancePath != null) {
             File instance = new File(instancePath);
-            final File shadowInstance = SaveToDiskTask.savepointFile(instance);
+            final File shadowInstance = SaveToDiskTask.getSavepointFile(instance.getName());
             if (shadowInstance.exists() && (shadowInstance.lastModified()
                     > instance.lastModified())) {
                 // the savepoint is newer than the saved value of the instance.

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormIndexTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormIndexTask.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.tasks;
+
+import android.os.AsyncTask;
+
+import org.javarosa.core.model.FormIndex;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FormController;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import timber.log.Timber;
+
+public class SaveFormIndexTask extends AsyncTask<Void, Void, String> {
+
+    private final SaveFormIndexListener listener;
+    private final FormIndex formIndex;
+
+    public interface SaveFormIndexListener {
+        void onSaveFormIndexError(String errorMessage);
+    }
+
+    public SaveFormIndexTask(SaveFormIndexListener listener, FormIndex formIndex) {
+        this.listener = listener;
+        this.formIndex = formIndex;
+    }
+
+    @Override
+    protected String doInBackground(Void... params) {
+        long start = System.currentTimeMillis();
+
+        FormController formController = Collect.getInstance().getFormController();
+
+        try {
+            File tempFormIndexFile = SaveToDiskTask.getFormIndexFile(formController.getInstancePath().getName());
+            exportFormIndexToFile(formIndex, tempFormIndexFile);
+
+            long end = System.currentTimeMillis();
+            Timber.i("SaveFormIndex ms: %s to %s", Long.toString(end - start), tempFormIndexFile.toString());
+
+            return null;
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            Timber.e(e);
+            return msg;
+        }
+    }
+
+    @Override
+    protected void onPostExecute(String errorMessage) {
+        super.onPostExecute(errorMessage);
+
+        if (listener != null && errorMessage != null) {
+            listener.onSaveFormIndexError(errorMessage);
+        }
+    }
+
+    public static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(savepointIndexFile));
+            oos.writeObject(formIndex);
+            oos.flush();
+            oos.close();
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+    }
+
+    public static FormIndex loadFormIndexFromFile() {
+        try {
+            String instanceName = Collect.getInstance()
+                    .getFormController()
+                    .getInstancePath()
+                    .getName();
+            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.getFormIndexFile(instanceName)));
+            return (FormIndex) ois.readObject();
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+        return null;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
@@ -63,7 +63,7 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
 
             try {
                 FormController formController = Collect.getInstance().getFormController();
-                File temp = SaveToDiskTask.savepointFile(formController.getInstancePath());
+                File temp = SaveToDiskTask.getSavepointFile(formController.getInstancePath().getName());
                 ByteArrayPayload payload = formController.getFilledInFormXml();
 
                 if (priority < lastPriorityUsed) {
@@ -75,7 +75,7 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
                 SaveToDiskTask.exportXmlFile(payload, temp.getAbsolutePath());
 
                 if (formIndex != null) {
-                    File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(formController.getInstancePath());
+                    File tempIndex = SaveToDiskTask.getFormIndexFile(formController.getInstancePath().getName());
                     FileUtils.exportFormIndexToFile(formIndex, tempIndex);
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
@@ -20,6 +20,7 @@ package org.odk.collect.android.tasks;
 
 import android.os.AsyncTask;
 
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.SavePointListener;
@@ -41,10 +42,12 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
 
     private final SavePointListener listener;
     private int priority;
+    private FormIndex formIndex;
 
-    public SavePointTask(SavePointListener listener) {
+    public SavePointTask(SavePointListener listener, FormIndex formIndex) {
         this.listener = listener;
         this.priority = ++lastPriorityUsed;
+        this.formIndex = formIndex;
     }
 
     @Override
@@ -69,6 +72,11 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
 
                 // write out xml
                 SaveToDiskTask.exportXmlFile(payload, temp.getAbsolutePath());
+
+                if (formIndex != null) {
+                    File tempIndex = SaveToDiskTask.savepointIndexFile(formController.getInstancePath());
+                    SaveToDiskTask.exportFormIndexToFile(formIndex, tempIndex);
+                }
 
                 long end = System.currentTimeMillis();
                 Timber.i("Savepoint ms: %s to %s", Long.toString(end - start), temp.toString());

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
@@ -20,12 +20,10 @@ package org.odk.collect.android.tasks;
 
 import android.os.AsyncTask;
 
-import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.SavePointListener;
 import org.odk.collect.android.logic.FormController;
-import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 
@@ -43,12 +41,10 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
 
     private final SavePointListener listener;
     private int priority;
-    private FormIndex formIndex;
 
-    public SavePointTask(SavePointListener listener, FormIndex formIndex) {
+    public SavePointTask(SavePointListener listener) {
         this.listener = listener;
         this.priority = ++lastPriorityUsed;
-        this.formIndex = formIndex;
     }
 
     @Override
@@ -73,11 +69,6 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
 
                 // write out xml
                 SaveToDiskTask.exportXmlFile(payload, temp.getAbsolutePath());
-
-                if (formIndex != null) {
-                    File tempIndex = SaveToDiskTask.getFormIndexFile(formController.getInstancePath().getName());
-                    FileUtils.exportFormIndexToFile(formIndex, tempIndex);
-                }
 
                 long end = System.currentTimeMillis();
                 Timber.i("Savepoint ms: %s to %s", Long.toString(end - start), temp.toString());

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SavePointTask.java
@@ -25,6 +25,7 @@ import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.SavePointListener;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 
@@ -74,8 +75,8 @@ public class SavePointTask extends AsyncTask<Void, Void, String> {
                 SaveToDiskTask.exportXmlFile(payload, temp.getAbsolutePath());
 
                 if (formIndex != null) {
-                    File tempIndex = SaveToDiskTask.savepointIndexFile(formController.getInstancePath());
-                    SaveToDiskTask.exportFormIndexToFile(formIndex, tempIndex);
+                    File tempIndex = SaveToDiskTask.savepointFormIndexIndexFile(formController.getInstancePath());
+                    FileUtils.exportFormIndexToFile(formIndex, tempIndex);
                 }
 
                 long end = System.currentTimeMillis();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -423,7 +423,7 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
             oos.writeObject(formIndex);
             oos.flush();
             oos.close();
-        } catch(Exception e) {
+        } catch (Exception e) {
             Timber.e(e);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -128,12 +128,10 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
             exportData(markCompleted);
 
             // attempt to remove any scratch file
-            File shadowInstance = savepointFile(formController.getInstancePath());
-            File shadowFormIndex = savepointFormIndexIndexFile(formController.getInstancePath());
-            if (shadowInstance.exists()) {
-                FileUtils.deleteAndReport(shadowInstance);
-                FileUtils.deleteAndReport(shadowFormIndex);
-            }
+            File shadowInstance = getSavepointFile(formController.getInstancePath().getName());
+            File shadowFormIndex = getFormIndexFile(formController.getInstancePath().getName());
+            FileUtils.deleteAndReport(shadowInstance);
+            FileUtils.deleteAndReport(shadowFormIndex);
 
             saveResult.setSaveResult(save ? SAVED_AND_EXIT : SAVED, markCompleted);
         } catch (EncryptionException e) {
@@ -234,19 +232,19 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
     }
 
     /**
-     * Return the name of the savepoint file for a given instance.
+     * Return the savepoint file for a given instance.
      */
-    public static File savepointFile(File instancePath) {
+    public static File getSavepointFile(String instanceName) {
         File tempDir = new File(Collect.CACHE_PATH);
-        return new File(tempDir, instancePath.getName() + ".save");
+        return new File(tempDir, instanceName + ".save");
     }
 
     /**
-     * Return the name of the savepoint formIndex file for a given instance.
+     * Return the formIndex file for a given instance.
      */
-    public static File savepointFormIndexIndexFile(File instancePath) {
+    public static File getFormIndexFile(String instanceName) {
         File tempDir = new File(Collect.CACHE_PATH);
-        return new File(tempDir, instancePath.getName() + ".index");
+        return new File(tempDir, instanceName + ".index");
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -19,7 +19,6 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 
-import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.form.api.FormEntryController;
 import org.odk.collect.android.R;
@@ -36,10 +35,8 @@ import org.odk.collect.android.utilities.EncryptionUtils.EncryptedFormInformatio
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.ObjectOutputStream;
 import java.io.RandomAccessFile;
 
 import timber.log.Timber;
@@ -132,7 +129,7 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
 
             // attempt to remove any scratch file
             File shadowInstance = savepointFile(formController.getInstancePath());
-            File shadowFormIndex = savepointIndexFile(formController.getInstancePath());
+            File shadowFormIndex = savepointFormIndexIndexFile(formController.getInstancePath());
             if (shadowInstance.exists()) {
                 FileUtils.deleteAndReport(shadowInstance);
                 FileUtils.deleteAndReport(shadowFormIndex);
@@ -245,9 +242,9 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
     }
 
     /**
-     * Return the name of the savepoint index file for a given instance.
+     * Return the name of the savepoint formIndex file for a given instance.
      */
-    public static File savepointIndexFile(File instancePath) {
+    public static File savepointFormIndexIndexFile(File instancePath) {
         File tempDir = new File(Collect.CACHE_PATH);
         return new File(tempDir, instancePath.getName() + ".index");
     }
@@ -415,17 +412,6 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
         //        }
         //
         //        return false;
-    }
-
-    public static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
-        try {
-            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(savepointIndexFile));
-            oos.writeObject(formIndex);
-            oos.flush();
-            oos.close();
-        } catch (Exception e) {
-            Timber.e(e);
-        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -19,6 +19,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.services.transport.payload.ByteArrayPayload;
 import org.javarosa.form.api.FormEntryController;
 import org.odk.collect.android.R;
@@ -35,8 +36,10 @@ import org.odk.collect.android.utilities.EncryptionUtils.EncryptedFormInformatio
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectOutputStream;
 import java.io.RandomAccessFile;
 
 import timber.log.Timber;
@@ -129,8 +132,10 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
 
             // attempt to remove any scratch file
             File shadowInstance = savepointFile(formController.getInstancePath());
+            File shadowFormIndex = savepointIndexFile(formController.getInstancePath());
             if (shadowInstance.exists()) {
                 FileUtils.deleteAndReport(shadowInstance);
+                FileUtils.deleteAndReport(shadowFormIndex);
             }
 
             saveResult.setSaveResult(save ? SAVED_AND_EXIT : SAVED, markCompleted);
@@ -237,6 +242,14 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
     public static File savepointFile(File instancePath) {
         File tempDir = new File(Collect.CACHE_PATH);
         return new File(tempDir, instancePath.getName() + ".save");
+    }
+
+    /**
+     * Return the name of the savepoint index file for a given instance.
+     */
+    public static File savepointIndexFile(File instancePath) {
+        File tempDir = new File(Collect.CACHE_PATH);
+        return new File(tempDir, instancePath.getName() + ".index");
     }
 
     /**
@@ -402,6 +415,17 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
         //        }
         //
         //        return false;
+    }
+
+    static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(savepointIndexFile));
+            oos.writeObject(formIndex);
+            oos.flush();
+            oos.close();
+        } catch(Exception e) {
+            Timber.e(e);
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -417,7 +417,7 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
         //        return false;
     }
 
-    static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
+    public static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
         try {
             ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(savepointIndexFile));
             oos.writeObject(formIndex);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -514,7 +514,7 @@ public class FileUtils {
             File instancePath = Collect.getInstance().getFormController().getInstancePath();
             ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.savepointIndexFile(instancePath)));
             return (FormIndex) ois.readObject();
-        } catch(Exception e) {
+        } catch (Exception e) {
             Timber.e(e);
         }
         return null;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -18,14 +18,12 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
 import org.apache.commons.io.IOUtils;
-import org.javarosa.core.model.FormIndex;
 import org.javarosa.xform.parse.XFormParser;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
 import org.kxml2.kdom.Node;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.tasks.SaveToDiskTask;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -34,8 +32,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.FileNameMap;
@@ -508,30 +504,5 @@ public class FileUtils {
         List<File> mediaFiles = new ArrayList<>();
         Collections.addAll(mediaFiles, new File(mediaFilesDir).listFiles());
         return mediaFiles;
-    }
-
-    public static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
-        try {
-            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(savepointIndexFile));
-            oos.writeObject(formIndex);
-            oos.flush();
-            oos.close();
-        } catch (Exception e) {
-            Timber.e(e);
-        }
-    }
-
-    public static FormIndex loadFormIndexFromFile() {
-        try {
-            String instanceName = Collect.getInstance()
-                    .getFormController()
-                    .getInstancePath()
-                    .getName();
-            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.getFormIndexFile(instanceName)));
-            return (FormIndex) ois.readObject();
-        } catch (Exception e) {
-            Timber.e(e);
-        }
-        return null;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -523,8 +523,11 @@ public class FileUtils {
 
     public static FormIndex loadFormIndexFromFile() {
         try {
-            File instancePath = Collect.getInstance().getFormController().getInstancePath();
-            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.savepointFormIndexIndexFile(instancePath)));
+            String instanceName = Collect.getInstance()
+                    .getFormController()
+                    .getInstancePath()
+                    .getName();
+            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.getFormIndexFile(instanceName)));
             return (FormIndex) ois.readObject();
         } catch (Exception e) {
             Timber.e(e);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -18,12 +18,14 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
 import org.apache.commons.io.IOUtils;
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.xform.parse.XFormParser;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
 import org.kxml2.kdom.Node;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.tasks.SaveToDiskTask;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.FileNameMap;
@@ -504,5 +507,16 @@ public class FileUtils {
         List<File> mediaFiles = new ArrayList<>();
         Collections.addAll(mediaFiles, new File(mediaFilesDir).listFiles());
         return mediaFiles;
+    }
+
+    public static FormIndex loadFormIndex() {
+        try {
+            File instancePath = Collect.getInstance().getFormController().getInstancePath();
+            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.savepointIndexFile(instancePath)));
+            return (FormIndex) ois.readObject();
+        } catch(Exception e) {
+            Timber.e(e);
+        }
+        return null;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.FileNameMap;
@@ -509,10 +510,21 @@ public class FileUtils {
         return mediaFiles;
     }
 
-    public static FormIndex loadFormIndex() {
+    public static void exportFormIndexToFile(FormIndex formIndex, File savepointIndexFile) {
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(savepointIndexFile));
+            oos.writeObject(formIndex);
+            oos.flush();
+            oos.close();
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+    }
+
+    public static FormIndex loadFormIndexFromFile() {
         try {
             File instancePath = Collect.getInstance().getFormController().getInstancePath();
-            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.savepointIndexFile(instancePath)));
+            ObjectInputStream ois = new ObjectInputStream(new FileInputStream(SaveToDiskTask.savepointFormIndexIndexFile(instancePath)));
             return (FormIndex) ois.readObject();
         } catch (Exception e) {
             Timber.e(e);

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="data_saved_error">Sorry, form save failed!</string>
     <string name="data_saved_ok">Form successfully saved!</string>
     <string name="save_point_error">Error saving recovery point: %s</string>
+    <string name="save_form_index_error">Error saving recovery form index: %s</string>
     <string name="default_completed">Default to finalized</string>
     <string name="default_completed_summary">Mark form as finalized by default</string>
     <string name="delete_confirm">Delete %s form(s)?</string>


### PR DESCRIPTION
Closes #1675 

#### What has been done to verify that this works as intended?
I've tested that scenario when the form is recovered from a savepoint and I can confirm that we are moved to the last know question if the `allow moving backwards` option is disabled.

#### Why is this the best possible solution? Were any other approaches considered?
It's the only solution I was able to imagine. It's also pretty easy.

#### Are there any risks to merging this code? If so, what are they?
It doesn't change existed behavior much so it should be safe. It saves and reads FormIndex from a file only if the `allow moving backwards` option is disabled. 
I've also added a test case for saving and reading FormIndex.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.