### PR TITLE
Fix #1552. Pictures taken by the SelfieWidget are rotated incorrectly on some devices.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -80,9 +80,8 @@ public class Camera2Fragment extends Fragment
         implements View.OnClickListener, FragmentCompat.OnRequestPermissionsResultCallback {
 
     /**
-     * Conversion from screen rotation to JPEG orientation,For front camera only.
+     * Conversion from screen rotation to JPEG orientation. For front camera only.
      */
-
     private static final SparseIntArray ORIENTATIONS = new SparseIntArray();
     private static final int REQUEST_CAMERA_PERMISSION = 1;
     private static final String FRAGMENT_DIALOG = "dialog";

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -80,30 +80,12 @@ public class Camera2Fragment extends Fragment
         implements View.OnClickListener, FragmentCompat.OnRequestPermissionsResultCallback {
 
     /**
-     * Conversion from screen rotation to JPEG orientation.
-     */
-
-    /*
-     * For front camera only.
-     * Bug fixed on 2018.2.17.
+     * Conversion from screen rotation to JPEG orientation,For front camera only.
      */
 
     private static final SparseIntArray ORIENTATIONS = new SparseIntArray();
     private static final int REQUEST_CAMERA_PERMISSION = 1;
     private static final String FRAGMENT_DIALOG = "dialog";
-
-    /**
-    * Fowling code only suits for back camera
-    *
-    * static {
-    * ORIENTATIONS.append(Surface.ROTATION_0, 90);
-    * ORIENTATIONS.append(Surface.ROTATION_90, 0);
-    * ORIENTATIONS.append(Surface.ROTATION_180, 270);
-    * ORIENTATIONS.append(Surface.ROTATION_270, 180);
-    * }
-    *
-    * For front camera, we use this:
-    * */
 
     static {
         ORIENTATIONS.append(Surface.ROTATION_0, 0);
@@ -839,21 +821,14 @@ public class Camera2Fragment extends Fragment
      * @param rotation The screen rotation.
      * @return The JPEG orientation (one of 0, 90, 270, and 360)
      * <p>
-     * Back Sensor orientation is 90 for most devices, or 270 for some devices (eg. Nexus 5X)
-     * Front Sensor is normally 270.
+     * The back sensor orientation is 90 for most devices, or 270 for some devices (eg. Nexus 5X)
+     * The front sensor orientation is 270 for most devices.
      * <p>
-     * Following code use only for back camera , not suitable for front camera
-     * {@code return (ORIENTATIONS.get(rotation) + sensorOrientation + 270) % 360;}
-     * <p>
-     * <p>
-     * The final degrees the jpeg need to be rotated will be the sum degrees of screen orientation and
-     * {@link CameraDevice } 's orientation.Just like the code below.
-     * And orientation is always the degrees something needs to rotate clockwise to be upright.
+     * The final number of degrees the JPEG needs to be rotated will be the sum of screen orientation and
+     * {@link CameraDevice }'s orientation. Just like the code below.
+     * And orientation is always the number of degrees something needs to rotate clockwise to be upright.
      */
     private int getOrientation(int rotation) {
-
-        // After bug #1552 fixed on 2018.2.17, we use this orientation expression to amend the camera direction.
-
         return (ORIENTATIONS.get(rotation) + sensorOrientation) % 360;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -82,15 +82,30 @@ public class Camera2Fragment extends Fragment
     /**
      * Conversion from screen rotation to JPEG orientation.
      */
+
+    /*
+     * For front camera only.
+     * Bug fixed on 2018.2.17.
+     */
+
     private static final SparseIntArray ORIENTATIONS = new SparseIntArray();
     private static final int REQUEST_CAMERA_PERMISSION = 1;
     private static final String FRAGMENT_DIALOG = "dialog";
 
+//    Fowling code only suits for back camera
+//    static {
+//        ORIENTATIONS.append(Surface.ROTATION_0, 90);
+//        ORIENTATIONS.append(Surface.ROTATION_90, 0);
+//        ORIENTATIONS.append(Surface.ROTATION_180, 270);
+//        ORIENTATIONS.append(Surface.ROTATION_270, 180);
+//    }
+
+    //    For front camera, we use this
     static {
-        ORIENTATIONS.append(Surface.ROTATION_0, 90);
-        ORIENTATIONS.append(Surface.ROTATION_90, 0);
-        ORIENTATIONS.append(Surface.ROTATION_180, 270);
-        ORIENTATIONS.append(Surface.ROTATION_270, 180);
+        ORIENTATIONS.append(Surface.ROTATION_0, 0);
+        ORIENTATIONS.append(Surface.ROTATION_90, 90);
+        ORIENTATIONS.append(Surface.ROTATION_180, 180);
+        ORIENTATIONS.append(Surface.ROTATION_270, 270);
     }
 
     /**
@@ -819,13 +834,23 @@ public class Camera2Fragment extends Fragment
      *
      * @param rotation The screen rotation.
      * @return The JPEG orientation (one of 0, 90, 270, and 360)
+     *
+     *  Back Sensor orientation is 90 for most devices, or 270 for some devices (eg. Nexus 5X)
+     *  Front Sensor is normally 270.
+     *
+     *  Following code use only for back camera , not suitable for front camera
+     *  {@code return (ORIENTATIONS.get(rotation) + sensorOrientation + 270) % 360;}
+     *
+     *
+     *  The final degrees the jpeg need to be rotated will be the sum degrees of screen orientation and
+     *  {@link CameraDevice } 's orientation.Just like the code below.
+     *  And orientation is always the degrees something needs to rotate clockwise to be upright.
      */
     private int getOrientation(int rotation) {
-        // Sensor orientation is 90 for most devices, or 270 for some devices (eg. Nexus 5X)
-        // We have to take that into account and rotate JPEG properly.
-        // For devices with orientation of 90, we simply return our mapping from ORIENTATIONS.
-        // For devices with orientation of 270, we need to rotate the JPEG 180 degrees.
-        return (ORIENTATIONS.get(rotation) + sensorOrientation + 270) % 360;
+
+        // After bug #1552 fixed on 2018.2.17, we use this orientation expression to amend the camera direction.
+
+        return (ORIENTATIONS.get(rotation) + sensorOrientation) % 360;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -92,15 +92,19 @@ public class Camera2Fragment extends Fragment
     private static final int REQUEST_CAMERA_PERMISSION = 1;
     private static final String FRAGMENT_DIALOG = "dialog";
 
-//    Fowling code only suits for back camera
-//    static {
-//        ORIENTATIONS.append(Surface.ROTATION_0, 90);
-//        ORIENTATIONS.append(Surface.ROTATION_90, 0);
-//        ORIENTATIONS.append(Surface.ROTATION_180, 270);
-//        ORIENTATIONS.append(Surface.ROTATION_270, 180);
-//    }
+    /**
+    * Fowling code only suits for back camera
+    *
+    * static {
+    * ORIENTATIONS.append(Surface.ROTATION_0, 90);
+    * ORIENTATIONS.append(Surface.ROTATION_90, 0);
+    * ORIENTATIONS.append(Surface.ROTATION_180, 270);
+    * ORIENTATIONS.append(Surface.ROTATION_270, 180);
+    * }
+    *
+    * For front camera, we use this:
+    * */
 
-    //    For front camera, we use this
     static {
         ORIENTATIONS.append(Surface.ROTATION_0, 0);
         ORIENTATIONS.append(Surface.ROTATION_90, 90);
@@ -834,17 +838,17 @@ public class Camera2Fragment extends Fragment
      *
      * @param rotation The screen rotation.
      * @return The JPEG orientation (one of 0, 90, 270, and 360)
-     *
-     *  Back Sensor orientation is 90 for most devices, or 270 for some devices (eg. Nexus 5X)
-     *  Front Sensor is normally 270.
-     *
-     *  Following code use only for back camera , not suitable for front camera
-     *  {@code return (ORIENTATIONS.get(rotation) + sensorOrientation + 270) % 360;}
-     *
-     *
-     *  The final degrees the jpeg need to be rotated will be the sum degrees of screen orientation and
-     *  {@link CameraDevice } 's orientation.Just like the code below.
-     *  And orientation is always the degrees something needs to rotate clockwise to be upright.
+     * <p>
+     * Back Sensor orientation is 90 for most devices, or 270 for some devices (eg. Nexus 5X)
+     * Front Sensor is normally 270.
+     * <p>
+     * Following code use only for back camera , not suitable for front camera
+     * {@code return (ORIENTATIONS.get(rotation) + sensorOrientation + 270) % 360;}
+     * <p>
+     * <p>
+     * The final degrees the jpeg need to be rotated will be the sum degrees of screen orientation and
+     * {@link CameraDevice } 's orientation.Just like the code below.
+     * And orientation is always the degrees something needs to rotate clockwise to be upright.
      */
     private int getOrientation(int rotation) {
 


### PR DESCRIPTION
Closes #1552

What has been done to verify that this works as intended?
Fix #1552. Pictures taken by the SelfieWidget are rotated incorrectly on some devices

Why is this the best possible solution? Were any other approaches considered?
Using official api, and maybe the least code, actually I‘ve just change some number and experession.

Are there any risks to merging this code? If so, what are they?
Maybe not support devices whose front camera isn't 270, I don’t have devices like that.

Do we need any specific form for testing your changes? If so, please attach one.
Test it on more devices, especially whose front camera isn't 270° placed.