### PR TITLE
fixes #1723 Restricted number of opened date dialog's to one

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractDateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractDateWidget.java
@@ -17,7 +17,6 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
-import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -128,12 +127,6 @@ public abstract class AbstractDateWidget extends QuestionWidget implements Binar
     private void createDateButton() {
         dateButton = getSimpleButton(getContext().getString(R.string.select_date));
         dateButton.setEnabled(!getFormEntryPrompt().isReadOnly());
-        dateButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showDatePickerDialog();
-            }
-        });
     }
 
     private void addViews() {


### PR DESCRIPTION
Closes #1723 

#### What has been done to verify that this works as intended?

Checked on Android 5.1.1 using the all widgets form.

#### Why is this the best possible solution? Were any other approaches considered?

Hiding any previously shown dialog was the best possible and feasible solution in my view.

#### Are there any risks to merging this code? If so, what are they?

NA

#### Do we need any specific form for testing your changes? If so, please attach one.
No, just the all widgets form will do.