### PR TITLE
cancelWaitingForData() method called multiple times

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -319,6 +319,7 @@ public class ODKView extends ScrollView implements OnLongClickListener {
                 if (binaryWidget.isWaitingForData()) {
                     try {
                         binaryWidget.setBinaryData(answer);
+                        binaryWidget.cancelWaitingForData();
                     } catch (Exception e) {
                         Timber.e(e);
                         ToastUtils.showLongToast(getContext().getString(R.string.error_attaching_binary_file,

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractDateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractDateWidget.java
@@ -105,7 +105,6 @@ public abstract class AbstractDateWidget extends QuestionWidget implements Binar
             date = (LocalDateTime) answer;
             setDateLabel();
         }
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -243,8 +243,6 @@ public class AlignedImageWidget extends QuestionWidget implements BaseImageWidge
         } else {
             Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
         }
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -250,8 +250,6 @@ public class AnnotateWidget extends QuestionWidget implements BaseImageWidget {
         } else {
             Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
         }
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -182,8 +182,6 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
         } else {
             Timber.e("Inserting Audio file FAILED");
         }
-
-        cancelWaitingForData();
     }
 
     private String getSourcePathFromUri(@NonNull Uri uri) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -89,7 +89,6 @@ public class BarcodeWidget extends QuestionWidget implements BinaryWidget {
             response = response.replaceAll("\\p{C}", "");
         }
         stringAnswer.setText(response);
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -114,7 +114,6 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
     @Override
     public void setBinaryData(Object answer) {
         this.answer.setText((String) answer);
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -136,7 +136,6 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget {
     @Override
     public void setBinaryData(Object answer) {
         dateWidget.setBinaryData(answer);
-        cancelWaitingForData();
     }
 
     public AbstractDateWidget getDateWidget() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
@@ -213,8 +213,6 @@ public class DrawWidget extends QuestionWidget implements BaseImageWidget {
         } else {
             Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
         }
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -122,7 +122,5 @@ public class ExDecimalWidget extends ExStringWidget {
     public void setBinaryData(Object answer) {
         DecimalData decimalData = ExternalAppsUtils.asDecimalData(answer);
         this.answer.setText(decimalData == null ? null : decimalData.getValue().toString());
-        cancelWaitingForData();
     }
-
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
@@ -111,7 +111,5 @@ public class ExIntegerWidget extends ExStringWidget {
     public void setBinaryData(Object answer) {
         IntegerData integerData = ExternalAppsUtils.asIntegerData(answer);
         this.answer.setText(integerData == null ? null : integerData.getValue().toString());
-        cancelWaitingForData();
     }
-
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
@@ -199,7 +199,6 @@ public class ExPrinterWidget extends QuestionWidget implements BinaryWidget {
      */
     @Override
     public void setBinaryData(Object answer) {
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -177,8 +177,6 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
     public void setBinaryData(Object answer) {
         StringData stringData = ExternalAppsUtils.asStringData(answer);
         this.answer.setText(stringData == null ? null : stringData.getValue().toString());
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -264,7 +264,6 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
         }
 
         updateButtonLabelsAndVisibility(true);
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -114,8 +114,6 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
     public void setBinaryData(Object answer) {
         String s = answer.toString();
         answerDisplay.setText(s);
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -121,7 +121,6 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
     @Override
     public void setBinaryData(Object answer) {
         answerDisplay.setText(answer.toString());
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -254,8 +254,6 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
         } else {
             Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
         }
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -230,8 +230,6 @@ public class ImageWidget extends QuestionWidget implements BaseImageWidget {
         } else {
             Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
         }
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -213,8 +213,6 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
         osmFileNameTextView.setText(osmFileName);
         osmFileNameHeaderTextView.setVisibility(View.VISIBLE);
         osmFileNameTextView.setVisibility(View.VISIBLE);
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
@@ -208,8 +208,6 @@ public class SignatureWidget extends QuestionWidget implements BaseImageWidget {
         } else {
             Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
         }
-
-        cancelWaitingForData();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -244,7 +244,6 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         }
 
         binaryName = newVideo.getName();
-        cancelWaitingForData();
 
         // Need to have this ugly code to account for
         // a bug in the Nexus 7 on 4.3 not returning the mediaUri in the data


### PR DESCRIPTION
Closes #1713 

#### What has been done to verify that this works as intended?
I've tested a form attached in #1713 

#### Why is this the best possible solution? Were any other approaches considered?
`setBinaryData()` is override in each widget. In each widget this method call `cancelWaitingForData()` method. The problem was that in some widgets we call `setBinaryData()` method from constructor too:

[GeoPointWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java#L127), [GeotraceWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java#L87), [GeoShapeWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java#L79), [BearingWidget](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java#L84)

That means this method is called every time the FormEntryActyvity is recreated (when we return after taking a photo for example) and `cancelWaitingForData()` is called too. So if we have a few widgets on one page and one of the mentioned above widgets is not empty and we try to take a photo (for example) `cancelWaitingForData()` method is called before we attach the photo and then we can't do that.

#### Are there any risks to merging this code? If so, what are they?
I moved `cancelWaitingForData()` to the main method in ODKView. I think it should be there. @jknightco can you see any risk. I think it's safe and it's the right place for calling that method. i don't know why it was called in each widget.

#### Do we need any specific form for testing your changes? If so, please attach one.
A form attached in #1713 is a good one.