### PR TITLE
Fix failing test - expected scale factor is 4

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/BitmapScaledToDisplayTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/BitmapScaledToDisplayTest.java
@@ -15,18 +15,22 @@ import static org.junit.Assert.assertEquals;
 @RunWith(AndroidJUnit4.class)
 public class BitmapScaledToDisplayTest {
 
+    /**
+     * These cases all have a window smaller than the image so the image should be scaled down.
+     * Note that the scaling isn't exact -- the factor is the closest power of 2 to the exact one.
+     */
     @Test
     @SuppressWarnings("ParenPad")
-    public void scaleDownBitmapWhenPossible() {
+    public void scaleDownBitmapWhenNeeded() {
         runScaleTest(1000,   1000,    500,    500,    500,    500,    false);
         runScaleTest( 600,    800,    600,    200,    150,    200,    false);
         runScaleTest( 500,    400,    250,    200,    250,    200,    false);
-        runScaleTest(2000,    800,    300,    400,    333,    133,    false);
+        runScaleTest(2000,    800,    300,    400,    500,    200,    false);
     }
 
     @Test
     @SuppressWarnings("ParenPad")
-    public void doNotScaleDownBitmapWhenNotPossible() {
+    public void doNotScaleDownBitmapWhenNotNeeded() {
         runScaleTest(1000,   1000,    2000,   2000,   1000,   1000,   false);
         runScaleTest( 600,    800,     600,    800,    600,    800,   false);
         runScaleTest( 500,    400,     600,    600,    500,    400,   false);


### PR DESCRIPTION
Fixes failing test.

#### What has been done to verify that this works as intended?
Ran test and verified it passes.

#### Why is this the best possible solution? Were any other approaches considered?
It fixes the test! I did sneak in something controversial, though. @shobhitagarwal1612, if you want me to change the test names back I will.

#### Are there any risks to merging this code? If so, what are they?
Absolute worst case is that it doesn't fix the test.

@shobhitagarwal1612 My guess is that you read the code and thought either it would use the nearest integer or the nearest multiple of 2 as a scale factor. It's actually the [inSampleSize](https://developer.android.com/reference/android/graphics/BitmapFactory.Options.html#inSampleSize) option that does the unexpected power of 2 thing so it's not very obvious. I added a little comment to help jog the next person's memory.

The thing that is not awesome about this scaling strategy is that in cases like that specific test, the image still doesn't fully fit on the screen. It might be better to go up to the next power of 2 instead. But that can be for another PR.