### PR TITLE
Default to Aggregate server type to avoid NPE

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferences.java
@@ -62,7 +62,7 @@ public class ServerPreferences extends ServerPreferencesFragment implements Pref
     }
 
     private void addPreferencesResource(CharSequence value) {
-        if (value.equals(getString(R.string.protocol_odk_default))) {
+        if (value == null || value.equals(getString(R.string.protocol_odk_default))) {
             setDefaultAggregatePaths();
             addAggregatePreferences();
         } else if (value.equals(getString(R.string.protocol_google_sheets))) {


### PR DESCRIPTION
Closes #1724

#### What has been done to verify that this works as intended?
Manually verified I can still set the server type and that it is retained after screen changes.

#### Why is this the best possible solution? Were any other approaches considered?
The only way I can imagine this state happening is if somehow we get to the server menu so quickly that the app hasn't initialized yet. I was not able to reproduce. I think it was hit by the Firebase robot tester. Even if this crash isn't likely to happen, this fix is safe and easy so we might as well get it in.

#### Are there any risks to merging this code? If so, what are they?
This being only a null check, the only possible risk is that if I got the condition wrong the server type could default to Aggregate in an overzealous way.

#### Do we need any specific form for testing your changes? If so, please attach one.