### PR TITLE
Refactors FormEntryActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -227,7 +227,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private ImageButton nextButton;
     private ImageButton backButton;
 
-    private Toolbar toolbar;
     private ODKView odkView;
 
     enum AnimationType {
@@ -274,21 +273,15 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         initToolbar();
 
         nextButton = findViewById(R.id.form_forward_button);
-        nextButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                beenSwiped = true;
-                showNextView();
-            }
+        nextButton.setOnClickListener(v -> {
+            beenSwiped = true;
+            showNextView();
         });
 
         backButton = findViewById(R.id.form_back_button);
-        backButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                beenSwiped = true;
-                showPreviousView();
-            }
+        backButton.setOnClickListener(v -> {
+            beenSwiped = true;
+            showPreviousView();
         });
 
         String startingXPath = null;
@@ -377,8 +370,8 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
                 } else if (uriMimeType != null && uriMimeType.equals(InstanceColumns.CONTENT_ITEM_TYPE)) {
                     // get the formId and version for this instance...
-                    String jrFormId = null;
-                    String jrVersion = null;
+                    String jrFormId;
+                    String jrVersion;
                     {
                         Cursor instanceCursor = null;
                         try {
@@ -540,9 +533,9 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     }
 
     private void initToolbar() {
-        toolbar = findViewById(R.id.toolbar);
-        setTitle(getString(R.string.loading_form));
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        setTitle(getString(R.string.loading_form));
     }
 
     /**
@@ -824,35 +817,26 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 final File newImage = new File(destImagePath);
                 FileUtils.copyFile(chosenImage, newImage);
                 ImageConverter.execute(newImage.getPath(), getWidgetWaitingForBinaryData(), this);
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        dismissDialog(SAVING_IMAGE_DIALOG);
-                        if (getCurrentViewIfODKView() != null) {
-                            getCurrentViewIfODKView().setBinaryData(newImage);
-                        }
-                        saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
-                        refreshCurrentView();
+                runOnUiThread(() -> {
+                    dismissDialog(SAVING_IMAGE_DIALOG);
+                    if (getCurrentViewIfODKView() != null) {
+                        getCurrentViewIfODKView().setBinaryData(newImage);
                     }
+                    saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
+                    refreshCurrentView();
                 });
             } else {
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        dismissDialog(SAVING_IMAGE_DIALOG);
-                        Timber.e("Could not receive chosen image");
-                        showCustomToast(getString(R.string.error_occured), Toast.LENGTH_SHORT);
-                    }
+                runOnUiThread(() -> {
+                    dismissDialog(SAVING_IMAGE_DIALOG);
+                    Timber.e("Could not receive chosen image");
+                    showCustomToast(getString(R.string.error_occured), Toast.LENGTH_SHORT);
                 });
             }
         } catch (GDriveConnectionException e) {
-            runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    dismissDialog(SAVING_IMAGE_DIALOG);
-                    Timber.e("Could not receive chosen image due to connection problem");
-                    showCustomToast(getString(R.string.gdrive_connection_exception), Toast.LENGTH_LONG);
-                }
+            runOnUiThread(() -> {
+                dismissDialog(SAVING_IMAGE_DIALOG);
+                Timber.e("Could not receive chosen image due to connection problem");
+                showCustomToast(getString(R.string.gdrive_connection_exception), Toast.LENGTH_LONG);
             });
         }
     }
@@ -1752,17 +1736,14 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
                             @Override
                             public void run() {
-                                FormEntryActivity.this.runOnUiThread(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        try {
-                                            Thread.sleep(500);
-                                        } catch (InterruptedException e) {
-                                            //This is rare
-                                            Timber.e(e);
-                                        }
-                                        showNextView();
+                                FormEntryActivity.this.runOnUiThread(() -> {
+                                    try {
+                                        Thread.sleep(500);
+                                    } catch (InterruptedException e) {
+                                        //This is rare
+                                        Timber.e(e);
                                     }
+                                    showNextView();
                                 });
                             }
                         }.start();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -341,7 +341,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             saveToDiskTask = (SaveToDiskTask) data;
         } else if (data == null) {
             if (!newForm) {
-                if (Collect.getInstance().getFormController() != null) {
+                if (getFormController() != null) {
                     refreshCurrentView();
                 } else {
                     Timber.w("Reloading form and restoring state.");
@@ -555,7 +555,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             savePointTask.execute();
 
             if (!allowMovingBackwards) {
-                FormController formController = Collect.getInstance().getFormController();
+                FormController formController = getFormController();
                 if (formController != null) {
                     new SaveFormIndexTask(this, formController.getFormIndex()).execute();
                 }
@@ -605,8 +605,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     @Override
     protected void onActivityResult(int requestCode, int resultCode, final Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         if (formController == null) {
             // we must be in the midst of a reload of the FormController.
             // try to save this callback data to the FormLoaderTask
@@ -815,10 +814,8 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
     private void saveChosenImage(Uri selectedImage) {
         // Copy file to sdcard
-        String instanceFolder1 = Collect.getInstance().getFormController().getInstancePath()
-                .getParent();
-        String destImagePath = instanceFolder1 + File.separator
-                + System.currentTimeMillis() + ".jpg";
+        String instanceFolder1 = getFormController().getInstancePath().getParent();
+        String destImagePath = instanceFolder1 + File.separator + System.currentTimeMillis() + ".jpg";
 
         File chosenImage;
         try {
@@ -888,9 +885,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      * changes, so they're resynchronized here.
      */
     public void refreshCurrentView() {
-        FormController formController = Collect.getInstance()
-                .getFormController();
-        int event = formController.getEvent();
+        int event = getFormController().getEvent();
 
         // When we refresh, repeat dialog state isn't maintained, so step back
         // to the previous
@@ -932,8 +927,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         menu.findItem(R.id.menu_goto).setVisible(useability)
                 .setEnabled(useability);
 
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
 
         useability = (boolean) AdminSharedPreferences.getInstance().get(AdminKeys.KEY_CHANGE_LANGUAGE)
                 && (formController != null)
@@ -952,8 +946,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         switch (item.getItemId()) {
             case R.id.menu_languages:
                 Collect.getInstance()
@@ -1008,8 +1001,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      * etc...), true otherwise.
      */
     private boolean saveAnswersForCurrentScreen(boolean evaluateConstraints) {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         // only try to save if the current event is a question or a field-list group
         // and current view is an ODKView (occasionally we show blank views that do not have any
         // controls to save data from)
@@ -1048,8 +1040,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         super.onCreateContextMenu(menu, v, menuInfo);
         Collect.getInstance().getActivityLogger()
                 .logInstanceAction(this, "onCreateContextMenu", "show");
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
 
         menu.add(0, v.getId(), 0, getString(R.string.clear_answer));
         if (formController.indexContainsRepeatableGroup()) {
@@ -1105,8 +1096,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      */
     @Override
     public Object onRetainCustomNonConfigurationInstance() {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         // if a form is loading, pass the loader task
         if (formLoaderTask != null
                 && formLoaderTask.getStatus() != AsyncTask.Status.FINISHED) {
@@ -1133,8 +1123,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      * @return newly created View
      */
     private View createView(int event, boolean advancingPage) {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
 
         setTitle(formController.getFormTitle());
 
@@ -1383,8 +1372,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private void showNextView() {
         state = null;
         try {
-            FormController formController = Collect.getInstance()
-                    .getFormController();
+            FormController formController = getFormController();
 
             // get constraint behavior preference value with appropriate default
             String constraintBehavior = (String) GeneralSharedPreferences.getInstance()
@@ -1459,7 +1447,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         if (allowMovingBackwards) {
             state = null;
             try {
-                FormController formController = Collect.getInstance().getFormController();
+                FormController formController = getFormController();
                 if (formController != null) {
                     // The answer is saved on a back swipe, but question constraints are
                     // ignored.
@@ -1599,11 +1587,11 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "showView", logString);
 
-        FormController formController = Collect.getInstance().getFormController();
+        FormController formController = getFormController();
         if (formController.getEvent() == FormEntryController.EVENT_QUESTION
                 || formController.getEvent() == FormEntryController.EVENT_GROUP
                 || formController.getEvent() == FormEntryController.EVENT_REPEAT) {
-            FormEntryPrompt[] prompts = Collect.getInstance().getFormController()
+            FormEntryPrompt[] prompts = getFormController()
                     .getQuestionPrompts();
             for (FormEntryPrompt p : prompts) {
                 List<TreeElement> attrs = p.getBindAttributes();
@@ -1633,8 +1621,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      * Creates and displays a dialog displaying the violated constraint.
      */
     private void createConstraintToast(FormIndex index, int saveStatus) {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         String constraintText;
         switch (saveStatus) {
             case FormEntryController.ANSWER_CONSTRAINT_VIOLATED:
@@ -1717,8 +1704,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             @Override
             public void onClick(DialogInterface dialog, int i) {
                 shownAlertDialogIsGroupRepeat = false;
-                FormController formController = Collect.getInstance()
-                        .getFormController();
+                FormController formController = getFormController();
                 switch (i) {
                     case BUTTON_POSITIVE: // yes, repeat
                         Collect.getInstance()
@@ -1785,8 +1771,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 }
             }
         };
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         if (formController.getLastRepeatCount() > 0) {
             alertDialog.setTitle(getString(R.string.leaving_repeat_ask));
             alertDialog.setMessage(getString(R.string.add_another_repeat,
@@ -1859,8 +1844,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 .getActivityLogger()
                 .logInstanceAction(this, "createDeleteRepeatConfirmDialog",
                         "show");
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
 
         alertDialog = new AlertDialog.Builder(this).create();
         String name = formController.getLastRepeatedGroupName();
@@ -1874,8 +1858,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int i) {
-                FormController formController = Collect.getInstance()
-                        .getFormController();
+                FormController formController = getFormController();
                 switch (i) {
                     case BUTTON_POSITIVE: // yes
                         Collect.getInstance()
@@ -1947,7 +1930,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private void createQuitDialog() {
         String title;
         {
-            FormController formController = Collect.getInstance().getFormController();
+            FormController formController = getFormController();
             title = (formController == null) ? null : formController.getFormTitle();
             if (title == null) {
                 title = getString(R.string.no_form_loaded);
@@ -1988,7 +1971,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                         manager.close();
                     }
 
-                    FormController formController = Collect.getInstance().getFormController();
+                    FormController formController = getFormController();
                     if (formController != null) {
                         formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_EXIT, 0, null, false, true);
                     }
@@ -2018,7 +2001,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
     // Cleanup when user exits a form without saving
     private void removeTempInstance() {
-        FormController formController = Collect.getInstance().getFormController();
+        FormController formController = getFormController();
 
         if (formController != null && formController.getInstancePath() != null) {
             SaveToDiskTask.removeSavepointFiles(formController.getInstancePath().getName());
@@ -2104,8 +2087,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     private void createLanguageDialog() {
         Collect.getInstance().getActivityLogger()
                 .logInstanceAction(this, "createLanguageDialog", "show");
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         final String[] languages = formController.getLanguages();
         int selected = -1;
         if (languages != null) {
@@ -2143,10 +2125,8 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                                                 "createLanguageDialog",
                                                 "changeLanguage."
                                                         + languages[whichButton]);
-                                FormController formController = Collect
-                                        .getInstance().getFormController();
-                                formController
-                                        .setLanguage(languages[whichButton]);
+                                FormController formController = getFormController();
+                                formController.setLanguage(languages[whichButton]);
                                 dialog.dismiss();
                                 if (formController.currentPromptIsQuestion()) {
                                     saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
@@ -2263,8 +2243,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
     @Override
     protected void onPause() {
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         dismissDialogs();
         // make sure we're not already saving to disk. if we are, currentPrompt
         // is getting constantly updated
@@ -2301,7 +2280,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             }
         }
 
-        FormController formController = Collect.getInstance().getFormController();
+        FormController formController = getFormController();
         Collect.getInstance().getActivityLogger().open();
 
         if (formLoaderTask != null) {
@@ -2579,8 +2558,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         dismissDialog(SAVING_DIALOG);
 
         int saveStatus = saveResult.getSaveResult();
-        FormController formController = Collect.getInstance()
-                .getFormController();
+        FormController formController = getFormController();
         switch (saveStatus) {
             case SaveToDiskTask.SAVED:
                 ToastUtils.showShortToast(R.string.data_saved_ok);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -79,6 +79,7 @@ import org.odk.collect.android.adapters.IconMenuListAdapter;
 import org.odk.collect.android.adapters.model.IconMenuItem;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
 import org.odk.collect.android.exception.GDriveConnectionException;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.external.ExternalDataManager;
@@ -104,7 +105,6 @@ import org.odk.collect.android.tasks.SaveResult;
 import org.odk.collect.android.tasks.SaveToDiskTask;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ApplicationConstants;
-import org.odk.collect.android.utilities.DbUtils;
 import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FileUtils;
@@ -986,7 +986,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                         .logInstanceAction(this, "onOptionsItemSelected",
                                 "MENU_SAVE");
                 // don't exit
-                saveDataToDisk(DO_NOT_EXIT, DbUtils.isInstanceComplete(false), null);
+                saveDataToDisk(DO_NOT_EXIT, InstancesDaoHelper.isInstanceComplete(false), null);
                 return true;
             case R.id.menu_goto:
                 state = null;
@@ -1172,7 +1172,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 // checkbox for if finished or ready to send
                 final CheckBox instanceComplete = endView
                         .findViewById(R.id.mark_finished);
-                instanceComplete.setChecked(DbUtils.isInstanceComplete(true));
+                instanceComplete.setChecked(InstancesDaoHelper.isInstanceComplete(true));
 
                 if (!(boolean) AdminSharedPreferences.getInstance().get(AdminKeys.KEY_MARK_AS_FINALIZED)) {
                     instanceComplete.setVisibility(View.GONE);
@@ -1994,7 +1994,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 if (item.getTextResId() == R.string.keep_changes) {
                     Collect.getInstance().getActivityLogger()
                             .logInstanceAction(this, "createQuitDialog", "saveAndExit");
-                    saveDataToDisk(EXIT, DbUtils.isInstanceComplete(false),
+                    saveDataToDisk(EXIT, InstancesDaoHelper.isInstanceComplete(false),
                             null);
                 } else {
                     Collect.getInstance().getActivityLogger()
@@ -2043,7 +2043,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         }
 
         // if it's not already saved, erase everything
-        if (!DbUtils.isInstanceAvailable(getInstancePath())) {
+        if (!InstancesDaoHelper.isInstanceAvailable(getInstancePath())) {
             // delete media first
             String instanceFolder = formController.getInstancePath().getParent();
             Timber.i("Attempting to delete: %s", instanceFolder);
@@ -2692,7 +2692,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         String action = getIntent().getAction();
         if (Intent.ACTION_PICK.equals(action) || Intent.ACTION_EDIT.equals(action)) {
             // caller is waiting on a picked form
-            Uri uri = DbUtils.getLastInstanceUri(getInstancePath());
+            Uri uri = InstancesDaoHelper.getLastInstanceUri(getInstancePath());
             if (uri != null) {
                 setResult(RESULT_OK, new Intent().setData(uri));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -535,7 +535,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         FormController formController = getFormController();
         if (formController != null) {
             if (formController.getInstancePath() != null) {
-                outState.putString(KEY_INSTANCEPATH, getInstancePath());
+                outState.putString(KEY_INSTANCEPATH, getAbsoluteInstancePath());
             }
             outState.putString(KEY_XPATH,
                     formController.getXPath(formController.getFormIndex()));
@@ -1955,7 +1955,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         }
 
         // if it's not already saved, erase everything
-        if (!InstancesDaoHelper.isInstanceAvailable(getInstancePath())) {
+        if (!InstancesDaoHelper.isInstanceAvailable(getAbsoluteInstancePath())) {
             // delete media first
             String instanceFolder = formController.getInstancePath().getParent();
             Timber.i("Attempting to delete: %s", instanceFolder);
@@ -1970,7 +1970,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         }
     }
 
-    private String getInstancePath() {
+    private String getAbsoluteInstancePath() {
         return getFormController().getInstancePath().getAbsolutePath();
     }
 
@@ -2586,7 +2586,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         String action = getIntent().getAction();
         if (Intent.ACTION_PICK.equals(action) || Intent.ACTION_EDIT.equals(action)) {
             // caller is waiting on a picked form
-            Uri uri = InstancesDaoHelper.getLastInstanceUri(getInstancePath());
+            Uri uri = InstancesDaoHelper.getLastInstanceUri(getAbsoluteInstancePath());
             if (uri != null) {
                 setResult(RESULT_OK, new Intent().setData(uri));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/ContentResolverHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/ContentResolverHelper.java
@@ -23,8 +23,11 @@ import org.odk.collect.android.logic.FormInfo;
 import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
-public class ContentResolverHelper {
+public final class ContentResolverHelper {
 
+    private ContentResolverHelper() {
+
+    }
 
     public static FormInfo getFormDetails(Uri uri) {
         FormInfo formInfo = null;

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/ContentResolverHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/ContentResolverHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.odk.collect.android.dao.helpers;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FormInfo;
+import org.odk.collect.android.provider.FormsProviderAPI;
+import org.odk.collect.android.provider.InstanceProviderAPI;
+
+public class ContentResolverHelper {
+
+
+    public static FormInfo getFormDetails(Uri uri) {
+        FormInfo formInfo = null;
+
+        ContentResolver contentResolver = Collect.getInstance().getContentResolver();
+
+        try (Cursor instanceCursor = contentResolver.query(uri, null, null, null, null)) {
+            if (instanceCursor != null && instanceCursor.getCount() > 0) {
+                instanceCursor.moveToFirst();
+                String instancePath = instanceCursor
+                        .getString(instanceCursor
+                                .getColumnIndex(
+                                        InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH));
+
+                String jrFormId = instanceCursor
+                        .getString(instanceCursor
+                                .getColumnIndex(InstanceProviderAPI.InstanceColumns.JR_FORM_ID));
+                int idxJrVersion = instanceCursor
+                        .getColumnIndex(InstanceProviderAPI.InstanceColumns.JR_VERSION);
+
+                String jrVersion = instanceCursor.isNull(idxJrVersion) ? null
+                        : instanceCursor
+                        .getString(idxJrVersion);
+                formInfo = new FormInfo(instancePath, jrFormId, jrVersion);
+            }
+        }
+        return formInfo;
+    }
+
+    public static String getFormPath(Uri uri) {
+        String formPath = null;
+        ContentResolver contentResolver = Collect.getInstance().getContentResolver();
+        try (Cursor c = contentResolver.query(uri, null, null, null, null)) {
+            if (c != null && c.getCount() == 1) {
+                c.moveToFirst();
+                formPath = c.getString(c.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH));
+            }
+        }
+        return formPath;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
@@ -25,10 +25,6 @@ public final class FormsDaoHelper {
 
     }
 
-    /**
-     * Returns the number of rows with the given query.
-     * If the cursor fails to open then returns -1.
-     */
     public static int getFormsCount(String selection, String[] selectionArgs) {
         int count = -1;
         try (Cursor c = new FormsDao().getFormsCursor(selection, selectionArgs)) {
@@ -36,7 +32,11 @@ public final class FormsDaoHelper {
                 count = c.getCount();
             }
         }
-        return count;
+        if (count == -1) {
+            throw new RuntimeException("Could not open the cursor properly");
+        } else {
+            return count;
+        }
     }
 
     public static String getFormPath(String selection, String[] selectionArgs) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
@@ -25,6 +25,10 @@ public final class FormsDaoHelper {
 
     }
 
+    /**
+     * Returns the number of rows with the given query.
+     * If the cursor fails to open then returns -1.
+     */
     public static int getFormsCount(String selection, String[] selectionArgs) {
         int count = -1;
         try (Cursor c = new FormsDao().getFormsCursor(selection, selectionArgs)) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
@@ -1,0 +1,7 @@
+package org.odk.collect.android.dao.helpers;
+
+/**
+ * @author Shobhit Agarwal
+ */
+public class FormsDaoHelper {
+}

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
@@ -19,7 +19,11 @@ import android.database.Cursor;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.provider.FormsProviderAPI;
 
-public class FormsDaoHelper {
+public final class FormsDaoHelper {
+
+    private FormsDaoHelper() {
+
+    }
 
     public static int getFormsCount(String selection, String[] selectionArgs) {
         int count = -1;

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
@@ -26,17 +26,13 @@ public final class FormsDaoHelper {
     }
 
     public static int getFormsCount(String selection, String[] selectionArgs) {
-        int count = -1;
         try (Cursor c = new FormsDao().getFormsCursor(selection, selectionArgs)) {
             if (c != null) {
-                count = c.getCount();
+                return c.getCount();
             }
         }
-        if (count == -1) {
-            throw new RuntimeException("Could not open the cursor properly");
-        } else {
-            return count;
-        }
+
+        throw new RuntimeException("Unable to get the forms count");
     }
 
     public static String getFormPath(String selection, String[] selectionArgs) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/FormsDaoHelper.java
@@ -1,7 +1,56 @@
+/*
+ * Copyright (C) 2018 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.odk.collect.android.dao.helpers;
 
-/**
- * @author Shobhit Agarwal
- */
+import android.database.Cursor;
+
+import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.provider.FormsProviderAPI;
+
 public class FormsDaoHelper {
+
+    public static int getFormsCount(String selection, String[] selectionArgs) {
+        int count = -1;
+        try (Cursor c = new FormsDao().getFormsCursor(selection, selectionArgs)) {
+            if (c != null) {
+                count = c.getCount();
+            }
+        }
+        return count;
+    }
+
+    public static String getFormPath(String selection, String[] selectionArgs) {
+        FormsDao formsDao = new FormsDao();
+        String formPath = null;
+        try (Cursor c = formsDao.getFormsCursor(selection, selectionArgs)) {
+            if (c != null && c.getCount() > 0) {
+                c.moveToFirst();
+                formPath = c.getString(c.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH));
+            }
+        }
+        return formPath;
+    }
+
+    public static String getFormLanguage(String formPath) {
+        String newLanguage = "";
+        try (Cursor c = new FormsDao().getFormsCursorForFormFilePath(formPath)) {
+            if (c.getCount() == 1) {
+                c.moveToFirst();
+                newLanguage = c.getString(c.getColumnIndex(FormsProviderAPI.FormsColumns.LANGUAGE));
+            }
+        }
+        return newLanguage;
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
@@ -1,18 +1,4 @@
-/*
- * Copyright (C) 2018 Shobhit Agarwal
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
-package org.odk.collect.android.utilities;
+package org.odk.collect.android.dao.helpers;
 
 import android.database.Cursor;
 import android.net.Uri;
@@ -26,11 +12,10 @@ import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import timber.log.Timber;
 
-public final class DbUtils {
-
-    private DbUtils() {
-
-    }
+/**
+ * @author Shobhit Agarwal
+ */
+public class InstancesDaoHelper {
 
     /**
      * Checks the database to determine if the current instance being edited has

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (C) 2018 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.odk.collect.android.dao.helpers;
 
 import android.database.Cursor;
@@ -12,9 +26,6 @@ import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import timber.log.Timber;
 
-/**
- * @author Shobhit Agarwal
- */
 public class InstancesDaoHelper {
 
     /**
@@ -69,7 +80,6 @@ public class InstancesDaoHelper {
         try (Cursor c = new InstancesDao().getInstancesCursorForFilePath(path)) {
             if (c != null) {
                 isAvailable = c.getCount() > 0;
-                c.close();
             }
         }
         return isAvailable;

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
@@ -26,7 +26,11 @@ import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import timber.log.Timber;
 
-public class InstancesDaoHelper {
+public final class InstancesDaoHelper {
+
+    private InstancesDaoHelper() {
+
+    }
 
     /**
      * Checks the database to determine if the current instance being edited has

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormInfo.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.odk.collect.android.logic;
+
+public class FormInfo {
+
+    private final String formVersion;
+    private final String formID;
+    private final String instancePath;
+
+    public FormInfo(String instancePath, String formID, String formVersion) {
+        this.instancePath = instancePath;
+        this.formID = formID;
+        this.formVersion = formVersion;
+    }
+
+    public String getFormVersion() {
+        return formVersion;
+    }
+
+    public String getFormID() {
+        return formID;
+    }
+
+    public String getInstancePath() {
+        return instancePath;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DbUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DbUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.database.Cursor;
+import android.net.Uri;
+
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.preferences.PreferenceKeys;
+import org.odk.collect.android.provider.InstanceProviderAPI;
+
+import timber.log.Timber;
+
+public final class DbUtils {
+
+    private DbUtils() {
+
+    }
+
+    /**
+     * Checks the database to determine if the current instance being edited has
+     * already been 'marked completed'. A form can be 'unmarked' complete and
+     * then resaved.
+     *
+     * @return true if form has been marked completed, false otherwise.
+     */
+    public static boolean isInstanceComplete(boolean end) {
+        // default to false if we're mid form
+        boolean complete = false;
+
+        FormController formController = Collect.getInstance().getFormController();
+        if (formController != null) {
+            // First check if we're at the end of the form, then check the preferences
+            complete = end && (boolean) GeneralSharedPreferences.getInstance()
+                    .get(PreferenceKeys.KEY_COMPLETED_DEFAULT);
+
+            // Then see if we've already marked this form as complete before
+            String path = formController.getInstancePath().getAbsolutePath();
+            try (Cursor c = new InstancesDao().getInstancesCursorForFilePath(path)) {
+                if (c != null && c.getCount() > 0) {
+                    c.moveToFirst();
+                    int columnIndex = c.getColumnIndex(InstanceProviderAPI.InstanceColumns.STATUS);
+                    String status = c.getString(columnIndex);
+                    if (InstanceProviderAPI.STATUS_COMPLETE.equals(status)) {
+                        complete = true;
+                    }
+                }
+            }
+        } else {
+            Timber.w("FormController has a null value");
+        }
+        return complete;
+    }
+
+    public static Uri getLastInstanceUri(String path) {
+        try (Cursor c = new InstancesDao().getInstancesCursorForFilePath(path)) {
+            if (c != null && c.getCount() > 0) {
+                // should only be one...
+                c.moveToFirst();
+                String id = c.getString(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID));
+                return Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI, id);
+            }
+        }
+        return null;
+    }
+
+    public static boolean isInstanceAvailable(String path) {
+        boolean isAvailable = false;
+        try (Cursor c = new InstancesDao().getInstancesCursorForFilePath(path)) {
+            if (c != null) {
+                isAvailable = c.getCount() > 0;
+                c.close();
+            }
+        }
+        return isAvailable;
+    }
+}


### PR DESCRIPTION
`FormEntryActivity` is one of the most important classes in the codebase and is huge in size. This makes the code less readable and complex.   
The purpose of this PR is to reduce the size of FormEntryActivity by moving the logic related to FormsDao, InstacesDao, and ContentResolvers into separate helper classes so that `FormEntryActivity` can be made more maintainable and less coupled

#### What has been done to verify that this works as intended?
Verified that this does not change the behavior by running the app on a physical device and tried saving, editing forms. 

#### Why is this the best possible solution? Were any other approaches considered?
I don't know if this is the best possible solution but this seemed like a decent approach to me. Feedback is most welcome.

#### Are there any risks to merging this code? If so, what are they?
Yes, refactoring always has some risks 

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form can be used