### PR TITLE
Don't try to delete forms when there is not one to delete

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -138,8 +138,10 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                     }
                 }
 
-                //Delete the forms not found in sdcard from the database
-                formsDao.deleteFormsFromIDs(idsToDelete.toArray(new String[idsToDelete.size()]));
+                if (!idsToDelete.isEmpty()) {
+                    //Delete the forms not found in sdcard from the database
+                    formsDao.deleteFormsFromIDs(idsToDelete.toArray(new String[idsToDelete.size()]));
+                }
 
                 // Step3: go through uriToUpdate to parse and update each in turn.
                 // This is slow because buildContentValues(...) is slow.


### PR DESCRIPTION
Closes #1794

#### What has been done to verify that this works as intended?
#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue but I guess it's a random crash we can't fix. The crash takes place only when deleting forms: https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java#L129

The problem is that we call that method everytime we open the list of forms or the list of forms to delete (even if a list of forms to delete is empty), it's really often and I think such a random crash might take place.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.