### PR TITLE
Fixed navigation back button after skipping a repeat group

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1347,7 +1347,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 }
 
                 if (showNavigationButtons) {
-                    adjustBackNavigationButtonVisibility();
+                    backButton.setEnabled(!formController.isCurrentQuestionFirstInForm() && allowMovingBackwards);
                     nextButton.setEnabled(true);
                 }
                 return odkView;
@@ -1374,24 +1374,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         if (odkView != null) {
             odkView.releaseWidgetResources();
             odkView = null;
-        }
-    }
-
-    /**
-     * Disables the back button if it is first question....
-     */
-    private void adjustBackNavigationButtonVisibility() {
-        FormController formController = Collect.getInstance().getFormController();
-        try {
-            FormIndex originalFormIndex = formController.getFormIndex();
-            backButton.setEnabled(!formController.isCurrentQuestionFirstInForm() && allowMovingBackwards);
-            if (formController.stepToPreviousEvent() == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
-                backButton.setEnabled(allowMovingBackwards);
-            }
-            formController.jumpToIndex(originalFormIndex);
-        } catch (JavaRosaException e) {
-            backButton.setEnabled(allowMovingBackwards);
-            Timber.e(e);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -429,11 +429,17 @@ public class FormController {
                 && indexIsInFieldList()));
     }
 
-    public boolean isCurrentQuestionFirstInForm() throws JavaRosaException {
+    public boolean isCurrentQuestionFirstInForm() {
+        boolean isFirstQuestion = true;
         FormIndex originalFormIndex = getFormIndex();
-        boolean firstQuestion = (stepToPreviousScreenEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM);
+        try {
+            isFirstQuestion =  stepToPreviousScreenEvent() == FormEntryController.EVENT_BEGINNING_OF_FORM
+                    && stepToNextScreenEvent() != FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+        } catch (JavaRosaException e) {
+            Timber.e(e);
+        }
         jumpToIndex(originalFormIndex);
-        return firstQuestion;
+        return isFirstQuestion;
     }
 
     /**


### PR DESCRIPTION
Closes #1798 

The issue was not very well described since I didn't know exactly what was wrong. Now I know that the problem took place when we had a repeat group and another group after that repeat and we tried to skip the repeat group. Everything was ok if we had a repeat group and a simple question after that. I attached forms below.

#### What has been done to verify that this works as intended?
I've tested a few different forms with repeat groups and without.

#### Why is this the best possible solution? Were any other approaches considered?
I just improved the `isCurrentQuestionFirstInForm()` method and removed unnecessary code.

#### Are there any risks to merging this code? If so, what are they?
Generally, it looks well and I used the same approach we use during swiping (swiping has worked well) so I guess it's ok but I can never be sure.

#### Do we need any specific form for testing your changes? If so, please attach one.
This case was broken: [RepeatGroupAndGroup.xml.txt](https://github.com/opendatakit/collect/files/1727865/RepeatGroupAndGroup.xml.txt)
This case worked ok: [RepeatGrouAndQuestion.xml.txt](https://github.com/opendatakit/collect/files/1727866/RepeatGrouAndQuestion.xml.txt)
