### PR TITLE
Cancel Google sheet form upload when activity destroyed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -64,12 +64,10 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
     private static final int GOOGLE_USER_DIALOG = 3;
     private static final String ALERT_MSG = "alertmsg";
     private static final String ALERT_SHOWING = "alertshowing";
-    private static final String INSTANCE_UPLOADED = "instanceuploaded";
     private ProgressDialog progressDialog;
     private AlertDialog alertDialog;
     private String alertMsg;
     private boolean alertShowing;
-    private boolean isInstanceUploaded;
     private Long[] instancesToSend;
     private InstanceGoogleSheetsUploader instanceGoogleSheetsUploader;
 
@@ -87,7 +85,6 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
         // default initializers
         alertMsg = getString(R.string.please_wait);
         alertShowing = false;
-        isInstanceUploaded = false;
 
         setTitle(getString(R.string.send_data));
 
@@ -99,9 +96,6 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
             }
             if (savedInstanceState.containsKey(ALERT_SHOWING)) {
                 alertShowing = savedInstanceState.getBoolean(ALERT_SHOWING, false);
-            }
-            if (savedInstanceState.containsKey(INSTANCE_UPLOADED)) {
-                isInstanceUploaded = savedInstanceState.getBoolean(INSTANCE_UPLOADED,false);
             }
         }
 
@@ -130,11 +124,6 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
     private void runTask() {
         instanceGoogleSheetsUploader = (InstanceGoogleSheetsUploader) getLastCustomNonConfigurationInstance();
         if (instanceGoogleSheetsUploader == null) {
-            if (isInstanceUploaded) {
-                // some of the instances  may be already uploaded on Google Sheets
-                finish();
-            }
-            isInstanceUploaded = true;
             instanceGoogleSheetsUploader = new InstanceGoogleSheetsUploader(accountsManager);
 
             // ensure we have a google account selected
@@ -252,7 +241,6 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
         super.onSaveInstanceState(outState);
         outState.putString(ALERT_MSG, alertMsg);
         outState.putBoolean(ALERT_SHOWING, alertShowing);
-        outState.putBoolean(INSTANCE_UPLOADED, isInstanceUploaded);
     }
 
     @Override
@@ -282,6 +270,7 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
             }
             instanceGoogleSheetsUploader.setUploaderListener(null);
         }
+        finish();
         super.onDestroy();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -64,10 +64,12 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
     private static final int GOOGLE_USER_DIALOG = 3;
     private static final String ALERT_MSG = "alertmsg";
     private static final String ALERT_SHOWING = "alertshowing";
+    private static final String INSTANCE_UPLOADED = "instanceuploaded";
     private ProgressDialog progressDialog;
     private AlertDialog alertDialog;
     private String alertMsg;
     private boolean alertShowing;
+    private boolean isInstanceUploaded;
     private Long[] instancesToSend;
     private InstanceGoogleSheetsUploader instanceGoogleSheetsUploader;
 
@@ -85,6 +87,7 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
         // default initializers
         alertMsg = getString(R.string.please_wait);
         alertShowing = false;
+        isInstanceUploaded = false;
 
         setTitle(getString(R.string.send_data));
 
@@ -96,6 +99,9 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
             }
             if (savedInstanceState.containsKey(ALERT_SHOWING)) {
                 alertShowing = savedInstanceState.getBoolean(ALERT_SHOWING, false);
+            }
+            if (savedInstanceState.containsKey(INSTANCE_UPLOADED)) {
+                isInstanceUploaded = savedInstanceState.getBoolean(INSTANCE_UPLOADED,false);
             }
         }
 
@@ -124,6 +130,11 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
     private void runTask() {
         instanceGoogleSheetsUploader = (InstanceGoogleSheetsUploader) getLastCustomNonConfigurationInstance();
         if (instanceGoogleSheetsUploader == null) {
+            if (isInstanceUploaded) {
+                // some of the instances  may be already uploaded on Google Sheets
+                finish();
+            }
+            isInstanceUploaded = true;
             instanceGoogleSheetsUploader = new InstanceGoogleSheetsUploader(accountsManager);
 
             // ensure we have a google account selected
@@ -241,6 +252,7 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
         super.onSaveInstanceState(outState);
         outState.putString(ALERT_MSG, alertMsg);
         outState.putBoolean(ALERT_SHOWING, alertShowing);
+        outState.putBoolean(INSTANCE_UPLOADED, isInstanceUploaded);
     }
 
     @Override
@@ -265,6 +277,9 @@ public class GoogleSheetsUploaderActivity extends AppCompatActivity implements I
     @Override
     protected void onDestroy() {
         if (instanceGoogleSheetsUploader != null) {
+            if (!instanceGoogleSheetsUploader.isCancelled()) {
+                instanceGoogleSheetsUploader.cancel(true);
+            }
             instanceGoogleSheetsUploader.setUploaderListener(null);
         }
         super.onDestroy();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -244,7 +244,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         ensureNumberOfColumnsIsValid(columnTitles.size());
 
         if (isCancelled()) {
-            throw new UploadException("Instance Upload Cancelled");
+            throw new UploadException(Collect.getInstance().getString(R.string.instance_upload_cancelled));
         }
 
         try {
@@ -270,7 +270,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             HashMap<String, String> answers = getAnswers(element, instanceFile, parentKey, key);
 
             if (isCancelled()) {
-                throw new UploadException("Instance Upload Cancelled");
+                throw new UploadException(Collect.getInstance().getString(R.string.instance_upload_cancelled));
             }
 
             if (shouldRowBeInserted(answers)) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -243,6 +243,10 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         List<Object> columnTitles = getColumnTitles(element);
         ensureNumberOfColumnsIsValid(columnTitles.size());
 
+        if (isCancelled()) {
+            throw new UploadException("Instance Upload Cancelled");
+        }
+
         try {
             List<List<Object>> sheetCells = getSheetCells(sheetTitle);
             if (sheetCells != null && !sheetCells.isEmpty()) { // we are editing an existed sheet
@@ -264,6 +268,11 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             }
 
             HashMap<String, String> answers = getAnswers(element, instanceFile, parentKey, key);
+
+            if (isCancelled()) {
+                throw new UploadException("Instance Upload Cancelled");
+            }
+
             if (shouldRowBeInserted(answers)) {
                 sheetsHelper.insertRow(spreadsheet.getSpreadsheetId(), sheetTitle,
                         new ValueRange().setValues(Collections.singletonList(prepareListOfValues(sheetCells.get(0), columnTitles, answers))));

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -585,4 +585,5 @@
     <string name="no_columns_to_upload">No columns found in the form to upload.</string>
     <string name="cannot_create_directory">Cannot create directory: %s</string>
     <string name="not_a_directory">%s exists, but is not a directory</string>
+    <string name="instance_upload_cancelled">Instance upload cancelled</string>
 </resources>


### PR DESCRIPTION
Closes #1777 

#### What has been done to verify that this works as intended?
Tested on physical device (Android 5.0 and 6.0) and behaviour found correct

#### Why is this the best possible solution? Were any other approaches considered?
This approach stops uploading forms to Google Sheets whenever activity gets destroyed and takes back the user to 'Send Finalized Form' Screen. Sometimes Android may kill activity in the background due to memory pressure. There may be other approaches possible.
 
#### Are there any risks to merging this code? If so, what are they?
No
#### Do we need any specific form for testing your changes? If so, please attach one.
I tested using  [odk-sheets.zip](https://github.com/opendatakit/collect/files/1693219/odk-sheets.zip)



