### PR TITLE
The user is not able to remove response on required data and time widget when only one value is adde

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -118,6 +118,7 @@ import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.TimerLogger;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.views.ODKView;
+import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangeWidget;
 import org.odk.collect.android.widgets.StringWidget;
@@ -991,7 +992,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
      * Clears the answer on the screen.
      */
     private void clearAnswer(QuestionWidget qw) {
-        if (qw.getAnswer() != null) {
+        if (qw.getAnswer() != null || qw instanceof DateTimeWidget) {
             qw.clearAnswer();
         }
     }


### PR DESCRIPTION
Closes #2076 

#### What has been done to verify that this works as intended?
As I said I'm not sure if it's a bug but I added a fix just in case @lognaturel you want to merge it.

#### Why is this the best possible solution? Were any other approaches considered?
If we add only one value in required DateTimeWidget it's treated as a null value so we need to clear such DateTimeWidget everytime that option is used not only when the answer is added.

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
[dateTimeTest.xml.txt](https://github.com/opendatakit/collect/files/1859435/dateTimeTest.xml.txt)
