### PR TITLE
Issue#1976 There are no separator lines in SelectOneSearchWidget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.2.0'
         classpath 'org.ow2.asm:asm:6.0' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.0'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.google.gms:google-services:3.2.0'
         classpath 'org.ow2.asm:asm:6.0' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.0'

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -16,10 +16,14 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
 import org.odk.collect.android.listeners.AudioPlayListener;
 
 import java.util.List;
@@ -41,9 +45,14 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
 
     @Override
     protected void addButtonsToLayout(List<Integer> tagList) {
+        LayoutInflater inflater = LayoutInflater.from(getContext());
         for (int i = 0; i < buttons.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
-                answerLayout.addView(buttons.get(i));
+                @SuppressLint("InflateParams")
+                RelativeLayout thisParentLayout = (RelativeLayout) inflater.inflate(R.layout.quick_select_layout, null);
+                LinearLayout questionLayout = (LinearLayout) thisParentLayout.getChildAt(0);
+                questionLayout.addView(createMediaLayout(i, buttons.get(i)));
+                answerLayout.addView(thisParentLayout);
             }
         }
     }
@@ -65,7 +74,6 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
                 buttons.add(createRadioButton(i));
             }
         }
-
         setUpSearchBox();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -16,14 +16,15 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
+import android.widget.RadioButton;
 
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.R;
 import org.odk.collect.android.listeners.AudioPlayListener;
 
 import java.util.List;
@@ -38,6 +39,7 @@ import java.util.List;
  */
 @SuppressLint("ViewConstructor")
 public class SelectOneSearchWidget extends AbstractSelectOneWidget implements OnCheckedChangeListener, AudioPlayListener {
+
     public SelectOneSearchWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt, false);
         createLayout();
@@ -48,11 +50,13 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
         LayoutInflater inflater = LayoutInflater.from(getContext());
         for (int i = 0; i < buttons.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
-                @SuppressLint("InflateParams")
-                RelativeLayout thisParentLayout = (RelativeLayout) inflater.inflate(R.layout.quick_select_layout, null);
-                LinearLayout questionLayout = (LinearLayout) thisParentLayout.getChildAt(0);
-                questionLayout.addView(createMediaLayout(i, buttons.get(i)));
-                answerLayout.addView(thisParentLayout);
+                answerLayout.addView(buttons.get(i));
+                //Get divider drawable and set to linearlayout
+                int[] attrs = { android.R.attr.listDivider };
+                TypedArray ta = getContext().obtainStyledAttributes(attrs);
+                Drawable divider = ta.getDrawable(0);
+                answerLayout.setDividerDrawable(divider);
+                answerLayout.setShowDividers(LinearLayout.SHOW_DIVIDER_MIDDLE);
             }
         }
     }
@@ -71,7 +75,8 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
 
         if (items != null) {
             for (int i = 0; i < items.size(); i++) {
-                buttons.add(createRadioButton(i));
+                RadioButton button = createRadioButton(i);
+                buttons.add(button);
             }
         }
         setUpSearchBox();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -75,8 +75,7 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
 
         if (items != null) {
             for (int i = 0; i < items.size(); i++) {
-                RadioButton button = createRadioButton(i);
-                buttons.add(button);
+                buttons.add(createRadioButton(i));
             }
         }
         setUpSearchBox();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2009 University of Washington
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -18,11 +18,9 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
-import android.view.LayoutInflater;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.LinearLayout;
-import android.widget.RadioButton;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.AudioPlayListener;
@@ -39,7 +37,6 @@ import java.util.List;
  */
 @SuppressLint("ViewConstructor")
 public class SelectOneSearchWidget extends AbstractSelectOneWidget implements OnCheckedChangeListener, AudioPlayListener {
-
     public SelectOneSearchWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt, false);
         createLayout();
@@ -47,7 +44,6 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
 
     @Override
     protected void addButtonsToLayout(List<Integer> tagList) {
-        LayoutInflater inflater = LayoutInflater.from(getContext());
         for (int i = 0; i < buttons.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
                 answerLayout.addView(buttons.get(i));
@@ -78,6 +74,7 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
                 buttons.add(createRadioButton(i));
             }
         }
+
         setUpSearchBox();
     }
 }


### PR DESCRIPTION
Closes #1976 

#### What has been done to verify that this works as intended?
The widget has been opened on different screen sizes(4, 4.5, 5, 5.5 and 9 inch) and different versions of Android (APIs: 22,23,24,25,26). The search for specific item and selection works fine.

#### Why is this the best possible solution? Were any other approaches considered?
I haven't gone through all widgets if other widgets have the same problem. This is the best solution for this issue because it doesn't have to deal with other classes/objects. It fetches default line separator and applies to the LinearLayout.

#### Are there any risks to merging this code? If so, what are they?
I don't think there is any risk of merging this update.

#### Do we need any specific form for testing your changes? If so, please attach one.
N/A

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.