### PR TITLE
Do not display the min value if it's not needed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
@@ -200,13 +200,13 @@ public abstract class RangeWidget extends QuestionWidget implements ButtonWidget
                 switch (action) {
                     case MotionEvent.ACTION_DOWN:
                         v.getParent().requestDisallowInterceptTouchEvent(true);
+                        break;
+                    case MotionEvent.ACTION_UP:
+                        v.getParent().requestDisallowInterceptTouchEvent(false);
                         if (actualValue == null) {
                             actualValue = rangeStart;
                             setUpActualValueLabel();
                         }
-                        break;
-                    case MotionEvent.ACTION_UP:
-                        v.getParent().requestDisallowInterceptTouchEvent(false);
                         break;
                 }
                 v.onTouchEvent(event);


### PR DESCRIPTION
Closes #2115 

#### What has been done to verify that this works as intended?
I tested `RangeWIdget`.

#### Why is this the best possible solution? Were any other approaches considered?
The fix from #1963 was ok I just moved the code to call it after MotionEvent.ACTION_UP to avoid displaying the min value if not needed.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `RangeWidget` like AllWIdgets form for example.