### PR TITLE
Form keeps saying it has an updated version even if I just downloaded it

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -84,7 +84,9 @@ public class FormsDao {
                     + FormsProviderAPI.FormsColumns.JR_VERSION + "=?";
         }
 
-        Cursor cursor = getFormsCursor(selection, selectionArgs);
+        String order = FormsProviderAPI.FormsColumns.DATE + " DESC"; //as long as we allow to store multiple forms with the same id and version number, choose the newest one
+
+        Cursor cursor = getFormsCursor(null, selection, selectionArgs, order);
         if (cursor != null) {
             try {
                 if (cursor.moveToFirst()) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -423,6 +423,11 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
     }
 
     private boolean isMediaFileAlreadyDownloaded(List<File> localMediaFiles, MediaFile newMediaFile) {
+        // TODO Zip files are ignored we should find a way to take them into account too
+        if (newMediaFile.getFilename().endsWith(".zip")) {
+            return true;
+        }
+        
         String mediaFileHash = newMediaFile.getHash();
         mediaFileHash = mediaFileHash.substring(4, mediaFileHash.length());
         for (File localMediaFile : localMediaFiles) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -409,15 +409,8 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
             String mediaDirPath = new FormsDao().getFormMediaPath(formId, formVersion);
             List<File> localMediaFiles = FileUtils.getAllFormMediaFiles(mediaDirPath);
             if (localMediaFiles != null) {
-                for (MediaFile mediaFile : newMediaFiles) {
-                    File file = getFileByName(localMediaFiles, mediaFile.getFilename());
-                    if (file != null) {
-                        String mediaFileHash = mediaFile.getHash();
-                        mediaFileHash = mediaFileHash.substring(4, mediaFileHash.length());
-                        if (!mediaFileHash.equals(FileUtils.getMd5Hash(file))) {
-                            return true;
-                        }
-                    } else {
+                for (MediaFile newMediaFile : newMediaFiles) {
+                    if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
                         return true;
                     }
                 }
@@ -429,14 +422,15 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
         return false;
     }
 
-    private File getFileByName(List<File> files, String fileName) {
-        for (File file : files) {
-            if (file.getName().equals(fileName)) {
-                return file;
+    private boolean isMediaFileAlreadyDownloaded(List<File> localMediaFiles, MediaFile newMediaFile) {
+        String mediaFileHash = newMediaFile.getHash();
+        mediaFileHash = mediaFileHash.substring(4, mediaFileHash.length());
+        for (File localMediaFile : localMediaFiles) {
+            if (mediaFileHash.equals(FileUtils.getMd5Hash(localMediaFile))) {
+                return true;
             }
         }
-
-        return null;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Closes #1720

#### What has been done to verify that this works as intended?
1. [Sample-preloading-form](https://opendatakit.org/downloads/download-info/sample-preloading-form/)
2. A form with external itemsets.
3. A form with simple media files

In all cases, I tested editing media files.

#### Why is this the best possible solution? Were any other approaches considered?
I improved checking media files because in some cases like (data preloading) files after downloading might be renamed but are still identical.

#### Are there any risks to merging this code? If so, what are they?
Implemented changes are related to media files only, so the risk is related to changes in media files.
In order to verify this pr such cases with media files should be tested.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.