### PR TITLE
Add onClick attribute only for elements that exist in the dataset

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
@@ -215,10 +215,20 @@ public abstract class SelectImageMapWidget extends SelectWidget {
     private void addOnClickAttributes(NodeList nodes) {
         for (int i = 0; i < nodes.getLength(); i++) {
             Node node = nodes.item(i);
-            if (node.getNodeType() == Node.ELEMENT_NODE && node.getAttributes().getNamedItem("id") != null) {
+            Node elementId = node.getAttributes().getNamedItem("id");
+            if (node.getNodeType() == Node.ELEMENT_NODE && elementId != null && doesElementExistInDataSet(elementId.getNodeValue())) {
                 ((Element) node).setAttribute("onClick", "clickOnArea(this.id)");
             }
         }
+    }
+
+    private boolean doesElementExistInDataSet(String elementId) {
+        for (SelectChoice item : items) {
+            if (item.getValue().equals(elementId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void addSizeAttributesIfNeeded(NodeList nodes) {


### PR DESCRIPTION
Closes #2107

#### What has been done to verify that this works as intended?
I tested this fix with the attached form.

#### Why is this the best possible solution? Were any other approaches considered?
We just should add `onClick` attributes only for elements with ID which exist in the dataset.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.