### PR TITLE
Break the infinity loop in specific form with metadata, fix #1833

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -521,7 +521,14 @@ public class FormController {
         List<FormIndex> indices = getIndicesForGroup(gd);
 
         // jump to the end of the group
-        formEntryController.jumpToIndex(indices.get(indices.size() - 1));
+        if (indices.size() == 0) {
+            // if field list is empty, there will be a infinity loop between stepOverGroup()
+            // and stepToNextEvent(boolean stepIntoGroup), so we use stepToNextEvent(STEP_INTO_GROUP)
+            // to break this loop and use another JavaRosaException to handle this.
+            return stepToNextEvent(STEP_INTO_GROUP);
+        } else {
+            formEntryController.jumpToIndex(indices.get(indices.size() - 1));
+        }
         return stepToNextEvent(STEP_OVER_GROUP);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -528,8 +528,8 @@ public class FormController {
             return stepToNextEvent(STEP_INTO_GROUP);
         } else {
             formEntryController.jumpToIndex(indices.get(indices.size() - 1));
+            return stepToNextEvent(STEP_OVER_GROUP);
         }
-        return stepToNextEvent(STEP_OVER_GROUP);
     }
 
     /**


### PR DESCRIPTION
Closes #1833 

#### What has been done to verify that this works as intended?
If field list is empty, method `stepOverGroup()` and `stepToNextEvent(boolean stepIntoGroup)` would call each other without an end, this may cause ANR and crash our app. Here is the log in Android debugger:

```
04-01 23:24:26.864 8017-8017/org.odk.collect.android W/System.err: java.lang.ArrayIndexOutOfBoundsException: length=0; index=-1
04-01 23:24:26.866 8017-8017/org.odk.collect.android W/System.err:     at java.util.ArrayList.get(ArrayList.java:439)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:525)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
        at org.odk.collect.android.logic.FormController.stepOverGroup(FormController.java:530)
        at org.odk.collect.android.logic.FormController.stepToNextEvent(FormController.java:506)
```

 I used a wrong parameter (`STEP_INTO_GROUP` in `stepToNextEvent()`) to simply break this infinity loop when `indices.size() == 0` and make sure Collect can still work, but different APIs may have different error messages in this situation. I don't know if we should build a specific dialog (which shows "Error: empty field list !") or just simply break this loop.

This is the current error dialog:

|   Android 8.1          |  Android 4.1      |
| ---- | :----: |
|<img src="https://i.loli.net/2018/04/02/5ac19f0d6c9c5.png" width = "300" align=center />|<img src="https://i.loli.net/2018/04/02/5ac1a39b63d67.png" width = "300" align=center />|


#### Why is this the best possible solution? Were any other approaches considered?
It cannot be the best solution, but it can be the easiest way to isolate this error and make sure our App still working.

#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
Please use this form [metadata2.xml](https://github.com/opendatakit/collect/files/1689484/metadata2.xml.txt)