### PR TITLE
Fixed current value not appearing when tapping on the min value

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
@@ -188,6 +188,10 @@ public abstract class RangeWidget extends QuestionWidget implements ButtonWidget
                 switch (action) {
                     case MotionEvent.ACTION_DOWN:
                         v.getParent().requestDisallowInterceptTouchEvent(true);
+                        if (actualValue == null) {
+                            actualValue = rangeStart;
+                            setUpActualValueLabel();
+                        }
                         break;
                     case MotionEvent.ACTION_UP:
                         v.getParent().requestDisallowInterceptTouchEvent(false);


### PR DESCRIPTION
Closes #1950

#### What has been done to verify that this works as intended?

Now current value is shown in range widgets when tapping the min value first time

#### Why is this the best possible solution? Were any other approaches considered?

This problem occurred because our `SeekBar`s progress in `RangeWidget` is 0, but we have customized and the thumb isn't visible when no value is selected, so it doesn't trigger the `onProgressChanged` and the current value is not shown when selecting the `rangeStart` value. I'v checked if the `actualValue` is null and set it to `rangeStart` and invalidated the current value.

#### Are there any risks to merging this code? If so, what are they?

No.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form with range widgets in it.