### PR TITLE
Disabling "select all" button when there is nothing to show

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -142,6 +142,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         });
 
         toggleButton = findViewById(R.id.toggle_button);
+        toggleButton.setEnabled(listView.getCheckedItemCount() > 0);
         toggleButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -656,6 +657,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             updateAdapter();
             selectSupersededForms();
             downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
+            toggleButton.setEnabled(listView.getCheckedItemCount() > 0);
             toggleButtonLabel(toggleButton, listView);
         }
     }


### PR DESCRIPTION
Closes #1919 

I have added two checks for disabling the "Select all" or "Clear all" button. One is in onCreate method, so it is disabled when we first enter the activity, and then in formListDownloadingComplete method, if there is data to be shown, the button becomes enabled.