### PR TITLE
Image select one widget does not allow answer to be removed

### DIFF
--- a/collect_app/src/main/assets/svg_map_helper.js
+++ b/collect_app/src/main/assets/svg_map_helper.js
@@ -34,6 +34,12 @@ function notifyChanges() {
     imageMapInterface.notifyChanges();
 }
 
+function clearAreas() {
+    selectedAreas.forEach(function(areaId) {
+        clickOnArea(areaId);
+    });
+}
+
 function addSelectedArea(selectedAreaId) {
     selectedAreas.add(selectedAreaId);
     document.getElementById(selectedAreaId).setAttribute('style', 'fill: #E65100');


### PR DESCRIPTION
Closes #1903 

#### What has been done to verify that this works as intended?
I've tested `selectOneWidget` and `SelectMultipleWidget` with `image-map` appearance form the `All widgets` form

#### Why is this the best possible solution? Were any other approaches considered?
I added missed function.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use the `All widgets` form.