### PR TITLE
Forms are not marked when user scrolls up and down

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -619,6 +619,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             // file clicked, download the file, mark checkbox.
             CheckBox cb = view.findViewById(R.id.checkbox);
             cb.setChecked(!cb.isChecked());
+            item.setSelected(cb.isChecked());
 
             if (toDownload.contains(item) && !cb.isChecked()) {
                 toDownload.remove(item);

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/FileArrayAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/FileArrayAdapter.java
@@ -80,7 +80,6 @@ public class FileArrayAdapter extends ArrayAdapter<DriveListItem> {
             text1.setText(item.getName());
             text2.setText(dateModified);
             checkBox.setChecked(item.isSelected());
-            checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> item.setSelected(buttonView.isChecked()));
         }
     }
 


### PR DESCRIPTION
Closes #2074

#### What has been done to verify that this works as intended?
I tested scrolling, checking, unchecking, downloading, opening folder, back button, shared with me
 
#### Why is this the best possible solution? Were any other approaches considered?
Whenever user scrolls up and down `onBind` is called which keeps adding listener to a checkbox due to which it was not working as expected I've removed listener and added code in `onItemClick` to modify the list item

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/18495162/38121683-8fea3882-33ee-11e8-80dc-b3c3e4bcbea4.gif)
