### PR TITLE
"Select all" button is disabled when there is no data to show in form download activity

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/AllWidgetsFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/AllWidgetsFormTest.java
@@ -56,7 +56,9 @@ import static android.support.test.espresso.intent.matcher.IntentMatchers.hasAct
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasData;
 import static android.support.test.espresso.intent.matcher.IntentMatchers.hasExtra;
 import static android.support.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
@@ -841,7 +843,19 @@ public class AllWidgetsFormTest {
 
     public void testTriggerWidget() {
 
+        boolean checkBoxBoolean = randomBoolean();
+
+        if (checkBoxBoolean) {
+            onVisibleCheckBox().perform(click());
+        }
+
+        // captures screenshot of trigger widget
         Screengrab.screenshot("trigger-widget");
+
+        openWidgetList();
+        onView(withText("Trigger widget")).perform(click());
+
+        onVisibleCheckBox().check(matches(checkBoxBoolean ? isChecked() : isNotChecked()));
 
         onView(withText("Trigger widget")).perform(swipeLeft());
     }
@@ -862,6 +876,10 @@ public class AllWidgetsFormTest {
         return onView(withClassName(endsWith("EditText")));
     }
 
+    private ViewInteraction onVisibleCheckBox() {
+        return onView(withClassName(endsWith("CheckBox")));
+    }
+
     // private void openWidget(String name) {
     //     openWidgetList();
     //     onView(withText(name)).perform(click());
@@ -877,6 +895,10 @@ public class AllWidgetsFormTest {
 
     private String randomString() {
         return RandomString.make();
+    }
+
+    private boolean randomBoolean() {
+        return random.nextBoolean();
     }
 
     private int randomInt() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -140,6 +140,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         });
 
         toggleButton = findViewById(R.id.toggle_button);
+        toggleButton.setEnabled(listView.getCheckedItemCount() > 0);
         toggleButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -646,6 +647,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             updateAdapter();
             selectSupersededForms();
             downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
+            toggleButton.setEnabled(listView.getCheckedItemCount() > 0);
             toggleButtonLabel(toggleButton, listView);
         }
     }


### PR DESCRIPTION
Closes #1919

I have added two checks for disabling the "Select all" or "Clear all" button. One is in onCreate method, so it is disabled when we first enter the activity, and then in formListDownloadingComplete method, if there is data to be shown, the button becomes enabled.