### PR TITLE
Don't use GoogleLocationClient even if Play Services available.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClients.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClients.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
+//import com.google.android.gms.common.ConnectionResult;
+//import com.google.android.gms.common.GoogleApiAvailability;
 
 /**
  * A helper class for getting a LocationClient based on whether or not Google Play Services are
@@ -24,6 +24,9 @@ public class LocationClients {
      * Checks and returns a {@link LocationClient} based on whether or not Google Play Services
      * are available.
      *
+     * 3/14/2018 - GoogleLocationClient removed because of user reports that accuracy does not get
+     * better than 10m.
+     *
      * @param context The Context the LocationClient will be used within.
      * @return An implementation of LocationClient.
      */
@@ -31,9 +34,7 @@ public class LocationClients {
 
         return testClient != null
                 ? testClient
-                : areGooglePlayServicesAvailable(context)
-                    ? new GoogleLocationClient(context)
-                    : new AndroidLocationClient(context);
+                : new AndroidLocationClient(context);
     }
 
     /**
@@ -44,10 +45,10 @@ public class LocationClients {
         LocationClients.testClient = testClient;
     }
 
-    private static boolean areGooglePlayServicesAvailable(@NonNull Context context) {
-        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
-        int status = googleApiAvailability.isGooglePlayServicesAvailable(context);
-
-        return status == ConnectionResult.SUCCESS;
-    }
+    //    private static boolean areGooglePlayServicesAvailable(@NonNull Context context) {
+    //        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
+    //        int status = googleApiAvailability.isGooglePlayServicesAvailable(context);
+    //
+    //        return status == ConnectionResult.SUCCESS;
+    //    }
 }


### PR DESCRIPTION
Addresses #2008

#### What has been done to verify that this works as intended?
Tried on Galaxy Tab A and Moto G4. Verified that both quickly get sub-10m accuracy when outside with a clear view of the sky.

#### Why is this the best possible solution? Were any other approaches considered?
It's not necessarily the best solution long-term but it's a non-intrusive temporary fix that we can verify now to make sure it gives the intended behavior. Using `LocationManager` directly has other benefits including that we can get the number of satellites in view and satellites included in fix.

#### Are there any risks to merging this code? If so, what are they?
Some users, especially in dense urban areas, may have been better served by the fused provider. An option to consider is to provide a setting.

#### Do we need any specific form for testing your changes? If so, please attach one.
The first geopoint question in All Widgets can be used. We need to confirm that on a range of devices it provides accuracies better than 10m when there's a good view of the sky.