### PR TITLE
Downgrade jacoco to 0.7.4+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,14 +184,14 @@ workflows:
           requires:
             - build_debug
           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
       - report_coverage:
           requires:
             - test_unit
             - test_instrumented
           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,14 +184,14 @@ workflows:
           requires:
             - build_debug
           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master
       - report_coverage:
           requires:
             - test_unit
             - test_instrumented
           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -20,7 +20,7 @@ apply plugin: 'jacoco'
  */
 
 jacoco {
-    toolVersion '0.7.9'
+    toolVersion '0.7.4+'
 }
 
 // Add checkstyle, findbugs, pmd and lint to the check task.


### PR DESCRIPTION
Closes #1897 

#### What has been done to verify that this works as intended?
The result file is getting generated using both the coverage files
https://codecov.io/github/opendatakit/collect/commit/7b35f3b98ec1b99f57a5455f61e3f8ad271f9281

#### Why is this the best possible solution? Were any other approaches considered?
The exec version of the coverage file generated by the firebase is 0x1006 while the one required was 0x1007. So the possible solution is to downgrade the jacoco version to 0.7.4+ to match their versions.
https://github.com/jacoco/jacoco/wiki/ExecFileVersions

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No