### PR TITLE
Background color change can be removed. Fix #1975

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -96,7 +96,6 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
             // (it's a spanned thing...)
             viewText.setText(viewText.getText().toString());
             viewText.setTextColor(playTextColor);
-            viewText.setBackgroundColor(playBackgroundTextColor);
             audioButton.playAudio();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -69,7 +69,6 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
     private MediaPlayer player;
     private AudioPlayListener audioPlayListener;
     private int playTextColor;
-    private int playBackgroundTextColor;
     
     private Context context;
 
@@ -102,10 +101,6 @@ public class MediaLayout extends RelativeLayout implements OnClickListener {
 
     public void setPlayTextColor(int textColor) {
         playTextColor = textColor;
-    }
-
-    public void setPlayTextBackgroundColor(int textColor) {
-        playBackgroundTextColor = textColor;
     }
 
     /*

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -68,8 +68,6 @@ public abstract class QuestionWidget
         extends RelativeLayout
         implements Widget, AudioPlayListener {
 
-    private static final int DEFAULT_PLAY_COLOR = Color.BLUE;
-
     private final int questionFontSize;
     private final FormEntryPrompt formEntryPrompt;
     private final MediaLayout questionMediaLayout;
@@ -78,7 +76,7 @@ public abstract class QuestionWidget
 
     private Bundle state;
 
-    private int playColor = DEFAULT_PLAY_COLOR;
+    private int playColor = ContextCompat.getColor(getContext() , R.color.tintColor);
 
     public QuestionWidget(Context context, FormEntryPrompt prompt) {
         super(context);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -69,7 +69,6 @@ public abstract class QuestionWidget
         implements Widget, AudioPlayListener {
 
     private static final int DEFAULT_PLAY_COLOR = Color.BLUE;
-    private static final int DEFAULT_PLAY_BACKGROUND_COLOR = Color.WHITE;
 
     private final int questionFontSize;
     private final FormEntryPrompt formEntryPrompt;
@@ -80,7 +79,6 @@ public abstract class QuestionWidget
     private Bundle state;
 
     private int playColor = DEFAULT_PLAY_COLOR;
-    private int playBackgroundColor = DEFAULT_PLAY_BACKGROUND_COLOR;
 
     public QuestionWidget(Context context, FormEntryPrompt prompt) {
         super(context);
@@ -187,17 +185,6 @@ public abstract class QuestionWidget
             }
         }
         questionMediaLayout.setPlayTextColor(getPlayColor());
-
-        String playBackgroundColorString = prompt.getFormElement().getAdditionalAttribute(null,
-                "playBackgroundColor");
-        if (playBackgroundColorString != null) {
-            try {
-                playBackgroundColor = Color.parseColor(playBackgroundColorString);
-            } catch (IllegalArgumentException e) {
-                Timber.e(e, "Argument %s is incorrect", playBackgroundColorString);
-            }
-        }
-        questionMediaLayout.setPlayTextBackgroundColor(getPlayBackgroundColor());
 
         return questionMediaLayout;
     }
@@ -602,9 +589,5 @@ public abstract class QuestionWidget
 
     public int getPlayColor() {
         return playColor;
-    }
-
-    public int getPlayBackgroundColor() {
-        return playBackgroundColor;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -145,7 +145,6 @@ public abstract class SelectWidget extends QuestionWidget {
 
         mediaLayout.setAudioListener(this);
         mediaLayout.setPlayTextColor(getPlayColor());
-        mediaLayout.setPlayTextBackgroundColor(getPlayBackgroundColor());
         playList.add(mediaLayout);
 
         if (index != items.size() - 1) {


### PR DESCRIPTION
Closes #1975

#### What has been done to verify that this works as intended?
Tested on physical device (Samsung galaxy J5) and some emulators.

#### Why is this the best possible solution? Were any other approaches considered?
@lognaturel said "Yes, I agree that highlighting the text is a sufficient indicator that audio is playing and that the background color change can be removed. " so I simply removed the code that changes the color of the background.

#### Are there any risks to merging this code? If so, what are they?
Because this issue is about removing unwanted highlighting which solved by deleting some lines of code so you might need to check whether that deletion affects something else or not.

#### Do we need any specific form for testing your changes? If so, please attach one.
'Birds' form can be tested.