### PR TITLE
Cannot choose an image from GD on Samsung Galaxy S4

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -617,8 +617,8 @@ public class MediaUtils {
      * @param uri The Uri to check
      * @return Whether the Uri authority is Google Drive.
      */
-    public static boolean isGoogleDriveDocument(Uri uri) {
-        return "com.google.android.apps.docs.storage".equals(uri.getAuthority())
+    private static boolean isGoogleDriveDocument(Uri uri) {
+        return uri.getAuthority().startsWith("com.google.android.apps.docs.storage")
                 || uri.getAuthority().startsWith("com.google.android.apps.photos.content");
     }
 


### PR DESCRIPTION
Closes #2151 

#### What has been done to verify that this works as intended?
I've tested Image widgets with GD using the mentioned device.

#### Why is this the best possible solution? Were any other approaches considered?
Don't know why but the in most case `uri.getAuthority()` returns 
`com.google.android.apps.docs.storage
`but for the mentioned device it's
`com.google.android.apps.docs.storage.legacy
`
#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `ImageWidget`

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.

No.