### PR TITLE
Ability to choose backward button on first page of TestRepeat.xml form

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1391,7 +1391,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         try {
             FormIndex originalFormIndex = formController.getFormIndex();
             backButton.setEnabled(!formController.isCurrentQuestionFirstInForm() && allowMovingBackwards);
-            if (formController.stepToNextScreenEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
+            if (formController.stepToPreviousEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                 backButton.setEnabled(allowMovingBackwards);
             }
             formController.jumpToIndex(originalFormIndex);


### PR DESCRIPTION
Closes #1722 

#### What has been done to verify that this works as intended?
I tested attached form (https://github.com/opendatakit/collect/issues/1722) and the `Biggest N of Set` which is available on the demo server.

#### Why is this the best possible solution? Were any other approaches considered?
Looks like it is a bug caused by refactoring.
I found an old version of the `adjustBackNavigationButtonVisibility()` method and it looked like (v1.8.1):

```java
    private void adjustBackNavigationButtonVisibility() {
        FormController formController = Collect.getInstance()
                .getFormController();
        try {
            boolean firstQuestion = formController.stepToPreviousScreenEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM;
            backButton.setEnabled(!firstQuestion);
            formController.stepToNextScreenEvent();
            if (formController.getEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                backButton.setEnabled(true);
                formController.stepToNextScreenEvent();
            }
        } catch (JavaRosaException e) {
            backButton.setEnabled(true);
            Timber.e(e);
        }
    }
```

the current one (master branch) is: 
```java
    private void adjustBackNavigationButtonVisibility() {
        FormController formController = Collect.getInstance().getFormController();
        try {
            FormIndex originalFormIndex = formController.getFormIndex();
            backButton.setEnabled(!formController.isCurrentQuestionFirstInForm() && allowMovingBackwards);
            if (formController.stepToNextScreenEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                backButton.setEnabled(allowMovingBackwards);
            }
            formController.jumpToIndex(originalFormIndex);
        } catch (JavaRosaException e) {
            backButton.setEnabled(allowMovingBackwards);
            Timber.e(e);
        }
    }
```

In the firs approach we used
```java
boolean firstQuestion = formController.stepToPreviousScreenEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM;
```

to check if the current index is the first question and after that, we weren't in the original index. Now since we use 
```java
formController.isCurrentQuestionFirstInForm()
```

we check it and go back to the original index (the `isCurrentQuestionFirstInForm()` method does that for us) that's why we don't need to use

```java
stepToNextScreenEvent
```

below anymore, we need stepToPreviousEvent() since we check if a repeat section exists in a lower index.


The code was so unclear before (v1.8.1)... we called this:
```java
if (formController.stepToNextScreenEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                backButton.setEnabled(allowMovingBackwards);
            }
```
to check for repeat section on a lower index. stepToNextScreenEvent to check a lower index...
Now it's much clearer since we use `isCurrentQuestionFirstInForm()` method and `stepToPreviousEvent() `then.

#### Are there any risks to merging this code? If so, what are they?
The risk is related to forms with repeat sections.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use forms mentioned above.
  