### PR TITLE
Support ImageMap widgets on Android 4

### DIFF
--- a/collect_app/src/main/assets/svg_map_helper.js
+++ b/collect_app/src/main/assets/svg_map_helper.js
@@ -17,8 +17,8 @@
 /**
 * JavaScript class which contains methods used for managing svg maps
 */
-var selectedAreas = new Set();
-var originalColors = new Map();
+var selectedAreas = [];
+var originalColors = {};
 var lastSelectedAreaId;
 var isSingleSelect;
 
@@ -36,12 +36,16 @@ function notifyChanges() {
 
 function clearAreas() {
     selectedAreas.forEach(function(areaId) {
-        clickOnArea(areaId);
+        if (selectedAreas.indexOf(areaId) !== -1) {
+            document.getElementById(areaId).setAttribute('style', 'fill: ' + originalColors[areaId]);
+        }
     });
+    selectedAreas = [];
+    notifyChanges();
 }
 
 function addSelectedArea(selectedAreaId) {
-    selectedAreas.add(selectedAreaId);
+    selectedAreas.push(selectedAreaId);
     document.getElementById(selectedAreaId).setAttribute('style', 'fill: #E65100');
     if (Boolean(isSingleSelect)) {
         lastSelectedAreaId = selectedAreaId;
@@ -49,7 +53,7 @@ function addSelectedArea(selectedAreaId) {
 }
 
 function addArea(areaId) {
-    originalColors.set(areaId, document.getElementById(areaId).style.color);
+    originalColors[areaId] = document.getElementById(areaId).style.color;
 }
 
 function setSelectMode(isSingleSelect) {
@@ -57,18 +61,18 @@ function setSelectMode(isSingleSelect) {
 }
 
 function clickOnArea(areaId) {
-    if (selectedAreas.has(areaId)) {
-        document.getElementById(areaId).setAttribute('style', 'fill: ' + originalColors.get(areaId));
-        selectedAreas.delete(areaId);
+    if (selectedAreas.indexOf(areaId) !== -1) {
+        document.getElementById(areaId).setAttribute('style', 'fill: ' + originalColors[areaId]);
+        selectedAreas.splice(selectedAreas.indexOf(areaId), 1);
         unselectArea(areaId);
     } else {
         if (Boolean(isSingleSelect) && !!lastSelectedAreaId) {
-            document.getElementById(lastSelectedAreaId).setAttribute('style', 'fill: ' + originalColors.get(lastSelectedAreaId));
-            selectedAreas.delete(lastSelectedAreaId);
+            document.getElementById(lastSelectedAreaId).setAttribute('style', 'fill: ' + originalColors[lastSelectedAreaId]);
+            selectedAreas.splice(selectedAreas.indexOf(lastSelectedAreaId), 1);
             unselectArea(lastSelectedAreaId);
         }
         document.getElementById(areaId).setAttribute('style', 'fill: #E65100');
-        selectedAreas.add(areaId);
+        selectedAreas.push(areaId);
         selectArea(areaId);
         lastSelectedAreaId = areaId;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
@@ -92,6 +92,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
 
     @Override
     public void clearAnswer() {
+        selections.clear();
         webView.loadUrl("javascript:clearAreas()");
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -18,8 +18,6 @@ import android.content.Context;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.R;
-import org.odk.collect.android.utilities.ToastUtils;
 
 import java.util.Locale;
 
@@ -207,12 +205,7 @@ public class WidgetFactory {
                 } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
                     questionWidget = new SelectOneSearchWidget(context, fep);
                 } else if (appearance.startsWith("image-map")) {
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-                        questionWidget = new SelectOneImageMapWidget(context, fep);
-                    } else {
-                        questionWidget = new SelectOneWidget(context, fep);
-                        ToastUtils.showLongToast(R.string.svg_not_supported_device);
-                    }
+                    questionWidget = new SelectOneImageMapWidget(context, fep);
                 } else {
                     questionWidget = new SelectOneWidget(context, fep);
                 }
@@ -246,12 +239,7 @@ public class WidgetFactory {
                 } else if (appearance.contains("autocomplete")) {
                     questionWidget = new SelectMultipleAutocompleteWidget(context, fep);
                 } else if (appearance.startsWith("image-map")) {
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-                        questionWidget = new SelectMultiImageMapWidget(context, fep);
-                    } else {
-                        questionWidget = new SelectMultiWidget(context, fep);
-                        ToastUtils.showLongToast(R.string.svg_not_supported_device);
-                    }
+                    questionWidget = new SelectMultiImageMapWidget(context, fep);
                 } else {
                     questionWidget = new SelectMultiWidget(context, fep);
                 }


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've tested `ImageMap` widgets on Android 4.2.2

#### Why is this the best possible solution? Were any other approaches considered?
Javascript collections like `Map()` and `Set()` used before don't' work on Android 4 so I needed to replace them.

#### Are there any risks to merging this code? If so, what are they?
We just should test both `ImageMap` widgets again (selecting / removing answers).

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use `AllWidgets` form.