### PR TITLE
separator lines added to SelectOneSearchWidget. fix #1976

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -18,6 +18,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.RadioButton;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.AudioPlayListener;
@@ -42,7 +43,9 @@ public class SelectOneSearchWidget extends SelectOneWidget implements OnCheckedC
     protected void addButtonsToLayout(List<Integer> tagList) {
         for (int i = 0; i < buttons.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
-                answerLayout.addView(buttons.get(i));
+                RadioButton radioButton = createRadioButton(i);
+//                answerLayout.addView(buttons.get(i));
+                answerLayout.addView(createMediaLayout(i, radioButton));
             }
         }
     }


### PR DESCRIPTION
Closes #1976 

**What has been done to verify that this works as intended?**
Separator lines in SelectOneWidget are created using the function createMediaLayout which contains the devider that creates separator lines, this function isn't called when creating SelectOneSearchWidget layout so we don't have separator lines in it as in the SelectOneWidget layout.
I added this function to SelectOneSearchWidget and now there're separator lines as in the SelectOneWidget.

**Why is this the best possible solution? Were any other approaches considered?**
I don't know if there's another approach to do this, but I think it's the shortest way to do it because it doesn't need a lot of modification.

**Are there any risks to merging this code? If so, what are they?**
No

**Do we need any specific form for testing your changes? If so, please attach one.**
SelectOneSearchWidget in All Widget.