### PR TITLE
Issue Fixed: Popup menu in Import/Export Settings exists only for one item

### DIFF
--- a/collect_app/src/main/res/drawable/ic_menu_share.xml
+++ b/collect_app/src/main/res/drawable/ic_menu_share.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="36dp"
+    android:height="36dp"
     android:viewportHeight="24"
     android:viewportWidth="24">
 

--- a/collect_app/src/main/res/drawable/ic_menu_share.xml
+++ b/collect_app/src/main/res/drawable/ic_menu_share.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="@color/black"
+        android:pathData="M18 16.08c-0.76 0-1.44 0.3 -1.96 0.77 L8.91 12.7c0.05-0.23 0.09 -0.46 0.09
+-0.7s-0.04-0.47-0.09-0.7l7.05-4.11c0.54 0.5 1.25 0.81 2.04 0.81 1.66 0 3-1.34
+3-3s-1.34-3-3-3-3 1.34-3 3c0 0.24 0.04 0.47 0.09 0.7L8.04 9.81C7.5 9.31 6.79 9 6
+9c-1.66 0-3 1.34-3 3s1.34 3 3 3c0.79 0 1.5-0.31 2.04-0.81l7.12 4.16c-0.05 0.21 -0.08
+0.43 -0.08 0.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31
+2.92-2.92s-1.31-2.92-2.92-2.92z" />
+</vector>

--- a/collect_app/src/main/res/menu/settings_menu.xml
+++ b/collect_app/src/main/res/menu/settings_menu.xml
@@ -16,12 +16,10 @@
         android:title="@string/share"
         android:icon="@drawable/ic_menu_share"
         app:showAsAction="always" />
-
     <item
         android:id="@+id/menu_save_preferences"
         android:actionProviderClass="android.widget.ShareActionProvider"
         android:title="@string/save_preferences"
         android:icon="@drawable/ic_save_black_36dp"
-        app:showAsAction="always"
-		/>
+        app:showAsAction="always"/>
 </menu>

--- a/collect_app/src/main/res/menu/settings_menu.xml
+++ b/collect_app/src/main/res/menu/settings_menu.xml
@@ -14,12 +14,14 @@
         android:id="@+id/menu_item_share"
         android:actionProviderClass="android.widget.ShareActionProvider"
         android:title="@string/share"
-        android:icon="@android:drawable/ic_menu_share"
+        android:icon="@drawable/ic_menu_share"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_save_preferences"
         android:actionProviderClass="android.widget.ShareActionProvider"
         android:title="@string/save_preferences"
-        app:showAsAction="never" />
+        android:icon="@drawable/ic_save_black_36dp"
+        app:showAsAction="always"
+		/>
 </menu>


### PR DESCRIPTION
+Added "Share" vector icon from  https://material.io/icons/#ic_share.
+Fixed Import/Export Settings menu.

Closes #1857  

#### What has been done to verify that this works as intended?
Steps to be followed
1. Go to Admin Settings -> Import/Export Settings
2. Open the popup menu.
Here you can check the icons in the top bar. Below is a comparison of screens before and after the fix
Before->
![wadasdsa](https://user-images.githubusercontent.com/10618953/36203693-74c2eb42-11ae-11e8-8c70-e6194cd91542.png)
After->
![screen_dark](https://user-images.githubusercontent.com/10618953/36203814-e87c83cc-11ae-11e8-8ea8-d438048235e3.png)

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution as its using vector graphics instead of PNGs. Vector graphics are more flexible and take less memory. They are automatically resized according to the screen size and pixel density. 
Another approach is to use PNGs but then we have to create different icons to support all screen sizes. 
 
#### Are there any risks to merging this code? If so, what are they?
No, there are no risks in merging my code.
#### Do we need any specific form for testing your changes? If so, please attach one.
No, as there are no forms involved with this screen.