### PR TITLE
Last fixes for repeatable groups 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -381,8 +381,8 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         }
         if (element.isRepeatable()) {
             answers.put(PARENT_KEY, parentKey);
-            answers.put(KEY, key);
         }
+        answers.put(KEY, key);
         return answers;
     }
 
@@ -393,8 +393,8 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         }
         if (element.isRepeatable()) {
             columnTitles.add(PARENT_KEY);
-            columnTitles.add(KEY);
         }
+        columnTitles.add(KEY);
         return columnTitles;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -384,8 +384,10 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         }
         if (element.isRepeatable()) {
             answers.put(PARENT_KEY, parentKey);
+            answers.put(KEY, key);
+        } else if (hasRepeatableGroups(element)) {
+            answers.put(KEY, key);
         }
-        answers.put(KEY, key);
         return answers;
     }
 
@@ -396,8 +398,10 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         }
         if (element.isRepeatable()) {
             columnTitles.add(PARENT_KEY);
+            columnTitles.add(KEY);
+        } else if (hasRepeatableGroups(element)) {
+            columnTitles.add(KEY);
         }
-        columnTitles.add(KEY);
         return columnTitles;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -225,6 +225,9 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             if (child.isRepeatable() && child.getMultiplicity() != TreeReference.INDEX_TEMPLATE) {
                 insertRows(child, key, getKeyBasedOnParentKey(key, child.getName(), repeatIndex++), instanceFile, getElementTitle(child));
             }
+            if (child.getMultiplicity() == TreeReference.INDEX_TEMPLATE) {
+                repeatIndex = 0;
+            }
         }
     }
 


### PR DESCRIPTION
@lognaturel 
just a quick fix without opening a new issue. I think you made a mistake https://github.com/opendatakit/collect/pull/2064/commits/b0b8cc5ee87bc6fb3bcec507baffd64c699933db
the main level of uploaded instance also should have KEY column since instanceId not always exists. The main level is not repeatable so it shouldn't be inside that if statement.

The second issue I fixed here was a problem discovered by @mmarciniak90  with multiple repeat groups on the same level - then the index was wrong.