### PR TITLE
Navigation buttons are not visible if user turns them on during filling form

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -300,11 +300,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         String instancePath = null;
         boolean newForm = true;
         autoSaved = false;
-        // only check the buttons if it's enabled in preferences
-        String navigation = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_NAVIGATION);
-        if (navigation.contains(PreferenceKeys.NAVIGATION_BUTTONS)) {
-            showNavigationButtons = true;
-        }
         allowMovingBackwards = (boolean) AdminSharedPreferences.getInstance().get(KEY_MOVING_BACKWARDS);
         if (savedInstanceState != null) {
             state = savedInstanceState;
@@ -2361,6 +2356,10 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     protected void onResume() {
         super.onResume();
 
+        String navigation = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_NAVIGATION);
+        if (navigation.contains(PreferenceKeys.NAVIGATION_BUTTONS)) {
+            showNavigationButtons = true;
+        }
         if (errorMessage != null) {
             if (alertDialog != null && !alertDialog.isShowing()) {
                 createErrorDialog(errorMessage, EXIT);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2357,9 +2357,10 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         super.onResume();
 
         String navigation = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_NAVIGATION);
-        if (navigation.contains(PreferenceKeys.NAVIGATION_BUTTONS)) {
-            showNavigationButtons = true;
-        }
+        showNavigationButtons = navigation.contains(PreferenceKeys.NAVIGATION_BUTTONS);
+        backButton.setVisibility(showNavigationButtons ? View.VISIBLE : View.GONE);
+        nextButton.setVisibility(showNavigationButtons ? View.VISIBLE : View.GONE);
+
         if (errorMessage != null) {
             if (alertDialog != null && !alertDialog.isShowing()) {
                 createErrorDialog(errorMessage, EXIT);
@@ -2400,14 +2401,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
         if (saveToDiskTask != null) {
             saveToDiskTask.setFormSavedListener(this);
-        }
-
-        if (showNavigationButtons) {
-            backButton.setVisibility(View.VISIBLE);
-            nextButton.setVisibility(View.VISIBLE);
-        } else {
-            backButton.setVisibility(View.GONE);
-            nextButton.setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
Closes #1574 

#### What has been done to verify that this works as intended?
I tested enabling/disabling navigation buttons when working with the form.
I also remember that buttons can be tricky there were some issues related to them like:

https://github.com/opendatakit/collect/issues/1722
https://github.com/opendatakit/collect/issues/1497
https://github.com/opendatakit/collect/issues/421
https://github.com/opendatakit/collect/issues/384

and I confirmed it works well with my changes.

#### Why is this the best possible solution? Were any other approaches considered?
When we return from General Setting to the form view onResume() method is called so we need to handle visibility of buttons there not in onCreate() method.

#### Are there any risks to merging this code? If so, what are they?
Yes as I said above button are really ticky and we should be careful testing various cases including repeat sections etc.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.