### PR TITLE
Update jacoco to latest release v0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.0.0'
-        classpath 'org.jacoco:org.jacoco.core:0.7.9'
-    }
-    configurations.all {
-        resolutionStrategy {
-            // use old jacoco so Robolectric test coverage is included in reports
-            // track https://github.com/paveldudka/JacocoEverywhere/issues/14 for a less hacky solution
-            force 'org.jacoco:org.jacoco.core:0.7.2.201409121644'
-        }
+        classpath 'org.jacoco:org.jacoco.core:0.8.0'
     }
 }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -154,12 +154,6 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
-
-            all {
-                jacoco {
-                    includeNoLocationClasses = true
-                }
-            }
         }
     }
 }

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -20,7 +20,12 @@ apply plugin: 'jacoco'
  */
 
 jacoco {
-    toolVersion '0.7.4+'
+    // https://bintray.com/bintray/jcenter/org.jacoco:org.jacoco.core
+    toolVersion = '0.8.0'
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
 }
 
 // Add checkstyle, findbugs, pmd and lint to the check task.
@@ -115,8 +120,12 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
     sourceDirectories = files(coverageSourceDirs)
     classDirectories = fileTree(
             dir: "${buildDir}/intermediates/classes/debug",
-            excludes: ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*',
-                       '**/*Test*.*', 'android/**/*.*',
+            excludes: ['**/R.class',
+                       '**/R$*.class',
+                       '**/BuildConfig.*',
+                       '**/Manifest*.*',
+                       '**/*Test*.*',
+                       'android/**/*.*',
                        '**/*_MembersInjector.class',
                        '**/Dagger*Component.class',
                        '**/Dagger*Component$Builder.class',


### PR DESCRIPTION
Some of the unit tests were not getting included in the code coverage report due to some bug in the old jacoco version that we were using. The latest version v0.8.0 is supposed to fix all that issue.

For eg. `Validator.java` is 100% covered but in codecov it displays 0%. 

#### What has been done to verify that this works as intended?
Tried running the report locally for unit tests and the code coverage increased as expected (`Validator` file showing 100% coverage and many others)

#### Why is this the best possible solution? Were any other approaches considered?
Tried approaching the `firebase-community` and they suggest this as one of the possible solutions

#### Are there any risks to merging this code? If so, what are they?
Before merging, we need to ensure that the file generated by 
firebase is also of the same version so that the report can be properly generated.

#### Do we need any specific form for testing your changes? If so, please attach one.
no