### PR TITLE
Fixed: Attempt to read from field 'double com.google.android.gms.maps.model.LatLng.b' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeGoogleMapActivity.java
@@ -193,7 +193,7 @@ public class GeoShapeGoogleMapActivity extends FragmentActivity implements Locat
         zoomLocationButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (curLocation != null) {
+                if (curLocation != null && curlatLng != null) {
                     map.animateCamera(CameraUpdateFactory.newLatLngZoom(curlatLng, 17));
                 }
                 zoomDialog.dismiss();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceGoogleMapActivity.java
@@ -606,7 +606,7 @@ public class GeoTraceGoogleMapActivity extends FragmentActivity implements Locat
     }
 
     private void zoomToMyLocation() {
-        if (curLocation != null) {
+        if (curLocation != null && curlatLng != null) {
             map.animateCamera(CameraUpdateFactory.newLatLngZoom(curlatLng, 17));
         }
 


### PR DESCRIPTION
Closes #1809 

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use the `AllWidgets` form but I wasn't able to reproduce the issue.