### PR TITLE
Don't require answer for trigger

### DIFF
--- a/collect_app/src/androidTest/assets/all_widgets.xml
+++ b/collect_app/src/androidTest/assets/all_widgets.xml
@@ -255,7 +255,7 @@
       <bind nodeset="/all-widgets/table_list_test/table_list_2" type="select"/>
       <bind nodeset="/all-widgets/table_list_test/list_widget" type="select1"/>
       <bind nodeset="/all-widgets/table_list_test/list_multi_widget" type="select"/>
-      <bind nodeset="/all-widgets/my_trigger" required="true()"/>
+      <bind nodeset="/all-widgets/my_trigger"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/all-widgets/meta/instanceID" readonly="true()" type="string"/>
     </model>
   </h:head>


### PR DESCRIPTION
#1828 marks required questions with an asterisk so the label text no longer matched. Since the form is supposed to focus on question types rather than modifiers, removing the required makes sense.

#### What has been done to verify that this works as intended?
Ran `./gradlew connectedAndroidTest`

#### Why is this the best possible solution? Were any other approaches considered?
Another option would have been to change the text for the view selection. I think making the form just about question types makes the most sense. This also makes it easier to use since previously it couldn't be finalized without trigger being set. I have also updated https://docs.google.com/spreadsheets/u/1/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0 accordingly.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.