### PR TITLE
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'char[] java.lang.String.toCharArray()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -405,24 +405,22 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
     }
 
     private boolean areNewerMediaFilesAvailable(String formId, String formVersion, List<MediaFile> newMediaFiles) {
-        if (newMediaFiles != null) {
-            String mediaDirPath = new FormsDao().getFormMediaPath(formId, formVersion);
-            List<File> localMediaFiles = FileUtils.getAllFormMediaFiles(mediaDirPath);
-            if (localMediaFiles != null) {
-                for (MediaFile newMediaFile : newMediaFiles) {
-                    if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
-                        return true;
-                    }
+        String mediaDirPath = new FormsDao().getFormMediaPath(formId, formVersion);
+        File[] localMediaFiles = new File(mediaDirPath).listFiles();
+        if (localMediaFiles != null) {
+            for (MediaFile newMediaFile : newMediaFiles) {
+                if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
+                    return true;
                 }
-            } else if (!newMediaFiles.isEmpty()) {
-                return true;
             }
+        } else if (!newMediaFiles.isEmpty()) {
+            return true;
         }
 
         return false;
     }
 
-    private boolean isMediaFileAlreadyDownloaded(List<File> localMediaFiles, MediaFile newMediaFile) {
+    private boolean isMediaFileAlreadyDownloaded(File[] localMediaFiles, MediaFile newMediaFile) {
         // TODO Zip files are ignored we should find a way to take them into account too
         if (newMediaFile.getFilename().endsWith(".zip")) {
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -39,10 +39,7 @@ import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 
 import timber.log.Timber;
 
@@ -498,11 +495,5 @@ public class FileUtils {
         }
 
         return bitmap;
-    }
-
-    public static List<File> getAllFormMediaFiles(String mediaFilesDir) {
-        List<File> mediaFiles = new ArrayList<>();
-        Collections.addAll(mediaFiles, new File(mediaFilesDir).listFiles());
-        return mediaFiles;
     }
 }


### PR DESCRIPTION
Closes #1737 

#### What has been done to verify that this works as intended?
I tested the case mentioned in #1737 

#### Why is this the best possible solution? Were any other approaches considered?
I just made the solution simple and solved the bug.

#### Are there any risks to merging this code? If so, what are they?
Now the solution is simpler we just get list of file and check for null https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1737?expand=1#diff-10d77d66d8d1d9f9edc5c6e5c1706489R410

The problem before was that I tried to add that null to a collection https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1737?expand=1#diff-7f825a8c77110cae6eb54336627d425fL505

So in y opinion now this part of code is really safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with media files.