### PR TITLE
Add background color to toast, fix #2100.

### DIFF
--- a/collect_app/src/main/res/layout-v26/toast_view.xml
+++ b/collect_app/src/main/res/layout-v26/toast_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 University of Washington
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:backgroundTint="#696969"
+    android:background="@android:drawable/toast_frame">
+
+            <TextView
+                android:id="@+id/message"
+                android:layout_gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="21sp"
+                android:textColor="@color/white"
+                />
+
+</LinearLayout>

--- a/collect_app/src/main/res/layout-v27/toast_view.xml
+++ b/collect_app/src/main/res/layout-v27/toast_view.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2009 University of Washington
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2009 University of Washington
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
@@ -17,16 +16,16 @@ the License.
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:backgroundTint="#696969"
     android:background="@android:drawable/toast_frame">
 
-            <TextView
-                android:id="@+id/message"
-                android:layout_gravity="center"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="21sp"
-                android:textColor="@color/white"
-                />
+    <TextView
+        android:id="@+id/message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_margin="15dp"
+        android:textColor="@color/black"
+        android:textColorHint="@color/black"
+        android:textSize="21sp" />
 
 </LinearLayout>


### PR DESCRIPTION
Closes #2100 

#### What has been done to verify that this works as intended?
Add a background color to toast in Android 8+

It looks like this:
 <img src="https://i.loli.net/2018/04/07/5ac83f4e7b7f9.png" width = "300" align=center />


#### Why is this the best possible solution? Were any other approaches considered?
I'm not sure whether to add a separate `layout-v27` or just add to the base `toast_view.xml`, but the `backgroundTint` require a API level higher than 21, so I just built this to a `layout-v27` folder.
#### Are there any risks to merging this code? If so, what are they?
N/A
#### Do we need any specific form for testing your changes? If so, please attach one.
No need.
#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.