### PR TITLE
Escape markdown characters using backslashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -79,10 +79,10 @@ public class TextUtils {
                 text, createSpan);
 
         //intermediary replacements keys for special characters, N/B: These symbols are not meant to be interpreted as markdown
-        text = text.replaceAll("(?s)\\\\#", "==");
-        text = text.replaceAll("(?s)\\\\\\\\", "!!");
-        text = text.replaceAll("(?s)\\\\_", "&&");
-        text = text.replaceAll("(?s)\\\\\\*", "@@");
+        text = text.replaceAll("(?s)\\\\#", "&#61;");
+        text = text.replaceAll("(?s)\\\\\\\\", "&#33;");
+        text = text.replaceAll("(?s)\\\\_", "&#43;");
+        text = text.replaceAll("(?s)\\\\\\*", "&#37;");
 
         // strong
         text = text.replaceAll("(?s)__(.*?)__", "<strong>$1</strong>");
@@ -91,8 +91,8 @@ public class TextUtils {
         // emphasis
         text = text.replaceAll("(?s)_([^\\s][^_\n]*)_", "<em>$1</em>");
         text = text.replaceAll("(?s)\\*([^\\s][^\\*\n]*)\\*", "<em>$1</em>");
-        text = text.replaceAll("(?s)!!_([^\\s][^_\n]*)!!_", "\\\\<em>$1\\\\</em>");
-        text = text.replaceAll("(?s)!!\\*([^\\s][^_\n]*)!!\\*", "\\\\<em>$1\\\\</em>");
+        text = text.replaceAll("(?s)&#33;_([^\\s][^_\n]*)&#33;_", "\\\\<em>$1\\\\</em>");
+        text = text.replaceAll("(?s)&#33;\\*([^\\s][^_\n]*)&#33;\\*", "\\\\<em>$1\\\\</em>");
 
         // links
         text = text.replaceAll("(?s)\\[([^\\]]*)\\]\\(([^\\)]+)\\)",
@@ -103,10 +103,10 @@ public class TextUtils {
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
         // replacing intermediary keys with the proper markdown symbols
-        text = text.replaceAll("(?s)==", "#");
-        text = text.replaceAll("(?s)@@", "*");
-        text = text.replaceAll("(?s)&&", "_");
-        text = text.replaceAll("(?s)!!", "\\\\");
+        text = text.replaceAll("(?s)&#61;", "#");
+        text = text.replaceAll("(?s)&#37;", "*");
+        text = text.replaceAll("(?s)&#43;", "_");
+        text = text.replaceAll("(?s)&#33;", "\\\\");
         return text;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -78,7 +78,7 @@ public class TextUtils {
         text = ReplaceCallback.replace("(?s)<\\s?span([^\\/\n]*)>((?:(?!<\\/).)+)<\\/\\s?span\\s?>",
                 text, createSpan);
 
-        //Intermediate replacements keys for special characters, N/B: These symbols are not meant to be interpreted as markdown
+        //intermediary replacements keys for special characters, N/B: These symbols are not meant to be interpreted as markdown
         text = text.replaceAll("(?s)\\\\#", "==");
         text = text.replaceAll("(?s)\\\\\\\\", "!!");
         text = text.replaceAll("(?s)\\\\_", "&&");
@@ -102,7 +102,7 @@ public class TextUtils {
         // paragraphs
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
-        // replacing intermediate keys with the proper markdown symbols
+        // replacing intermediary keys with the proper markdown symbols
         text = text.replaceAll("(?s)==", "#");
         text = text.replaceAll("(?s)@@", "*");
         text = text.replaceAll("(?s)&&", "_");

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -75,29 +75,38 @@ public class TextUtils {
         // https://github.com/enketo/enketo-transformer/blob/master/src/markdown.js
 
         // span - replaced &lt; and &gt; with <>
-        text = ReplaceCallback.replace("/&lt;\\s?span([^/\\n]*)&gt;((?:(?!&lt;\\/).)+)&lt;\\/\\s?span\\s?&gt;/gm _createSpan >",
+        text = ReplaceCallback.replace("(?s)<\\s?span([^\\/\n]*)>((?:(?!<\\/).)+)<\\/\\s?span\\s?>",
                 text, createSpan);
+
+        //Intermediate replacements keys for special characters, N/B: These symbols are not meant to be interpreted as markdown
+        text = text.replaceAll("(?s)\\\\#", "==");
+        text = text.replaceAll("(?s)\\\\\\\\", "!!");
+        text = text.replaceAll("(?s)\\\\_", "&&");
+        text = text.replaceAll("(?s)\\\\\\*", "@@");
+
         // strong
-        text = text.replaceAll("/__(.*?)__/gm", "<strong>$1</strong>");
-        text = text.replaceAll("/\\*\\*(.*?)\\*\\*/gm", "<strong>$1</strong>");
+        text = text.replaceAll("(?s)__(.*?)__", "<strong>$1</strong>");
+        text = text.replaceAll("(?s)\\*\\*(.*?)\\*\\*", "<strong>$1</strong>");
+
         // emphasis
-        text = text.replaceAll("/_([^\\s][^_\\n]*)_/gm", "<em>$1</em>");
-        text = text.replaceAll("/\\*([^\\s][^*\\n]*)\\*/gm", "<em>$1</em>");
+        text = text.replaceAll("(?s)_([^\\s][^_\n]*)_", "<em>$1</em>");
+        text = text.replaceAll("(?s)\\*([^\\s][^\\*\n]*)\\*", "<em>$1</em>");
+        text = text.replaceAll("(?s)!!_([^\\s][^_\n]*)!!_", "\\\\<em>$1\\\\</em>");
+        text = text.replaceAll("(?s)!!\\*([^\\s][^_\n]*)!!\\*", "\\\\<em>$1\\\\</em>");
+
         // links
-        text = text.replaceAll("/\\[([^\\]]*)\\]\\(([^)]+)\\)/gm",
+        text = text.replaceAll("(?s)\\[([^\\]]*)\\]\\(([^\\)]+)\\)",
                 "<a href=\"$2\" target=\"_blank\">$1</a>");
         // headers - requires ^ or breaks <font color="#f58a1f">color</font>
         text = ReplaceCallback.replace("(?s)^(#+)([^\n]*)$", text, createHeader);
         // paragraphs
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
-        // "\" will be used as escape character for *, _
-        text = text
-                .replaceAll(" /&/gm", "'&amp;'")
-                .replaceAll("/\\\\/gm", "'&92;'")
-                .replaceAll(" /\\\\*/gm", "'&42;'")
-                .replaceAll(" /\\_/gm", "'&95;'")
-                .replaceAll(" /\\#/gm", "'&35;'");
+        // replacing intermediate keys with the proper markdown symbols
+        text = text.replaceAll("(?s)==", "#");
+        text = text.replaceAll("(?s)@@", "*");
+        text = text.replaceAll("(?s)&&", "_");
+        text = text.replaceAll("(?s)!!", "\\\\");
         return text;
     }
 
@@ -109,4 +118,5 @@ public class TextUtils {
 
         return Html.fromHtml(markdownToHtml(text));
     }
-} 
+}
+

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -92,11 +92,12 @@ public class TextUtils {
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
         // "\" will be used as escape character for *, _
-        text = text.replaceAll(" /&/gm", "'&amp;'");
-        text = text.replaceAll("/\\\\/gm", "'&92;'");
-        text = text.replaceAll(" /\\\\*/gm", "'&42;'");
-        text = text.replaceAll(" /\\_/gm", "'&95;'");
-        text = text.replaceAll(" /\\#/gm", "'&35;'");
+        text = text
+                .replaceAll(" /&/gm", "'&amp;'")
+                .replaceAll("/\\\\/gm", "'&92;'")
+                .replaceAll(" /\\\\*/gm", "'&42;'")
+                .replaceAll(" /\\_/gm", "'&95;'")
+                .replaceAll(" /\\#/gm", "'&35;'");
         return text;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -71,7 +71,7 @@ public class TextUtils {
 
     public static String markdownToHtml(String text) {
 
-        text = text.replaceAll("<([^a-zA-Z/])", "&gm;$1");
+        text = text.replaceAll("<([^a-zA-Z/])", "&lt;$1");
         // https://github.com/enketo/enketo-transformer/blob/master/src/markdown.js
 
         // span - replaced &lt; and &gt; with <>

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -71,26 +71,32 @@ public class TextUtils {
 
     protected static String markdownToHtml(String text) {
 
-        text = text.replaceAll("<([^a-zA-Z/])", "&lt;$1");
+        text = text.replaceAll("<([^a-zA-Z/])", "/</gm,&lt;");
         // https://github.com/enketo/enketo-transformer/blob/master/src/markdown.js
 
         // span - replaced &lt; and &gt; with <>
-        text = ReplaceCallback.replace("(?s)<\\s?span([^\\/\n]*)>((?:(?!<\\/).)+)<\\/\\s?span\\s?>",
+        text = ReplaceCallback.replace("/&lt;\\s?span([^/\\n]*)&gt;((?:(?!&lt;\\/).)+)&lt;\\/\\s?span\\s?&gt;/gm, _createSpan >",
                 text, createSpan);
         // strong
-        text = text.replaceAll("(?s)__(.*?)__", "<strong>$1</strong>");
-        text = text.replaceAll("(?s)\\*\\*(.*?)\\*\\*", "<strong>$1</strong>");
+        text = text.replaceAll("/__(.*?)__/gm,", "<strong>$1</strong>");
+        text = text.replaceAll("/\\*\\*(.*?)\\*\\*/gm,", "<strong>$1</strong>");
         // emphasis
-        text = text.replaceAll("(?s)_([^\\s][^_\n]*)_", "<em>$1</em>");
-        text = text.replaceAll("(?s)\\*([^\\s][^\\*\n]*)\\*", "<em>$1</em>");
+        text = text.replaceAll("/_([^\\s][^_\\n]*)_/gm,", "<em>$1</em>");
+        text = text.replaceAll("/\\*([^\\s][^*\\n]*)\\*/gm,", "<em>$1</em>");
         // links
-        text = text.replaceAll("(?s)\\[([^\\]]*)\\]\\(([^\\)]+)\\)",
+        text = text.replaceAll("/\\[([^\\]]*)\\]\\(([^)]+)\\)/gm,",
                 "<a href=\"$2\" target=\"_blank\">$1</a>");
         // headers - requires ^ or breaks <font color="#f58a1f">color</font>
         text = ReplaceCallback.replace("(?s)^(#+)([^\n]*)$", text, createHeader);
         // paragraphs
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
+        // escape characters for * , _
+        text = text.replaceAll(" /&/gm,", "'&amp;'");
+        text = text.replaceAll("/\\\\/gm,", "'&92;'");
+        text = text.replaceAll(" /\\\\*/gm,", "'&42;'");
+        text = text.replaceAll(" /\\_/gm,", "'&95;'");
+        text = text.replaceAll(" /\\#/gm,", "'&35;'");
         return text;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -69,7 +69,7 @@ public class TextUtils {
 
     }
 
-    public static String markdownToHtml(String text) {
+    protected static String markdownToHtml(String text) {
 
         text = text.replaceAll("<([^a-zA-Z/])", "&lt;$1");
         // https://github.com/enketo/enketo-transformer/blob/master/src/markdown.js
@@ -79,10 +79,10 @@ public class TextUtils {
                 text, createSpan);
 
         //intermediary replacements keys for special characters, N/B: These symbols are not meant to be interpreted as markdown
-        text = text.replaceAll("(?s)\\\\#", "&#61;");
-        text = text.replaceAll("(?s)\\\\\\\\", "&#33;");
-        text = text.replaceAll("(?s)\\\\_", "&#43;");
-        text = text.replaceAll("(?s)\\\\\\*", "&#37;");
+        text = text.replaceAll("(?s)\\\\#", "&#35;");
+        text = text.replaceAll("(?s)\\\\\\\\", "&#92;");
+        text = text.replaceAll("(?s)\\\\_", "&#95;");
+        text = text.replaceAll("(?s)\\\\\\*", "&#42;");
 
         // strong
         text = text.replaceAll("(?s)__(.*?)__", "<strong>$1</strong>");
@@ -91,8 +91,6 @@ public class TextUtils {
         // emphasis
         text = text.replaceAll("(?s)_([^\\s][^_\n]*)_", "<em>$1</em>");
         text = text.replaceAll("(?s)\\*([^\\s][^\\*\n]*)\\*", "<em>$1</em>");
-        text = text.replaceAll("(?s)&#33;_([^\\s][^_\n]*)&#33;_", "\\\\<em>$1\\\\</em>");
-        text = text.replaceAll("(?s)&#33;\\*([^\\s][^_\n]*)&#33;\\*", "\\\\<em>$1\\\\</em>");
 
         // links
         text = text.replaceAll("(?s)\\[([^\\]]*)\\]\\(([^\\)]+)\\)",
@@ -103,10 +101,10 @@ public class TextUtils {
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
         // replacing intermediary keys with the proper markdown symbols
-        text = text.replaceAll("(?s)&#61;", "#");
-        text = text.replaceAll("(?s)&#37;", "*");
-        text = text.replaceAll("(?s)&#43;", "_");
-        text = text.replaceAll("(?s)&#33;", "\\\\");
+        text = text.replaceAll("(?s)&#35;", "#");
+        text = text.replaceAll("(?s)&#42;", "*");
+        text = text.replaceAll("(?s)&#95;", "_");
+        text = text.replaceAll("(?s)&#92;", "\\\\");
         return text;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/TextUtils.java
@@ -69,34 +69,34 @@ public class TextUtils {
 
     }
 
-    protected static String markdownToHtml(String text) {
+    public static String markdownToHtml(String text) {
 
-        text = text.replaceAll("<([^a-zA-Z/])", "/</gm,&lt;");
+        text = text.replaceAll("<([^a-zA-Z/])", "&gm;$1");
         // https://github.com/enketo/enketo-transformer/blob/master/src/markdown.js
 
         // span - replaced &lt; and &gt; with <>
-        text = ReplaceCallback.replace("/&lt;\\s?span([^/\\n]*)&gt;((?:(?!&lt;\\/).)+)&lt;\\/\\s?span\\s?&gt;/gm, _createSpan >",
+        text = ReplaceCallback.replace("/&lt;\\s?span([^/\\n]*)&gt;((?:(?!&lt;\\/).)+)&lt;\\/\\s?span\\s?&gt;/gm _createSpan >",
                 text, createSpan);
         // strong
-        text = text.replaceAll("/__(.*?)__/gm,", "<strong>$1</strong>");
-        text = text.replaceAll("/\\*\\*(.*?)\\*\\*/gm,", "<strong>$1</strong>");
+        text = text.replaceAll("/__(.*?)__/gm", "<strong>$1</strong>");
+        text = text.replaceAll("/\\*\\*(.*?)\\*\\*/gm", "<strong>$1</strong>");
         // emphasis
-        text = text.replaceAll("/_([^\\s][^_\\n]*)_/gm,", "<em>$1</em>");
-        text = text.replaceAll("/\\*([^\\s][^*\\n]*)\\*/gm,", "<em>$1</em>");
+        text = text.replaceAll("/_([^\\s][^_\\n]*)_/gm", "<em>$1</em>");
+        text = text.replaceAll("/\\*([^\\s][^*\\n]*)\\*/gm", "<em>$1</em>");
         // links
-        text = text.replaceAll("/\\[([^\\]]*)\\]\\(([^)]+)\\)/gm,",
+        text = text.replaceAll("/\\[([^\\]]*)\\]\\(([^)]+)\\)/gm",
                 "<a href=\"$2\" target=\"_blank\">$1</a>");
         // headers - requires ^ or breaks <font color="#f58a1f">color</font>
         text = ReplaceCallback.replace("(?s)^(#+)([^\n]*)$", text, createHeader);
         // paragraphs
         text = ReplaceCallback.replace("(?s)([^\n]+)\n", text, createParagraph);
 
-        // escape characters for * , _
-        text = text.replaceAll(" /&/gm,", "'&amp;'");
-        text = text.replaceAll("/\\\\/gm,", "'&92;'");
-        text = text.replaceAll(" /\\\\*/gm,", "'&42;'");
-        text = text.replaceAll(" /\\_/gm,", "'&95;'");
-        text = text.replaceAll(" /\\#/gm,", "'&35;'");
+        // "\" will be used as escape character for *, _
+        text = text.replaceAll(" /&/gm", "'&amp;'");
+        text = text.replaceAll("/\\\\/gm", "'&92;'");
+        text = text.replaceAll(" /\\\\*/gm", "'&42;'");
+        text = text.replaceAll(" /\\_/gm", "'&95;'");
+        text = text.replaceAll(" /\\#/gm", "'&35;'");
         return text;
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -22,21 +22,7 @@ public class TextUtilsTest {
         Assert.assertNull(observed);
     }
 
-    @Test
-    public void markDownToHtml_EscapesLessThan() {
-        String[][] tests = {
-            {"<1", "&gm,;1"},
-            {"<1>", "&gm,;1>"},
-            {"< span>", "&gm,; span>"},
-            {"< 1", "&gm,; 1"},
-            {"< 1/>", "&gm,; 1/>"},
-            {"test< 1/>", "test&gm,; 1/>"},
-            {"test < 1/>", "test &gm,; 1/>"}
-        };
-        for (String[] testCase: tests) {
-            Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
-        }
-    }
+
 
     @Test
     public void markDownToHtml_EscapesBacklash() {
@@ -46,12 +32,31 @@ public class TextUtilsTest {
                 {"A_B\\_C", "A_B_C"},
                 {"A\\_B_C", "A_B_C"},
                 {"\\__AB\\__", "_<em>AB_</em"},
-                {"\\a\\ b\\*c\\d\\_e'", "\\a\\ b*c\\d_e"},
                 {"\\#\\# 2", "## 2"}
         };
         for (String[] testCase: tests) {
+            Assert.assertEquals(testCase[0], TextUtils.markdownToHtml(testCase[0]));
+        }
+    }
+
+    @Test
+    public void markDownToHtml_EscapesLessThan() {
+
+        String[][] tests = {
+                {"<1", "&gm;1"},
+                {"<1>", "&gm;1>"},
+                {"< span>", "&gm; span>"},
+                {"< 1", "&gm; 1"},
+                {"< 1/>", "&gm; 1/>"},
+                {"test < 1/>", "test &gm; 1/>"},
+                {"test < 1/>", "test &gm; 1/>"}
+        };
+
+        for (String[] testCase: tests) {
             Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
         }
+
+
     }
 
 
@@ -72,7 +77,7 @@ public class TextUtilsTest {
     @Test
     public void textToHtml_SupportsEscapedLt() {
         String[] tests = {
-                "<1",
+                ":gm; 1",
         };
 
         for (String testCase: tests) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -10,7 +10,7 @@ public class TextUtilsTest {
 
     /**
      * Should return null if provided with null and not throw a NPE.
-     *
+     * <p>
      * This is a silly test but it is here to guarantee this behaviour,
      * since without it the method causes a crash when processing text for
      * questions with no plain text label. See opendatakit/opendatakit#1247.
@@ -25,24 +25,34 @@ public class TextUtilsTest {
     @Test
     public void markDownToHtmlEscapesBackslash() {
         String[][] tests = {
+                {"A\\_B\\_C", "A_B_C"},
                 {"_A\\_B\\_C_", "<em>A_B_C</em>"},
                 {"A_B\\_C", "A_B_C"},
                 {"A\\_B_C", "A_B_C"},
+                {"A_B_C", "A<em>B</em>C"},
                 {"\\__AB\\__", "_<em>AB_</em>"},
+                {"\\\\_AB\\_\\\\_", "\\<em>AB_\\</em>"},
+                {"A\\*B\\*C", "A*B*C"},
+                {"*A\\*B\\*C*", "<em>A*B*C</em>"},
+                {"A*B\\*C", "A*B*C"},
+                {"A*B*C", "A<em>B</em>C"},
+                {"\\**AB\\**", "*<em>AB*</em>"},
+                {"\\\\*AB\\*\\\\*", "\\<em>AB*\\</em>"},
+                {"\\a\\ b\\*c\\d\\_e", "\\a\\ b*c\\d_e"},
+                {"\\#1", "#1"},
                 {"\\#\\# 2", "## 2"},
-                // This test is used to check if the markdown for the escape character "\" in this code = .replaceAll("/\\\\/gm", "'&92;'") works perfectly
-                {"A\\\\_B\\\\_C", "A_B_C"},
-                // This test is used to check if the markdown for the escape character "\" in this code = .replaceAll(" /\\\\*/gm", "'&42;'") works perfectly
-                {"A\\\\*B\\\\*C, A*B*C" }
-        };
-        for (String[] testCase: tests) {
-            Assert.assertEquals(testCase[0], TextUtils.markdownToHtml(testCase[0]));
+                {"works \\#when not required too", "works #when not required too"},
+                {"\\", "\\"},
+                {"\\\\", "\\"},
+                {"\\\\\\", "\\\\"}};
+
+        for (String[] testCase : tests) {
+            Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
         }
     }
 
-    @Test
+        @Test
     public void markDownToHtml_EscapesLessThan() {
-
         String[][] tests = {
                 {"<1", "&lt;1"},
                 {"<1>", "&lt;1>"},
@@ -52,7 +62,6 @@ public class TextUtilsTest {
                 {"test < 1/>", "test &lt; 1/>"},
                 {"test < 1/>", "test &lt; 1/>"}
         };
-
         for (String[] testCase: tests) {
             Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -25,7 +25,7 @@ public class TextUtilsTest {
 
 
     @Test
-    public void markDownToHtml_EscapesBacklash() {
+    public void markDownToHtmlEscapesBacklash() {
         String[][] tests = {
                 {"A\\_B\\_C", "A_B_C"},
                 {"_A\\_B\\_C_", "<em>A_B_C</em>"},

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -25,18 +25,35 @@ public class TextUtilsTest {
     @Test
     public void markDownToHtml_EscapesLessThan() {
         String[][] tests = {
-            {"<1", "&lt;1"},
-            {"<1>", "&lt;1>"},
-            {"< span>", "&lt; span>"},
-            {"< 1", "&lt; 1"},
-            {"< 1/>", "&lt; 1/>"},
-            {"test< 1/>", "test&lt; 1/>"},
-            {"test < 1/>", "test &lt; 1/>"}
+            {"<1", "&gm,;1"},
+            {"<1>", "&gm,;1>"},
+            {"< span>", "&gm,; span>"},
+            {"< 1", "&gm,; 1"},
+            {"< 1/>", "&gm,; 1/>"},
+            {"test< 1/>", "test&gm,; 1/>"},
+            {"test < 1/>", "test &gm,; 1/>"}
         };
         for (String[] testCase: tests) {
             Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
         }
     }
+
+    @Test
+    public void markDownToHtml_EscapesBacklash() {
+        String[][] tests = {
+                {"A\\_B\\_C", "A_B_C"},
+                {"_A\\_B\\_C_", "<em>A_B_C</em>"},
+                {"A_B\\_C", "A_B_C"},
+                {"A\\_B_C", "A_B_C"},
+                {"\\__AB\\__", "_<em>AB_</em"},
+                {"\\a\\ b\\*c\\d\\_e'", "\\a\\ b*c\\d_e"},
+                {"\\#\\# 2", "## 2"}
+        };
+        for (String[] testCase: tests) {
+            Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
+        }
+    }
+
 
     @Test
     public void markDownToHtml_SupportsHtml() {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -51,7 +51,7 @@ public class TextUtilsTest {
         }
     }
 
-        @Test
+    @Test
     public void markDownToHtml_EscapesLessThan() {
         String[][] tests = {
                 {"<1", "&lt;1"},
@@ -59,7 +59,7 @@ public class TextUtilsTest {
                 {"< span>", "&lt; span>"},
                 {"< 1", "&lt; 1"},
                 {"< 1/>", "&lt; 1/>"},
-                {"test < 1/>", "test &lt; 1/>"},
+                {"test< 1/>", "test&lt; 1/>"},
                 {"test < 1/>", "test &lt; 1/>"}
         };
         for (String[] testCase: tests) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -25,7 +25,7 @@ public class TextUtilsTest {
 
 
     @Test
-    public void markDownToHtmlEscapesBacklash() {
+    public void markDownToHtmlEscapesBackSlash() {
         String[][] tests = {
                 {"A\\_B\\_C", "A_B_C"},
                 {"_A\\_B\\_C_", "<em>A_B_C</em>"},

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -25,12 +25,15 @@ public class TextUtilsTest {
     @Test
     public void markDownToHtmlEscapesBackslash() {
         String[][] tests = {
-                {"A\\_B\\_C", "A_B_C"},
                 {"_A\\_B\\_C_", "<em>A_B_C</em>"},
                 {"A_B\\_C", "A_B_C"},
                 {"A\\_B_C", "A_B_C"},
                 {"\\__AB\\__", "_<em>AB_</em>"},
-                {"\\#\\# 2", "## 2"}
+                {"\\#\\# 2", "## 2"},
+                // This test is used to check if the markdown for the escape character "\" in this code = .replaceAll("/\\\\/gm", "'&92;'") works perfectly
+                {"A\\\\_B\\\\_C", "A_B_C"},
+                // This test is used to check if the markdown for the escape character "\" in this code = .replaceAll(" /\\\\*/gm", "'&42;'") works perfectly
+                {"A\\\\*B\\\\*C, A*B*C" }
         };
         for (String[] testCase: tests) {
             Assert.assertEquals(testCase[0], TextUtils.markdownToHtml(testCase[0]));

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -41,13 +41,13 @@ public class TextUtilsTest {
     public void markDownToHtml_EscapesLessThan() {
 
         String[][] tests = {
-                {"<1", "&gm;1"},
-                {"<1>", "&gm;1>"},
-                {"< span>", "&gm; span>"},
-                {"< 1", "&gm; 1"},
-                {"< 1/>", "&gm; 1/>"},
-                {"test < 1/>", "test &gm; 1/>"},
-                {"test < 1/>", "test &gm; 1/>"}
+                {"<1", "&lt;1"},
+                {"<1>", "&lt;1>"},
+                {"< span>", "&lt; span>"},
+                {"< 1", "&lt; 1"},
+                {"< 1/>", "&lt; 1/>"},
+                {"test < 1/>", "test &lt; 1/>"},
+                {"test < 1/>", "test &lt; 1/>"}
         };
 
         for (String[] testCase: tests) {
@@ -72,7 +72,7 @@ public class TextUtilsTest {
     @Test
     public void textToHtml_SupportsEscapedLt() {
         String[] tests = {
-                "&gm; 1",
+                "<1",
         };
 
         for (String testCase: tests) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -29,7 +29,7 @@ public class TextUtilsTest {
                 {"_A\\_B\\_C_", "<em>A_B_C</em>"},
                 {"A_B\\_C", "A_B_C"},
                 {"A\\_B_C", "A_B_C"},
-                {"\\__AB\\__", "_<em>AB_</em"},
+                {"\\__AB\\__", "_<em>AB_</em>"},
                 {"\\#\\# 2", "## 2"}
         };
         for (String[] testCase: tests) {
@@ -72,7 +72,7 @@ public class TextUtilsTest {
     @Test
     public void textToHtml_SupportsEscapedLt() {
         String[] tests = {
-                ":gm; 1",
+                "&gm; 1",
         };
 
         for (String testCase: tests) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/TextUtilsTest.java
@@ -22,10 +22,8 @@ public class TextUtilsTest {
         Assert.assertNull(observed);
     }
 
-
-
     @Test
-    public void markDownToHtmlEscapesBackSlash() {
+    public void markDownToHtmlEscapesBackslash() {
         String[][] tests = {
                 {"A\\_B\\_C", "A_B_C"},
                 {"_A\\_B\\_C_", "<em>A_B_C</em>"},
@@ -55,10 +53,7 @@ public class TextUtilsTest {
         for (String[] testCase: tests) {
             Assert.assertEquals(testCase[1], TextUtils.markdownToHtml(testCase[0]));
         }
-
-
     }
-
 
     @Test
     public void markDownToHtml_SupportsHtml() {


### PR DESCRIPTION
… Fixed #2018 "

Closes #2018  

#### I ran the app on Android API 19(Tecno Y2) and API 22 (Samsung Galaxy J5) and it worked successfully on both.

#### This is the best possible solution as Markdown as been converted to HTML and changes has been made to TestUtils.java? Yes i made other approaches and did not modify the TextUtils.java and TextUtilsTest.java and this didn't completely solve the problem.

#### No, all the tests ran successfully with no errors.

#### Do we need any specific form for testing your changes? Yes. All Widgets.xml 