### PR TITLE
Fix bug in RelativeLayout with empty content under RTL language, fix #1914.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -16,7 +16,9 @@ package org.odk.collect.android.views;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.view.Gravity;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -24,6 +26,7 @@ import android.widget.TextView;
 import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.utilities.ViewIds;
+import org.odk.collect.android.widgets.QuestionWidget;
 
 public class HierarchyElementView extends RelativeLayout {
 
@@ -53,7 +56,11 @@ public class HierarchyElementView extends RelativeLayout {
         LayoutParams l =
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-//        l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
+        l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
+        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 16) {
+            l.addRule(RelativeLayout.END_OF, icon.getId());
+            primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
+        }
         addView(primaryTextView, l);
 
         secondaryTextView = new TextView(context);
@@ -64,8 +71,12 @@ public class HierarchyElementView extends RelativeLayout {
         LayoutParams lp =
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-//        lp.addRule(RelativeLayout.BELOW, primaryTextView.getId());
-//        lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
+        lp.addRule(RelativeLayout.BELOW, primaryTextView.getId());
+        lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
+        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 16) {
+            lp.addRule(RelativeLayout.END_OF, icon.getId());
+            secondaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
+        }
         addView(secondaryTextView, lp);
 
         setPadding(dipToPx(8), dipToPx(4), dipToPx(8), dipToPx(8));

--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -56,10 +56,14 @@ public class HierarchyElementView extends RelativeLayout {
         LayoutParams l =
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
-        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 16) {
+        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 17) {
             l.addRule(RelativeLayout.END_OF, icon.getId());
             primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
+        }else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17){
+            l.addRule(RelativeLayout.END_OF, icon.getId());
+            primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
+        }else {
+            l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         }
         addView(primaryTextView, l);
 
@@ -72,10 +76,15 @@ public class HierarchyElementView extends RelativeLayout {
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
         lp.addRule(RelativeLayout.BELOW, primaryTextView.getId());
-        lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
-        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 16) {
+        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 17) {
+            lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
             lp.addRule(RelativeLayout.END_OF, icon.getId());
             secondaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
+        }else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17){
+            lp.addRule(RelativeLayout.END_OF, icon.getId());
+            secondaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
+        }else {
+            lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         }
         addView(secondaryTextView, lp);
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -56,10 +56,7 @@ public class HierarchyElementView extends RelativeLayout {
         LayoutParams l =
                 new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 17) {
-            l.addRule(RelativeLayout.END_OF, icon.getId());
-            primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
-        } else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17) {
+        if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 16) {
             l.addRule(RelativeLayout.END_OF, icon.getId());
             primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.Gravity;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -25,7 +26,7 @@ import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.utilities.ViewIds;
 
-public class HierarchyElementView extends RelativeLayout {
+public class HierarchyElementView extends LinearLayout {
 
     private TextView primaryTextView;
     private TextView secondaryTextView;
@@ -51,9 +52,9 @@ public class HierarchyElementView extends RelativeLayout {
         primaryTextView.setId(ViewIds.generateViewId());
         primaryTextView.setGravity(Gravity.CENTER_VERTICAL);
         LayoutParams l =
-                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+                new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
+//        l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         addView(primaryTextView, l);
 
         secondaryTextView = new TextView(context);
@@ -62,10 +63,10 @@ public class HierarchyElementView extends RelativeLayout {
         secondaryTextView.setGravity(Gravity.CENTER_VERTICAL);
 
         LayoutParams lp =
-                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+                new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
-        lp.addRule(RelativeLayout.BELOW, primaryTextView.getId());
-        lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
+//        lp.addRule(RelativeLayout.BELOW, primaryTextView.getId());
+//        lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         addView(secondaryTextView, lp);
 
         setPadding(dipToPx(8), dipToPx(4), dipToPx(8), dipToPx(8));

--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -59,10 +59,10 @@ public class HierarchyElementView extends RelativeLayout {
         if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT > 17) {
             l.addRule(RelativeLayout.END_OF, icon.getId());
             primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
-        }else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17){
+        } else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17) {
             l.addRule(RelativeLayout.END_OF, icon.getId());
             primaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
-        }else {
+        } else {
             l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         }
         addView(primaryTextView, l);
@@ -80,10 +80,10 @@ public class HierarchyElementView extends RelativeLayout {
             lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
             lp.addRule(RelativeLayout.END_OF, icon.getId());
             secondaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
-        }else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17){
+        } else if (QuestionWidget.isRTL() && Build.VERSION.SDK_INT == 17) {
             lp.addRule(RelativeLayout.END_OF, icon.getId());
             secondaryTextView.setTextDirection(View.TEXT_DIRECTION_RTL);
-        }else {
+        } else {
             lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         }
         addView(secondaryTextView, lp);

--- a/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/HierarchyElementView.java
@@ -18,7 +18,6 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.view.Gravity;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -26,7 +25,7 @@ import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.utilities.ViewIds;
 
-public class HierarchyElementView extends LinearLayout {
+public class HierarchyElementView extends RelativeLayout {
 
     private TextView primaryTextView;
     private TextView secondaryTextView;
@@ -52,7 +51,7 @@ public class HierarchyElementView extends LinearLayout {
         primaryTextView.setId(ViewIds.generateViewId());
         primaryTextView.setGravity(Gravity.CENTER_VERTICAL);
         LayoutParams l =
-                new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
 //        l.addRule(RelativeLayout.RIGHT_OF, icon.getId());
         addView(primaryTextView, l);
@@ -63,7 +62,7 @@ public class HierarchyElementView extends LinearLayout {
         secondaryTextView.setGravity(Gravity.CENTER_VERTICAL);
 
         LayoutParams lp =
-                new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+                new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
                         LayoutParams.WRAP_CONTENT);
 //        lp.addRule(RelativeLayout.BELOW, primaryTextView.getId());
 //        lp.addRule(RelativeLayout.RIGHT_OF, icon.getId());


### PR DESCRIPTION
Closes #1914 

#### What has been done to verify that this works as intended?
In this situation, the empty views were caused by a bug in RelativeLayout under RTL languages circumstance. With method  `addRule()` in RTL situation, RelativeLayout won't draw views because we used a `RelativeLayout.RIGHT_OF` parameter, If known this, it would be easy for me to address this problem. The most hard part about this fix are some problems in API 17, it's a special API, maybe Google wants to use it for a transition one, I don't know, so I added some special checks with this API.

Tests results:

|   Android 4.1.1           |  Android 4.2      |
| ---- | :----: |
|<img src="https://i.loli.net/2018/03/29/5abcff2bb58b5.png" width = "300" align=center />|<img src="https://i.loli.net/2018/03/29/5abcff447e501.png" width = "300" align=center />|

|   Android 5.1           |  Android 6.0     |
| ---- | :----: |
|<img src="https://i.loli.net/2018/03/29/5abcff608993e.png" width = "300" align=center />|<img src="https://i.loli.net/2018/03/29/5abcff71b2947.png" width = "300" align=center />|

|   Android 7.0          |  Android 8.1      |
| ---- | :----: |
|<img src="https://i.loli.net/2018/03/29/5abcff85ea20a.png" width = "300" align=center />|<img src="https://i.loli.net/2018/03/29/5abcff97a900c.png" width = "300" align=center />|
#### Why is this the best possible solution? Were any other approaches considered?
In my view, this is the best solution without a big modification.
If there are any better approaches to address this issue, pls let me know, I will be glad to learn and improve this :))).
#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
No need.