### PR TITLE
WIP: Add image crop view

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -309,6 +309,7 @@ the specific language governing permissions and limitations under the License.
         <activity android:name=".activities.WebViewActivity" />
         <activity android:name=".activities.CaptureSelfieVideoActivity" />
         <activity android:name=".activities.CaptureSelfieVideoActivityNewApi" />
+        <activity android:name=".activities.ImageCropActivity"/>
     </application>
 
 </manifest>

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -662,6 +662,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             case RequestCodes.ANNOTATE_IMAGE:
             case RequestCodes.SIGNATURE_CAPTURE:
             case RequestCodes.IMAGE_CAPTURE:
+                Timber.w("===> RequestCodes.IMAGE_CAPTURE");
                 /*
                  * We saved the image to the tempfile_path, but we really want it to
                  * be in: /sdcard/odk/instances/[current instnace]/something.jpg so
@@ -690,6 +691,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
             case RequestCodes.ALIGNED_IMAGE:
+                Timber.w("===> RequestCodes.ALIGNED_IMAGE");
                 /*
                  * We saved the image to the tempfile_path; the app returns the full
                  * path to the saved file in the EXTRA_OUTPUT extra. Take that file
@@ -714,6 +716,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
             case RequestCodes.IMAGE_CHOOSER:
+                Timber.w("===> RequestCodes.IMAGE_CHOOSER");
                 /*
                  * We have a saved image somewhere, but we really want it to be in:
                  * /sdcard/odk/instances/[current instnace]/something.jpg so we move

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -662,7 +662,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
             case RequestCodes.ANNOTATE_IMAGE:
             case RequestCodes.SIGNATURE_CAPTURE:
             case RequestCodes.IMAGE_CAPTURE:
-                Timber.w("===> RequestCodes.IMAGE_CAPTURE");
                 /*
                  * We saved the image to the tempfile_path, but we really want it to
                  * be in: /sdcard/odk/instances/[current instnace]/something.jpg so
@@ -689,9 +688,12 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                     getCurrentViewIfODKView().setBinaryData(nf);
                 }
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
+
+                Intent intent_crop = new Intent(getApplicationContext(), ImageCropActivity.class);
+                intent_crop.putExtra("crop_path", nf.getAbsolutePath());
+                startActivity(intent_crop);
                 break;
             case RequestCodes.ALIGNED_IMAGE:
-                Timber.w("===> RequestCodes.ALIGNED_IMAGE");
                 /*
                  * We saved the image to the tempfile_path; the app returns the full
                  * path to the saved file in the EXTRA_OUTPUT extra. Take that file
@@ -716,7 +718,6 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
                 break;
             case RequestCodes.IMAGE_CHOOSER:
-                Timber.w("===> RequestCodes.IMAGE_CHOOSER");
                 /*
                  * We have a saved image somewhere, but we really want it to be in:
                  * /sdcard/odk/instances/[current instnace]/something.jpg so we move

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -146,7 +146,7 @@ import static org.odk.collect.android.utilities.FormDefCache.writeCacheAsync;
  *
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Thomas Smyth, Sassafras Tech Collective (tom@sassafrastech.com; constraint behavior
- *         option)
+ * option)
  */
 public class FormEntryActivity extends AppCompatActivity implements AnimationListener,
         FormLoaderListener, FormSavedListener, AdvanceToNextListener,
@@ -688,10 +688,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                     getCurrentViewIfODKView().setBinaryData(nf);
                 }
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
-
-                Intent intent_crop = new Intent(getApplicationContext(), ImageCropActivity.class);
-                intent_crop.putExtra("crop_path", nf.getAbsolutePath());
-                startActivity(intent_crop);
+                startCropView(nf.getAbsolutePath());
                 break;
             case RequestCodes.ALIGNED_IMAGE:
                 /*
@@ -716,6 +713,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                     getCurrentViewIfODKView().setBinaryData(nf);
                 }
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
+                startCropView(nf.getAbsolutePath());
                 break;
             case RequestCodes.IMAGE_CHOOSER:
                 /*
@@ -788,6 +786,12 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
         refreshCurrentView();
     }
 
+    private void startCropView(String imageUrl) {
+        Intent intent_crop = new Intent(getApplicationContext(), ImageCropActivity.class);
+        intent_crop.putExtra("crop_path", imageUrl);
+        startActivity(intent_crop);
+    }
+
     private void saveChosenImage(Uri selectedImage) {
         // Copy file to sdcard
         String instanceFolder1 = getFormController().getInstanceFile().getParent();
@@ -800,6 +804,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
                 final File newImage = new File(destImagePath);
                 FileUtils.copyFile(chosenImage, newImage);
                 ImageConverter.execute(newImage.getPath(), getWidgetWaitingForBinaryData(), this);
+                startCropView(destImagePath);
                 runOnUiThread(() -> {
                     dismissDialog(SAVING_IMAGE_DIALOG);
                     if (getCurrentViewIfODKView() != null) {
@@ -826,7 +831,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
     private QuestionWidget getWidgetWaitingForBinaryData() {
         QuestionWidget questionWidget = null;
-        for (QuestionWidget qw :  ((ODKView) currentView).getWidgets()) {
+        for (QuestionWidget qw : ((ODKView) currentView).getWidgets()) {
             if (qw.isWaitingForData()) {
                 questionWidget = qw;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -146,7 +146,7 @@ import static org.odk.collect.android.utilities.FormDefCache.writeCacheAsync;
  *
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Thomas Smyth, Sassafras Tech Collective (tom@sassafrastech.com; constraint behavior
- * option)
+ *         option)
  */
 public class FormEntryActivity extends AppCompatActivity implements AnimationListener,
         FormLoaderListener, FormSavedListener, AdvanceToNextListener,
@@ -787,9 +787,9 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
     }
 
     private void startCropView(String imageUrl) {
-        Intent intent_crop = new Intent(getApplicationContext(), ImageCropActivity.class);
-        intent_crop.putExtra("crop_path", imageUrl);
-        startActivity(intent_crop);
+        Intent intentCrop = new Intent(getApplicationContext(), ImageCropActivity.class);
+        intentCrop.putExtra("crop_path", imageUrl);
+        startActivity(intentCrop);
     }
 
     private void saveChosenImage(Uri selectedImage) {
@@ -831,7 +831,7 @@ public class FormEntryActivity extends AppCompatActivity implements AnimationLis
 
     private QuestionWidget getWidgetWaitingForBinaryData() {
         QuestionWidget questionWidget = null;
-        for (QuestionWidget qw : ((ODKView) currentView).getWidgets()) {
+        for (QuestionWidget qw :  ((ODKView) currentView).getWidgets()) {
             if (qw.isWaitingForData()) {
                 questionWidget = qw;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
@@ -34,10 +34,11 @@ import java.io.OutputStream;
 
 import timber.log.Timber;
 
+
 public class ImageCropActivity extends AppCompatActivity implements View.OnClickListener {
 
     private CropImageView cropImageView;
-    private Bitmap bitmapBefore, bitmapCroped;
+    private Bitmap bitmapBefore;
     private String imageUrl;
 
     @Override
@@ -50,15 +51,16 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
     private void initViews() {
         cropImageView = findViewById(R.id.cropview);
         cropImageView.setVisibility(View.GONE);
-        Button btnCrop = findViewById(R.id.btn_crop);
-        Button btnRedo = findViewById(R.id.btn_redo);
-        Button btnSave = findViewById(R.id.btn_save);
-        Button btnNot = findViewById(R.id.btn_not);
 
-        btnSave.setOnClickListener(this);
-        btnRedo.setOnClickListener(this);
+        Button btnCrop = findViewById(R.id.btn_crop);
         btnCrop.setOnClickListener(this);
+        Button btnRedo = findViewById(R.id.btn_redo);
+        btnRedo.setOnClickListener(this);
+        Button btnSave = findViewById(R.id.btn_save);
+        btnSave.setOnClickListener(this);
+        Button btnNot = findViewById(R.id.btn_not);
         btnNot.setOnClickListener(this);
+
 
         Intent intent = getIntent();
         imageUrl = intent.getStringExtra("crop_path");
@@ -72,12 +74,12 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
 
     @Override
     public void onClick(View v) {
+        Bitmap bitmapCroped;
         cropImageView.setVisibility(View.GONE);
         switch (v.getId()) {
             case R.id.btn_crop:
                 cropImageView.setDrawable(cropImageView.getCropImage(), 200, 200);
                 cropImageView.setVisibility(View.VISIBLE);
-                bitmapCroped = cropImageView.getCropImage();
                 break;
             case R.id.btn_redo:
                 cropImageView.setDrawable(bitmapBefore, 200, 200);
@@ -90,12 +92,12 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
                 bitmapCroped = cropImageView.getCropImage();
                 try {
                     File file = new File(imageUrl);
-                    OutputStream fOut = new FileOutputStream(file);
-                    bitmapCroped.compress(Bitmap.CompressFormat.JPEG, 100, fOut);
-                    fOut.flush(); // Not really required
-                    fOut.close();
+                    OutputStream out = new FileOutputStream(file);
+                    bitmapCroped.compress(Bitmap.CompressFormat.JPEG, 100, out);
+                    out.flush(); // Not really required
+                    out.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Timber.e(e.toString());
                 }
                 finish();
                 break;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
@@ -16,16 +16,68 @@
 
 package org.odk.collect.android.activities;
 
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.views.CropImageView;
 
-public class ImageCropActivity extends AppCompatActivity {
+import timber.log.Timber;
+
+public class ImageCropActivity extends AppCompatActivity implements View.OnClickListener {
+
+    private CropImageView cropImageView;
+    private Bitmap bitmapBefore, bitmapCroped;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_image_crop);
+        initViews();
+    }
+
+    private void initViews() {
+        cropImageView = findViewById(R.id.cropview);
+        cropImageView.setVisibility(View.GONE);
+        Button btnCrop = findViewById(R.id.btn_crop);
+        Button btnRedo = findViewById(R.id.btn_redo);
+        Button btnSave = findViewById(R.id.btn_save);
+
+        btnSave.setOnClickListener(this);
+        btnRedo.setOnClickListener(this);
+        btnCrop.setOnClickListener(this);
+
+        Intent intent = getIntent();
+        String imageUrl = intent.getStringExtra("crop_path");
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+        bitmapBefore = BitmapFactory.decodeFile(imageUrl, options);
+        cropImageView.setDrawable(bitmapBefore, 200, 200);
+        cropImageView.setVisibility(View.VISIBLE);
+    }
+
+
+    @Override
+    public void onClick(View v) {
+        cropImageView.setVisibility(View.GONE);
+        switch (v.getId()) {
+            case R.id.btn_crop:
+                cropImageView.setDrawable(cropImageView.getCropImage(), 200, 200);
+                cropImageView.setVisibility(View.VISIBLE);
+                break;
+            case R.id.btn_redo:
+                cropImageView.setDrawable(bitmapBefore, 200, 200);
+                cropImageView.setVisibility(View.VISIBLE);
+                break;
+            case R.id.btn_save:
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
@@ -27,12 +27,18 @@ import android.widget.Button;
 import org.odk.collect.android.R;
 import org.odk.collect.android.views.CropImageView;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
 import timber.log.Timber;
 
 public class ImageCropActivity extends AppCompatActivity implements View.OnClickListener {
 
     private CropImageView cropImageView;
     private Bitmap bitmapBefore, bitmapCroped;
+    private String imageUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,7 +59,7 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
         btnCrop.setOnClickListener(this);
 
         Intent intent = getIntent();
-        String imageUrl = intent.getStringExtra("crop_path");
+        imageUrl = intent.getStringExtra("crop_path");
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inPreferredConfig = Bitmap.Config.ARGB_8888;
         bitmapBefore = BitmapFactory.decodeFile(imageUrl, options);
@@ -69,12 +75,24 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
             case R.id.btn_crop:
                 cropImageView.setDrawable(cropImageView.getCropImage(), 200, 200);
                 cropImageView.setVisibility(View.VISIBLE);
+                bitmapCroped = cropImageView.getCropImage();
                 break;
             case R.id.btn_redo:
                 cropImageView.setDrawable(bitmapBefore, 200, 200);
                 cropImageView.setVisibility(View.VISIBLE);
                 break;
             case R.id.btn_save:
+                bitmapCroped = cropImageView.getCropImage();
+                try {
+                    File file = new File(imageUrl);
+                    OutputStream fOut = new FileOutputStream(file);
+                    bitmapCroped.compress(Bitmap.CompressFormat.JPEG, 100, fOut);
+                    fOut.flush(); // Not really required
+                    fOut.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                finish();
                 break;
             default:
                 break;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
@@ -53,10 +53,12 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
         Button btnCrop = findViewById(R.id.btn_crop);
         Button btnRedo = findViewById(R.id.btn_redo);
         Button btnSave = findViewById(R.id.btn_save);
+        Button btnNot = findViewById(R.id.btn_not);
 
         btnSave.setOnClickListener(this);
         btnRedo.setOnClickListener(this);
         btnCrop.setOnClickListener(this);
+        btnNot.setOnClickListener(this);
 
         Intent intent = getIntent();
         imageUrl = intent.getStringExtra("crop_path");
@@ -80,6 +82,9 @@ public class ImageCropActivity extends AppCompatActivity implements View.OnClick
             case R.id.btn_redo:
                 cropImageView.setDrawable(bitmapBefore, 200, 200);
                 cropImageView.setVisibility(View.VISIBLE);
+                break;
+            case R.id.btn_not:
+                finish();
                 break;
             case R.id.btn_save:
                 bitmapCroped = cropImageView.getCropImage();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ImageCropActivity.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Yizheng Huang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.activities;
+
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+
+import org.odk.collect.android.R;
+
+public class ImageCropActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_image_crop);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FloatDrawable.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FloatDrawable.java
@@ -25,41 +25,40 @@ import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 public class FloatDrawable extends Drawable {
 
-    private Context mContext;
+    private Context context;
     private int offset = 50;
-    private Paint mLinePaint = new Paint();
-    private Paint mLinePaint2 = new Paint();
-
-    {
-        mLinePaint.setARGB(200, 50, 50, 50);
-        mLinePaint.setStrokeWidth(1F);
-        mLinePaint.setStyle(Paint.Style.STROKE);
-        mLinePaint.setAntiAlias(true);
-        mLinePaint.setColor(Color.WHITE);
-
-        mLinePaint2.setARGB(200, 50, 50, 50);
-        mLinePaint2.setStrokeWidth(7F);
-        mLinePaint2.setStyle(Paint.Style.STROKE);
-        mLinePaint2.setAntiAlias(true);
-        mLinePaint2.setColor(Color.WHITE);
-    }
+    private Paint linePaint = new Paint();
+    private Paint linePaint2 = new Paint();
 
     public FloatDrawable(Context context) {
         super();
-        this.mContext = context;
+        this.context = context;
+
+        linePaint.setARGB(200, 50, 50, 50);
+        linePaint.setStrokeWidth(1F);
+        linePaint.setStyle(Paint.Style.STROKE);
+        linePaint.setAntiAlias(true);
+        linePaint.setColor(Color.WHITE);
+
+        linePaint2.setARGB(200, 50, 50, 50);
+        linePaint2.setStrokeWidth(7F);
+        linePaint2.setStyle(Paint.Style.STROKE);
+        linePaint2.setAntiAlias(true);
+        linePaint2.setColor(Color.WHITE);
 
     }
 
     // adaption problem addressed here.
     public int getBorderWidth() {
-        return dipToPx(mContext, offset);
+        return dipToPx(context, offset);
     }
 
     public int getBorderHeight() {
-        return dipToPx(mContext, offset);
+        return dipToPx(context, offset);
     }
 
     @Override
@@ -70,63 +69,63 @@ public class FloatDrawable extends Drawable {
         int right = getBounds().right;
         int bottom = getBounds().bottom;
 
-        Rect mRect = new Rect(left + dipToPx(mContext, offset) / 2,
-                top + dipToPx(mContext, offset) / 2,
-                right - dipToPx(mContext, offset) / 2,
-                bottom - dipToPx(mContext, offset) / 2);
+        Rect rect = new Rect(left + dipToPx(context, offset) / 2,
+                top + dipToPx(context, offset) / 2,
+                right - dipToPx(context, offset) / 2,
+                bottom - dipToPx(context, offset) / 2);
         //Default Rect
-        canvas.drawRect(mRect, mLinePaint);
+        canvas.drawRect(rect, linePaint);
         //Lines in Rect
-        canvas.drawLine((left + dipToPx(mContext, offset) / 2 - 3.5f),
-                top + dipToPx(mContext, offset) / 2,
-                left + dipToPx(mContext, offset) - 8f,
-                top + dipToPx(mContext, offset) / 2, mLinePaint2);
-        canvas.drawLine(left + dipToPx(mContext, offset) / 2,
-                top + dipToPx(mContext, offset) / 2,
-                left + dipToPx(mContext, offset) / 2,
-                top + dipToPx(mContext, offset) / 2 + 30, mLinePaint2);
-        canvas.drawLine(right - dipToPx(mContext, offset) + 8f,
-                top + dipToPx(mContext, offset) / 2,
-                right - dipToPx(mContext, offset) / 2,
-                top + dipToPx(mContext, offset) / 2, mLinePaint2);
-        canvas.drawLine(right - dipToPx(mContext, offset) / 2,
-                top + dipToPx(mContext, offset) / 2 - 3.5f,
-                right - dipToPx(mContext, offset) / 2,
-                top + dipToPx(mContext, offset) / 2 + 30, mLinePaint2);
-        canvas.drawLine((left + dipToPx(mContext, offset) / 2 - 3.5f),
-                bottom - dipToPx(mContext, offset) / 2,
-                left + dipToPx(mContext, offset) - 8f,
-                bottom - dipToPx(mContext, offset) / 2, mLinePaint2);
-        canvas.drawLine((left + dipToPx(mContext, offset) / 2),
-                bottom - dipToPx(mContext, offset) / 2,
-                left + dipToPx(mContext, offset) / 2,
-                bottom - dipToPx(mContext, offset) / 2 - 30f, mLinePaint2);
-        canvas.drawLine((right - dipToPx(mContext, offset) + 8f),
-                bottom - dipToPx(mContext, offset) / 2,
-                right - dipToPx(mContext, offset) / 2,
-                bottom - dipToPx(mContext, offset) / 2, mLinePaint2);
-        canvas.drawLine((right - dipToPx(mContext, offset) / 2),
-                bottom - dipToPx(mContext, offset) / 2 - 30f,
-                right - dipToPx(mContext, offset) / 2,
-                bottom - dipToPx(mContext, offset) / 2 + 3.5f, mLinePaint2);
+        canvas.drawLine((left + dipToPx(context, offset) / 2 - 3.5f),
+                top + dipToPx(context, offset) / 2,
+                left + dipToPx(context, offset) - 8f,
+                top + dipToPx(context, offset) / 2, linePaint2);
+        canvas.drawLine(left + dipToPx(context, offset) / 2,
+                top + dipToPx(context, offset) / 2,
+                left + dipToPx(context, offset) / 2,
+                top + dipToPx(context, offset) / 2 + 30, linePaint2);
+        canvas.drawLine(right - dipToPx(context, offset) + 8f,
+                top + dipToPx(context, offset) / 2,
+                right - dipToPx(context, offset) / 2,
+                top + dipToPx(context, offset) / 2, linePaint2);
+        canvas.drawLine(right - dipToPx(context, offset) / 2,
+                top + dipToPx(context, offset) / 2 - 3.5f,
+                right - dipToPx(context, offset) / 2,
+                top + dipToPx(context, offset) / 2 + 30, linePaint2);
+        canvas.drawLine((left + dipToPx(context, offset) / 2 - 3.5f),
+                bottom - dipToPx(context, offset) / 2,
+                left + dipToPx(context, offset) - 8f,
+                bottom - dipToPx(context, offset) / 2, linePaint2);
+        canvas.drawLine((left + dipToPx(context, offset) / 2),
+                bottom - dipToPx(context, offset) / 2,
+                left + dipToPx(context, offset) / 2,
+                bottom - dipToPx(context, offset) / 2 - 30f, linePaint2);
+        canvas.drawLine((right - dipToPx(context, offset) + 8f),
+                bottom - dipToPx(context, offset) / 2,
+                right - dipToPx(context, offset) / 2,
+                bottom - dipToPx(context, offset) / 2, linePaint2);
+        canvas.drawLine((right - dipToPx(context, offset) / 2),
+                bottom - dipToPx(context, offset) / 2 - 30f,
+                right - dipToPx(context, offset) / 2,
+                bottom - dipToPx(context, offset) / 2 + 3.5f, linePaint2);
     }
 
     @Override
     public void setBounds(@NonNull Rect bounds) {
-        super.setBounds(new Rect(bounds.left - dipToPx(mContext, offset) / 2,
-                bounds.top - dipToPx(mContext, offset) / 2,
-                bounds.right + dipToPx(mContext, offset) / 2,
-                bounds.bottom + dipToPx(mContext, offset) / 2));
+        super.setBounds(new Rect(bounds.left - dipToPx(context, offset) / 2,
+                bounds.top - dipToPx(context, offset) / 2,
+                bounds.right + dipToPx(context, offset) / 2,
+                bounds.bottom + dipToPx(context, offset) / 2));
     }
 
     @Override
     public void setAlpha(int alpha) {
-
+        // setAlpha value
     }
 
     @Override
-    public void setColorFilter(ColorFilter cf) {
-
+    public void setColorFilter(@Nullable ColorFilter colorFilter) {
+        // set color filter
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FloatDrawable.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FloatDrawable.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 Yizheng Huang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+
+public class FloatDrawable extends Drawable {
+
+    private Context mContext;
+    private int offset = 50;
+    private Paint mLinePaint = new Paint();
+    private Paint mLinePaint2 = new Paint();
+
+    {
+        mLinePaint.setARGB(200, 50, 50, 50);
+        mLinePaint.setStrokeWidth(1F);
+        mLinePaint.setStyle(Paint.Style.STROKE);
+        mLinePaint.setAntiAlias(true);
+        mLinePaint.setColor(Color.WHITE);
+
+        mLinePaint2.setARGB(200, 50, 50, 50);
+        mLinePaint2.setStrokeWidth(7F);
+        mLinePaint2.setStyle(Paint.Style.STROKE);
+        mLinePaint2.setAntiAlias(true);
+        mLinePaint2.setColor(Color.WHITE);
+    }
+
+    public FloatDrawable(Context context) {
+        super();
+        this.mContext = context;
+
+    }
+
+    // adaption problem addressed here.
+    public int getBorderWidth() {
+        return dipToPx(mContext, offset);
+    }
+
+    public int getBorderHeight() {
+        return dipToPx(mContext, offset);
+    }
+
+    @Override
+    public void draw(@NonNull Canvas canvas) {
+
+        int left = getBounds().left;
+        int top = getBounds().top;
+        int right = getBounds().right;
+        int bottom = getBounds().bottom;
+
+        Rect mRect = new Rect(left + dipToPx(mContext, offset) / 2,
+                top + dipToPx(mContext, offset) / 2,
+                right - dipToPx(mContext, offset) / 2,
+                bottom - dipToPx(mContext, offset) / 2);
+        //Default Rect
+        canvas.drawRect(mRect, mLinePaint);
+        //Lines in Rect
+        canvas.drawLine((left + dipToPx(mContext, offset) / 2 - 3.5f),
+                top + dipToPx(mContext, offset) / 2,
+                left + dipToPx(mContext, offset) - 8f,
+                top + dipToPx(mContext, offset) / 2, mLinePaint2);
+        canvas.drawLine(left + dipToPx(mContext, offset) / 2,
+                top + dipToPx(mContext, offset) / 2,
+                left + dipToPx(mContext, offset) / 2,
+                top + dipToPx(mContext, offset) / 2 + 30, mLinePaint2);
+        canvas.drawLine(right - dipToPx(mContext, offset) + 8f,
+                top + dipToPx(mContext, offset) / 2,
+                right - dipToPx(mContext, offset) / 2,
+                top + dipToPx(mContext, offset) / 2, mLinePaint2);
+        canvas.drawLine(right - dipToPx(mContext, offset) / 2,
+                top + dipToPx(mContext, offset) / 2 - 3.5f,
+                right - dipToPx(mContext, offset) / 2,
+                top + dipToPx(mContext, offset) / 2 + 30, mLinePaint2);
+        canvas.drawLine((left + dipToPx(mContext, offset) / 2 - 3.5f),
+                bottom - dipToPx(mContext, offset) / 2,
+                left + dipToPx(mContext, offset) - 8f,
+                bottom - dipToPx(mContext, offset) / 2, mLinePaint2);
+        canvas.drawLine((left + dipToPx(mContext, offset) / 2),
+                bottom - dipToPx(mContext, offset) / 2,
+                left + dipToPx(mContext, offset) / 2,
+                bottom - dipToPx(mContext, offset) / 2 - 30f, mLinePaint2);
+        canvas.drawLine((right - dipToPx(mContext, offset) + 8f),
+                bottom - dipToPx(mContext, offset) / 2,
+                right - dipToPx(mContext, offset) / 2,
+                bottom - dipToPx(mContext, offset) / 2, mLinePaint2);
+        canvas.drawLine((right - dipToPx(mContext, offset) / 2),
+                bottom - dipToPx(mContext, offset) / 2 - 30f,
+                right - dipToPx(mContext, offset) / 2,
+                bottom - dipToPx(mContext, offset) / 2 + 3.5f, mLinePaint2);
+    }
+
+    @Override
+    public void setBounds(@NonNull Rect bounds) {
+        super.setBounds(new Rect(bounds.left - dipToPx(mContext, offset) / 2,
+                bounds.top - dipToPx(mContext, offset) / 2,
+                bounds.right + dipToPx(mContext, offset) / 2,
+                bounds.bottom + dipToPx(mContext, offset) / 2));
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+
+    }
+
+    @Override
+    public void setColorFilter(ColorFilter cf) {
+
+    }
+
+    @Override
+    public int getOpacity() {
+        return PixelFormat.UNKNOWN;
+    }
+
+    public int dipToPx(Context context, float dpValue) {
+        final float scale = context.getResources().getDisplayMetrics().density;
+        return (int) (dpValue * scale + 0.5f);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/views/CropImageView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/CropImageView.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2018 Yizheng Huang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.views;
+
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Matrix;
+import android.graphics.Rect;
+import android.graphics.Region;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+
+import org.odk.collect.android.utilities.FloatDrawable;
+
+public class CropImageView extends View {
+    // Touch point
+    private float mX_1 = 0;
+    private float mY_1 = 0;
+    // Touch events
+    private final int STATUS_SINGLE = 1;
+    private final int STATUS_MULTI_START = 2;
+    private final int STATUS_MULTI_TOUCHING = 3;
+    // Current status
+    private int mStatus = STATUS_SINGLE;
+    // Default height & width
+    private int cropWidth;
+    private int cropHeight;
+    // Four points of the float layer
+    private final int EDGE_LT = 1;
+    private final int EDGE_RT = 2;
+    private final int EDGE_LB = 3;
+    private final int EDGE_RB = 4;
+    private final int EDGE_MOVE_IN = 5;
+    private final int EDGE_MOVE_OUT = 6;
+    private final int EDGE_NONE = 7;
+
+    public int currentEdge = EDGE_NONE;
+
+    protected float oriRationWH = 0;
+
+    protected Drawable mDrawable;
+    protected FloatDrawable mFloatDrawable;
+
+    protected Rect mDrawableSrc = new Rect();
+    protected Rect mDrawableDst = new Rect();
+    protected Rect mDrawableFloat = new Rect();
+    protected boolean isFirst = true;
+    private boolean isTouchInSquare = true;
+
+    protected Context mContext;
+    private Bitmap mBitmap;
+
+    public CropImageView(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public CropImageView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    public CropImageView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        init(context);
+    }
+
+    @SuppressLint("NewApi")
+    private void init(Context context) {
+        this.mContext = context;
+        try {
+            // use a software way to draw views.
+            this.setLayerType(LAYER_TYPE_SOFTWARE, null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        mFloatDrawable = new FloatDrawable(context);
+    }
+
+    public void setDrawable(Bitmap bitmap, int cropWidth, int cropHeight) {
+        mBitmap = bitmap;
+        this.mDrawable = new BitmapDrawable(bitmap);
+        this.cropWidth = cropWidth;
+        this.cropHeight = cropHeight;
+        this.isFirst = true;
+        invalidate();
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+        int widthSize = MeasureSpec.getSize(widthMeasureSpec);
+        int heightSize = MeasureSpec.getSize(heightMeasureSpec);
+
+        if (mBitmap != null) {
+            if ((mBitmap.getHeight() > heightSize) && (mBitmap.getHeight() > mBitmap.getWidth())) {
+                widthSize = heightSize * mBitmap.getWidth() / mBitmap.getHeight();
+            } else if ((mBitmap.getWidth() > widthSize) && (mBitmap.getWidth() > mBitmap.getHeight())) {
+                heightSize = widthSize * mBitmap.getHeight() / mBitmap.getWidth();
+            } else {
+                heightSize = mBitmap.getHeight();
+                widthSize = mBitmap.getWidth();
+            }
+        }
+        setMeasuredDimension(widthSize, heightSize);
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+
+        if (event.getPointerCount() > 1) {
+            if (mStatus == STATUS_SINGLE) {
+                mStatus = STATUS_MULTI_START;
+            } else if (mStatus == STATUS_MULTI_START) {
+                mStatus = STATUS_MULTI_TOUCHING;
+            }
+        } else {
+            if (mStatus == STATUS_MULTI_START
+                    || mStatus == STATUS_MULTI_TOUCHING) {
+                mX_1 = event.getX();
+                mY_1 = event.getY();
+            }
+
+            mStatus = STATUS_SINGLE;
+        }
+
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                mX_1 = event.getX();
+                mY_1 = event.getY();
+                currentEdge = getTouch((int) mX_1, (int) mY_1);
+                break;
+
+            case MotionEvent.ACTION_UP:
+                break;
+
+            case MotionEvent.ACTION_POINTER_UP:
+                currentEdge = EDGE_NONE;
+                break;
+
+            case MotionEvent.ACTION_MOVE:
+                if (mStatus == STATUS_MULTI_TOUCHING) {
+                    // TODO if it's a multi touch case.
+                    break;
+                } else if (mStatus == STATUS_SINGLE) {
+                    int dx = (int) (event.getX() - mX_1);
+                    int dy = (int) (event.getY() - mY_1);
+
+                    mX_1 = event.getX();
+                    mY_1 = event.getY();
+
+                    // TODO If touch point is out of a border, we should turn back。
+                    // We should add this improvement here. but may cause a bug when
+                    // touch point is moving to fast.
+//                    if (mX_1 > getWidth() || mX_1 < 0 || mY_1 > getHeight() || mY_1 < 0) {
+//                        break;
+//                    }
+                    if (!(dx == 0 && dy == 0)) {
+                        switch (currentEdge) {
+                            case EDGE_LT:
+                                mDrawableFloat.set(mDrawableFloat.left + dx,
+                                        mDrawableFloat.top + dy,
+                                        mDrawableFloat.right,
+                                        mDrawableFloat.bottom);
+                                break;
+
+                            case EDGE_RT:
+                                mDrawableFloat.set(mDrawableFloat.left,
+                                        mDrawableFloat.top + dy,
+                                        mDrawableFloat.right + dx,
+                                        mDrawableFloat.bottom);
+                                break;
+
+                            case EDGE_LB:
+                                mDrawableFloat.set(mDrawableFloat.left + dx,
+                                        mDrawableFloat.top,
+                                        mDrawableFloat.right,
+                                        mDrawableFloat.bottom + dy);
+                                break;
+
+                            case EDGE_RB:
+                                mDrawableFloat.set(mDrawableFloat.left,
+                                        mDrawableFloat.top,
+                                        mDrawableFloat.right + dx,
+                                        mDrawableFloat.bottom + dy);
+                                break;
+
+                            case EDGE_MOVE_IN:
+                                // We should take a look at user's finger point, which moving every time.
+                                isTouchInSquare = mDrawableFloat.contains((int) event.getX(),
+                                        (int) event.getY());
+                                if (isTouchInSquare) {
+                                    mDrawableFloat.offset(dx, dy);
+                                }
+                                break;
+
+                            case EDGE_MOVE_OUT:
+                                break;
+                        }
+                        mDrawableFloat.sort();
+                        invalidate();
+                    }
+                }
+                break;
+        }
+        return true;
+    }
+
+    // according to the initial touch point, we can know which corner user has touched
+    public int getTouch(int eventX, int eventY) {
+        Rect mFloatDrawableRect = mFloatDrawable.getBounds();
+        int mFloatDrawableWidth = mFloatDrawable.getBorderWidth();
+        int mFloatDrawableHeight = mFloatDrawable.getBorderHeight();
+        if (mFloatDrawableRect.left <= eventX
+                && eventX < (mFloatDrawableRect.left + mFloatDrawableWidth)
+                && mFloatDrawableRect.top <= eventY
+                && eventY < (mFloatDrawableRect.top + mFloatDrawableHeight)) {
+            return EDGE_LT;
+        } else if ((mFloatDrawableRect.right - mFloatDrawableWidth) <= eventX
+                && eventX < mFloatDrawableRect.right
+                && mFloatDrawableRect.top <= eventY
+                && eventY < (mFloatDrawableRect.top + mFloatDrawableHeight)) {
+            return EDGE_RT;
+        } else if (mFloatDrawableRect.left <= eventX
+                && eventX < (mFloatDrawableRect.left + mFloatDrawableWidth)
+                && (mFloatDrawableRect.bottom - mFloatDrawableHeight) <= eventY
+                && eventY < mFloatDrawableRect.bottom) {
+            return EDGE_LB;
+        } else if ((mFloatDrawableRect.right - mFloatDrawableWidth) <= eventX
+                && eventX < mFloatDrawableRect.right
+                && (mFloatDrawableRect.bottom - mFloatDrawableHeight) <= eventY
+                && eventY < mFloatDrawableRect.bottom) {
+            return EDGE_RB;
+        } else if (mFloatDrawableRect.contains(eventX, eventY)) {
+            return EDGE_MOVE_IN;
+        }
+        return EDGE_MOVE_OUT;
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+
+        if (mDrawable == null) {
+            return;
+        }
+
+        if (mDrawable.getIntrinsicWidth() == 0 || mDrawable.getIntrinsicHeight() == 0) {
+            return;
+        }
+
+        configureBounds();
+        mDrawable.draw(canvas);
+        canvas.save();
+        canvas.clipRect(mDrawableFloat, Region.Op.DIFFERENCE);
+        canvas.drawColor(Color.parseColor("#a0000000"));
+        canvas.restore();
+        mFloatDrawable.draw(canvas);
+    }
+
+    protected void configureBounds() {
+        // configureBounds called in onDraw()
+        if (isFirst) {
+            oriRationWH = ((float) mDrawable.getIntrinsicWidth())
+                    / ((float) mDrawable.getIntrinsicHeight());
+
+            final float scale = mContext.getResources().getDisplayMetrics().density;
+            int mDrawableW = (int) (mDrawable.getIntrinsicWidth() * scale + 0.5f);
+            if ((mDrawable.getIntrinsicHeight() * scale + 0.5f) > getHeight()) {
+                mDrawableW = (int) ((mDrawable.getIntrinsicWidth() * scale + 0.5f)
+                        * (getHeight() / (mDrawable.getIntrinsicHeight() * scale + 0.5f)));
+            }
+            int w = Math.min(getWidth(), mDrawableW);
+            int h = (int) (w / oriRationWH);
+
+            int left = (getWidth() - w) / 2;
+            int top = (getHeight() - h) / 2;
+            int right = left + w;
+            int bottom = top + h;
+
+            mDrawableSrc.set(left, top, right, bottom);
+            mDrawableDst.set(mDrawableSrc);
+
+            int floatWidth = dipToPx(mContext, cropWidth);
+            int floatHeight = dipToPx(mContext, cropHeight);
+
+            if (floatWidth > getWidth()) {
+                floatWidth = getWidth();
+                floatHeight = cropHeight * floatWidth / cropWidth;
+            }
+
+            if (floatHeight > getHeight()) {
+                floatHeight = getHeight();
+                floatWidth = cropWidth * floatHeight / cropHeight;
+            }
+
+            int floatLeft = (getWidth() - floatWidth) / 2;
+            int floatTop = (getHeight() - floatHeight) / 2;
+            mDrawableFloat.set(floatLeft, floatTop, floatLeft + floatWidth, floatTop + floatHeight);
+
+            isFirst = false;
+        } else if (getTouch((int) mX_1, (int) mY_1) == EDGE_MOVE_IN) {
+            if (mDrawableFloat.left < 0) {
+                mDrawableFloat.right = mDrawableFloat.width();
+                mDrawableFloat.left = 0;
+            }
+            if (mDrawableFloat.top < 0) {
+                mDrawableFloat.bottom = mDrawableFloat.height();
+                mDrawableFloat.top = 0;
+            }
+            if (mDrawableFloat.right > getWidth()) {
+                mDrawableFloat.left = getWidth() - mDrawableFloat.width();
+                mDrawableFloat.right = getWidth();
+            }
+            if (mDrawableFloat.bottom > getHeight()) {
+                mDrawableFloat.top = getHeight() - mDrawableFloat.height();
+                mDrawableFloat.bottom = getHeight();
+            }
+            mDrawableFloat.set(mDrawableFloat.left, mDrawableFloat.top, mDrawableFloat.right,
+                    mDrawableFloat.bottom);
+        } else {
+            if (mDrawableFloat.left < 0) {
+                mDrawableFloat.left = 0;
+            }
+            if (mDrawableFloat.top < 0) {
+                mDrawableFloat.top = 0;
+            }
+            if (mDrawableFloat.right > getWidth()) {
+                mDrawableFloat.right = getWidth();
+                mDrawableFloat.left = getWidth() - mDrawableFloat.width();
+            }
+            if (mDrawableFloat.bottom > getHeight()) {
+                mDrawableFloat.bottom = getHeight();
+                mDrawableFloat.top = getHeight() - mDrawableFloat.height();
+            }
+            mDrawableFloat.set(mDrawableFloat.left, mDrawableFloat.top, mDrawableFloat.right,
+                    mDrawableFloat.bottom);
+        }
+
+        mDrawable.setBounds(mDrawableDst);
+        mFloatDrawable.setBounds(mDrawableFloat);
+    }
+
+    public Bitmap getCropImage() {
+        Bitmap tmpBitmap = Bitmap.createBitmap(getWidth(), getHeight(), Bitmap.Config.RGB_565);
+        Canvas canvas = new Canvas(tmpBitmap);
+        mDrawable.draw(canvas);
+
+        Matrix matrix = new Matrix();
+        float scale = (float) (mDrawableSrc.width())
+                / (float) (mDrawableDst.width());
+        matrix.postScale(scale, scale);
+
+        Bitmap ret = Bitmap.createBitmap(tmpBitmap, mDrawableFloat.left,
+                mDrawableFloat.top, mDrawableFloat.width(),
+                mDrawableFloat.height(), matrix, true);
+        tmpBitmap.recycle();
+        return ret;
+    }
+
+    public int dipToPx(Context context, float dpValue) {
+        final float scale = context.getResources().getDisplayMetrics().density;
+        return (int) (dpValue * scale + 0.5f);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -161,7 +161,6 @@ public class ImageWidget extends BaseImageWidget {
     }
 
     private void captureImage() {
-        Timber.e("===> ImageWidget captureImage");
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "captureButton",
                 "click", getFormEntryPrompt().getIndex());
         errorTextView.setVisibility(View.GONE);
@@ -200,7 +199,6 @@ public class ImageWidget extends BaseImageWidget {
     }
 
     private void chooseImage() {
-        Timber.e("===> ImageWidget chooseImage");
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "chooseButton",
                 "click", getFormEntryPrompt().getIndex());
         errorTextView.setVisibility(View.GONE);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -161,6 +161,7 @@ public class ImageWidget extends BaseImageWidget {
     }
 
     private void captureImage() {
+        Timber.e("===> ImageWidget captureImage");
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "captureButton",
                 "click", getFormEntryPrompt().getIndex());
         errorTextView.setVisibility(View.GONE);
@@ -199,6 +200,7 @@ public class ImageWidget extends BaseImageWidget {
     }
 
     private void chooseImage() {
+        Timber.e("===> ImageWidget chooseImage");
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "chooseButton",
                 "click", getFormEntryPrompt().getIndex());
         errorTextView.setVisibility(View.GONE);

--- a/collect_app/src/main/res/layout/activity_image_crop.xml
+++ b/collect_app/src/main/res/layout/activity_image_crop.xml
@@ -1,48 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".activities.ImageCropActivity">
 
 
-    <org.odk.collect.android.views.CropImageView
-        android:id="@+id/cropview"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center" />
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
+        <org.odk.collect.android.views.CropImageView
+            android:id="@+id/cropview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:visibility="gone" />
+
+    </FrameLayout>
 
     <LinearLayout
+        android:id="@+id/bot_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:visibility="visible">
 
         <Button
             android:id="@+id/btn_crop"
-            android:layout_width="0dp"
-            android:layout_height="50dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/crop_image" />
 
         <Button
             android:id="@+id/btn_redo"
-            android:layout_width="0dp"
-            android:layout_height="50dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/crop_redo" />
 
         <Button
             android:id="@+id/btn_save"
-            android:layout_width="0dp"
-            android:layout_height="50dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:text="@string/crop_save" />
 
     </LinearLayout>
 
 
-</RelativeLayout>
+</LinearLayout>
+

--- a/collect_app/src/main/res/layout/activity_image_crop.xml
+++ b/collect_app/src/main/res/layout/activity_image_crop.xml
@@ -49,6 +49,13 @@
             android:layout_weight="1"
             android:text="@string/crop_save" />
 
+        <Button
+            android:id="@+id/btn_not"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/crop_undo" />
+
     </LinearLayout>
 
 

--- a/collect_app/src/main/res/layout/activity_image_crop.xml
+++ b/collect_app/src/main/res/layout/activity_image_crop.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.ImageCropActivity">
+
+
+    <org.odk.collect.android.views.CropImageView
+        android:id="@+id/cropview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center" />
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/btn_crop"
+            android:layout_width="0dp"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:text="@string/crop_image" />
+
+        <Button
+            android:id="@+id/btn_redo"
+            android:layout_width="0dp"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:text="@string/crop_redo" />
+
+        <Button
+            android:id="@+id/btn_save"
+            android:layout_width="0dp"
+            android:layout_height="50dp"
+            android:layout_weight="1"
+            android:text="@string/crop_save" />
+
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -522,10 +522,10 @@
     <string name="form_delete_message">Deleting selected forms</string>
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
-    <string name="crop_image">Crop Image</string>
-    <string name="crop_save">Save Image</string>
-    <string name="crop_redo">Redo Crop</string>
-    <string name="crop_undo">Don\'t Crop</string>
+    <string name="crop_image">crop image</string>
+    <string name="crop_save">save image</string>
+    <string name="crop_redo">redo crop</string>
+    <string name="crop_undo">don\'t crop</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
     <string name="image_size_large">Large (3072px)</string>
     <string name="image_size_medium">Medium (2048px)</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -522,6 +522,9 @@
     <string name="form_delete_message">Deleting selected forms</string>
     <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
     <string name="search">Search</string>
+    <string name="crop_image">Crop Image</string>
+    <string name="crop_save">Save Image</string>
+    <string name="crop_redo">Redo Crop</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
     <string name="image_size_large">Large (3072px)</string>
     <string name="image_size_medium">Medium (2048px)</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -525,6 +525,7 @@
     <string name="crop_image">Crop Image</string>
     <string name="crop_save">Save Image</string>
     <string name="crop_redo">Redo Crop</string>
+    <string name="crop_undo">Don\'t Crop</string>
     <string name="null_intent_value">The external application did not provide expected information.</string>
     <string name="image_size_large">Large (3072px)</string>
     <string name="image_size_medium">Medium (2048px)</string>


### PR DESCRIPTION
Closes #2104 

#### What has been done to verify that this works as intended?
- Added a custom view which allows **image cropping**.
- Added them to all operations related to image picking (image shooting and selfie).

Screen records:
![68747470733a2f2f692e6c6f6c692e6e65742f323031382f30342f31302f356163633561613838393465652e676966](https://user-images.githubusercontent.com/15646062/38743045-ac91546a-3f70-11e8-81c8-d9386fecdbf9.gif)



#### Why is this the best possible solution? Were any other approaches considered?
Maybe we can use third-party libraries that support image cropping.
But DIY is a good choice.
#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
No need.
#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
If needed, will do.