### PR TITLE
Thousands sep

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -62,7 +62,6 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
     }
 
     private static String getDecimalFormattedString(String value) {
-
         String[] splitValue = value.split("\\.");
         String beforeDecimal = value;
         String afterDecimal = null;

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -15,8 +15,6 @@ import timber.log.Timber;
  */
 
 public class ThousandsSeparatorTextWatcher implements TextWatcher {
-
-    private DecimalFormat df;
     private EditText editText;
     private static String thousandSeparator;
     private static String decimalMarker;
@@ -24,7 +22,7 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
 
     public ThousandsSeparatorTextWatcher(EditText editText) {
         this.editText = editText;
-        df = new DecimalFormat("#,###.##");
+        DecimalFormat df = new DecimalFormat("#,###.##");
         df.setDecimalSeparatorAlwaysShown(true);
         thousandSeparator = Character.toString(df.getDecimalFormatSymbols().getGroupingSeparator());
         decimalMarker = Character.toString(df.getDecimalFormatSymbols().getDecimalSeparator());

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -44,7 +44,7 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
             editText.removeTextChangedListener(this);
             String value = editText.getText().toString();
 
-            if (value != null && !value.equals("")) {
+            if (!value.equals("")) {
                 String str = editText.getText().toString().replaceAll(thousandSeparator, "");
                 if (!value.equals("")) {
                     editText.setText(getDecimalFormattedString(str));

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -14,7 +14,7 @@ import timber.log.Timber;
  * The custom TextWatcher that automatically adds thousand separators in EditText.
  */
 
-public class ThousandSeparatorTextWatcher implements TextWatcher {
+public class ThousandsSeparatorTextWatcher implements TextWatcher {
 
     private DecimalFormat df;
     private EditText editText;
@@ -22,7 +22,7 @@ public class ThousandSeparatorTextWatcher implements TextWatcher {
     private static String decimalMarker;
     private int cursorPosition;
 
-    public ThousandSeparatorTextWatcher(EditText editText) {
+    public ThousandsSeparatorTextWatcher(EditText editText) {
         this.editText = editText;
         df = new DecimalFormat("#,###.##");
         df.setDecimalSeparatorAlwaysShown(true);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
@@ -27,7 +27,7 @@ import android.widget.EditText;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.listeners.ThousandSeparatorTextWatcher;
+import org.odk.collect.android.listeners.ThousandsSeparatorTextWatcher;
 
 import java.text.NumberFormat;
 import java.util.Locale;
@@ -60,7 +60,7 @@ public class DecimalWidget extends StringWidget {
 
         this.useThousandSeparator = useThousandSeparator;
         if (useThousandSeparator) {
-            answerText.addTextChangedListener(new ThousandSeparatorTextWatcher(answerText));
+            answerText.addTextChangedListener(new ThousandsSeparatorTextWatcher(answerText));
         }
 
         // only 15 characters allowed
@@ -116,7 +116,7 @@ public class DecimalWidget extends StringWidget {
     @Override
     public String getAnswerText() {
         if (useThousandSeparator) {
-            return ThousandSeparatorTextWatcher.getOriginalString(super.getAnswerText());
+            return ThousandsSeparatorTextWatcher.getOriginalString(super.getAnswerText());
         }
         return super.getAnswerText();
     }
@@ -126,7 +126,7 @@ public class DecimalWidget extends StringWidget {
         clearFocus();
         String s = getAnswerTextField().getText().toString();
         if (useThousandSeparator) {
-            s = ThousandSeparatorTextWatcher.getOriginalString(s);
+            s = ThousandsSeparatorTextWatcher.getOriginalString(s);
         }
 
         if (s.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/IntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/IntegerWidget.java
@@ -27,7 +27,7 @@ import android.widget.EditText;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.listeners.ThousandSeparatorTextWatcher;
+import org.odk.collect.android.listeners.ThousandsSeparatorTextWatcher;
 
 import java.util.Locale;
 
@@ -54,7 +54,7 @@ public class IntegerWidget extends StringWidget {
 
         this.useThousandSeparator = useThousandSeparator;
         if (useThousandSeparator) {
-            answerText.addTextChangedListener(new ThousandSeparatorTextWatcher(answerText));
+            answerText.addTextChangedListener(new ThousandsSeparatorTextWatcher(answerText));
         }
 
         // only allows numbers and no periods
@@ -105,7 +105,7 @@ public class IntegerWidget extends StringWidget {
     @Override
     public String getAnswerText() {
         if (useThousandSeparator) {
-            return ThousandSeparatorTextWatcher.getOriginalString(super.getAnswerText());
+            return ThousandsSeparatorTextWatcher.getOriginalString(super.getAnswerText());
         }
         return super.getAnswerText();
     }
@@ -115,7 +115,7 @@ public class IntegerWidget extends StringWidget {
         clearFocus();
         String s = getAnswerTextField().getText().toString();
         if (useThousandSeparator) {
-            s = ThousandSeparatorTextWatcher.getOriginalString(s);
+            s = ThousandsSeparatorTextWatcher.getOriginalString(s);
         }
 
         if (s.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringNumberWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringNumberWidget.java
@@ -25,7 +25,7 @@ import android.widget.EditText;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.listeners.ThousandSeparatorTextWatcher;
+import org.odk.collect.android.listeners.ThousandsSeparatorTextWatcher;
 
 /**
  * Widget that restricts values to integers.
@@ -51,7 +51,7 @@ public class StringNumberWidget extends StringWidget {
 
         this.useThousandSeparator = useThousandSeparator;
         if (useThousandSeparator) {
-            answerTextField.addTextChangedListener(new ThousandSeparatorTextWatcher(answerTextField));
+            answerTextField.addTextChangedListener(new ThousandsSeparatorTextWatcher(answerTextField));
         }
 
         answerTextField.setKeyListener(new DigitsKeyListener() {
@@ -89,7 +89,7 @@ public class StringNumberWidget extends StringWidget {
         String s = getAnswerText();
 
         if (useThousandSeparator) {
-            s = ThousandSeparatorTextWatcher.getOriginalString(s);
+            s = ThousandsSeparatorTextWatcher.getOriginalString(s);
         }
 
         if (s.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -122,12 +122,12 @@ public class WidgetFactory {
                         } else if (appearance.startsWith("ex:")) {
                             questionWidget = new ExStringWidget(context, fep);
                         } else if (appearance.contains("numbers")) {
-                            boolean useThousandSeparator = false;
+                            boolean useThousandsSeparator = false;
                             if (appearance.contains("thousands-sep")) {
-                                useThousandSeparator = true;
+                                useThousandsSeparator = true;
                             }
                             questionWidget = new StringNumberWidget(context, fep, readOnlyOverride,
-                                    useThousandSeparator);
+                                    useThousandsSeparator);
                         } else if (appearance.equals("url")) {
                             questionWidget = new UrlWidget(context, fep);
                         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -76,7 +76,7 @@ public class WidgetFactory {
                             questionWidget = new BearingWidget(context, fep);
                         } else {
                             boolean useThousandSeparator = false;
-                            if (appearance.contains("thousand-sep")) {
+                            if (appearance.contains("thousands-sep")) {
                                 useThousandSeparator = true;
                             }
                             questionWidget = new DecimalWidget(context, fep, readOnlyOverride,
@@ -88,7 +88,7 @@ public class WidgetFactory {
                             questionWidget = new ExIntegerWidget(context, fep);
                         } else {
                             boolean useThousandSeparator = false;
-                            if (appearance.contains("thousand-sep")) {
+                            if (appearance.contains("thousands-sep")) {
                                 useThousandSeparator = true;
                             }
                             questionWidget = new IntegerWidget(context, fep, readOnlyOverride,
@@ -123,7 +123,7 @@ public class WidgetFactory {
                             questionWidget = new ExStringWidget(context, fep);
                         } else if (appearance.contains("numbers")) {
                             boolean useThousandSeparator = false;
-                            if (appearance.contains("thousand-sep")) {
+                            if (appearance.contains("thousands-sep")) {
                                 useThousandSeparator = true;
                             }
                             questionWidget = new StringNumberWidget(context, fep, readOnlyOverride,


### PR DESCRIPTION
Uses appearance name agreed on in https://forum.opendatakit.org/t/spec-addition-proposal-appearance-for-thousands-separators-in-numeric-fields/10948

Please review commit by commit.

#### What has been done to verify that this works as intended?
Used the form [thousands-separator.xml.txt](https://github.com/opendatakit/collect/files/1556967/thousands-separator.xml.txt)

#### Why is this the best possible solution? Were any other approaches considered?
For now this just changes the appearance name, the names of related identifiers and corrects a couple of easy issues. I considered splitting those into separate PRs but with separate commits I think it's clear enough.

#### Are there any risks to merging this code? If so, what are they?
Mostly IDE-led refactors which increases safety. The worst case is that it could break an unreleased feature.

#### Do we need any specific form for testing your changes? If so, please attach one.