### PR TITLE
Avoid NPE when DateTimeZone is null

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
@@ -85,8 +85,11 @@ public class DateTimeUtils {
 
     public static LocalDateTime skipDaylightSavingGapIfExists(LocalDateTime date) {
         final DateTimeZone dtz = DateTimeZone.getDefault();
-        while (dtz.isLocalDateTimeGap(date)) {
-            date = date.plusMinutes(1);
+
+        if (dtz != null) {
+            while (dtz.isLocalDateTimeGap(date)) {
+                date = date.plusMinutes(1);
+            }
         }
         return date;
     }


### PR DESCRIPTION
Closes #1725 

#### What has been done to verify that this works as intended?
I tried the coptic calendar and verified it still works.

#### Why is this the best possible solution? Were any other approaches considered?
I didn't try to reproduce it -- I think it was triggered by the Firebase random robot. I did verify that DateTimeZone can be null and just wrapped a null check.

#### Are there any risks to merging this code? If so, what are they?
Worst case is that this somehow doesn't fix the problem but given that we know the line that crashes, that's pretty unlikely.

#### Do we need any specific form for testing your changes? If so, please attach one.