### PR TITLE
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -401,7 +401,7 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
     }
 
     private boolean isNewerFormVersionAvailable(String md5Hash) {
-        return new FormsDao().getFormsCursorForMd5Hash(md5Hash).getCount() == 0;
+        return md5Hash != null && new FormsDao().getFormsCursorForMd5Hash(md5Hash).getCount() == 0;
     }
 
     private boolean areNewerMediaFilesAvailable(String formId, String formVersion, List<MediaFile> newMediaFiles) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -706,7 +706,7 @@ public class DownloadFormsTask extends
                     String currentFileHash = FileUtils.getMd5Hash(finalMediaFile);
                     String downloadFileHash = getMd5Hash(toDownload.getHash());
 
-                    if (!currentFileHash.contentEquals(downloadFileHash)) {
+                    if (currentFileHash != null && downloadFileHash != null && !currentFileHash.contentEquals(downloadFileHash)) {
                         // if the hashes match, it's the same file
                         // otherwise delete our current one and replace it with the new one
                         FileUtils.deleteAndReport(finalMediaFile);
@@ -755,6 +755,6 @@ public class DownloadFormsTask extends
     }
 
     static String getMd5Hash(String hash) {
-        return hash.substring(MD5_COLON_PREFIX.length());
+        return hash == null ? null : hash.substring(MD5_COLON_PREFIX.length());
     }
 }


### PR DESCRIPTION
Closes #1739 

#### What has been done to verify that this works as intended?
Since I wasn't able to reproduce the issue I tested it only with hardcoded null values.

#### Why is this the best possible solution? Were any other approaches considered?
It's just for avoiding NullPointerExceptions.

#### Are there any risks to merging this code? If so, what are they?
No. I just protect form NullPointerExceptions, but downloading forms and displaying a message about available update may be tested just in case.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.