### PR TITLE
Updates regarding About Fragment ( Fixes #1802 and #1846)

### DIFF
--- a/collect_app/src/main/res/layout/about_preferences_item.xml
+++ b/collect_app/src/main/res/layout/about_preferences_item.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:gravity="center_vertical"
+    android:paddingRight="?android:attr/scrollbarSize">
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="15dip"
+        android:layout_marginRight="6dip"
+        android:layout_marginTop="6dip"
+        android:layout_marginBottom="6dip"
+        android:layout_weight="1">
+
+        <ImageView android:id="@+id/ImageView01"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_save_grey_32dp_wrapped"
+            android:layout_alignParentLeft="true" />
+
+        <TextView
+            android:id="@android:id/title"
+            android:paddingLeft="20dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_toEndOf="@+id/ImageView01"
+            android:layout_toRightOf="@+id/ImageView01"
+            android:ellipsize="marquee"
+            android:fadingEdge="horizontal"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
+
+        <TextView
+            android:id="@android:id/summary"
+            android:paddingLeft="20dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@android:id/title"
+            android:layout_toEndOf="@+id/ImageView01"
+            android:layout_toRightOf="@+id/ImageView01"
+            android:textSize="12sp"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+
+
+    </RelativeLayout>
+
+    <!-- Preference should place its actual preference widget here. -->
+    <LinearLayout android:id="@android:id/widget_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:gravity="center_vertical"
+        android:orientation="vertical" />
+
+</LinearLayout>

--- a/collect_app/src/main/res/layout/about_preferences_item.xml
+++ b/collect_app/src/main/res/layout/about_preferences_item.xml
@@ -3,28 +3,36 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    android:baselineAligned="false">
 
     <RelativeLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dip"
+        android:layout_marginStart="15dip"
         android:layout_marginRight="6dip"
+        android:layout_marginEnd="6dip"
         android:layout_marginTop="6dip"
         android:layout_marginBottom="6dip"
         android:layout_weight="1">
 
         <ImageView
+            android:contentDescription="@string/about_image_content_desc"
             android:id="@android:id/icon"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
             android:background="@color/grey" />
 
         <TextView
             android:id="@android:id/title"
             android:paddingLeft="20dp"
+            android:paddingStart="20dp"
+            android:paddingRight="20dp"
+            android:paddingEnd="20dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
@@ -37,6 +45,9 @@
         <TextView
             android:id="@android:id/summary"
             android:paddingLeft="20dp"
+            android:paddingStart="20dp"
+            android:paddingRight="20dp"
+            android:paddingEnd="20dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@android:id/title"

--- a/collect_app/src/main/res/layout/about_preferences_item.xml
+++ b/collect_app/src/main/res/layout/about_preferences_item.xml
@@ -15,13 +15,12 @@
         android:layout_weight="1">
 
         <ImageView
-            android:id="@+android:id/icon"
+            android:id="@android:id/icon"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_alignParentLeft="true"
             android:layout_centerVertical="true"
-            android:backgroundTint="@color/black"
-            android:src="@drawable/ic_menu_save" />
+            android:background="@color/grey" />
 
         <TextView
             android:id="@android:id/title"

--- a/collect_app/src/main/res/layout/about_preferences_item.xml
+++ b/collect_app/src/main/res/layout/about_preferences_item.xml
@@ -3,8 +3,7 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
-    android:gravity="center_vertical"
-    android:paddingRight="?android:attr/scrollbarSize">
+    android:gravity="center_vertical">
 
     <RelativeLayout
         android:layout_width="wrap_content"
@@ -15,11 +14,14 @@
         android:layout_marginBottom="6dip"
         android:layout_weight="1">
 
-        <ImageView android:id="@+id/ImageView01"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/ic_save_grey_32dp_wrapped"
-            android:layout_alignParentLeft="true" />
+        <ImageView
+            android:id="@+android:id/icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:backgroundTint="@color/black"
+            android:src="@drawable/ic_menu_save" />
 
         <TextView
             android:id="@android:id/title"
@@ -27,8 +29,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
-            android:layout_toEndOf="@+id/ImageView01"
-            android:layout_toRightOf="@+id/ImageView01"
+            android:layout_toEndOf="@+android:id/icon"
+            android:layout_toRightOf="@+android:id/icon"
             android:ellipsize="marquee"
             android:fadingEdge="horizontal"
             android:textAppearance="?android:attr/textAppearanceLarge" />
@@ -39,8 +41,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@android:id/title"
-            android:layout_toEndOf="@+id/ImageView01"
-            android:layout_toRightOf="@+id/ImageView01"
+            android:layout_toEndOf="@+android:id/icon"
+            android:layout_toRightOf="@+android:id/icon"
             android:textSize="12sp"
             android:textAppearance="?android:attr/textAppearanceSmall"/>
 

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -294,9 +294,9 @@
     <string name="username_error_whitespace">Leading or trailing whitespace not allowed in usernames</string>
     <string name="google_play_services_error_occured">Unable to access Google Maps. Is Google Play Services installed?</string>
     <string name="about_preferences">About</string>
-    <string name="tell_your_friends">Share ODK Collect with your colleagues</string>
+    <string name="tell_your_friends">Share Us !</string>
     <string name="tell_your_friends_msg">Download the ODK Collect app!</string>
-    <string name="leave_a_review">Leave a review on the Google Play Store</string>
+    <string name="leave_a_review">Review us at Google Play Store</string>
     <!-- Geo string added in feature-geofeatures branch-->
     <string name="map_preferences">Mapping</string>
     <string name="map_sdk_selector_title">Mapping SDK</string>
@@ -377,11 +377,11 @@
     <string name="parser_exception">XPathParser Exception: \"%s\"</string>
     <string name="selected_answer">Selected: %s</string>
     <string name="version_number">Version: %s</string>
-    <string name="odk_website">Visit the ODK website</string>
-    <string name="odk_website_summary">Open Data Kit (ODK) is used to collect data for social good in challenging environments.</string>
-    <string name="odk_forum">Join the ODK forum</string>
-    <string name="odk_forum_summary">Join the forum to get support, request features, contribute code/translations!</string>
-    <string name="all_open_source_licenses">Open source libraries and licenses</string>
+    <string name="odk_website">About Us</string>
+    <string name="odk_website_summary">Visit our Open Data Kit(ODK) Website and get to know more about us</string>
+    <string name="odk_forum">Join Us</string>
+    <string name="odk_forum_summary">Join us at the ODK forum and be a part of a vibrant , thriving and ever-growing open source community! </string>
+    <string name="all_open_source_licenses">Open Source Libraries and Licenses</string>
 
     <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in W 18°48'8" -->
     <string name="west">W %1$s%2$s%3$s</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -576,4 +576,5 @@
     <string name="newer_version_of_a_form_info">This is an updated version of a form you already have!</string>
     <string name="svg_file_does_not_exist">SVG file does not exist!</string>
     <string name="svg_not_supported_device">ImageMap widget requires Android 5 (Lollipop) or newer. Your device is not supported!</string>
+    <string name="about_image_content_desc">Allocates the Icon for the custom PreferenceScreen Option</string>
 </resources>

--- a/collect_app/src/main/res/xml/about_preferences.xml
+++ b/collect_app/src/main/res/xml/about_preferences.xml
@@ -1,37 +1,36 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceScreen
-        android:layout="@layout/about_preferences_item"
-        android:key="odk_website"
         android:icon="@android:drawable/ic_menu_help"
+        android:key="odk_website"
+        android:layout="@layout/about_preferences_item"
         android:summary="@string/odk_website_summary"
-        android:title="@string/odk_website"/>
+        android:title="@string/odk_website" />
 
     <PreferenceScreen
-        android:layout="@layout/about_preferences_item"
+        android:icon="@android:drawable/ic_menu_myplaces"
         android:key="odk_forum"
+        android:layout="@layout/about_preferences_item"
         android:summary="@string/odk_forum_summary"
-        android:title="@string/odk_forum"
-        android:icon="@android:drawable/ic_menu_myplaces"/>
+        android:title="@string/odk_forum" />
 
     <PreferenceScreen
-        android:layout="@layout/about_preferences_item"
-        android:key="tell_your_friends"
-        android:title="@string/tell_your_friends"
         android:icon="@android:drawable/ic_menu_share"
-        />
+        android:key="tell_your_friends"
+        android:layout="@layout/about_preferences_item"
+        android:title="@string/tell_your_friends" />
 
     <PreferenceScreen
-        android:layout="@layout/about_preferences_item"
-        android:key="leave_a_review"
-        android:title="@string/leave_a_review"
         android:icon="@android:drawable/ic_menu_edit"
-        />
+        android:key="leave_a_review"
+        android:layout="@layout/about_preferences_item"
+        android:title="@string/leave_a_review" />
 
     <PreferenceScreen
-        android:layout="@layout/about_preferences_item"
+        android:layout_height="match_parent"
+        android:icon="@android:drawable/ic_menu_info_details"
         android:key="open_source_licenses"
-        android:icon="@android:drawable/ic_input_get"
+        android:layout="@layout/about_preferences_item"
         android:title="@string/all_open_source_licenses" />
 
 

--- a/collect_app/src/main/res/xml/about_preferences.xml
+++ b/collect_app/src/main/res/xml/about_preferences.xml
@@ -3,6 +3,7 @@
     <PreferenceScreen
         android:layout="@layout/about_preferences_item"
         android:key="odk_website"
+        android:icon="@android:drawable/ic_menu_help"
         android:summary="@string/odk_website_summary"
         android:title="@string/odk_website"/>
 
@@ -10,21 +11,27 @@
         android:layout="@layout/about_preferences_item"
         android:key="odk_forum"
         android:summary="@string/odk_forum_summary"
-        android:title="@string/odk_forum"/>
+        android:title="@string/odk_forum"
+        android:icon="@android:drawable/ic_menu_myplaces"/>
 
     <PreferenceScreen
         android:layout="@layout/about_preferences_item"
         android:key="tell_your_friends"
-        android:title="@string/tell_your_friends" />
+        android:title="@string/tell_your_friends"
+        android:icon="@android:drawable/ic_menu_share"
+        />
 
     <PreferenceScreen
         android:layout="@layout/about_preferences_item"
         android:key="leave_a_review"
-        android:title="@string/leave_a_review" />
+        android:title="@string/leave_a_review"
+        android:icon="@android:drawable/ic_menu_edit"
+        />
 
     <PreferenceScreen
         android:layout="@layout/about_preferences_item"
         android:key="open_source_licenses"
+        android:icon="@android:drawable/ic_input_get"
         android:title="@string/all_open_source_licenses" />
 
 

--- a/collect_app/src/main/res/xml/about_preferences.xml
+++ b/collect_app/src/main/res/xml/about_preferences.xml
@@ -1,25 +1,31 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceScreen
+        android:layout="@layout/about_preferences_item"
         android:key="odk_website"
         android:summary="@string/odk_website_summary"
         android:title="@string/odk_website"/>
 
     <PreferenceScreen
+        android:layout="@layout/about_preferences_item"
         android:key="odk_forum"
         android:summary="@string/odk_forum_summary"
         android:title="@string/odk_forum"/>
 
     <PreferenceScreen
+        android:layout="@layout/about_preferences_item"
         android:key="tell_your_friends"
         android:title="@string/tell_your_friends" />
 
     <PreferenceScreen
+        android:layout="@layout/about_preferences_item"
         android:key="leave_a_review"
         android:title="@string/leave_a_review" />
 
     <PreferenceScreen
+        android:layout="@layout/about_preferences_item"
         android:key="open_source_licenses"
         android:title="@string/all_open_source_licenses" />
+
 
 </PreferenceScreen>


### PR DESCRIPTION
Closes #1846 

I have added a  new layout file about_preferences_item.xml which allows us to give a customized layout to each option in AboutPreferencesFragment and have edited the label and summaries directly from strings.xml
(This could also close the issue #1802 )

#### What has been done to verify that this works as intended?

I have run this on my physical Android device and works as intended.
Device Specs:
Sony Xperia C4 Dual E5363 ( Android 6.0)

#### Why is this the best possible solution? Were any other approaches considered?
I have designed the layout in accordance with the Material Design Guidelines suggested by Android 
https://material.io/guidelines/patterns/help-feedback.html#help-feedback-behavior
This guarantees a minimalistic and intuitive user interface combined with visual cues.

#### Are there any risks to merging this code? If so, what are they?
No risks that I know of.

#### Do we need any specific form for testing your changes? If so, please attach one.
No testing needed