### PR TITLE
FIx #1900 Pictures taken by the SelfieWidget are rotated incorrectly …

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
@@ -40,7 +40,7 @@ import timber.log.Timber;
 public class CaptureSelfieActivity extends Activity {
     private Camera camera;
     private CameraPreview preview;
-    private Camera.CameraInfo mCameraInfo;
+    private Camera.CameraInfo cameraInfo;
 
     /**
      * Conversion from screen rotation constant to the number of degrees.
@@ -118,7 +118,7 @@ public class CaptureSelfieActivity extends Activity {
 
             if (camInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
                 camera = Camera.open(camNo);
-                mCameraInfo = camInfo;
+                cameraInfo = camInfo;
                 camera.setDisplayOrientation(90);
 
             }
@@ -126,11 +126,11 @@ public class CaptureSelfieActivity extends Activity {
 
         // Set the rotation of the camera which the output picture need.
         if (camera != null) {
-            Camera.Parameters mParameters;
-            mParameters = camera.getParameters();
+            Camera.Parameters parameters;
+            parameters = camera.getParameters();
             int rotation = ORIENTATIONS.get(getWindowManager().getDefaultDisplay().getRotation());
-            mParameters.setRotation(calcCameraRotation(rotation));
-            camera.setParameters(mParameters);
+            parameters.setRotation(calcCameraRotation(rotation));
+            camera.setParameters(parameters);
         } else {
             Timber.e("No Available front camera");
         }
@@ -193,6 +193,6 @@ public class CaptureSelfieActivity extends Activity {
      * @return Number of degrees to rotate image in order for it to view correctly.
      */
     private int calcCameraRotation(int screenOrientationDegrees) {
-        return (mCameraInfo.orientation + screenOrientationDegrees) % 360;
+        return (cameraInfo.orientation + screenOrientationDegrees) % 360;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
@@ -131,7 +131,7 @@ public class CaptureSelfieActivity extends Activity {
             parameters.setRotation(calcCameraRotation(rotation));
             camera.setParameters(parameters);
         } else {
-            Timber.e("No Available front camera");
+            Timber.w("No Available front camera");
         }
 
         return camera;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
@@ -106,7 +106,7 @@ public class CaptureSelfieActivity extends Activity {
     }
 
     /**
-     * Get an available front {@link Camera} instance, and do some initialization for it.
+     * Gets an available front {@link Camera} instance, and does some initialization for it.
      *
      * @return an available front {@link Camera} instance
      */
@@ -126,8 +126,7 @@ public class CaptureSelfieActivity extends Activity {
 
         // Set the rotation of the camera which the output picture need.
         if (camera != null) {
-            Camera.Parameters parameters;
-            parameters = camera.getParameters();
+            Camera.Parameters parameters = camera.getParameters();
             int rotation = ORIENTATIONS.get(getWindowManager().getDefaultDisplay().getRotation());
             parameters.setRotation(calcCameraRotation(rotation));
             camera.setParameters(parameters);
@@ -182,7 +181,7 @@ public class CaptureSelfieActivity extends Activity {
     }
 
     /**
-     * Calculate the front camera rotation
+     * Calculates the front camera rotation
      * <p>
      * This calculation is applied to the output JPEG either via Exif Orientation tag
      * or by actually transforming the bitmap. (Determined by vendor camera API implementation)


### PR DESCRIPTION
…on Android 4.4 and 4.2

Closes #1900 

The cause may be that the step to set the **output orientation was forgotten** on the version before. 
  
In this commit, I set the output rotation once the camera instance is obtained.

Test has passed on 7.0.1 using the old Camera API (actually the version android 4.2 and 4.4 use).

More tests are needed.

@mmarciniak90 