### PR TITLE
Collect 1961

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
@@ -65,7 +65,7 @@ public class InstanceServerUploaderTest extends MockedServerTest {
         POST: {
             RecordedRequest r = nextRequest();
             assertEquals("POST", r.getMethod());
-            assertEquals("/submission", r.getPath());
+            assertMatches("/submission\\?deviceID=\\w+%3A\\w+", r.getPath());
             assertMatches("Dalvik/.* org.odk.collect.android/.*", r.getHeader("User-Agent"));
             assertEquals("1.0", r.getHeader("X-OpenRosa-Version"));
             assertEquals("gzip,deflate", r.getHeader("Accept-Encoding"));

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
@@ -196,6 +196,12 @@ public class InstanceServerUploader extends InstanceUploader {
                                 openRosaServer = true;
                                 // trust the server to tell us a new location
                                 // ... and possibly to use https instead.
+                                // Re-add params if server didn't respond with params
+                                if (newURI.getQuery() == null) {
+                                    newURI = newURI.buildUpon()
+                                            .encodedQuery(submissionUri.getEncodedQuery())
+                                            .build();
+                                }
                                 uriRemap.put(submissionUri, newURI);
                                 submissionUri = newURI;
                             } else {


### PR DESCRIPTION
Closes #1961 

#### What has been done to verify that this works as intended?

Tested this on actual phone and tablets against stateless server API shown in the issue's description to confirm it addresses the issues described. Also, tested against Aggregate using https://opendatakit.appspot.com to confirm that the additional parameter has no negative influence on submitting forms.

#### Why is this the best possible solution? Were any other approaches considered?

The solution here allows stateless servers to reliably associate the device id to submissions and only attempts to add parameters when server implementations do not already return parameters in the `Location` header. Changing the server protocol to echo parameters back to clients in the `Location` header was also considered, but other clients (like Briefcase) may be adversely affected by that change.

#### Are there any risks to merging this code? If so, what are they?

Existing server implementations coupled directly to the *lack* of parameters coming from the Collect client requests will break. However, this is highly unusual for handling HTTP parameters.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. I tested this with the sample form from https://opendatakit.appspot.com