### PR TITLE
Message in ErrorDialog won't be doubled , fix #1826

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1311,7 +1311,11 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
         } catch (JavaRosaException e) {
             Timber.d(e);
-            createErrorDialog(e.getMessage() + "\n\n" + e.getCause().getMessage(), DO_NOT_EXIT);
+            if (e.getMessage().equals(e.getCause().getMessage())) {
+                createErrorDialog(e.getMessage(), DO_NOT_EXIT);
+            } else {
+                createErrorDialog(e.getMessage() + "\n\n" + e.getCause().getMessage(), DO_NOT_EXIT);
+            }
         }
 
         return createView(event, advancingPage);


### PR DESCRIPTION
Closes #1826 

#### What has been done to verify that this works as intended?
In the method `createViewForFormBeginning` in file `FormEntryActivity.java` , I found `e.getMessage()` and `e.getCause().getMessage()` are equal, so with dialog message: `e.getMessage() + "\n\n" + e.getCause().getMessage()`  the message would be doubled. We should check if these two messages are equal and make it appear only once.

This is screenshot:

<img src="https://i.loli.net/2018/03/31/5abfa95bbffa3.png" width = "350" align=center />

#### Why is this the best possible solution? Were any other approaches considered?
I don't think there are other approaches to address this.
#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
Please use form attached in issue description: [g6Error.xml](https://github.com/opendatakit/collect/files/1689060/g6Error.xml.txt)