### PR TITLE
Use auto-send attribute instead of auto-submit

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
@@ -28,7 +28,7 @@ import timber.log.Timber;
 
 import static android.provider.BaseColumns._ID;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_DELETE;
-import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SUBMIT;
+import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SEND;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.DATE;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.DESCRIPTION;
@@ -260,7 +260,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
                     .begin(db)
                     .alter()
                     .table(FORMS_TABLE_NAME)
-                    .addColumn(AUTO_SUBMIT, "text")
+                    .addColumn(AUTO_SEND, "text")
                     .end();
 
             CustomSQLiteQueryBuilder
@@ -292,7 +292,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
                 + SUBMISSION_URI + " text, "
                 + BASE64_RSA_PUBLIC_KEY + " text, "
                 + JRCACHE_FILE_PATH + " text not null, "
-                + AUTO_SUBMIT + " text,"
+                + AUTO_SEND + " text,"
                 + AUTO_DELETE + " text);");
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -520,6 +520,6 @@ public class FormsProvider extends ContentProvider {
         sFormsProjectionMap.put(FormsColumns.JRCACHE_FILE_PATH, FormsColumns.JRCACHE_FILE_PATH);
         sFormsProjectionMap.put(FormsColumns.LANGUAGE, FormsColumns.LANGUAGE);
         sFormsProjectionMap.put(FormsColumns.AUTO_DELETE, FormsColumns.AUTO_DELETE);
-        sFormsProjectionMap.put(FormsColumns.AUTO_SUBMIT, FormsColumns.AUTO_SUBMIT);
+        sFormsProjectionMap.put(FormsColumns.AUTO_SEND, FormsColumns.AUTO_SEND);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -51,7 +51,8 @@ public final class FormsProviderAPI {
         public static final String SUBMISSION_URI = "submissionUri"; // can be null
         public static final String BASE64_RSA_PUBLIC_KEY = "base64RsaPublicKey"; // can be null
         public static final String AUTO_DELETE = "autoDelete"; // can be null
-        public static final String AUTO_SUBMIT = "autoSubmit"; // can be null
+        // Column is called autoSubmit for legacy support but the attribute is auto-send
+        public static final String AUTO_SEND = "autoSubmit"; // can be null
 
         // these are generated for you (but you can insert something else if you want)
         public static final String DISPLAY_SUBTEXT = "displaySubtext";

--- a/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
 
-import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SUBMIT;
+import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SEND;
 
 public class NetworkReceiver extends BroadcastReceiver implements InstanceUploaderListener {
 
@@ -158,20 +158,20 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
     /**
      * @param isFormAutoSendOptionEnabled represents whether the auto-send option is enabled at the app level
      *
-     * If the form explicitly sets the auto-submit property, then it overrides the preferences.
+     * If the form explicitly sets the auto-send property, then it overrides the preferences.
      */
     private boolean isFormAutoSendEnabled(String jrFormId, boolean isFormAutoSendOptionEnabled) {
         Cursor cursor = new FormsDao().getFormsCursorForFormId(jrFormId);
-        String autoSubmit = null;
+        String autoSend = null;
         if (cursor != null && cursor.moveToFirst()) {
             try {
-                int autoSubmitColumnIndex = cursor.getColumnIndex(AUTO_SUBMIT);
-                autoSubmit = cursor.getString(autoSubmitColumnIndex);
+                int autoSendColumnIndex = cursor.getColumnIndex(AUTO_SEND);
+                autoSend = cursor.getString(autoSendColumnIndex);
             } finally {
                 cursor.close();
             }
         }
-        return autoSubmit == null ? isFormAutoSendOptionEnabled : Boolean.valueOf(autoSubmit);
+        return autoSend == null ? isFormAutoSendOptionEnabled : Boolean.valueOf(autoSend);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -299,7 +299,7 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
             updateValues.put(FormsColumns.BASE64_RSA_PUBLIC_KEY, base64RsaPublicKey);
         }
         updateValues.put(FormsColumns.AUTO_DELETE, fields.get(FileUtils.AUTO_DELETE));
-        updateValues.put(FormsColumns.AUTO_SUBMIT, fields.get(FileUtils.AUTO_SUBMIT));
+        updateValues.put(FormsColumns.AUTO_SEND, fields.get(FileUtils.AUTO_SEND));
         
         // Note, the path doesn't change here, but it needs to be included so the
         // update will automatically update the .md5 and the cache path.

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -327,7 +327,7 @@ public class DownloadFormsTask extends
         v.put(FormsColumns.SUBMISSION_URI,          formInfo.get(FileUtils.SUBMISSIONURI));
         v.put(FormsColumns.BASE64_RSA_PUBLIC_KEY,   formInfo.get(FileUtils.BASE64_RSA_PUBLIC_KEY));
         v.put(FormsColumns.AUTO_DELETE,             formInfo.get(FileUtils.AUTO_DELETE));
-        v.put(FormsColumns.AUTO_SUBMIT,             formInfo.get(FileUtils.AUTO_SUBMIT));
+        v.put(FormsColumns.AUTO_SEND,             formInfo.get(FileUtils.AUTO_SEND));
         Uri uri = formsDao.saveForm(v);
         Collect.getInstance().getActivityLogger().logAction(this, "insert",
                 formFile.getAbsolutePath());

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -58,7 +58,7 @@ public class FileUtils {
     public static final String SUBMISSIONURI = "submission";
     public static final String BASE64_RSA_PUBLIC_KEY = "base64RsaPublicKey";
     public static final String AUTO_DELETE = "autoDelete";
-    public static final String AUTO_SUBMIT = "autoSubmit";
+    public static final String AUTO_SEND = "autoSend";
     static int bufSize = 16 * 1024; // May be set by unit test
 
     private FileUtils() {
@@ -369,13 +369,14 @@ public class FileUtils {
             final Element submission = model.getElement(xforms, "submission");
             final String base64RsaPublicKey = submission.getAttributeValue(null, "base64RsaPublicKey");
             final String autoDelete = submission.getAttributeValue(null, "auto-delete");
-            final String autoSubmit = submission.getAttributeValue(null, "auto-send");
+            final String autoSend = submission.getAttributeValue(null, "auto-send");
+
             fields.put(SUBMISSIONURI, submission.getAttributeValue(null, "action"));
             fields.put(BASE64_RSA_PUBLIC_KEY,
                     (base64RsaPublicKey == null || base64RsaPublicKey.trim().length() == 0)
                             ? null : base64RsaPublicKey.trim());
             fields.put(AUTO_DELETE, autoDelete);
-            fields.put(AUTO_SUBMIT, autoSubmit);
+            fields.put(AUTO_SEND, autoSend);
         } catch (Exception e) {
             Timber.i("XML file %s does not have a submission element", xmlFile.getAbsolutePath());
             // and that's totally fine.

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -369,7 +369,7 @@ public class FileUtils {
             final Element submission = model.getElement(xforms, "submission");
             final String base64RsaPublicKey = submission.getAttributeValue(null, "base64RsaPublicKey");
             final String autoDelete = submission.getAttributeValue(null, "auto-delete");
-            final String autoSubmit = submission.getAttributeValue(null, "auto-submit");
+            final String autoSubmit = submission.getAttributeValue(null, "auto-send");
             fields.put(SUBMISSIONURI, submission.getAttributeValue(null, "action"));
             fields.put(BASE64_RSA_PUBLIC_KEY,
                     (base64RsaPublicKey == null || base64RsaPublicKey.trim().length() == 0)


### PR DESCRIPTION
Closes #1952 

#### What has been done to verify that this works as intended?
Ran with a form with `auto-send` set to true, verified that form attempts to send.

#### Why is this the best possible solution? Were any other approaches considered?
I also considered changing the specification to `auto-submit` but I think that is more disruptive. The feature was listed in release notes as `auto-send`, it's now in pyxform and `auto-send` has been agreed on for a while.

This is something I should have noticed in code review but didn't. My apologies, @grzesiek2010.

#### Are there any risks to merging this code? If so, what are they?
This could be disruptive if someone has started using `auto-submit`. This is unlikely since the feature was released under 3 days ago, not announced broadly and required modifying XML. To mitigate the risk, we'll post an update on the forum.

The renaming was done with Android Studio support so no risk there.

#### Do we need any specific form for testing your changes? If so, please attach one.
[settings-sheet.xlsx](https://github.com/opendatakit/collect/files/1768782/settings-sheet.xlsx)

I don't think this needs re-testing but adding the `needs testing` flag so @mmarciniak90 sees the change.