### PR TITLE
Added Background Service to download Form

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -308,6 +308,8 @@ the specific language governing permissions and limitations under the License.
 
         <activity
             android:name=".activities.WebViewActivity" />
+
+        <service android:name=".services.DownloadFormService"/>
     </application>
 
 </manifest>

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -42,6 +42,7 @@ import org.odk.collect.android.listeners.FormDownloaderListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.preferences.PreferencesActivity;
+import org.odk.collect.android.services.DownloadFormService;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.AuthDialogUtility;
@@ -73,8 +74,11 @@ import timber.log.Timber;
  * @author Carl Hartung (carlhartung@gmail.com)
  */
 public class FormDownloadList extends FormListActivity implements FormListDownloaderListener,
-        FormDownloaderListener, AuthDialogUtility.AuthDialogUtilityResultListener, AdapterView.OnItemClickListener {
+        AuthDialogUtility.AuthDialogUtilityResultListener, AdapterView.OnItemClickListener {
     private static final String FORM_DOWNLOAD_LIST_SORTING_ORDER = "formDownloadListSortingOrder";
+
+    private static final String ACTION_DOWNLOAD_FORM = "downloadForm";
+    private static final String FORM_LIST = "formList" ;
 
     private static final int PROGRESS_DIALOG = 1;
     private static final int AUTH_DIALOG = 2;
@@ -106,7 +110,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private Button downloadButton;
 
     private DownloadFormListTask downloadFormListTask;
-    private DownloadFormsTask downloadFormsTask;
     private Button toggleButton;
 
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<String, FormDetails>();
@@ -219,17 +222,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 } catch (IllegalArgumentException e) {
                     Timber.i("Attempting to close a dialog that was not previously opened");
                 }
-                downloadFormsTask = null;
-            }
-        } else if (getLastNonConfigurationInstance() instanceof DownloadFormsTask) {
-            downloadFormsTask = (DownloadFormsTask) getLastNonConfigurationInstance();
-            if (downloadFormsTask.getStatus() == AsyncTask.Status.FINISHED) {
-                try {
-                    dismissDialog(PROGRESS_DIALOG);
-                } catch (IllegalArgumentException e) {
-                    Timber.i("Attempting to close a dialog that was not previously opened");
-                }
-                downloadFormsTask = null;
+
             }
         } else if (formNamesAndURLs.isEmpty() && getLastNonConfigurationInstance() == null) {
             // first time, so get the formlist
@@ -390,10 +383,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                                     downloadFormListTask.cancel(true);
                                     downloadFormListTask = null;
                                 }
-                                if (downloadFormsTask != null) {
-                                    showDialog(CANCELLATION_DIALOG);
-                                    downloadFormsTask.cancel(true);
-                                }
                             }
                         };
                 progressDialog.setTitle(getString(R.string.downloading_data));
@@ -499,11 +488,12 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
         if (totalCount > 0) {
             // show dialog box
-            showDialog(PROGRESS_DIALOG);
-
-            downloadFormsTask = new DownloadFormsTask();
-            downloadFormsTask.setDownloaderListener(this);
-            downloadFormsTask.execute(filesToDownload);
+           Intent downloadFormIntent = new Intent(this, DownloadFormService.class);
+           Bundle bundle = new Bundle();
+           bundle.putParcelableArrayList(FORM_LIST,filesToDownload);
+           downloadFormIntent.putExtras(bundle);
+           downloadFormIntent.setAction(ACTION_DOWNLOAD_FORM);
+           startService(downloadFormIntent);
         } else {
             ToastUtils.showShortToast(R.string.noselect_error);
         }
@@ -512,11 +502,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     @Override
     public Object onRetainCustomNonConfigurationInstance() {
-        if (downloadFormsTask != null) {
-            return downloadFormsTask;
-        } else {
             return downloadFormListTask;
-        }
     }
 
 
@@ -524,9 +510,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onDestroy() {
         if (downloadFormListTask != null) {
             downloadFormListTask.setDownloaderListener(null);
-        }
-        if (downloadFormsTask != null) {
-            downloadFormsTask.setDownloaderListener(null);
         }
         super.onDestroy();
     }
@@ -536,9 +519,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onResume() {
         if (downloadFormListTask != null) {
             downloadFormListTask.setDownloaderListener(this);
-        }
-        if (downloadFormsTask != null) {
-            downloadFormsTask.setDownloaderListener(this);
         }
         if (alertShowing) {
             createAlertDialog(alertTitle, alertMsg, shouldExit);
@@ -695,49 +675,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         alertShowing = true;
         this.shouldExit = shouldExit;
         alertDialog.show();
-    }
-
-
-    @Override
-    public void progressUpdate(String currentFile, int progress, int total) {
-        alertMsg = getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total));
-        progressDialog.setMessage(alertMsg);
-    }
-
-
-    @Override
-    public void formsDownloadingComplete(HashMap<FormDetails, String> result) {
-        if (downloadFormsTask != null) {
-            downloadFormsTask.setDownloaderListener(null);
-        }
-
-        if (progressDialog.isShowing()) {
-            // should always be true here
-            progressDialog.dismiss();
-        }
-
-        Set<FormDetails> keys = result.keySet();
-        StringBuilder b = new StringBuilder();
-        for (FormDetails k : keys) {
-            b.append(k.getFormName() + " ("
-                    + ((k.getFormVersion() != null)
-                    ? (this.getString(R.string.version) + ": " + k.getFormVersion() + " ")
-                    : "") + "ID: " + k.getFormID() + ") - " + result.get(k));
-            b.append("\n\n");
-        }
-
-        createAlertDialog(getString(R.string.download_forms_result), b.toString().trim(), EXIT);
-    }
-
-    @Override
-    public void formsDownloadingCancelled() {
-        if (downloadFormsTask != null) {
-            downloadFormsTask.setDownloaderListener(null);
-            downloadFormsTask = null;
-        }
-        if (cancelDialog.isShowing()) {
-            cancelDialog.dismiss();
-        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormDetails.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormDetails.java
@@ -14,9 +14,12 @@
 
 package org.odk.collect.android.logic;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.io.Serializable;
 
-public class FormDetails implements Serializable {
+public class FormDetails implements Parcelable {
     private static final long serialVersionUID = 1L;
 
     private String errorStr;
@@ -43,6 +46,29 @@ public class FormDetails implements Serializable {
         this.isNewerFormVersionAvailable = isNewerFormVersionAvailable;
         this.areNewerMediaFilesAvailable = areNewerMediaFilesAvailable;
     }
+
+    protected FormDetails(Parcel in) {
+        errorStr = in.readString();
+        formName = in.readString();
+        downloadUrl = in.readString();
+        manifestUrl = in.readString();
+        formID = in.readString();
+        formVersion = in.readString();
+        isNewerFormVersionAvailable = in.readByte() != 0;
+        areNewerMediaFilesAvailable = in.readByte() != 0;
+    }
+
+    public static final Creator<FormDetails> CREATOR = new Creator<FormDetails>() {
+        @Override
+        public FormDetails createFromParcel(Parcel in) {
+            return new FormDetails(in);
+        }
+
+        @Override
+        public FormDetails[] newArray(int size) {
+            return new FormDetails[size];
+        }
+    };
 
     public String getErrorStr() {
         return errorStr;
@@ -74,5 +100,22 @@ public class FormDetails implements Serializable {
 
     public boolean areNewerMediaFilesAvailable() {
         return areNewerMediaFilesAvailable;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeString(errorStr);
+        parcel.writeString(formName);
+        parcel.writeString(downloadUrl);
+        parcel.writeString(manifestUrl);
+        parcel.writeString(formID);
+        parcel.writeString(formVersion);
+        parcel.writeByte((byte) (isNewerFormVersionAvailable ? 1 : 0));
+        parcel.writeByte((byte) (areNewerMediaFilesAvailable ? 1 : 0));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/services/DownloadFormService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/services/DownloadFormService.java
@@ -1,0 +1,113 @@
+package org.odk.collect.android.services;
+
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.listeners.FormDownloaderListener;
+import org.odk.collect.android.logic.FormDetails;
+import org.odk.collect.android.tasks.DownloadFormsTask;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * Created by sahil on 28/2/18.
+ */
+
+public class DownloadFormService extends Service implements FormDownloaderListener{
+
+    private static final String FORM_LIST = "formList" ;
+    private static final String ACTION_DOWNLOAD_FORM = "downloadForm";
+    private static final String ACTION_CANCEL = "cancelFormDownload";
+    private DownloadFormsTask downloadFormsTask;
+    private NotificationManagerCompat notificationManagerCompat;
+    private static final int DOWNLOADING_NOTIFICATION = 112121;
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        notificationManagerCompat = NotificationManagerCompat.from(this);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        switch (intent.getAction()){
+            case ACTION_DOWNLOAD_FORM:
+                ArrayList<FormDetails> list = intent.getExtras().getParcelableArrayList(FORM_LIST);
+                downloadFormsTask = new DownloadFormsTask();
+                downloadFormsTask.setDownloaderListener(this);
+                downloadFormsTask.execute(list);
+                return Service.START_NOT_STICKY;
+            case ACTION_CANCEL:
+                formsDownloadingCancelled();
+                return  Service.START_NOT_STICKY;
+            default:
+                return super.onStartCommand(intent, flags, startId);
+        }
+
+
+    }
+
+
+    @Override
+    public void formsDownloadingComplete(HashMap<FormDetails, String> result) {
+        if (downloadFormsTask != null) {
+            downloadFormsTask.setDownloaderListener(null);
+        }
+
+        Set<FormDetails> keys = result.keySet();
+        StringBuilder b = new StringBuilder();
+        for (FormDetails k : keys) {
+            b.append(k.getFormName() + " ("
+                    + ((k.getFormVersion() != null)
+                    ? (this.getString(R.string.version) + ": " + k.getFormVersion() + " ")
+                    : "") + "ID: " + k.getFormID() + ") - " + result.get(k));
+            b.append("\n\n");
+        }
+        notificationManagerCompat.cancel(DOWNLOADING_NOTIFICATION);
+        notificationManagerCompat.notify(DOWNLOADING_NOTIFICATION, notificationBuilder(this,b.toString()).build());
+
+    }
+
+    @Override
+    public void progressUpdate(String currentFile, int progress, int total) {
+           notificationManagerCompat.notify(DOWNLOADING_NOTIFICATION,notificationBuilder(this, getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total))).build());
+    }
+
+    @Override
+    public void formsDownloadingCancelled() {
+        if (downloadFormsTask != null) {
+            downloadFormsTask.setDownloaderListener(null);
+            downloadFormsTask = null;
+        }
+        notificationManagerCompat.cancel(DOWNLOADING_NOTIFICATION);
+        stopSelf();
+
+    }
+
+    private NotificationCompat.Builder notificationBuilder(Context context, String notificationContent){
+        Intent cancelIntent = new Intent(this, DownloadFormService.class);
+        cancelIntent.setAction(ACTION_CANCEL);
+        PendingIntent cancelPendingIntent = PendingIntent.getService(context,0,cancelIntent,0);
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context)
+                .setSmallIcon(R.drawable.notes)
+                .setContentTitle(getString(R.string.downloading_data))
+                .setContentText(notificationContent)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .addAction(R.drawable.notes,getString(R.string.cancel_download_form),cancelPendingIntent);
+        return mBuilder;
+    }
+}

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -576,4 +576,5 @@
     <string name="newer_version_of_a_form_info">This is an updated version of a form you already have!</string>
     <string name="svg_file_does_not_exist">SVG file does not exist!</string>
     <string name="svg_not_supported_device">ImageMap widget requires Android 5 (Lollipop) or newer. Your device is not supported!</string>
+    <string name="cancel_download_form">Cancel</string>
 </resources>


### PR DESCRIPTION
Closes #1934 

#### What has been done to verify that this works as intended?
In order to download the form in the background , I have  created a service which will download the forms in the background and created a status notification to notify the user about the current status with an option to cancel the download the forms.

#### Why is this the best possible solution? Were any other approaches considered?
Created a background service is better option for an ultimate ux experience than foreground download of the forms such that user can do extra stuff on the application while downloading the form

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No