### PR TITLE
Show thousands separators in hierarchy view

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -29,19 +29,18 @@ public class FormEntryPromptUtils {
 
     public static String getAnswerText(FormEntryPrompt fep, Context context) {
         IAnswerData data = fep.getAnswerValue();
-        String text;
         final String appearance = fep.getQuestion().getAppearanceAttr();
-        
+
         if (data instanceof DateTimeData) {
-            text = DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
+            return DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
                     DateTimeUtils.getDatePickerDetails(appearance), true, context);
-        } else if (data instanceof DateData) {
-            text = DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
-                    DateTimeUtils.getDatePickerDetails(appearance), false, context);
-        } else {
-            text = fep.getAnswerText();
         }
 
-        return text;
+        if (data instanceof DateData) {
+            return DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
+                    DateTimeUtils.getDatePickerDetails(appearance), false, context);
+        }
+
+        return fep.getAnswerText();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -30,12 +30,14 @@ public class FormEntryPromptUtils {
     public static String getAnswerText(FormEntryPrompt fep, Context context) {
         IAnswerData data = fep.getAnswerValue();
         String text;
+        final String appearance = fep.getQuestion().getAppearanceAttr();
+        
         if (data instanceof DateTimeData) {
             text = DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
-                    DateTimeUtils.getDatePickerDetails(fep.getQuestion().getAppearanceAttr()), true, context);
+                    DateTimeUtils.getDatePickerDetails(appearance), true, context);
         } else if (data instanceof DateData) {
             text = DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
-                    DateTimeUtils.getDatePickerDetails(fep.getQuestion().getAppearanceAttr()), false, context);
+                    DateTimeUtils.getDatePickerDetails(appearance), false, context);
         } else {
             text = fep.getAnswerText();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -43,7 +43,7 @@ public class FormEntryPromptUtils {
                     DateTimeUtils.getDatePickerDetails(appearance), false, context);
         }
 
-        if (appearance != null && appearance.contains("thousands-sep")) {
+        if (data != null && appearance != null && appearance.contains("thousands-sep")) {
             try {
                 final BigDecimal answerAsDecimal = new BigDecimal(fep.getAnswerText());
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -23,6 +23,8 @@ import org.javarosa.core.model.data.DateTimeData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.util.Date;
 
 public class FormEntryPromptUtils {
@@ -39,6 +41,20 @@ public class FormEntryPromptUtils {
         if (data instanceof DateData) {
             return DateTimeUtils.getDateTimeLabel((Date) data.getValue(),
                     DateTimeUtils.getDatePickerDetails(appearance), false, context);
+        }
+
+        if (appearance != null && appearance.contains("thousands-sep")) {
+            try {
+                final BigDecimal answerAsDecimal = new BigDecimal(fep.getAnswerText());
+
+                DecimalFormat df = new DecimalFormat();
+                df.setGroupingSize(3);
+                df.setGroupingUsed(true);
+                df.setMaximumFractionDigits(Integer.MAX_VALUE);
+                return df.format(answerAsDecimal);
+            } catch (NumberFormatException e) {
+                return fep.getAnswerText();
+            }
         }
 
         return fep.getAnswerText();


### PR DESCRIPTION
Closes #1709. Best reviewed commit by commit.

#### What has been done to verify that this works as intended?
Filled out the form [thousands-separator.xml.txt](https://github.com/opendatakit/collect/files/1557666/thousands-separator.xml.txt) in a couple different locales and with varying numbers of digits.

#### Why is this the best possible solution? Were any other approaches considered?
I used standard Java methods instead of writing something custom. Without calling `setMaximumFractionDigits` fraction digits were limited to 3. I considered the max of 340 described at https://developer.android.com/reference/java/text/DecimalFormat.html#setMaximumFractionDigits(int) but that seemed like a weird magic number.

#### Are there any risks to merging this code? If so, what are they?
This affects how all questions' answers are shown on the hierarchy view so an error could make that screen unusable.

#### Do we need any specific form for testing your changes? If so, please attach one.
[thousands-separator.xml.txt](https://github.com/opendatakit/collect/files/1557666/thousands-separator.xml.txt)