### PR TITLE
line separator added. Fix #1976.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -42,7 +42,7 @@ public class SelectOneSearchWidget extends SelectOneWidget implements OnCheckedC
     protected void addButtonsToLayout(List<Integer> tagList) {
         for (int i = 0; i < buttons.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
-                answerLayout.addView(buttons.get(i));
+                answerLayout.addView(createMediaLayout(i, buttons.get(i)));
             }
         }
     }


### PR DESCRIPTION
Closes #1976 

#### What has been done to verify that this works as intended?
Tested on physical device(ASUS Zenfone) and other emulators.
#### Why is this the best possible solution? Were any other approaches considered?
Line separator was already present in the SelectOneWidget form and it was working fine, so using same method in the SelectOneSearchWidget won't create any problem and hence the best way.
#### Are there any risks to merging this code? If so, what are they?
No risks at all.
#### Do we need any specific form for testing your changes? If so, please attach one.
You will need SelectOneSearchWidget and SelectOneWidget form.