### PR TITLE
Display warning in SelectMultiWidget when select_multiple names have spaces in them #1964

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 
 /**
- * SelctMultiWidget handles multiple selection fields using checkboxes.
+ * SelectMultiWidget handles multiple selection fields using checkboxes.
  *
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Yaw Anokwa (yanokwa@gmail.com)

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -18,9 +18,12 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
+import android.view.View;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.TextView;
 
+import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
@@ -34,7 +37,6 @@ import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 import java.util.ArrayList;
 import java.util.List;
 
-import timber.log.Timber;
 
 /**
  * SelctMultiWidget handles multiple selection fields using checkboxes.
@@ -155,6 +157,13 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
 
     protected void createLayout() {
         if (items != null) {
+
+            // check if any values have spaces
+            String valuesWithSpaces = getValuesWithSpaces();
+            if (valuesWithSpaces != null) {
+                answerLayout.addView(createWarning(valuesWithSpaces));
+            }
+
             for (int i = 0; i < items.size(); i++) {
                 CheckBox checkBox = createCheckBox(i);
                 checkBoxes.add(checkBox);
@@ -163,6 +172,25 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
             addAnswerView(answerLayout);
         }
         checkboxInit = false;
+    }
+
+    protected View createWarning(String valuesWithSpaces) {
+        TextView warning = new TextView(getContext());
+        warning.setText(getContext().getResources().getString(R.string.invalid_space_in_answer, valuesWithSpaces));
+        warning.setPadding(10, 10, 10, 10);
+        return warning;
+    }
+
+    protected String getValuesWithSpaces() {
+        StringBuilder valuesWithSpaces = new StringBuilder();
+        for (SelectChoice selectChoice : items) {
+            String value = selectChoice.getValue();
+            if (value.contains(" ")) {
+                valuesWithSpaces.append(value);
+                valuesWithSpaces.append(",");
+            }
+        }
+        return valuesWithSpaces.length() > 0 ? valuesWithSpaces.substring(0, valuesWithSpaces.length() - 1) : null;
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -146,7 +146,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
                 String value = items.get(index).getValue();
                 if (isChecked && value != null && value.contains(" ")) {
 
-                    String warning = context.getString(R.string.invalid_space_in_answer, value);
+                    String warning = context.getString(R.string.invalid_space_in_answer_singular, value);
                     ToastUtils.showLongToast(warning);
                 }
             }
@@ -176,7 +176,13 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
 
     protected View createWarning(String valuesWithSpaces) {
         TextView warning = new TextView(getContext());
-        warning.setText(getContext().getResources().getString(R.string.invalid_space_in_answer, valuesWithSpaces));
+
+        if (!valuesWithSpaces.contains(",")) {
+            warning.setText(getContext().getResources().getString(R.string.invalid_space_in_answer_singular, valuesWithSpaces));
+        } else {
+            warning.setText(getContext().getResources().getString(R.string.invalid_space_in_answer_plural, valuesWithSpaces));
+        }
+
         warning.setPadding(10, 10, 10, 10);
         return warning;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -25,12 +25,16 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.TextUtils;
+import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import timber.log.Timber;
 
 /**
  * SelctMultiWidget handles multiple selection fields using checkboxes.
@@ -43,9 +47,11 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
     protected ArrayList<CheckBox> checkBoxes;
     private boolean checkboxInit = true;
     private List<Selection> ve;
+    private Context context;
 
     public SelectMultiWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
+        this.context = context;
         checkBoxes = new ArrayList<>();
         ve = new ArrayList<>();
         if (getFormEntryPrompt().getAnswerValue() != null) {
@@ -131,6 +137,15 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
                     } else {
                         buttonView.setChecked(true);
                     }
+                }
+
+                // show warning when selected choice value has spaces
+                int index = (int) checkBox.getTag();
+                String value = items.get(index).getValue();
+                if (isChecked && value != null && value.contains(" ")){
+                    String errorMsg = context.getString(R.string.invalid_space_in_answer, value);
+                    Timber.e(errorMsg);
+                    ToastUtils.showLongToast(errorMsg);
                 }
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -142,7 +142,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
                 // show warning when selected choice value has spaces
                 int index = (int) checkBox.getTag();
                 String value = items.get(index).getValue();
-                if (isChecked && value != null && value.contains(" ")){
+                if (isChecked && value != null && value.contains(" ")) {
                     String errorMsg = context.getString(R.string.invalid_space_in_answer, value);
                     Timber.e(errorMsg);
                     ToastUtils.showLongToast(errorMsg);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -49,7 +49,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
     protected ArrayList<CheckBox> checkBoxes;
     private boolean checkboxInit = true;
     private List<Selection> ve;
-    private Context context;
+    private final Context context;
 
     public SelectMultiWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
@@ -177,11 +177,8 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
     protected View createWarning(String valuesWithSpaces) {
         TextView warning = new TextView(getContext());
 
-        if (!valuesWithSpaces.contains(",")) {
-            warning.setText(getContext().getResources().getString(R.string.invalid_space_in_answer_singular, valuesWithSpaces));
-        } else {
-            warning.setText(getContext().getResources().getString(R.string.invalid_space_in_answer_plural, valuesWithSpaces));
-        }
+        warning.setText(getContext().getResources().getString((valuesWithSpaces.contains(",") ?
+                R.string.invalid_space_in_answer_plural : R.string.invalid_space_in_answer_singular), valuesWithSpaces));
 
         warning.setPadding(10, 10, 10, 10);
         return warning;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -143,6 +143,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
                 int index = (int) checkBox.getTag();
                 String value = items.get(index).getValue();
                 if (isChecked && value != null && value.contains(" ")) {
+
                     String errorMsg = context.getString(R.string.invalid_space_in_answer, value);
                     Timber.e(errorMsg);
                     ToastUtils.showLongToast(errorMsg);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -137,7 +137,6 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
 
     protected void createLayout() {
         if (items != null) {
-
             // check if any values have spaces
             String valuesWithSpaces = getValuesWithSpaces();
             if (valuesWithSpaces != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -144,9 +144,8 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
                 String value = items.get(index).getValue();
                 if (isChecked && value != null && value.contains(" ")) {
 
-                    String errorMsg = context.getString(R.string.invalid_space_in_answer, value);
-                    Timber.e(errorMsg);
-                    ToastUtils.showLongToast(errorMsg);
+                    String warning = context.getString(R.string.invalid_space_in_answer, value);
+                    ToastUtils.showLongToast(warning);
                 }
             }
         });

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="get_location">Record Location</string>
     <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
     <string name="invalid_answer_error">Sorry, this response is invalid!</string>
-    <string name="invalid_space_in_answer">Invalid Answer: The value \"%s\" should not have any spaces</string>
+    <string name="invalid_space_in_answer">Warning: underlying value \"%s\" has spaces</string>
     <string name="jump_to_beginning">Go To Start</string>
     <string name="jump_to_end">Go To End</string>
     <string name="jump_to_previous">Go Up</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="get_location">Record Location</string>
     <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
     <string name="invalid_answer_error">Sorry, this response is invalid!</string>
+    <string name="invalid_space_in_answer">Invalid Answer: The value \"%s\" should not have any spaces</string>
     <string name="jump_to_beginning">Go To Start</string>
     <string name="jump_to_end">Go To End</string>
     <string name="jump_to_previous">Go Up</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -85,7 +85,8 @@
     <string name="get_location">Record Location</string>
     <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
     <string name="invalid_answer_error">Sorry, this response is invalid!</string>
-    <string name="invalid_space_in_answer">Warning: underlying value \"%s\" has spaces</string>
+    <string name="invalid_space_in_answer_singular">Warning: underlying value %s has spaces</string>
+    <string name="invalid_space_in_answer_plural">Warning: underlying values %s have spaces</string>
     <string name="jump_to_beginning">Go To Start</string>
     <string name="jump_to_end">Go To End</string>
     <string name="jump_to_previous">Go Up</string>


### PR DESCRIPTION
Partially addresses [#1964](https://github.com/opendatakit/collect/issues/1964) 

#### What has been done to verify that this works as intended?
Tested using the sample XML [Multiple Spaces](https://github.com/opendatakit/collect/files/1776932/multiple-spaces.xml.txt) provided by @lognaturel 
Also tested with using an XML without any spaces in its values

#### Why is this the best possible solution? Were any other approaches considered?
My approach was to update the `SelectMultiWidget` 

STEPS:

1. Get selected choice
2. Check if value contains any spaces
3. If true display warning

#### Are there any risks to merging this code? If so, what are they?
None

#### Do we need any specific form for testing your changes? If so, please attach one.
None

#### Screenshot
![screenshot-1521118110867](https://user-images.githubusercontent.com/12151807/37464150-c9d4a322-2857-11e8-85c2-d6c27788da5a.jpg)


