### PR TITLE
Toggle button text fix #2039

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -418,8 +418,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             ((FormDownloadListAdapter) listView.getAdapter()).notifyDataSetChanged();
         }
         toggleButton.setEnabled(filteredFormList.size() > 0);
-        toggleButtonLabel(toggleButton, listView);
         checkPreviouslyCheckedItems();
+        toggleButtonLabel(toggleButton, listView);
     }
 
     @Override


### PR DESCRIPTION
Closes #2039 

The problem was that App change Toggle Button label, then It check forms that is previously checked. I just changed the order of these operations, so I don't see any problem if my changes are merged.