### PR TITLE
Fix: Handle image chooser intent

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -154,9 +154,9 @@ public class ShowQRCodeFragment extends Fragment implements View.OnClickListener
                     startActivityForResult(photoPickerIntent, SELECT_PHOTO);
                 } else {
                     Toast.makeText(getActivity(),
-                            getString(R.string.activity_not_found, "choose image"),
+                            getString(R.string.activity_not_found, "select image"),
                             Toast.LENGTH_SHORT).show();
-                    Timber.w(getString(R.string.activity_not_found, "choose image"));
+                    Timber.w(getString(R.string.activity_not_found, "select image"));
                 }
                 break;
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -35,6 +35,7 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
@@ -149,7 +150,14 @@ public class ShowQRCodeFragment extends Fragment implements View.OnClickListener
             case R.id.btnSelect:
                 Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
                 photoPickerIntent.setType("image/*");
-                startActivityForResult(photoPickerIntent, SELECT_PHOTO);
+                if (photoPickerIntent.resolveActivity(getActivity().getPackageManager()) != null) {
+                    startActivityForResult(photoPickerIntent, SELECT_PHOTO);
+                } else {
+                    Toast.makeText(getActivity(),
+                            getString(R.string.activity_not_found, "choose image"),
+                            Toast.LENGTH_SHORT).show();
+                    Timber.w(getString(R.string.activity_not_found, "choose image"));
+                }
                 break;
 
             case R.id.edit_qrcode:


### PR DESCRIPTION
Closes #1932 

#### What has been done to verify that this works as intended?
#### Why is this the best possible solution? Were any other approaches considered?
It handles check for the `packageManager()` , an ideal solution

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

@lognaturel please review