### PR TITLE
Fixed inconsistency geopoint widgets button name

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -158,7 +158,7 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
             } else {
                 getLocationButton.setVisibility(View.VISIBLE);
                 getLocationButton.setText(getContext().getString(
-                        dataAvailable ? R.string.get_point : R.string.get_point));
+                        dataAvailable ? R.string.view_change_location : R.string.get_point));
             }
 
             if (useMaps) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -158,7 +158,7 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
             } else {
                 getLocationButton.setVisibility(View.VISIBLE);
                 getLocationButton.setText(getContext().getString(
-                        dataAvailable ? R.string.view_change_location : R.string.get_point));
+                        dataAvailable ? R.string.change_location : R.string.get_point));
             }
 
             if (useMaps) {

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="constraint_behavior_on_swipe">Validate upon forward swipe</string>
     <string name="constraint_behavior_on_finalize">Defer validation until finalized</string>
     <string name="view_change_location">View or Change Location</string>
+    <string name="change_location">Change Location</string>
     <string name="open_url">Open Url</string>
     <string name="get_bearing">Record Bearing</string>
     <string name="replace_bearing">Replace Bearing</string>


### PR DESCRIPTION
- Closes #1859 
- Just fixed the ternary operator logic as suggested in @lognaturel 's https://github.com/opendatakit/collect/pull/1928#discussion_r171993613 and added a new string "Change Location". 
- It lacks the translations for this new statement.

#### What has been done to verify that this works as intended?
I've been experimenting the Geopoint widgets, but I'm having trouble reproducing the issue problem. I picked up where the previous contributor left. 
I ran the application on an emulator - Nexus 5 API 26 with Android 8.0.

#### Why is this the best possible solution? Were any other approaches considered?
The solution appeared to have the bug in the logic for the lack of available data. No.

#### Are there any risks to merging this code? If so, what are they?
There are no risks by merging this code.

#### Do we need any specific form for testing your changes? If so, please attach one.
I'm using `All Widgets` form.