### PR TITLE
Use JavaRosa latest snapshot

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -196,7 +196,7 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.5'
     implementation group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     implementation group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
-    implementation(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.6.1') {
+    implementation(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.7.0-SNAPSHOT') {
         exclude module: 'joda-time'
     }
     implementation group: 'org.osmdroid', name: 'osmdroid-android', version: '5.6.4'


### PR DESCRIPTION
Update to just-released JavaRosa 2.7.0-SNAPSHOT.

#### What has been done to verify that this works as intended?
Compiled it to make sure the snapshot was available remotely.

#### Why is this the best possible solution? Were any other approaches considered?
We want to include the new JavaRosa version in the beta.

#### Are there any risks to merging this code? If so, what are they?
This new JavaRosa version makes one potentially risky change which involves reevaluating triggerables when a repeat is deleted. See [changes](https://github.com/opendatakit/javarosa/compare/v2.6.1...master). This could lead to slowdowns for people who have lots of repeats and are doing things like computing a sum at the end. We will highlight this in the beta notes.

#### Do we need any specific form for testing your changes? If so, please attach one.