### PR TITLE
Fixed toggle button doesn't work as expected

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -438,6 +438,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             ((FormDownloadListAdapter) listView.getAdapter()).notifyDataSetChanged();
         }
         toggleButton.setEnabled(filteredFormList.size() > 0);
+        toggleButtonLabel(toggleButton, listView);
         checkPreviouslyCheckedItems();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -318,6 +318,7 @@ public class InstanceUploaderList extends InstanceListActivity
     protected void updateAdapter() {
         listAdapter.changeCursor(getCursor());
         checkPreviouslyCheckedItems();
+        toggleButtonLabel(findViewById(R.id.toggle_button), listView);
     }
 
     private Cursor getCursor() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FileManagerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FileManagerFragment.java
@@ -82,6 +82,7 @@ public abstract class FileManagerFragment extends AppListFragment {
     @Override
     protected void updateAdapter() {
         checkPreviouslyCheckedItems();
+        toggleButtonLabel(toggleButton, getListView());
         deleteButton.setEnabled(areCheckedItems());
     }
 }


### PR DESCRIPTION
Closes #1868 

#### What has been done to verify that this works as intended?
I have tested the app on the emulator (Google Pixel XL, API level 26) and found the behavior to be correct.

#### Why is this the best possible solution? Were any other approaches considered?
The issue was that the "Clear/Select All" button would not update its label when the list contents changed (when a search was performed, the list contents would be narrowed down, but when the search was canceled/broadened the contents would update, adding more elements, thus, the "Select All" button would need to be enabled again). As a solution i have called the `toggleButtonLabel()` method in the `updateAdapter()` of the affected lists, so now everything works as intended.
#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
No.