### PR TITLE
fixed no basemap for USGS Topo

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/spatial/TileSourceFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/spatial/TileSourceFactory.java
@@ -22,7 +22,7 @@ public class TileSourceFactory {
         usgsTopo = new OnlineTileSourceBase(
                 context.getString(R.string.openmap_usgs_topo),
                 0, 18, 256, "",
-                new String[] { "http://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/" }) {
+                new String[] { "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/" }) {
             @Override
             public String getTileURLString(MapTile tile) {
                 return getBaseUrl() + tile.getZoomLevel() + "/" + tile.getY() + "/" + tile.getX();
@@ -32,7 +32,7 @@ public class TileSourceFactory {
         usgsSat = new OnlineTileSourceBase(
                 context.getString(R.string.openmap_usgs_sat),
                 0, 18, 256, "",
-                new String[]{"http://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/"}) {
+                new String[]{"https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/"}) {
             @Override
             public String getTileURLString(MapTile tile) {
                 return getBaseUrl() + tile.getZoomLevel() + "/" + tile.getY() + "/" + tile.getX();


### PR DESCRIPTION
Closes #1770

#### What has been done to verify that this works as intended?
I have tested this in an android emulator in Android SDK.

#### Why is this the best possible solution? Were any other approaches considered?
This was a typo in the URL, that was fixed and verified.

#### Are there any risks to merging this code? If so, what are they?
None that I know of.

#### Do we need any specific form for testing your changes? If so, please attach one.
Set the Mapping SDK to OSM and BaseMap to USGS Topo or Imagery.  Previously there were no tiles no tiles are recieved.