### PR TITLE
Fix junit validation error

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/location/GeoActivityTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/location/GeoActivityTest.java
@@ -13,7 +13,7 @@ import static junit.framework.Assert.assertTrue;
 public class GeoActivityTest {
 
     @Rule
-    ActivityTestRule<GeoActivity> activityTestRule;
+    public ActivityTestRule<GeoActivity> activityTestRule;
 
     @Test
     public void shouldDoSomething() {


### PR DESCRIPTION
org.junit.internal.runners.rules.ValidationError: The @Rule 'activityTestRule' must be public.
    at org.junit.internal.runners.rules.RuleMemberValidator.validate(RuleMemberValidator.java:222)
    at org.junit.internal.runners.rules.RuleMemberValidator.validateMember(RuleMemberValidator.java:99)

I didn't notice this after merging in the file because I only reran the first part of the workflow.

CC @jknightco 