### PR TITLE
Exception java.util.IllegalFormatConversionException: %d can't formatjava.lang.String arguments

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -25,7 +25,6 @@ import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.Window;
-import android.view.accessibility.AccessibilityManager;
 import android.widget.DatePicker;
 
 import org.javarosa.form.api.FormEntryPrompt;
@@ -36,8 +35,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
 import timber.log.Timber;
-
-import static android.content.Context.ACCESSIBILITY_SERVICE;
 
 /**
  * Displays a DatePicker widget. DateWidget handles leap years and does not allow dates that do not
@@ -79,7 +76,7 @@ public class DateWidget extends AbstractDateWidget implements DatePickerDialog.O
         if (!isBrokenSamsungDevice() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             theme = themeUtils.getMaterialDialogTheme();
         }
-        if (!datePickerDetails.isCalendarMode() || (isBrokenSamsungDevice() && isTalkBackActive())) {
+        if (!datePickerDetails.isCalendarMode() || isBrokenSamsungDevice()) {
             theme = themeUtils.getHoloDialogTheme();
         }
 
@@ -91,11 +88,6 @@ public class DateWidget extends AbstractDateWidget implements DatePickerDialog.O
         return (Build.MANUFACTURER.equalsIgnoreCase("samsung")
                 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
                 && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1);
-    }
-
-    // https://stackoverflow.com/a/34853067/5479029
-    private boolean isTalkBackActive() {
-        return ((AccessibilityManager) getContext().getSystemService(ACCESSIBILITY_SERVICE)).isTouchExplorationEnabled();
     }
 
     // Exposed for testing purposes to avoid reflection.


### PR DESCRIPTION
Closes #2003 

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?
It's the same problem like here https://github.com/opendatakit/collect/issues/1424 then the issue was caught for Samsung devices when talkback was active. I guess there is another case (it's not only related to talkback) but I'm can't reproduce the issue so I would just recommend using `android.R.style.Theme_Holo_Light_Dialog` for all Samsung devices with Android Lolipop.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No.