### PR TITLE
Avoid . as thousands marker and always use it as decimal marker

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -22,7 +22,7 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
 
     public ThousandsSeparatorTextWatcher(EditText editText) {
         this.editText = editText;
-        DecimalFormat df = new DecimalFormat("#,###.##");
+        DecimalFormat df = new DecimalFormat();
         df.setDecimalSeparatorAlwaysShown(true);
         thousandSeparator = Character.toString(df.getDecimalFormatSymbols().getGroupingSeparator());
     }

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -18,7 +18,6 @@ import timber.log.Timber;
 public class ThousandsSeparatorTextWatcher implements TextWatcher {
     private EditText editText;
     private static String thousandSeparator;
-    private static String decimalMarker;
     private int cursorPosition;
 
     public ThousandsSeparatorTextWatcher(EditText editText) {
@@ -26,7 +25,6 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
         DecimalFormat df = new DecimalFormat("#,###.##");
         df.setDecimalSeparatorAlwaysShown(true);
         thousandSeparator = Character.toString(df.getDecimalFormatSymbols().getGroupingSeparator());
-        decimalMarker = Character.toString(df.getDecimalFormatSymbols().getDecimalSeparator());
     }
 
     @Override
@@ -61,7 +59,10 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
     }
 
     private static String getDecimalFormattedString(String value) {
-        String[] splitValue = value.split("\\.");
+        // Always use a period because keyboard isn't localized. See DecimalWidget.
+        String decimalMarker = ".";
+
+        String[] splitValue = value.split(Pattern.quote(decimalMarker));
         String beforeDecimal = value;
         String afterDecimal = null;
         String finalResult = "";

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -5,6 +5,7 @@ import android.text.TextWatcher;
 import android.widget.EditText;
 
 import java.text.DecimalFormat;
+import java.util.regex.Pattern;
 
 import timber.log.Timber;
 
@@ -43,7 +44,7 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
             String value = editText.getText().toString();
 
             if (!value.equals("")) {
-                String str = editText.getText().toString().replaceAll(thousandSeparator, "");
+                String str = editText.getText().toString().replaceAll(Pattern.quote(thousandSeparator), "");
                 if (!value.equals("")) {
                     editText.setText(getDecimalFormattedString(str));
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -25,6 +25,11 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
         DecimalFormat df = new DecimalFormat();
         df.setDecimalSeparatorAlwaysShown(true);
         thousandSeparator = Character.toString(df.getDecimalFormatSymbols().getGroupingSeparator());
+
+        // The decimal marker is always "." (see DecimalWidget) so avoid it as thousands separator
+        if (thousandSeparator.equals(".")) {
+            thousandSeparator = " ";
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -54,9 +54,14 @@ public class FormEntryPromptUtils {
                 df.setMaximumFractionDigits(Integer.MAX_VALUE);
 
                 // Use . as decimal marker for consistency with DecimalWidget
-                DecimalFormatSymbols periodAlways = new DecimalFormatSymbols();
-                periodAlways.setDecimalSeparator('.');
-                df.setDecimalFormatSymbols(periodAlways);
+                DecimalFormatSymbols customFormat = new DecimalFormatSymbols();
+                customFormat.setDecimalSeparator('.');
+
+                if (df.getDecimalFormatSymbols().getGroupingSeparator() == '.') {
+                    customFormat.setGroupingSeparator(' ');
+                }
+
+                df.setDecimalFormatSymbols(customFormat);
 
                 return df.format(answerAsDecimal);
             } catch (NumberFormatException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -25,6 +25,7 @@ import org.javarosa.form.api.FormEntryPrompt;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Date;
 
 public class FormEntryPromptUtils {
@@ -51,6 +52,12 @@ public class FormEntryPromptUtils {
                 df.setGroupingSize(3);
                 df.setGroupingUsed(true);
                 df.setMaximumFractionDigits(Integer.MAX_VALUE);
+
+                // Use . as decimal marker for consistency with DecimalWidget
+                DecimalFormatSymbols periodAlways = new DecimalFormatSymbols();
+                periodAlways.setDecimalSeparator('.');
+                df.setDecimalFormatSymbols(periodAlways);
+
                 return df.format(answerAsDecimal);
             } catch (NumberFormatException e) {
                 return fep.getAnswerText();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DecimalWidget.java
@@ -75,6 +75,7 @@ public class DecimalWidget extends StringWidget {
 
         if (d != null) {
             // truncate to 15 digits max in US locale
+            // use US locale because DigitsKeyListener can't be localized before API 26
             NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
             nf.setMaximumFractionDigits(15);
             nf.setMaximumIntegerDigits(15);


### PR DESCRIPTION
Closes #1715 

#### What has been done to verify that this works as intended?
Tried decimal with `thousands-sep` appearance in German (. thousands / , decimal), French (" " thousands / , decimal) and US English (, thousands / .decimal). The intent is that German act like French and all locales use . as the decimal marker because of an Android limitation (https://issuetracker.google.com/issues/36907764)

#### Why is this the best possible solution? Were any other approaches considered?
See https://forum.opendatakit.org/t/odk-collect-v1-12-beta/10965/6. I think this provides the most consistent and least confusing behavior. Another approach could be to always use the US English markers but as a French speaker I appreciate space being used as the thousands separator. I think that will be less confusing to people in locales that typically use commas as decimal separators.

#### Are there any risks to merging this code? If so, what are they?
There may be other marker combinations this breaks.

#### Do we need any specific form for testing your changes? If so, please attach one.
[thousands-separator.xml.txt](https://github.com/opendatakit/collect/files/1561056/thousands-separator.xml.txt)