### PR TITLE
Toggle button in "Send Finalized Form" and "Delete Saved Form"

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -322,7 +322,6 @@ public class InstanceUploaderList extends InstanceListActivity implements
     @Override
     protected void updateAdapter() {
         getSupportLoaderManager().restartLoader(LOADER_ID, null, this);
-        toggleButtonLabel(findViewById(R.id.toggle_button), listView);
     }
 
     @NonNull
@@ -341,6 +340,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
         hideProgressBarIfAllowed();
         listAdapter.changeCursor(cursor);
         checkPreviouslyCheckedItems();
+        toggleButtonLabel(findViewById(R.id.toggle_button), listView);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FileManagerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FileManagerFragment.java
@@ -95,9 +95,6 @@ public abstract class FileManagerFragment extends AppListFragment implements Loa
     @Override
     protected void updateAdapter() {
         getLoaderManager().restartLoader(LOADER_ID, null, this);
-        checkPreviouslyCheckedItems();
-        toggleButtonLabel(toggleButton, getListView());
-        deleteButton.setEnabled(areCheckedItems());
     }
 
     @NonNull
@@ -111,6 +108,10 @@ public abstract class FileManagerFragment extends AppListFragment implements Loa
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         hideProgressBarIfAllowed();
         listAdapter.swapCursor(cursor);
+
+        checkPreviouslyCheckedItems();
+        toggleButtonLabel(toggleButton, getListView());
+        deleteButton.setEnabled(areCheckedItems());
 
         if (getListView().getCount() == 0) {
             toggleButton.setEnabled(false);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FileManagerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FileManagerFragment.java
@@ -115,6 +115,8 @@ public abstract class FileManagerFragment extends AppListFragment implements Loa
 
         if (getListView().getCount() == 0) {
             toggleButton.setEnabled(false);
+        } else {
+            toggleButton.setEnabled(true);
         }
     }
 


### PR DESCRIPTION
Closes #2153 

#### What has been done to verify that this works as intended?
Tested on a physical device (Android 7.1) and behaviour found correct

#### Why is this the best possible solution? Were any other approaches considered?
Button label is refreshed before listview is updated, I've added label change method in `onLoadFinished` so that it changes when the list gets updated.

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue at https://github.com/opendatakit/docs/issues/new and include the link below.
No