### PR TITLE
Updated dependencies that do not need Play Services Update (Fixed #1990)

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -174,14 +174,14 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
-    implementation group: 'com.android.support', name: 'support-v13', version: '27.0.2'
-    implementation group: 'com.android.support', name: 'customtabs', version: '27.0.2'
-    implementation group: 'com.android.support', name: 'design', version: '27.0.2'
-    implementation group: 'com.android.support', name: 'appcompat-v7', version: '27.0.2'
-    implementation group: 'com.android.support', name: 'design', version: '27.0.2'
-    implementation group: 'com.android.support', name: 'cardview-v7', version: '27.0.2'
-    implementation group: 'com.android.support', name: 'multidex', version: '1.0.2'
-    implementation group: 'com.android.support', name: 'exifinterface', version: '27.0.2'
+    implementation group: 'com.android.support', name: 'support-v13', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'customtabs', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'design', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'appcompat-v7', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'design', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'cardview-v7', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'multidex', version: '1.0.3'
+    implementation group: 'com.android.support', name: 'exifinterface', version: '27.1.0'
     implementation group: 'com.google.android.gms', name: 'play-services-analytics', version: '10.0.1'
     implementation group: 'com.google.android.gms', name: 'play-services-auth', version: '10.0.1'
     implementation group: 'com.google.android.gms', name: 'play-services-maps', version: '10.0.1'
@@ -217,7 +217,7 @@ dependencies {
     implementation(group: 'com.google.apis', name: 'google-api-services-sheets', version: 'v4-rev463-1.22.0') {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation group: 'com.jakewharton.timber', name: 'timber', version: '4.5.1'
+    implementation group: 'com.jakewharton.timber', name: 'timber', version: '4.6.0'
     implementation group: 'com.google.zxing', name: 'core', version: '3.3.0'
     implementation group: 'com.journeyapps', name: 'zxing-android-embedded', version: '3.5.0'
     implementation group: 'net.danlew', name: 'android.joda', version: '2.9.9'
@@ -231,7 +231,7 @@ dependencies {
     odkCollectReleaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
 
     // Android Architecture Components:
-    implementation "android.arch.lifecycle:extensions:1.0.0"
+    implementation "android.arch.lifecycle:extensions:1.1.0"
 
     // Dagger:
     implementation 'com.google.dagger:dagger-android:2.11'
@@ -240,8 +240,8 @@ dependencies {
     annotationProcessor 'com.google.dagger:dagger-compiler:2.11'
 
     // RxJava 2:
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.6'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.10'
 
     // Better "Subjects" for Rx:
     implementation 'com.jakewharton.rxrelay2:rxrelay:2.0.0'


### PR DESCRIPTION
Updated several outdated dependencies, that do not require Play Services
update, in build.gradle. Dependencies requiring Play Services update have
not been updated in this commit as it is a big download and, as suggested,
it should not be updated at this time.

Closes #1990 

#### What has been done to verify that this works as intended?

Cleaned the project and tested it on a physical device. 
Device used [Xiaomi Redmi Note 4 ; Android 7.0 API24]

#### Why is this the best possible solution? Were any other approaches considered?

The simplest possible way was to update the outdated versions to new versions.

#### Are there any risks to merging this code? If so, what are they?

No, as per my understanding.

#### Do we need any specific form for testing your changes? If so, please attach one.

None, as per my understanding.