### PR TITLE
Delete unused method from ZipUtils.java

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
@@ -69,7 +69,7 @@ public final class ZipUtils {
 
         // extract the new file
         try (
-            targetFile = new File(zipFile.getParentFile(), fileName);
+            File targetFile = new File(zipFile.getParentFile(), fileName);
             FileOutputStream fileOutputStream = null
         ) {
             fileOutputStream = new FileOutputStream(targetFile);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
@@ -43,8 +43,7 @@ public final class ZipUtils {
 
     public static void unzip(File[] zipFiles) {
         for (File zipFile : zipFiles) {
-            ZipInputStream zipInputStream = null;
-            try {
+            try (ZipInputStream zipInputStream = null) {
                 zipInputStream = new ZipInputStream(new FileInputStream(zipFile));
                 ZipEntry zipEntry;
                 while ((zipEntry = zipInputStream.getNextEntry()) != null) {
@@ -52,15 +51,12 @@ public final class ZipUtils {
                 }
             } catch (Exception e) {
                 Timber.e(e);
-            } finally {
-                IOUtils.closeQuietly(zipInputStream);
             }
         }
     }
 
-    private static File doExtractInTheSameFolder(File zipFile, ZipInputStream zipInputStream,
+    private static void doExtractInTheSameFolder(File zipFile, ZipInputStream zipInputStream,
                                                  ZipEntry zipEntry) throws IOException {
-        File targetFile;
         String fileName = zipEntry.getName();
 
         Timber.i("Found zipEntry with name: %s", fileName);
@@ -72,16 +68,14 @@ public final class ZipUtils {
         }
 
         // extract the new file
-        targetFile = new File(zipFile.getParentFile(), fileName);
-        FileOutputStream fileOutputStream = null;
-        try {
+        try (
+            targetFile = new File(zipFile.getParentFile(), fileName);
+            FileOutputStream fileOutputStream = null
+        ) {
             fileOutputStream = new FileOutputStream(targetFile);
             IOUtils.copy(zipInputStream, fileOutputStream);
-        } finally {
-            IOUtils.closeQuietly(fileOutputStream);
         }
 
         Timber.i("Extracted file \"%s\" out of %s", fileName, zipFile.getName());
-        return targetFile;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
@@ -43,8 +43,7 @@ public final class ZipUtils {
 
     public static void unzip(File[] zipFiles) {
         for (File zipFile : zipFiles) {
-            try (ZipInputStream zipInputStream = null) {
-                zipInputStream = new ZipInputStream(new FileInputStream(zipFile));
+            try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(zipFile))) {
                 ZipEntry zipEntry;
                 while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                     doExtractInTheSameFolder(zipFile, zipInputStream, zipEntry);
@@ -57,6 +56,7 @@ public final class ZipUtils {
 
     private static void doExtractInTheSameFolder(File zipFile, ZipInputStream zipInputStream,
                                                  ZipEntry zipEntry) throws IOException {
+        File targetFile;
         String fileName = zipEntry.getName();
 
         Timber.i("Found zipEntry with name: %s", fileName);
@@ -64,15 +64,12 @@ public final class ZipUtils {
         if (fileName.contains("/") || fileName.contains("\\")) {
             // that means that this is a directory of a file inside a directory, so ignore it
             Timber.w("Ignored: %s", fileName);
-            return null;
+            return;
         }
 
         // extract the new file
-        try (
-            File targetFile = new File(zipFile.getParentFile(), fileName);
-            FileOutputStream fileOutputStream = null
-        ) {
-            fileOutputStream = new FileOutputStream(targetFile);
+        targetFile = new File(zipFile.getParentFile(), fileName);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(targetFile)) {
             IOUtils.copy(zipInputStream, fileOutputStream);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ZipUtils.java
@@ -58,33 +58,12 @@ public final class ZipUtils {
         }
     }
 
-    public static File extractFirstZipEntry(File zipFile, boolean deleteAfterUnzip)
-            throws IOException {
-        ZipInputStream zipInputStream = null;
-        File targetFile = null;
-        try {
-            zipInputStream = new ZipInputStream(new FileInputStream(zipFile));
-            ZipEntry zipEntry = zipInputStream.getNextEntry();
-            if (zipEntry != null) {
-                targetFile = doExtractInTheSameFolder(zipFile, zipInputStream, zipEntry);
-            }
-        } finally {
-            IOUtils.closeQuietly(zipInputStream);
-        }
-
-        if (deleteAfterUnzip && targetFile != null && targetFile.exists()) {
-            FileUtils.deleteAndReport(zipFile);
-        }
-
-        return targetFile;
-    }
-
     private static File doExtractInTheSameFolder(File zipFile, ZipInputStream zipInputStream,
                                                  ZipEntry zipEntry) throws IOException {
         File targetFile;
         String fileName = zipEntry.getName();
 
-        Timber.w("Found zipEntry with name: %s", fileName);
+        Timber.i("Found zipEntry with name: %s", fileName);
 
         if (fileName.contains("/") || fileName.contains("\\")) {
             // that means that this is a directory of a file inside a directory, so ignore it
@@ -102,7 +81,7 @@ public final class ZipUtils {
             IOUtils.closeQuietly(fileOutputStream);
         }
 
-        Timber.w("Extracted file \"%s\" out of %s", fileName, zipFile.getName());
+        Timber.i("Extracted file \"%s\" out of %s", fileName, zipFile.getName());
         return targetFile;
     }
 }


### PR DESCRIPTION
Removed unused extractFirstZipEntry() method from ZipUtils.java. Timber.w replaced with Timber.i in two lines.

Closes #1434 

#### What has been done to verify that this works as intended? App rebuild. Runs as usual.

#### Are there any risks to merging this code? None

@shobhitagarwal1612 @lognaturel 