### PR TITLE
Reset shared preferences before starting the QRCodeUtils tests

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/utilities/QRCodeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/QRCodeUtilsTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.robolectric.RobolectricTestRunner;
 
 import java.io.File;
@@ -40,6 +41,7 @@ public class QRCodeUtilsTest {
 
     @Before
     public void setup() {
+        GeneralSharedPreferences.getInstance().loadDefaultPreferences();
         savedQrCodeImage.delete();
         md5File.delete();
     }


### PR DESCRIPTION
Fixes the failing build

#### What has been done to verify that this works as intended?
Ran the test locally

#### Why is this the best possible solution? Were any other approaches considered?
Probably the test is failing due to the saved preferences from the last test. So it is better to clear all prefs before running the test 

#### Are there any risks to merging this code? If so, what are they?
No 

#### Do we need any specific form for testing your changes? If so, please attach one.