### PR TITLE
Update selectedInstances when toggle is clicked. Fix #1884

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
@@ -264,11 +264,11 @@ public class DataManagerList extends InstanceListFragment
             case R.id.toggle_button:
                 ListView lv = getListView();
                 boolean allChecked = toggleChecked(lv);
-                if(allChecked){
+                if (allChecked) {
                     for (int i = 0; i < lv.getCount(); i++) {
                         selectedInstances.add(lv.getItemIdAtPosition(i));
                     }
-                }else{
+                } else {
                     selectedInstances.clear();
                 }
                 toggleButtonLabel(toggleButton, getListView());

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
@@ -264,6 +264,13 @@ public class DataManagerList extends InstanceListFragment
             case R.id.toggle_button:
                 ListView lv = getListView();
                 boolean allChecked = toggleChecked(lv);
+                if(allChecked){
+                    for (int i = 0; i < lv.getCount(); i++) {
+                        selectedInstances.add(lv.getItemIdAtPosition(i));
+                    }
+                }else{
+                    selectedInstances.clear();
+                }
                 toggleButtonLabel(toggleButton, getListView());
                 deleteButton.setEnabled(allChecked);
                 break;

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -246,11 +246,11 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
             case R.id.toggle_button:
                 ListView lv = getListView();
                 boolean allChecked = toggleChecked(lv);
-                if(allChecked){
+                if (allChecked) {
                     for (int i = 0; i < lv.getCount(); i++) {
                         selectedInstances.add(lv.getItemIdAtPosition(i));
                     }
-                }else{
+                } else {
                     selectedInstances.clear();
                 }
                 toggleButtonLabel(toggleButton, getListView());

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -246,6 +246,13 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
             case R.id.toggle_button:
                 ListView lv = getListView();
                 boolean allChecked = toggleChecked(lv);
+                if(allChecked){
+                    for (int i = 0; i < lv.getCount(); i++) {
+                        selectedInstances.add(lv.getItemIdAtPosition(i));
+                    }
+                }else{
+                    selectedInstances.clear();
+                }
                 toggleButtonLabel(toggleButton, getListView());
                 deleteButton.setEnabled(allChecked);
                 break;


### PR DESCRIPTION
Closes #1884 

The general issue was that whenever the user interacted with the search bar (click search, return, erase text), the app only remembered to check manually clicked items and not those selected by"select all". This was because selectedInstances is updated whenever an item is clicked (FileManagerFragment line 72) but not when "selected all" is. This is fixed simply by updating it in FormManagerList and DataManagerList.

#### What has been done to verify that this works as intended?
Manual tests. Please contact me if you can help me with unit tests. I will try to get used to using them in the future.

#### Why is this the best possible solution? Were any other approaches considered?
You can also update selectedInstances at a lower level, in AppListFragment. However, this will require to either declare selectedInstances as static or to remove the static modifier from the two methods that handle toggle behavior. I assumed there is a reason why that code was written the way it was so I decided to fix the issue without modifying anything. If it's ok to make these changes, it might be better to move the code i added to that class.

#### Are there any risks to merging this code? If so, what are they? 
no (pretty sure the project won't explode from 14 lines of added code)

#### Do we need any specific form for testing your changes? If so, please attach one.
That issue was not associated with any forms.