### PR TITLE
Request link to docs issue in PR template and contributing guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Closes #
 
 #### Do we need any specific form for testing your changes? If so, please attach one.
 
-#### Does this change require updates to documentation? If so, please link to the filed issue in the docs repo.
+#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,5 @@ Closes #
 #### Are there any risks to merging this code? If so, what are they?
 
 #### Do we need any specific form for testing your changes? If so, please attach one.
+
+#### Does this change require updates to documentation? If so, please link to the filed issue in the docs repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ To contribute code to ODK Collect, you will need to open a [pull request](https:
 
 1. Document your reasoning. Your commit messages should make it clear why each change has been made.
 
+1. If your pull request makes user-facing changes, we likely need to update documentation. [File an issue on the docs repo](https://github.com/opendatakit/docs/issues/new) describing the changes.
+
 1. Follow the guidelines below.
 
 ## The review process
@@ -57,6 +59,7 @@ We try to have at least two people review every pull request and we encourage ev
 - What other functionality could this PR affect? Does that functionality still work as intended?
 - Was the change verified with several different devices and Android versions?
 - Is the code easy to understand and to maintain?
+- Is there sufficient detail to inform any changes to documentation?
 
 When a pull request is first created, @opendatakit-bot tags it as `needs review` to indicate that code review is needed. Community members review the code and leave their comments, verifying that the changes included are relevant and properly address the issue. A maintainer does a thorough code review and when satisfied with the code, tags the pull request as `needs testing` to indicate the need for a manual [black-box testing](https://en.wikipedia.org/wiki/Black-box_testing) pass. A pull request may go back and forth between `needs testing` and `needs review` until the behavior is thoroughly verified. Once the behavior has been thoroughly verified, the pull request is tagged as `behavior verified`. A maintainer then merges the changes. Pull requests that need more complete reviews including review of approach and/or appropriateness are tagged with `reviews wanted`. Any community member is encouraged to participate in the review process!
 


### PR DESCRIPTION
We sometimes forget to file an issue against the docs when behavior changes. This PR attempts to remedy that. 