### PR TITLE
Problem with field-list and constraints

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -683,22 +683,26 @@ public class FormController {
     public FailedConstraint saveAllScreenAnswers(HashMap<FormIndex, IAnswerData> answers,
                                                  boolean evaluateConstraints) throws JavaRosaException {
         if (currentPromptIsQuestion()) {
+            // save answers
             for (FormIndex index : answers.keySet()) {
                 // Within a group, you can only save for question events
                 if (getEvent(index) == FormEntryController.EVENT_QUESTION) {
-                    int saveStatus;
-                    IAnswerData answer = answers.get(index);
-                    if (evaluateConstraints) {
-                        saveStatus = answerQuestion(index, answer);
-                        if (saveStatus != FormEntryController.ANSWER_OK) {
-                            return new FailedConstraint(index, saveStatus);
-                        }
-                    } else {
-                        saveAnswer(index, answer);
-                    }
+                    saveAnswer(index, answers.get(index));
                 } else {
                     Timber.w("Attempted to save an index referencing something other than a question: %s",
                             index.getReference().toString());
+                }
+            }
+            if (evaluateConstraints) { // check if answers are valid
+                int saveStatus;
+                for (FormIndex index : answers.keySet()) {
+                    // Within a group, you can only save for question events
+                    if (getEvent(index) == FormEntryController.EVENT_QUESTION) {
+                        saveStatus = answerQuestion(index, answers.get(index));
+                        if (saveStatus != FormEntryController.ANSWER_OK) {
+                            return new FailedConstraint(index, saveStatus);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #2041 

#### What has been done to verify that this works as intended?
I tested the mentioned case.

#### Why is this the best possible solution? Were any other approaches considered?
The problem is that currently, we check whether an answer is valid and then save it. It works well when we have one question per screen. But if we have two (or more) questions on one page it might be a problem.
Why?
Let say we have two questions:
1. Q1 constraint that this answer must be different than the answer for Q2
options: select one [A, B] 
2. Q2
options: select one [A, B]

I answer:
Q1: A
Q2: B

and navigate forward (while navigating answer are saved). Then I go back and change answers - now I have:
Q1: B
Q2: A

I try to navigate forward and I can't because I see a message that my answer is wrong. It's different (B!=A) so why?
The problem is that after navigating backward I had saved answers
Q1: A
Q2: B

after changing them to 
Q1: B
Q2: A
and navigating forward our algorithm started checking if each one is valid. but as I said we save new answers after checking them so in Q2 it still remembers the previous answer - B (B=B) so I can't navigate forward.

That's why we need to save all answers first and then validate them.

#### Are there any risks to merging this code? If so, what are they?
Isn't saving answers before validating them dangerous. I can't see any scenario but can't be sure as well.

Can't be sure but I think it's safe and the previous approach was just to limit operations.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached in the issue #2041 