### PR TITLE
Removed Menu from Get Blank Form Activity. Fixes #1937

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -19,15 +19,12 @@ import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.SparseBooleanArray;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.AdapterView;
@@ -41,7 +38,6 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.listeners.FormDownloaderListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
 import org.odk.collect.android.logic.FormDetails;
-import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.AuthDialogUtility;
@@ -79,7 +75,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private static final int PROGRESS_DIALOG = 1;
     private static final int AUTH_DIALOG = 2;
     private static final int CANCELLATION_DIALOG = 3;
-    private static final int MENU_PREFERENCES = Menu.FIRST;
 
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
     private static final String BUNDLE_FORM_MAP = "formmap";
@@ -342,31 +337,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         outState.putBoolean(SHOULD_EXIT, shouldExit);
         outState.putSerializable(FORMLIST, formList);
         outState.putSerializable(SELECTED_FORMS, selectedForms);
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        Collect.getInstance().getActivityLogger().logAction(this, "onCreateOptionsMenu", "show");
-        super.onCreateOptionsMenu(menu);
-
-        menu
-                .add(0, MENU_PREFERENCES, 0, R.string.general_preferences)
-                .setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER);
-        return true;
-    }
-
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case MENU_PREFERENCES:
-                Collect.getInstance().getActivityLogger().logAction(this, "onMenuItemSelected",
-                        "MENU_PREFERENCES");
-                Intent i = new Intent(this, PreferencesActivity.class);
-                startActivity(i);
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
     }
 
 


### PR DESCRIPTION
This commit removed the unnecessary menu from the Get Blank Form activity.

With this change, it solved the issue #1937.

Closes #1937 

#### What has been done to verify that this works as intended?
Run the latest code on emulator and there's no menu showing up on the Get Blank Form activity.

#### Why is this the best possible solution? Were any other approaches considered?
An alternative approach was to recheck user preference when the user gets back to the activity after changing preference and then load blank forms accordingly.
But it would have lead to an additional check every time user comes back to the activity even if he doesn't change any preference.
Also the ability to change the same preference is available on the MainActivity and the same menu in this activity was providing duplication.
So, to avoid duplication and to avoid an additional check, this was the best approach.

#### Are there any risks to merging this code? If so, what are they?
There are no risks to merge this code.

#### Do we need any specific form for testing your changes? If so, please attach one.
You don't need any form. Just run the app, open the Get Blank Form activity and you can see the changes.