### PR TITLE
Issue Fix: Selection with autoadvance isn't displayed properly for right-to-left languages

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -150,6 +150,10 @@ android {
     dexOptions {
         javaMaxHeapSize '2048M'
     }
+	
+	lintOptions {
+          abortOnError false
+    }
 
     testOptions.unitTests.includeAndroidResources true
 }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -154,7 +154,6 @@ android {
 	lintOptions {
           abortOnError false
     }
-
     testOptions.unitTests.includeAndroidResources true
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -295,7 +295,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                 && !CheckBox.class.isAssignableFrom(text.getClass());
 
         // Determine the layout constraints...
-        if(!QuestionWidget.isLanguageRTL(getContext())) {
+        if (!QuestionWidget.isLanguageRTL(getContext())) {
             // Language is LTR
             if (viewText.getText().length() == 0 && (imageView != null || missingImage != null)) {
                 // No text; has image. The image is treated as question/choice icon.

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -44,6 +44,7 @@ import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.ViewIds;
+import org.odk.collect.android.widgets.QuestionWidget;
 
 import java.io.File;
 
@@ -70,9 +71,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
     private AudioPlayListener audioPlayListener;
     private int playTextColor;
     private int playBackgroundTextColor;
-    
     private Context context;
-
     private CharSequence originalText;
 
 
@@ -151,8 +150,8 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
     }
 
     public void setAVT(FormIndex index, String selectionDesignator, TextView text, String audioURI,
-            String imageURI, String videoURI,
-            final String bigImageURI) {
+                       String imageURI, String videoURI,
+                       final String bigImageURI) {
         this.selectionDesignator = selectionDesignator;
         this.index = index;
         viewText = text;
@@ -161,17 +160,17 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
         this.videoURI = videoURI;
 
         // Layout configurations for our elements in the relative layout
-        RelativeLayout.LayoutParams textParams =
-                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+        LayoutParams textParams =
+                new LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        RelativeLayout.LayoutParams audioParams =
-                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+        LayoutParams audioParams =
+                new LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        RelativeLayout.LayoutParams imageParams =
-                new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT,
+        LayoutParams imageParams =
+                new LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        RelativeLayout.LayoutParams videoParams =
-                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+        LayoutParams videoParams =
+                new LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
 
         // First set up the audio button
@@ -237,10 +236,10 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                             public void onClick(View v) {
                                 if (bigImageURI != null) {
                                     Collect.getInstance().getActivityLogger().logInstanceAction(
-                                        this, "onClick",
-                                        "showImagePromptBigImage" + MediaLayout.this.selectionDesignator,
-                                        MediaLayout.this.index);
-                                    
+                                            this, "onClick",
+                                            "showImagePromptBigImage" + MediaLayout.this.selectionDesignator,
+                                            MediaLayout.this.index);
+
                                     try {
                                         File bigImage = new File(ReferenceManager
                                                 .instance()
@@ -296,99 +295,199 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                 && !CheckBox.class.isAssignableFrom(text.getClass());
 
         // Determine the layout constraints...
-        // Assumes LTR, TTB reading bias!
-        if (viewText.getText().length() == 0 && (imageView != null || missingImage != null)) {
-            // No text; has image. The image is treated as question/choice icon.
-            // The Text view may just have a radio button or checkbox. It
-            // needs to remain in the layout even though it is blank.
-            //
-            // The image view, as created above, will dynamically resize and
-            // center itself. We want it to resize but left-align itself
-            // in the resized area and we want a white background, as otherwise
-            // it will show a grey bar to the right of the image icon.
-            if (imageView != null) {
-                imageView.setScaleType(ScaleType.FIT_START);
-            }
-            //
-            // In this case, we have:
-            // Text upper left; image upper, left edge aligned with text right edge;
-            // audio upper right; video below audio on right.
-            textParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-            textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-            if (isNotAMultipleChoiceField) {
-                imageParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
-            } else {
-                imageParams.addRule(RelativeLayout.RIGHT_OF, viewText.getId());
-            }
-            imageParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-            if (audioButton != null && videoButton == null) {
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                audioParams.setMargins(0, 0, 11, 0);
-                imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
-            } else if (audioButton == null && videoButton != null) {
-                videoParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-                videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                videoParams.setMargins(0, 0, 11, 0);
-                imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
-            } else if (audioButton != null && videoButton != null) {
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                audioParams.setMargins(0, 0, 11, 0);
-                imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
-                videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
-                videoParams.setMargins(0, 20, 11, 0);
-                imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
-            } else {
-                // the image will implicitly scale down to fit within parent...
-                // no need to bound it by the width of the parent...
-                if (!isNotAMultipleChoiceField) {
-                    imageParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+        if(!QuestionWidget.isLanguageRTL(getContext())) {
+            // Language is LTR
+            if (viewText.getText().length() == 0 && (imageView != null || missingImage != null)) {
+                // No text; has image. The image is treated as question/choice icon.
+                // The Text view may just have a radio button or checkbox. It
+                // needs to remain in the layout even though it is blank.
+                //
+                // The image view, as created above, will dynamically resize and
+                // center itself. We want it to resize but left-align itself
+                // in the resized area and we want a white background, as otherwise
+                // it will show a grey bar to the right of the image icon.
+                if (imageView != null) {
+                    imageView.setScaleType(ScaleType.FIT_START);
                 }
-            }
-            imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
-        } else {
-            // We have a non-blank text label -- image is below the text.
-            // In this case, we want the image to be centered...
-            if (imageView != null) {
-                imageView.setScaleType(ScaleType.FIT_START);
-            }
-            //
-            // Text upper left; audio upper right; video below audio on right.
-            // image below text, audio and video buttons; left-aligned with text.
-            textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-            textParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
-            if (audioButton != null && videoButton == null) {
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                audioParams.setMargins(0, 0, 11, 0);
-                textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
-            } else if (audioButton == null && videoButton != null) {
-                videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                videoParams.setMargins(0, 0, 11, 0);
-                textParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
-            } else if (audioButton != null && videoButton != null) {
-                audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                audioParams.setMargins(0, 0, 11, 0);
-                textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
-                videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-                videoParams.setMargins(0, 20, 11, 0);
-                videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
-            } else {
-                textParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-            }
+                //
+                // In this case, we have:
+                // Text upper left; image upper, left edge aligned with text right edge;
+                // audio upper right; video below audio on right.
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
 
-            if (imageView != null || missingImage != null) {
-                imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
-                imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
-                if (videoButton != null) {
-                    imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
-                } else if (audioButton != null) {
-                    imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                if (isNotAMultipleChoiceField) {
+                    imageParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
+                } else {
+                    imageParams.addRule(RelativeLayout.RIGHT_OF, viewText.getId());
                 }
-                imageParams.addRule(RelativeLayout.BELOW, viewText.getId());
+                imageParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                if (audioButton != null && videoButton == null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    audioParams.setMargins(0, 0, 11, 0);
+                    imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                } else if (audioButton == null && videoButton != null) {
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    videoParams.setMargins(0, 0, 11, 0);
+                    imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                } else if (audioButton != null && videoButton != null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    audioParams.setMargins(0, 0, 11, 0);
+                    imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
+                    videoParams.setMargins(0, 20, 11, 0);
+                    imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                } else {
+                    // the image will implicitly scale down to fit within parent...
+                    // no need to bound it by the width of the parent...
+                    if (!isNotAMultipleChoiceField) {
+                        imageParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    }
+                }
+                imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
             } else {
-                textParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                // We have a non-blank text label -- image is below the text.
+                // In this case, we want the image to be centered...
+                if (imageView != null) {
+                    imageView.setScaleType(ScaleType.FIT_START);
+                }
+                //
+                // Text upper left; audio upper right; video below audio on right.
+                // image below text, audio and video buttons; left-aligned with text.
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                if (audioButton != null && videoButton == null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    audioParams.setMargins(0, 0, 11, 0);
+                    textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                } else if (audioButton == null && videoButton != null) {
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    videoParams.setMargins(0, 0, 11, 0);
+                    textParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                } else if (audioButton != null && videoButton != null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    audioParams.setMargins(0, 0, 11, 0);
+                    textParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    videoParams.setMargins(0, 20, 11, 0);
+                    videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
+                } else {
+                    textParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                }
+
+                if (imageView != null || missingImage != null) {
+                    imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                    imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    if (videoButton != null) {
+                        imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                    } else if (audioButton != null) {
+                        imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    }
+                    imageParams.addRule(RelativeLayout.BELOW, viewText.getId());
+                } else {
+                    textParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                }
+            }
+        }else{
+            //Language is RTL
+            if (viewText.getText().length() == 0 && (imageView != null || missingImage != null)) {
+                // No text; has image. The image is treated as question/choice icon.
+                // The Text view may just have a radio button or checkbox. It
+                // needs to remain in the layout even though it is blank.
+                //
+                // The image view, as created above, will dynamically resize and
+                // center itself. We want it to resize but right-align itself
+                // in the resized area and we want a white background, as otherwise
+                // it will show a grey bar to the left of the image icon.
+                if (imageView != null) {
+                    imageView.setScaleType(ScaleType.FIT_START);
+                }
+                //
+                // In this case, we have:
+                // Text upper right; image upper, right edge aligned with text left edge;
+                // audio upper left; video below audio on left.
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+
+                if (isNotAMultipleChoiceField) {
+                    imageParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
+                } else {
+                    imageParams.addRule(RelativeLayout.RIGHT_OF, viewText.getId());
+                }
+                imageParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                if (audioButton != null && videoButton == null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    audioParams.setMargins(11, 0, 0, 0);
+                    imageParams.addRule(RelativeLayout.RIGHT_OF, audioButton.getId());
+                } else if (audioButton == null && videoButton != null) {
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    videoParams.setMargins(11, 0, 0, 0);
+                    imageParams.addRule(RelativeLayout.RIGHT_OF, videoButton.getId());
+                } else if (audioButton != null && videoButton != null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    audioParams.setMargins(11, 0, 0, 0);
+                    imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
+                    videoParams.setMargins(11, 20, 0, 0);
+                    imageParams.addRule(RelativeLayout.RIGHT_OF, videoButton.getId());
+                } else {
+                    // the image will implicitly scale down to fit within parent...
+                    // no need to bound it by the width of the parent...
+                    if (!isNotAMultipleChoiceField) {
+                        imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    }
+                }
+                imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+            } else {
+                // We have a non-blank text label -- image is below the text.
+                // In this case, we want the image to be centered...
+                if (imageView != null) {
+                    imageView.setScaleType(ScaleType.FIT_START);
+                }
+                //
+                // Text upper right; audio upper left; video below audio on left.
+                // image below text, audio and video buttons; right-aligned with text.
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                textParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                if (audioButton != null && videoButton == null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    audioParams.setMargins(11, 0, 0, 0);
+                    textParams.addRule(RelativeLayout.RIGHT_OF, audioButton.getId());
+                } else if (audioButton == null && videoButton != null) {
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    videoParams.setMargins(11, 0, 0, 0);
+                    textParams.addRule(RelativeLayout.RIGHT_OF, videoButton.getId());
+                } else if (audioButton != null && videoButton != null) {
+                    audioParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    audioParams.setMargins(11, 0, 0, 0);
+                    textParams.addRule(RelativeLayout.RIGHT_OF, audioButton.getId());
+                    videoParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                    videoParams.setMargins(11, 20, 0, 0);
+                    videoParams.addRule(RelativeLayout.BELOW, audioButton.getId());
+                } else {
+                    textParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+                }
+
+                if (imageView != null || missingImage != null) {
+                    imageParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                    imageParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
+                    if (videoButton != null) {
+                        imageParams.addRule(RelativeLayout.LEFT_OF, videoButton.getId());
+                    } else if (audioButton != null) {
+                        imageParams.addRule(RelativeLayout.LEFT_OF, audioButton.getId());
+                    }
+                    imageParams.addRule(RelativeLayout.BELOW, viewText.getId());
+                } else {
+                    textParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                }
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -392,7 +392,7 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
                     textParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
                 }
             }
-        }else{
+        } else {
             //Language is RTL
             if (viewText.getText().length() == 0 && (imageView != null || missingImage != null)) {
                 // No text; has image. The image is treated as question/choice icon.

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -22,10 +22,10 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
@@ -46,9 +46,9 @@ import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.ActivityLogger;
 import org.odk.collect.android.exception.JavaRosaException;
-import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.utilities.ViewIds;
@@ -59,6 +59,7 @@ import org.odk.collect.android.widgets.interfaces.Widget;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 
@@ -125,7 +126,7 @@ public abstract class QuestionWidget
         addHelpTextView(getHelpTextView());
     }
 
-    /** Releases resources held by this widget */
+    /** Releases resources held by this widget*/
     public void release() {
         if (player != null) {
             player.release();
@@ -133,7 +134,20 @@ public abstract class QuestionWidget
         }
     }
 
-    protected void injectDependencies(DependencyProvider dependencyProvider) {}
+    /**
+     * author: vrjgamer
+     * This function checks if current set language is RTL
+     * it returns true if its RTL else false.
+     */
+    public static boolean isLanguageRTL(Context context) {
+        Locale currentLocale = context.getResources().getConfiguration().locale;
+        int directionality = Character.getDirectionality(currentLocale.getDisplayName().charAt(0));
+        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
+                directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+    }
+
+    protected void injectDependencies(DependencyProvider dependencyProvider) {
+    }
 
     private MediaLayout createQuestionMediaLayout(FormEntryPrompt prompt) {
         String promptText = prompt.getLongText();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
@@ -18,6 +18,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.RadioButton;
@@ -130,6 +131,12 @@ public class SelectOneWidget
         radioButton.setId(ViewIds.generateViewId());
         radioButton.setEnabled(!getFormEntryPrompt().isReadOnly());
         radioButton.setFocusable(!getFormEntryPrompt().isReadOnly());
+
+        if (isLanguageRTL(getContext())) {
+            radioButton.setGravity(Gravity.END);
+        } else {
+            radioButton.setGravity(Gravity.START);
+        }
 
         if (items.get(index).getValue().equals(selectedValue)) {
             radioButton.setChecked(true);

--- a/collect_app/src/main/res/drawable/ic_menu_share.xml
+++ b/collect_app/src/main/res/drawable/ic_menu_share.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="36dp"
+    android:height="36dp"
     android:viewportHeight="24"
     android:viewportWidth="24">
 

--- a/collect_app/src/main/res/drawable/ic_menu_share.xml
+++ b/collect_app/src/main/res/drawable/ic_menu_share.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="@color/black"
+        android:pathData="M18 16.08c-0.76 0-1.44 0.3 -1.96 0.77 L8.91 12.7c0.05-0.23 0.09 -0.46 0.09
+-0.7s-0.04-0.47-0.09-0.7l7.05-4.11c0.54 0.5 1.25 0.81 2.04 0.81 1.66 0 3-1.34
+3-3s-1.34-3-3-3-3 1.34-3 3c0 0.24 0.04 0.47 0.09 0.7L8.04 9.81C7.5 9.31 6.79 9 6
+9c-1.66 0-3 1.34-3 3s1.34 3 3 3c0.79 0 1.5-0.31 2.04-0.81l7.12 4.16c-0.05 0.21 -0.08
+0.43 -0.08 0.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31
+2.92-2.92s-1.31-2.92-2.92-2.92z" />
+</vector>

--- a/collect_app/src/main/res/drawable/ic_save_black_32dp.xml
+++ b/collect_app/src/main/res/drawable/ic_save_black_32dp.xml
@@ -6,6 +6,6 @@
         android:viewportHeight="24.0"
         android:viewportWidth="24.0">
     <path
-        android:fillColor="@color/grey"
+        android:fillColor="@color/black"
         android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
 </vector>

--- a/collect_app/src/main/res/menu/settings_menu.xml
+++ b/collect_app/src/main/res/menu/settings_menu.xml
@@ -16,12 +16,10 @@
         android:title="@string/share"
         android:icon="@drawable/ic_menu_share"
         app:showAsAction="always" />
-
     <item
         android:id="@+id/menu_save_preferences"
         android:actionProviderClass="android.widget.ShareActionProvider"
         android:title="@string/save_preferences"
         android:icon="@drawable/ic_save_black_36dp"
-        app:showAsAction="always"
-		/>
+        app:showAsAction="always"/>
 </menu>

--- a/collect_app/src/main/res/menu/settings_menu.xml
+++ b/collect_app/src/main/res/menu/settings_menu.xml
@@ -14,12 +14,14 @@
         android:id="@+id/menu_item_share"
         android:actionProviderClass="android.widget.ShareActionProvider"
         android:title="@string/share"
-        android:icon="@android:drawable/ic_menu_share"
+        android:icon="@drawable/ic_menu_share"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_save_preferences"
         android:actionProviderClass="android.widget.ShareActionProvider"
         android:title="@string/save_preferences"
-        app:showAsAction="never" />
+        android:icon="@drawable/ic_save_black_36dp"
+        app:showAsAction="always"
+		/>
 </menu>


### PR DESCRIPTION
Closes #1849 

+Updated All Select One Widgets for RTL languages.

#### What has been done to verify that this works as intended?
I checked it on a physical device Moto G4+ running Android 7.1, on Nexus emulator running 5.0 & 4.3.
The Widgets were perfectly adapting to the selected Language direction (RTL & LTR). 

**Output**
![xcfhvbjh](https://user-images.githubusercontent.com/10618953/36395560-c6abb6a2-15df-11e8-9e7e-941b171612e9.png)

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution because it supports all the targeted api levels (16 to 26). There other methods like using TextAlignment or LayoutDirection but they need min. api level of 17.

#### Are there any risks to merging this code? If so, what are they?
No there no risk in merging my code. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form that contains Select one widget of any type, especially the one that this issue targets, Select one widget auto-advance. Then select any language either RTL or LTR, from `General Setting -> User Interface -> Language`. Test if the widgets adapt themselves to the language direction.