### PR TITLE
updated SelectOneWidget for RTL languages

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -133,15 +133,15 @@ public abstract class QuestionWidget
         }
     }
 
-	//source:: https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
-	public static boolean isRTL() {
-		return isRTL(Locale.getDefault());
-	}
+//source:: https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
+    public static boolean isRTL() {
+        return isRTL(Locale.getDefault());
+    }
 
-	public static boolean isRTL(Locale locale) {
-		final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
-		return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
-	}
+    private static boolean isRTL(Locale locale) {
+        final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
+        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+    }
 	
     protected void injectDependencies(DependencyProvider dependencyProvider) {}
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -132,7 +132,7 @@ public abstract class QuestionWidget
             player = null;
         }
     }
-    
+
     //source::https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
     public static boolean isRTL() {
         return isRTL(Locale.getDefault());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -132,6 +132,7 @@ public abstract class QuestionWidget
             player = null;
         }
     }
+    
     //source::https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
     public static boolean isRTL() {
         return isRTL(Locale.getDefault());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -132,17 +132,16 @@ public abstract class QuestionWidget
             player = null;
         }
     }
+    //source::https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
+    public static boolean isRTL() {
+        return isRTL(Locale.getDefault());
+    }
 
- //source:: https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
- public static boolean isRTL() {
-  return isRTL(Locale.getDefault());
- }
+    private static boolean isRTL(Locale locale) {
+        final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
+        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+    }
 
- private static boolean isRTL(Locale locale) {
-  final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
-  return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
- }
-	
     protected void injectDependencies(DependencyProvider dependencyProvider) {}
 
     private MediaLayout createQuestionMediaLayout(FormEntryPrompt prompt) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -58,6 +58,7 @@ import org.odk.collect.android.widgets.interfaces.Widget;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 
@@ -132,6 +133,16 @@ public abstract class QuestionWidget
         }
     }
 
+	//source:: https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
+	public static boolean isRTL() {
+		return isRTL(Locale.getDefault());
+	}
+
+	public static boolean isRTL(Locale locale) {
+		final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
+		return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+	}
+	
     protected void injectDependencies(DependencyProvider dependencyProvider) {}
 
     private MediaLayout createQuestionMediaLayout(FormEntryPrompt prompt) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -133,15 +133,15 @@ public abstract class QuestionWidget
         }
     }
 
-//source:: https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
-    public static boolean isRTL() {
-        return isRTL(Locale.getDefault());
-    }
+ //source:: https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
+ public static boolean isRTL() {
+  return isRTL(Locale.getDefault());
+ }
 
-    private static boolean isRTL(Locale locale) {
-        final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
-        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
-    }
+ private static boolean isRTL(Locale locale) {
+  final int directionality = Character.getDirectionality(locale.getDisplayName().charAt(0));
+  return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC;
+ }
 	
     protected void injectDependencies(DependencyProvider dependencyProvider) {}
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
@@ -18,6 +18,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.RadioButton;
@@ -130,7 +131,14 @@ public class SelectOneWidget
         radioButton.setId(ViewIds.generateViewId());
         radioButton.setEnabled(!getFormEntryPrompt().isReadOnly());
         radioButton.setFocusable(!getFormEntryPrompt().isReadOnly());
-
+		
+		//adapt radioButton text as per language direction
+		if (isRTL()) {
+            radioButton.setGravity(Gravity.END);
+        } else {
+            radioButton.setGravity(Gravity.START);
+        }
+		
         if (items.get(index).getValue().equals(selectedValue)) {
             radioButton.setChecked(true);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
@@ -131,14 +131,14 @@ public class SelectOneWidget
         radioButton.setId(ViewIds.generateViewId());
         radioButton.setEnabled(!getFormEntryPrompt().isReadOnly());
         radioButton.setFocusable(!getFormEntryPrompt().isReadOnly());
-		
-		//adapt radioButton text as per language direction
-		if (isRTL()) {
+
+        //adapt radioButton text as per language direction
+        if (isRTL()) {
             radioButton.setGravity(Gravity.END);
         } else {
             radioButton.setGravity(Gravity.START);
         }
-		
+
         if (items.get(index).getValue().equals(selectedValue)) {
             radioButton.setChecked(true);
         }


### PR DESCRIPTION
Closes #1849 

#### What has been done to verify that this works as intended?
I checked it on a physical device Moto G4+ running Android 7.1, on Nexus emulator running 5.0 & 4.3.
The Widgets were perfectly adapting to the selected Language direction (RTL & LTR).

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution because it supports all the targeted api levels (16 to 26). There other methods like using TextAlignment or LayoutDirection but they need min. api level of 17.

#### Are there any risks to merging this code? If so, what are they?
No there no risk in merging my code. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form that contains Select one widget auto-advance. Then select any language either RTL or LTR, from `General Setting -> User Interface -> Language`. Test if the widgets adapt themselves to the language direction.