### PR TITLE
Position in form download list adapter getView is beyond end of filteredFormList

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -235,7 +235,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
         listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
         listView.setItemsCanFocus(false);
-        listView.setAdapter(new FormDownloadListAdapter(this, filteredFormList, formNamesAndURLs));
 
         sortingOptions = new String[]{
                 getString(R.string.sort_by_name_asc), getString(R.string.sort_by_name_desc)

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -431,7 +431,11 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             filteredFormList.addAll(formList);
         }
         sortList();
-        listView.setAdapter(new FormDownloadListAdapter(this, filteredFormList, formNamesAndURLs));
+        if (listView.getAdapter() == null) {
+            listView.setAdapter(new FormDownloadListAdapter(this, filteredFormList, formNamesAndURLs));
+        } else {
+            ((FormDownloadListAdapter) listView.getAdapter()).notifyDataSetChanged();
+        }
 
         checkPreviouslyCheckedItems();
     }


### PR DESCRIPTION
Closes #1756 

#### What has been done to verify that this works as intended?
I tested the `FormDownloadList` - opening, rotating, downloading.

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue but I debugged the project and noticed a strange behavior that the constructor from the `FormDownloadListAdapter` is called twice. the first call comes from the line I removed and the second is from https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java#L435 in the first case both lists we pass are empty in fact but then the second case is performed immediately with appropriate lists (before the line mentioned in reports is performed that's why I can't reproduce the issue but I'm pretty sure it's possible using older devices or maybe connecting to a poor network).

#### Are there any risks to merging this code? If so, what are they?
We just need to test the `FormDownloadList` to be sure the line I removed wasn't necessary and it's safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.