### PR TITLE
Button view is active after refresh cancel

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -437,7 +437,11 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         } else {
             ((FormDownloadListAdapter) listView.getAdapter()).notifyDataSetChanged();
         }
-
+        if(filteredFormList.size() > 0){
+            toggleButton.setEnabled(true);
+        }else{
+            toggleButton.setEnabled(false);
+        }
         checkPreviouslyCheckedItems();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -437,11 +437,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         } else {
             ((FormDownloadListAdapter) listView.getAdapter()).notifyDataSetChanged();
         }
-        if(filteredFormList.size() > 0){
-            toggleButton.setEnabled(true);
-        }else{
-            toggleButton.setEnabled(false);
-        }
+        toggleButton.setEnabled(filteredFormList.size() > 0);
         checkPreviouslyCheckedItems();
     }
 

--- a/collect_app/src/main/res/layout/remote_file_manage_list.xml
+++ b/collect_app/src/main/res/layout/remote_file_manage_list.xml
@@ -26,27 +26,35 @@ the License.
         android:layout_height="wrap_content"
         android:layout_below="@id/toolbar" />
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
-        android:orientation="vertical">
+        android:layout_below="@id/toolbar">
 
-        <ListView
-            android:id="@android:id/list"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"/>
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:layout_above="@+id/buttonholder">
 
-        <TextView
-            android:id="@android:id/empty"
-            style="@style/emptyViewStyle"
-            android:text="@string/no_items_display" />
+            <ListView
+                android:id="@android:id/list"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"/>
+
+            <TextView
+                android:id="@android:id/empty"
+                style="@style/emptyViewStyle"
+                android:text="@string/no_items_display" />
+
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/buttonholder"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
             android:orientation="horizontal"
             android:weightSum="3">
 
@@ -80,6 +88,6 @@ the License.
                 android:textAllCaps="false"
                 android:textSize="16sp" />
         </LinearLayout>
-    </LinearLayout>
+    </RelativeLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
Closes #1805 

#### What has been done to verify that this works as intended?
Tried on Physical Device (Android 5.0 and 6.0) and behaviour found correct 
#### Why is this the best possible solution? Were any other approaches considered?
TextView with id `android:id="@android:id/empty"` automatically understands we're asking if the `Listview` is empty. So whenever list gets empty, textview gets displayed and everything in that view gets invisible.
So to make sure the button view gets visible even after list gets empty I've added `List` and `TextView` in another `LinearLayout`

Another solution could be adding `TextView` and checking whenever adapter gets updated whether the list is empty or not, if it is empty then show `TextView` and make visibilty of `ListView` `Gone.`
#### Are there any risks to merging this code? If so, what are they?
No
#### Do we need any specific form for testing your changes? If so, please attach one.
No