### PR TITLE
Undo our failed attempt at reliable asynchronous FormDef cache saving

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -108,7 +108,6 @@ import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.android.utilities.FormDefCache;
 import org.odk.collect.android.utilities.ImageConverter;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -127,15 +126,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
-import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_MOVING_BACKWARDS;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.FormDefCache.writeCacheAsync;
 
 /**
  * FormEntryActivity is responsible for displaying questions, animating
@@ -250,8 +246,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     private ActivityAvailability activityAvailability = new ActivityAvailability(this);
 
     private boolean shouldOverrideAnimations = false;
-
-    private final CompositeDisposable formDefCacheCompositeDisposable = new CompositeDisposable();
 
     /**
      * Called when the activity is first created.
@@ -2313,7 +2307,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         }
         releaseOdkView();
-        formDefCacheCompositeDisposable.dispose();
         super.onDestroy();
 
     }
@@ -2477,18 +2470,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
 
         refreshCurrentView();
-
-        if (formDef != null) {
-            final File cachedFormDefFile = FormDefCache.getCacheFile(new File(formPath));
-
-            if (cachedFormDefFile.exists()) {
-                Timber.i("FormDef %s is already in the cache", cachedFormDefFile.toString());
-            } else {
-                Disposable formDefCacheDisposable =
-                        writeCacheAsync(formDef, cachedFormDefFile).subscribe(() -> { }, Timber::e);
-                formDefCacheCompositeDisposable.add(formDefCacheDisposable);
-            }
-        }
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -123,7 +123,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         final String formPath = path[0];
         final File formXml = new File(formPath);
 
-        final FormDef formDef = createFormDefFromCacheOrXml(formXml);
+        final FormDef formDef = createFormDefFromCacheOrXml(formPath, formXml);
 
         if (errorMsg != null || formDef == null) {
             return null;
@@ -218,7 +218,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         return data;
     }
 
-    private FormDef createFormDefFromCacheOrXml(File formXml) {
+    private FormDef createFormDefFromCacheOrXml(String formPath, File formXml) {
         publishProgress(
                 Collect.getInstance().getString(R.string.survey_loading_reading_form_message));
 
@@ -240,6 +240,9 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
                 Timber.i("Loaded in %.3f seconds.",
                         (System.currentTimeMillis() - start) / 1000F);
                 formDef = formDefFromXml;
+
+                FormDefCache.writeCache(formDef, formPath);
+
                 return formDefFromXml;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Closes #2144

Our asynchronous FormDef cache saving implementation has a bug. It initializes the form before caching it, possibly resulting in one instance’s data being loaded into other instances.

Affected users should reset the form load cache in the Admin Settings.

#### What has been done to verify that this works as intended?
I ran through these [reproduction steps](https://github.com/opendatakit/javarosa/issues/301) before and after, and saw that the problem is corrected.

#### Why is this the best possible solution? Were any other approaches considered?
I considered trying to make the asynchronous approach work, but given that `FormDef`s are mutable, that’s really scary.

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
[random.xml](https://github.com/opendatakit/javarosa/issues/301) 

#### Does this change require updates to documentation? If so, please file an issue at [Here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

