### PR TITLE
Turn off debuggable builds for release

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -96,7 +96,6 @@ android {
                 signingConfig signingConfigs.release
             }
             minifyEnabled(true)
-            testCoverageEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             resValue("bool", "FIREBASE_CRASH_ENABLED", "false")
         }
@@ -106,7 +105,6 @@ android {
                 signingConfig signingConfigs.release
             }
             minifyEnabled(true)
-            testCoverageEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             resValue("bool", "FIREBASE_CRASH_ENABLED", "true")
         }


### PR DESCRIPTION
Uploading the current release build into the Google Play store results in an error because the APK is debuggable. This is due to a change in #1893 which set `testCoverageEnabled(true)` and thus enabled debugging.

#### What has been done to verify that this works as intended?
I've confirmed that removing `testCoverageEnabled(true)` results in an APK that can be uploaded to Google Play.

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change that works

#### Are there any risks to merging this code? If so, what are they?
This might break codecov analytics, but that's a low price to pay.