### PR TITLE
User is able to change validation option although Admin blocks all options of moving backwards

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesFragment.java
@@ -48,8 +48,8 @@ import static org.odk.collect.android.preferences.AdminKeys.KEY_IMPORT_SETTINGS;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_JUMP_TO;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_MOVING_BACKWARDS;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_SAVE_MID;
-import static org.odk.collect.android.preferences.AdminKeys.KEY_CONSTRAINT_BEHAVIOR;
 import static org.odk.collect.android.preferences.AdminKeys.ALLOW_OTHER_WAYS_OF_EDITING_FORM;
+import static org.odk.collect.android.preferences.PreferenceKeys.CONSTRAINT_BEHAVIOR_ON_SWIPE;
 
 public class AdminPreferencesFragment extends BasePreferenceFragment implements Preference.OnPreferenceClickListener {
 
@@ -207,8 +207,6 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
             prefMgr.setSharedPreferencesMode(MODE_WORLD_READABLE);
 
             addPreferencesFromResource(R.xml.user_settings_access_preferences);
-
-            findPreference(KEY_CONSTRAINT_BEHAVIOR).setEnabled((Boolean) AdminSharedPreferences.getInstance().get(ALLOW_OTHER_WAYS_OF_EDITING_FORM));
         }
 
         @Override
@@ -271,7 +269,7 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
             AdminSharedPreferences.getInstance().save(KEY_EDIT_SAVED, false);
             AdminSharedPreferences.getInstance().save(KEY_SAVE_MID, false);
             AdminSharedPreferences.getInstance().save(KEY_JUMP_TO, false);
-            AdminSharedPreferences.getInstance().save(KEY_CONSTRAINT_BEHAVIOR, true);
+            GeneralSharedPreferences.getInstance().save(PreferenceKeys.KEY_CONSTRAINT_BEHAVIOR, CONSTRAINT_BEHAVIOR_ON_SWIPE);
 
             findPreference(KEY_JUMP_TO).setEnabled(false);
             findPreference(KEY_SAVE_MID).setEnabled(false);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -22,6 +22,7 @@ import android.view.View;
 
 import org.odk.collect.android.R;
 
+import static org.odk.collect.android.preferences.AdminKeys.ALLOW_OTHER_WAYS_OF_EDITING_FORM;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_CONSTRAINT_BEHAVIOR;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_IMAGE_SIZE;
@@ -70,6 +71,7 @@ public class FormManagementPreferences extends BasePreferenceFragment {
                             return true;
                         }
                     });
+            pref.setEnabled((Boolean) AdminSharedPreferences.getInstance().get(ALLOW_OTHER_WAYS_OF_EDITING_FORM));
         }
     }
 


### PR DESCRIPTION
Closes #1704 

#### What has been done to verify that this works as intended?
I tested this scenario:
1. Admin blocks moving backwards
2. Admin select 'Yes' on dialog
3. User goes to General Settings -> Form management-> Constraint processing
4. User is able to change validation option to 'Defer validation until finalized'

#### Why is this the best possible solution? Were any other approaches considered?
It's just a fix.

#### Are there any risks to merging this code? If so, what are they?
No, I just block an appropriate option thanks to this fix.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.