### PR TITLE
Add mocks for loadFormIndexFromFile

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormIndexSavepointTest.java
@@ -19,7 +19,10 @@ package org.odk.collect.android.utilities;
 import org.javarosa.core.model.FormIndex;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.tasks.SaveFormIndexTask;
 import org.odk.collect.android.tasks.SaveToDiskTask;
 
@@ -27,16 +30,27 @@ import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 // Verify that a FormIndex can be saved to and restored from a file
 @RunWith(MockitoJUnitRunner.class)
 public class FormIndexSavepointTest {
 
+    @Mock
+    private FormController formController;
+
     @Test
     public void saveAndReadFormIndexTest() {
+        String instanceName = "test.xml";
+
+        // for loadFormIndexFromFile
+        File instancePath = new File(Collect.INSTANCES_PATH + File.separator + instanceName);
+        when(formController.getInstancePath()).thenReturn(instancePath);
+        Collect.getInstance().setFormController(formController);
+
         FormIndex originalFormIndex = FormIndex.createBeginningOfFormIndex();
-        File tempIndex = SaveToDiskTask.getFormIndexFile("test.xml");
-        SaveFormIndexTask.exportFormIndexToFile(originalFormIndex, tempIndex);
+        File indexFile = SaveToDiskTask.getFormIndexFile(instanceName);
+        SaveFormIndexTask.exportFormIndexToFile(originalFormIndex, indexFile);
 
         FormIndex readFormIndex = SaveFormIndexTask.loadFormIndexFromFile();
 


### PR DESCRIPTION
Fixes failing test. I'm really sorry! 😩

#### What has been done to verify that this works as intended?
Ran test and confirmed it passes.

#### Why is this the best possible solution? Were any other approaches considered?
This brings back code removed in #1719. I must have missed that `loadFormIndexFromFile` needs to get the file information from the `formController`.

#### Are there any risks to merging this code? If so, what are they?
No, this only affects tests.

#### Do we need any specific form for testing your changes? If so, please attach one.