### PR TITLE
Repeat count after group in jump screen breadcrumb

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -43,6 +43,7 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
+import org.odk.collect.android.views.ODKView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -195,28 +196,19 @@ public class FormHierarchyActivity extends AppCompatActivity implements AdapterV
         refreshView();
     }
 
-
     private String getCurrentPath() {
         FormController formController = Collect.getInstance().getFormController();
         FormIndex index = formController.getFormIndex();
         // move to enclosing group...
         index = formController.stepIndexOut(index);
 
-        String path = "";
+        List<FormEntryCaption> groups = new ArrayList<>();
         while (index != null) {
-
-            path =
-                    formController.getCaptionPrompt(index).getLongText()
-                            + " ("
-                            + (formController.getCaptionPrompt(index)
-                            .getMultiplicity() + 1) + ") > " + path;
-
+            groups.add(0, formController.getCaptionPrompt(index));
             index = formController.stepIndexOut(index);
         }
-        // return path?
-        return path.substring(0, path.length() - 2);
+        return ODKView.getGroupsPath(groups.toArray(new FormEntryCaption[groups.size()]));
     }
-
 
     public void refreshView() {
         try {

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -275,11 +275,10 @@ public class ODKView extends ScrollView implements OnLongClickListener {
         String path = getGroupsPath(groups);
 
         // build view
-        if (path.length() > 0) {
+        if (!path.isEmpty()) {
             TextView tv = new TextView(getContext());
             tv.setText(path);
-            int questionFontsize = Collect.getQuestionFontsize();
-            tv.setTextSize(TypedValue.COMPLEX_UNIT_DIP, questionFontsize - 4);
+            tv.setTextSize(TypedValue.COMPLEX_UNIT_DIP, Collect.getQuestionFontsize() - 4);
             tv.setPadding(0, 0, 0, 5);
             view.addView(tv, layout);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -271,6 +271,20 @@ public class ODKView extends ScrollView implements OnLongClickListener {
      * // * Add a TextView containing the hierarchy of groups to which the question belongs. //
      */
     private void addGroupText(FormEntryCaption[] groups) {
+        String s = getGroupsPath(groups);
+
+        // build view
+        if (s.length() > 0) {
+            TextView tv = new TextView(getContext());
+            tv.setText(s.substring(0, s.length() - 3));
+            int questionFontsize = Collect.getQuestionFontsize();
+            tv.setTextSize(TypedValue.COMPLEX_UNIT_DIP, questionFontsize - 4);
+            tv.setPadding(0, 0, 0, 5);
+            view.addView(tv, layout);
+        }
+    }
+
+    public static String getGroupsPath(FormEntryCaption[] groups) {
         StringBuilder s = new StringBuilder("");
         String t;
         int i;
@@ -289,17 +303,8 @@ public class ODKView extends ScrollView implements OnLongClickListener {
             }
         }
 
-        // build view
-        if (s.length() > 0) {
-            TextView tv = new TextView(getContext());
-            tv.setText(s.substring(0, s.length() - 3));
-            int questionFontsize = Collect.getQuestionFontsize();
-            tv.setTextSize(TypedValue.COMPLEX_UNIT_DIP, questionFontsize - 4);
-            tv.setPadding(0, 0, 0, 5);
-            view.addView(tv, layout);
-        }
+        return s.toString();
     }
-
 
     public void setFocus(Context context) {
         if (widgets.size() > 0) {

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -286,20 +286,22 @@ public class ODKView extends ScrollView implements OnLongClickListener {
 
     public static String getGroupsPath(FormEntryCaption[] groups) {
         StringBuilder s = new StringBuilder("");
-        String t;
-        int i;
-        // list all groups in one string
-        for (FormEntryCaption g : groups) {
-            i = g.getMultiplicity() + 1;
-            t = g.getLongText();
-            if (t != null) {
-                s.append(t);
-                if (g.repeats() && i > 0) {
-                    s.append(" (")
-                            .append(i)
-                            .append(")");
+        if (groups != null) {
+            String t;
+            int i;
+            // list all groups in one string
+            for (FormEntryCaption g : groups) {
+                i = g.getMultiplicity() + 1;
+                t = g.getLongText();
+                if (t != null) {
+                    s.append(t);
+                    if (g.repeats() && i > 0) {
+                        s.append(" (")
+                                .append(i)
+                                .append(")");
+                    }
+                    s.append(" > ");
                 }
-                s.append(" > ");
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -271,12 +271,12 @@ public class ODKView extends ScrollView implements OnLongClickListener {
      * // * Add a TextView containing the hierarchy of groups to which the question belongs. //
      */
     private void addGroupText(FormEntryCaption[] groups) {
-        String s = getGroupsPath(groups);
+        String path = getGroupsPath(groups);
 
         // build view
-        if (s.length() > 0) {
+        if (path.length() > 0) {
             TextView tv = new TextView(getContext());
-            tv.setText(s);
+            tv.setText(path);
             int questionFontsize = Collect.getQuestionFontsize();
             tv.setTextSize(TypedValue.COMPLEX_UNIT_DIP, questionFontsize - 4);
             tv.setPadding(0, 0, 0, 5);
@@ -285,7 +285,7 @@ public class ODKView extends ScrollView implements OnLongClickListener {
     }
 
     public static String getGroupsPath(FormEntryCaption[] groups) {
-        StringBuilder s = new StringBuilder("");
+        StringBuilder path = new StringBuilder("");
         if (groups != null) {
             String t;
             int i;
@@ -295,21 +295,21 @@ public class ODKView extends ScrollView implements OnLongClickListener {
                 i = g.getMultiplicity() + 1;
                 t = g.getLongText();
                 if (t != null) {
-                    s.append(t);
+                    path.append(t);
                     if (g.repeats() && i > 0) {
-                        s.append(" (")
+                        path.append(" (")
                                 .append(i)
                                 .append(")");
                     }
                     if (index < groups.length) {
-                        s.append(" > ");
+                        path.append(" > ");
                     }
                     index++;
                 }
             }
         }
 
-        return s.toString();
+        return path.toString();
     }
 
     public void setFocus(Context context) {

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -276,7 +276,7 @@ public class ODKView extends ScrollView implements OnLongClickListener {
         // build view
         if (s.length() > 0) {
             TextView tv = new TextView(getContext());
-            tv.setText(s.substring(0, s.length() - 3));
+            tv.setText(s);
             int questionFontsize = Collect.getQuestionFontsize();
             tv.setTextSize(TypedValue.COMPLEX_UNIT_DIP, questionFontsize - 4);
             tv.setPadding(0, 0, 0, 5);
@@ -289,6 +289,7 @@ public class ODKView extends ScrollView implements OnLongClickListener {
         if (groups != null) {
             String t;
             int i;
+            int index = 1;
             // list all groups in one string
             for (FormEntryCaption g : groups) {
                 i = g.getMultiplicity() + 1;
@@ -300,7 +301,10 @@ public class ODKView extends ScrollView implements OnLongClickListener {
                                 .append(i)
                                 .append(")");
                     }
-                    s.append(" > ");
+                    if (index < groups.length) {
+                        s.append(" > ");
+                    }
+                    index++;
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -288,18 +288,19 @@ public class ODKView extends ScrollView implements OnLongClickListener {
     public static String getGroupsPath(FormEntryCaption[] groups) {
         StringBuilder path = new StringBuilder("");
         if (groups != null) {
-            String t;
-            int i;
+            String longText;
+            int multiplicity;
             int index = 1;
             // list all groups in one string
-            for (FormEntryCaption g : groups) {
-                i = g.getMultiplicity() + 1;
-                t = g.getLongText();
-                if (t != null) {
-                    path.append(t);
-                    if (g.repeats() && i > 0) {
-                        path.append(" (")
-                                .append(i)
+            for (FormEntryCaption group : groups) {
+                multiplicity = group.getMultiplicity() + 1;
+                longText = group.getLongText();
+                if (longText != null) {
+                    path.append(longText);
+                    if (group.repeats() && multiplicity > 0) {
+                        path
+                                .append(" (")
+                                .append(multiplicity)
                                 .append(")");
                     }
                     if (index < groups.length) {

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.NonNull;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -284,6 +285,7 @@ public class ODKView extends ScrollView implements OnLongClickListener {
         }
     }
 
+    @NonNull
     public static String getGroupsPath(FormEntryCaption[] groups) {
         StringBuilder path = new StringBuilder("");
         if (groups != null) {


### PR DESCRIPTION
Closes #1670 

#### What has been done to verify that this works as intended?
I tested attached forms.
I confirmed that the proper path is displayed in ODKView and in FormHierarchyActyvity.

#### Why is this the best possible solution? Were any other approaches considered?
It was displayed properly in ODKView but the bug was in FormHierarchyActivity, now we use the same proper method.

#### Are there any risks to merging this code? If so, what are they?
Risk of regression since I refactored the code to be able to use one method in both places we display the path.

#### Do we need any specific form for testing your changes? If so, please attach one.
A form with nested groups (repeat group inside) like: 
[nested-repeats.xml.txt](https://github.com/opendatakit/collect/files/1575844/nested-repeats.xml.txt)
[nestedGroupsRepeatSecond.xml.txt](https://github.com/opendatakit/collect/files/1576353/nestedGroupsRepeatSecond.xml.txt)

I tested also other cases with nested groups:
[nestedGroupsRepeatFirst.xml.txt](https://github.com/opendatakit/collect/files/1576355/nestedGroupsRepeatFirst.xml.txt)
[nestedGroups.xml.txt](https://github.com/opendatakit/collect/files/1576356/nestedGroups.xml.txt)

