### PR TITLE
Fix required dateTime

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -76,7 +76,7 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget {
     public IAnswerData getAnswer() {
         clearFocus();
 
-        if (dateWidget.isNullAnswer() && timeWidget.isNullAnswer()) {
+        if (isNullAnswer()) {
             return null;
         } else {
             if (timeWidget.isNullAnswer()) {
@@ -154,5 +154,11 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
+    }
+
+    private boolean isNullAnswer() {
+        return getFormEntryPrompt().isRequired()
+                ? dateWidget.isNullAnswer() || timeWidget.isNullAnswer()
+                : dateWidget.isNullAnswer() && timeWidget.isNullAnswer();
     }
 }


### PR DESCRIPTION
Closes #2054

#### What has been done to verify that this works as intended?
I tested the attached form.

#### Why is this the best possible solution? Were any other approaches considered?
A user shouldn't be able to add only one value (date or time) if `DateTimeWidget` is required.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
There is a test form attached to the issue.


@lognaturel I forgot about this issue but we may want to add the fix to the next release