### PR TITLE
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'char[] java.lang.String.toCharArray()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -406,15 +406,17 @@ public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String
 
     private boolean areNewerMediaFilesAvailable(String formId, String formVersion, List<MediaFile> newMediaFiles) {
         String mediaDirPath = new FormsDao().getFormMediaPath(formId, formVersion);
-        File[] localMediaFiles = new File(mediaDirPath).listFiles();
-        if (localMediaFiles != null) {
-            for (MediaFile newMediaFile : newMediaFiles) {
-                if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
-                    return true;
+        if (mediaDirPath != null) {
+            File[] localMediaFiles = new File(mediaDirPath).listFiles();
+            if (localMediaFiles != null) {
+                for (MediaFile newMediaFile : newMediaFiles) {
+                    if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
+                        return true;
+                    }
                 }
+            } else if (!newMediaFiles.isEmpty()) {
+                return true;
             }
-        } else if (!newMediaFiles.isEmpty()) {
-            return true;
         }
 
         return false;


### PR DESCRIPTION
Closes #1737 

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.