### PR TITLE
Added additional imagery base map option

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/spatial/MapHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/spatial/MapHelper.java
@@ -66,6 +66,7 @@ public class MapHelper {
     private static final String OPENMAP_STREETS = "openmap_streets";
     private static final String OPENMAP_USGS_TOPO = "openmap_usgs_topo";
     private static final String OPENMAP_USGS_SAT = "openmap_usgs_sat";
+    private static final String OPENMAP_USGS_IMG = "openmap_usgs_img";
     private static final String OPENMAP_STAMEN_TERRAIN = "openmap_stamen_terrain";
     private static final String OPENMAP_CARTODB_POSITRON = "openmap_cartodb_positron";
     private static final String OPENMAP_CARTODB_DARKMATTER = "openmap_cartodb_darkmatter";
@@ -142,7 +143,11 @@ public class MapHelper {
                 case OPENMAP_USGS_SAT:
                     tileSource = tileFactory.getUsgsSat();
                     break;
-
+                    
+                case OPENMAP_USGS_IMG:
+                    tileSource = tileFactory.getUsgsImg();
+                    break;
+                    
                 case OPENMAP_STAMEN_TERRAIN:
                     tileSource = tileFactory.getStamenTerrain();
                     break;

--- a/collect_app/src/main/java/org/odk/collect/android/spatial/TileSourceFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/spatial/TileSourceFactory.java
@@ -14,6 +14,7 @@ import org.osmdroid.tileprovider.tilesource.XYTileSource;
 public class TileSourceFactory {
     public final OnlineTileSourceBase usgsTopo;
     public final OnlineTileSourceBase usgsSat;
+    public final OnlineTileSourceBase usgsImg;
     public final OnlineTileSourceBase stamenTerrain;
     public final OnlineTileSourceBase cartoDbPositron;
     public final OnlineTileSourceBase cartoDbDarkMatter;
@@ -68,6 +69,10 @@ public class TileSourceFactory {
 
     public OnlineTileSourceBase getUsgsSat() {
         return usgsSat;
+    }
+ 
+     public OnlineTileSourceBase getUsgsImg() {
+        return usgsImg;
     }
 
     public OnlineTileSourceBase getStamenTerrain() {

--- a/collect_app/src/main/java/org/odk/collect/android/spatial/TileSourceFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/spatial/TileSourceFactory.java
@@ -38,6 +38,16 @@ public class TileSourceFactory {
                 return getBaseUrl() + tile.getZoomLevel() + "/" + tile.getY() + "/" + tile.getX();
             }
         };
+     
+        usgsImg = new OnlineTileSourceBase(
+                context.getString(R.string.openmap_usgs_img),
+                0, 18, 256, "",
+                new String[]{"https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/"}) {
+            @Override
+            public String getTileURLString(MapTile tile) {
+                return getBaseUrl() + tile.getZoomLevel() + "/" + tile.getY() + "/" + tile.getX();
+            }
+        };
 
         stamenTerrain = new XYTileSource(context.getString(R.string.openmap_stamen_terrain),
                 0, 18, 256, ".jpg", new String[] {

--- a/collect_app/src/main/res/values/arrays.xml
+++ b/collect_app/src/main/res/values/arrays.xml
@@ -93,6 +93,7 @@ the specific language governing permissions and limitations under the License. -
         <item>openmap_streets</item>
         <item>openmap_usgs_topo</item>
         <item>openmap_usgs_sat</item>
+        <item>openmap_usgs_img</item>
         <item>openmap_stamen_terrain</item>
         <item>openmap_cartodb_positron</item>
         <item>openmap_cartodb_darkmatter</item>
@@ -101,6 +102,7 @@ the specific language governing permissions and limitations under the License. -
         <item>@string/openmap_streets</item>
         <item>@string/openmap_usgs_topo</item>
         <item>@string/openmap_usgs_sat</item>
+        <item>@string/openmap_usgs_img</item>
         <item>@string/openmap_stamen_terrain</item>
         <item>@string/openmap_cartodb_positron</item>
         <item>@string/openmap_cartodb_darkmatter</item>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -306,7 +306,8 @@
     <string name="show_map_sdk">Show Map SDK Options</string>
     <string name="openmap_streets">OSM Streets</string>
     <string name="openmap_usgs_topo">USGS National Map Topo</string>
-    <string name="openmap_usgs_sat">USGS National Map Sat</string>
+    <string name="openmap_usgs_sat">USGS National Map Hybrid</string>
+    <string name="openmap_usgs_img">USGS National Map Imagery</string>
     <string name="openmap_stamen_terrain">Stamen Terrain</string>
     <string name="openmap_cartodb_positron">CartoDB Positron</string>
     <string name="openmap_cartodb_darkmatter">CartoDB Dark Matter</string>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Tested in Android SDK Emulator

#### Why is this the best possible solution? Were any other approaches considered?
I attempted to conform to established practices in the codebase.  No other approaches have been considered

#### Are there any risks to merging this code? If so, what are they?
None that I know of, since currently this complies and runs on the emulator.

#### Do we need any specific form for testing your changes? If so, please attach one.
Change the setting in the menu to OSM SDK and select the new USGS National Map Imagery option for the base map.