### PR TITLE
'Go Back' button for Shared Drive 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -658,9 +658,11 @@ public class GoogleDriveActivity extends AppCompatActivity implements View.OnCli
             // SharedWithMe, and root:
             String currentDir = params[0];
 
-            if (!myDrive && currentDir.equals(ROOT_KEY)) {
-                query = "sharedWithMe=true";
-                folderIdStack.removeAllElements();
+            if (!myDrive) {
+                if (currentDir.equals(ROOT_KEY) || folderIdStack.empty()) {
+                    query = "sharedWithMe=true";
+                    folderIdStack.removeAllElements();
+                }
             }
 
             query += " and trashed=false";


### PR DESCRIPTION
Closes #1631 

#### What has been done to verify that this works as intended?
Tested on physical device (Android 5.0 and 6.0) and behaviour found correct

#### Why is this the best possible solution? Were any other approaches considered?
Empty list needs to be checked for **Shared Drive** also.

#### Are there any risks to merging this code? If so, what are they?
No
#### Do we need any specific form for testing your changes? If so, please attach one.
No