### PR TITLE
Upgrade to Firebase Crashlytics from Firebase Crash Reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,14 @@ buildscript {
     repositories {
         jcenter()
         google()
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.2.0'
+        classpath 'org.ow2.asm:asm:6.0' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.0'
+        classpath 'io.fabric.tools:gradle:1.25.2'
     }
 }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'io.fabric'
 apply from: '../config/quality.gradle'
 apply from: '../config/jacoco.gradle'
 
@@ -98,7 +99,7 @@ android {
             }
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            resValue("bool", "FIREBASE_CRASH_ENABLED", "false")
+            resValue("bool", "FIREBASE_CRASHLYTICS_ENABLED", "false")
         }
         // Release build for the original ODK Collect app
         odkCollectRelease {
@@ -107,12 +108,12 @@ android {
             }
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            resValue("bool", "FIREBASE_CRASH_ENABLED", "true")
+            resValue("bool", "FIREBASE_CRASHLYTICS_ENABLED", "true")
         }
         debug {
             debuggable(true)
             testCoverageEnabled(true)
-            resValue("bool", "FIREBASE_CRASH_ENABLED", "false")
+            resValue("bool", "FIREBASE_CRASHLYTICS_ENABLED", "false")
         }
     }
 
@@ -191,7 +192,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
     implementation group: 'com.google.firebase', name: 'firebase-core', version: '10.0.1'
-    implementation group: 'com.google.firebase', name: 'firebase-crash', version: '10.0.1'
+    implementation group: 'com.crashlytics.sdk.android', name: 'crashlytics', version: '2.9.1'
     implementation(group: 'com.google.http-client', name: 'google-http-client', version: '1.22.0') {
         exclude group: 'org.apache.httpcomponents'
     }

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -294,8 +294,8 @@ the specific language governing permissions and limitations under the License.
             tools:replace="android:value" /> <!-- integer/google_play_services_version -->
 
         <meta-data
-            android:name="firebase_crash_collection_enabled"
-            android:value="@bool/FIREBASE_CRASH_ENABLED" />
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="@bool/FIREBASE_CRASHLYTICS_ENABLED" />
 
         <uses-library
             android:name="com.google.android.maps"

--- a/collect_app/src/main/assets/open_source_licenses.html
+++ b/collect_app/src/main/assets/open_source_licenses.html
@@ -38,7 +38,7 @@ limitations under the License.
         <b>Firebase Core</b>
     </li>
     <li>
-        <b>Firebase Crash</b>
+        <b>Firebase Crashlytics</b>
     </li>
     <li>
         <b>Google API Client</b>

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -30,9 +30,9 @@ import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
+import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.Tracker;
-import com.google.firebase.crash.FirebaseCrash;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
 
@@ -328,10 +328,10 @@ public class Collect extends Application implements HasActivityInjector {
                 return;
             }
 
-            FirebaseCrash.logcat(priority, tag, message);
+            Crashlytics.log(priority, tag, message);
 
             if (t != null && priority == Log.ERROR) {
-                FirebaseCrash.report(t);
+                Crashlytics.logException(t);
             }
         }
     }

--- a/config/lint.xml
+++ b/config/lint.xml
@@ -34,7 +34,7 @@
     </issue>
     <issue id="UnusedResources" severity="error">
         <ignore path="res/values/dimens.xml"/>
-        <ignore regexp="ga_trackingId|google_crash_reporting_api_key"/>
+        <ignore regexp="ga_trackingId|google_crash_reporting_api_key|project_id"/>
     </issue>
 
     <issue id="TimberExceptionLogging" severity="error"/>


### PR DESCRIPTION
Closes #1040 

#### What has been done to verify that this works as intended?
I didn't test it because we need to enable Crashlytics (I don't have permissions).
I used this guide https://firebase.google.com/docs/crashlytics/upgrade-from-crash-reporting?authuser=0
Once we enable Crashlytics and merge this pr we can release a beta version and investigate logs.

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.