### PR TITLE
Update gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,3 +27,14 @@ allprojects {
 configurations.all {
     transitive = true
 }
+
+ext {
+    // Play Services is a big download so it should only be upgraded if necessary and after
+    // community discussion and a warning period.
+    playServicesVersion = '10.0.1'
+
+    supportLibraryVersion = '27.1.1'
+    leakyCanaryVersion = '1.5.4'
+    daggerVersion = '2.14'
+    rxLifecycleVersion = '2.2.1'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:3.2.0'
         classpath 'org.ow2.asm:asm:6.0' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.0'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -175,14 +175,14 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
-    implementation group: 'com.android.support', name: 'support-v13', version: '27.1.0'
-    implementation group: 'com.android.support', name: 'customtabs', version: '27.1.0'
-    implementation group: 'com.android.support', name: 'design', version: '27.1.0'
-    implementation group: 'com.android.support', name: 'appcompat-v7', version: '27.1.0'
-    implementation group: 'com.android.support', name: 'design', version: '27.1.0'
-    implementation group: 'com.android.support', name: 'cardview-v7', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'support-v13', version: '27.1.1'
+    implementation group: 'com.android.support', name: 'customtabs', version: '27.1.1'
+    implementation group: 'com.android.support', name: 'design', version: '27.1.1'
+    implementation group: 'com.android.support', name: 'appcompat-v7', version: '27.1.1'
+    implementation group: 'com.android.support', name: 'design', version: '27.1.1'
+    implementation group: 'com.android.support', name: 'cardview-v7', version: '27.1.1'
     implementation group: 'com.android.support', name: 'multidex', version: '1.0.3'
-    implementation group: 'com.android.support', name: 'exifinterface', version: '27.1.0'
+    implementation group: 'com.android.support', name: 'exifinterface', version: '27.1.1'
     implementation group: 'com.google.android.gms', name: 'play-services-analytics', version: '10.0.1'
     implementation group: 'com.google.android.gms', name: 'play-services-auth', version: '10.0.1'
     implementation group: 'com.google.android.gms', name: 'play-services-maps', version: '10.0.1'
@@ -191,7 +191,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
     implementation group: 'com.google.firebase', name: 'firebase-core', version: '10.0.1'
-    implementation group: 'com.crashlytics.sdk.android', name: 'crashlytics', version: '2.9.1'
+    implementation group: 'com.crashlytics.sdk.android', name: 'crashlytics', version: '2.9.2'
     implementation(group: 'com.google.http-client', name: 'google-http-client', version: '1.22.0') {
         exclude group: 'org.apache.httpcomponents'
     }
@@ -200,7 +200,7 @@ dependencies {
     }
 
     implementation group: 'com.rarepebble', name: 'colorpicker', version: '2.3.1'
-    implementation group: 'commons-io', name: 'commons-io', version: '2.5'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
     implementation group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     implementation group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
     implementation(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.9.0') {
@@ -233,13 +233,13 @@ dependencies {
     odkCollectReleaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
 
     // Android Architecture Components:
-    implementation "android.arch.lifecycle:extensions:1.1.0"
+    implementation "android.arch.lifecycle:extensions:1.1.1"
 
     // Dagger:
-    implementation 'com.google.dagger:dagger-android:2.11'
-    implementation 'com.google.dagger:dagger-android-support:2.11'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.11'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.11'
+    implementation 'com.google.dagger:dagger-android:2.14'
+    implementation 'com.google.dagger:dagger-android-support:2.14'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.14'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.14'
 
     // RxJava 2:
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -219,7 +219,7 @@ dependencies {
     implementation(group: 'com.google.apis', name: 'google-api-services-sheets', version: 'v4-rev463-1.22.0') {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation group: 'com.jakewharton.timber', name: 'timber', version: '4.6.0'
+    implementation group: 'com.jakewharton.timber', name: 'timber', version: '4.7.0'
     implementation group: 'com.google.zxing', name: 'core', version: '3.3.0'
     implementation group: 'com.journeyapps', name: 'zxing-android-embedded', version: '3.5.0'
     implementation group: 'net.danlew', name: 'android.joda', version: '2.9.9'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -66,7 +66,6 @@ if (secretsFile.exists()) {
 
 android {
     compileSdkVersion(27)
-    buildToolsVersion('26.0.2')
 
     defaultConfig {
         applicationId('org.odk.collect.android')
@@ -262,7 +261,7 @@ dependencies {
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 
     // Used to generate documentation screenshots.
-    androidTestCompile 'tools.fastlane:screengrab:1.1.0'
+    androidTestImplementation 'tools.fastlane:screengrab:1.1.0'
 
     // Testing-only dependencies
     testImplementation group: 'junit', name: 'junit', version: '4.12'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -177,23 +177,27 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
-    implementation group: 'com.android.support', name: 'support-v13', version: '27.1.1'
-    implementation group: 'com.android.support', name: 'customtabs', version: '27.1.1'
-    implementation group: 'com.android.support', name: 'design', version: '27.1.1'
-    implementation group: 'com.android.support', name: 'appcompat-v7', version: '27.1.1'
-    implementation group: 'com.android.support', name: 'design', version: '27.1.1'
-    implementation group: 'com.android.support', name: 'cardview-v7', version: '27.1.1'
+    implementation group: 'com.android.support', name: 'support-v13', version: "${rootProject.supportLibraryVersion}"
+    implementation group: 'com.android.support', name: 'customtabs', version: "${rootProject.supportLibraryVersion}"
+    implementation group: 'com.android.support', name: 'design', version: "${rootProject.supportLibraryVersion}"
+    implementation group: 'com.android.support', name: 'appcompat-v7', version: "${rootProject.supportLibraryVersion}"
+    implementation group: 'com.android.support', name: 'design', version: "${rootProject.supportLibraryVersion}"
+    implementation group: 'com.android.support', name: 'cardview-v7', version: "${rootProject.supportLibraryVersion}"
+    implementation group: 'com.android.support', name: 'exifinterface', version: "${rootProject.supportLibraryVersion}"
     implementation group: 'com.android.support', name: 'multidex', version: '1.0.3'
-    implementation group: 'com.android.support', name: 'exifinterface', version: '27.1.1'
-    implementation group: 'com.google.android.gms', name: 'play-services-analytics', version: '10.0.1'
-    implementation group: 'com.google.android.gms', name: 'play-services-auth', version: '10.0.1'
-    implementation group: 'com.google.android.gms', name: 'play-services-maps', version: '10.0.1'
-    implementation group: 'com.google.android.gms', name: 'play-services-location', version: '10.0.1'
+
+    implementation group: 'com.google.android.gms', name: 'play-services-analytics', version: "${rootProject.playServicesVersion}"
+    implementation group: 'com.google.android.gms', name: 'play-services-auth', version: "${rootProject.playServicesVersion}"
+    implementation group: 'com.google.android.gms', name: 'play-services-maps', version: "${rootProject.playServicesVersion}"
+    implementation group: 'com.google.android.gms', name: 'play-services-location', version: "${rootProject.playServicesVersion}"
+
+    implementation group: 'com.google.firebase', name: 'firebase-core', version: "${rootProject.playServicesVersion}"
+    implementation group: 'com.crashlytics.sdk.android', name: 'crashlytics', version: '2.9.2'
+
     implementation(group: 'com.google.code.gson', name: 'gson', version: '2.6.2') {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation group: 'com.google.firebase', name: 'firebase-core', version: '10.0.1'
-    implementation group: 'com.crashlytics.sdk.android', name: 'crashlytics', version: '2.9.2'
+
     implementation(group: 'com.google.http-client', name: 'google-http-client', version: '1.22.0') {
         exclude group: 'org.apache.httpcomponents'
     }
@@ -227,21 +231,21 @@ dependencies {
     implementation group: 'net.danlew', name: 'android.joda', version: '2.9.9'
 
     // Real LeakCanary for debug builds only: notifications, analysis, etc
-    debugImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android', version: '1.5.4'
+    debugImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android', version: "${rootProject.leakyCanaryVersion}"
     // No-Op version of LeakCanary for release builds: no notifications, no analysis, nothing
-    releaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
-    testImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
-    androidTestImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
-    odkCollectReleaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: '1.5.4'
+    releaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
+    testImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
+    androidTestImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
+    odkCollectReleaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
 
     // Android Architecture Components:
     implementation "android.arch.lifecycle:extensions:1.1.1"
 
     // Dagger:
-    implementation 'com.google.dagger:dagger-android:2.14'
-    implementation 'com.google.dagger:dagger-android-support:2.14'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.14'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.14'
+    implementation "com.google.dagger:dagger-android:${rootProject.daggerVersion}"
+    implementation "com.google.dagger:dagger-android-support:${rootProject.daggerVersion}"
+    annotationProcessor "com.google.dagger:dagger-android-processor:${rootProject.daggerVersion}"
+    annotationProcessor "com.google.dagger:dagger-compiler:${rootProject.daggerVersion}"
 
     // RxJava 2:
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
@@ -254,9 +258,9 @@ dependencies {
     implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
 
     // RxLifecycle (binds subscription cleanup to component lifecycle):
-    implementation 'com.trello.rxlifecycle2:rxlifecycle:2.2.1'
-    implementation 'com.trello.rxlifecycle2:rxlifecycle-android:2.2.1'
-    implementation 'com.trello.rxlifecycle2:rxlifecycle-android-lifecycle:2.2.1'
+    implementation "com.trello.rxlifecycle2:rxlifecycle:${rootProject.rxLifecycleVersion}"
+    implementation "com.trello.rxlifecycle2:rxlifecycle-android:${rootProject.rxLifecycleVersion}"
+    implementation "com.trello.rxlifecycle2:rxlifecycle-android-lifecycle:${rootProject.rxLifecycleVersion}"
 
     // Makes binding to Views easy:
     implementation 'com.jakewharton:butterknife:8.8.1'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -177,66 +177,66 @@ allprojects {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
-    implementation group: 'com.android.support', name: 'support-v13', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'customtabs', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'design', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'appcompat-v7', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'design', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'cardview-v7', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'exifinterface', version: "${rootProject.supportLibraryVersion}"
-    implementation group: 'com.android.support', name: 'multidex', version: '1.0.3'
+    implementation "com.android.support:support-v13:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:customtabs:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:design:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:appcompat-v7:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:design:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:cardview-v7:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:exifinterface:${rootProject.supportLibraryVersion}"
+    implementation "com.android.support:multidex:1.0.3"
 
-    implementation group: 'com.google.android.gms', name: 'play-services-analytics', version: "${rootProject.playServicesVersion}"
-    implementation group: 'com.google.android.gms', name: 'play-services-auth', version: "${rootProject.playServicesVersion}"
-    implementation group: 'com.google.android.gms', name: 'play-services-maps', version: "${rootProject.playServicesVersion}"
-    implementation group: 'com.google.android.gms', name: 'play-services-location', version: "${rootProject.playServicesVersion}"
+    implementation "com.google.android.gms:play-services-analytics:${rootProject.playServicesVersion}"
+    implementation "com.google.android.gms:play-services-auth:${rootProject.playServicesVersion}"
+    implementation "com.google.android.gms:play-services-maps:${rootProject.playServicesVersion}"
+    implementation "com.google.android.gms:play-services-location:${rootProject.playServicesVersion}"
 
-    implementation group: 'com.google.firebase', name: 'firebase-core', version: "${rootProject.playServicesVersion}"
-    implementation group: 'com.crashlytics.sdk.android', name: 'crashlytics', version: '2.9.2'
+    implementation "com.google.firebase:firebase-core:${rootProject.playServicesVersion}"
+    implementation "com.crashlytics.sdk.android:crashlytics:2.9.2"
 
-    implementation(group: 'com.google.code.gson', name: 'gson', version: '2.6.2') {
+    implementation("com.google.code.gson:gson:2.6.2") {
         exclude group: 'org.apache.httpcomponents'
     }
 
-    implementation(group: 'com.google.http-client', name: 'google-http-client', version: '1.22.0') {
+    implementation("com.google.http-client:google-http-client:1.22.0") {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation(group: 'com.google.oauth-client', name: 'google-oauth-client', version: '1.22.0') {
+    implementation("com.google.oauth-client:google-oauth-client:1.22.0") {
         exclude group: 'org.apache.httpcomponents'
     }
 
-    implementation group: 'com.rarepebble', name: 'colorpicker', version: '2.3.1'
-    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
-    implementation group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    implementation group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
-    implementation(group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.9.0') {
+    implementation "com.rarepebble:colorpicker:2.3.1"
+    implementation "commons-io:commons-io:2.6"
+    implementation "net.sf.kxml:kxml2:2.3.0"
+    implementation "net.sf.opencsv:opencsv:2.3"
+    implementation("org.opendatakit:opendatakit-javarosa:2.9.0") {
         exclude module: 'joda-time'
     }
 
-    implementation group: 'org.osmdroid', name: 'osmdroid-android', version: '5.6.4'
-    implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.6.1-RC1'
-    implementation group: 'pub.devrel', name: 'easypermissions', version: '0.2.1'
-    implementation(group: 'com.google.api-client', name: 'google-api-client-android', version: '1.22.0') {
+    implementation "org.osmdroid:osmdroid-android:5.6.4"
+    implementation "org.slf4j:slf4j-android:1.6.1-RC1"
+    implementation "pub.devrel:easypermissions:0.2.1"
+    implementation("com.google.api-client:google-api-client-android:1.22.0") {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation(group: 'com.google.apis', name: 'google-api-services-drive', version: 'v3-rev64-1.22.0') {
+    implementation("com.google.apis:google-api-services-drive:v3-rev64-1.22.0") {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation(group: 'com.google.apis', name: 'google-api-services-sheets', version: 'v4-rev463-1.22.0') {
+    implementation("com.google.apis:google-api-services-sheets:v4-rev463-1.22.0") {
         exclude group: 'org.apache.httpcomponents'
     }
-    implementation group: 'com.jakewharton.timber', name: 'timber', version: '4.7.0'
-    implementation group: 'com.google.zxing', name: 'core', version: '3.3.0'
-    implementation group: 'com.journeyapps', name: 'zxing-android-embedded', version: '3.5.0'
-    implementation group: 'net.danlew', name: 'android.joda', version: '2.9.9'
+    implementation "com.jakewharton.timber:timber:4.7.0"
+    implementation "com.google.zxing:core:3.3.0"
+    implementation "com.journeyapps:zxing-android-embedded:3.5.0"
+    implementation "net.danlew:android.joda:2.9.9"
 
     // Real LeakCanary for debug builds only: notifications, analysis, etc
-    debugImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android', version: "${rootProject.leakyCanaryVersion}"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:${rootProject.leakyCanaryVersion}"
     // No-Op version of LeakCanary for release builds: no notifications, no analysis, nothing
-    releaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
-    testImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
-    androidTestImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
-    odkCollectReleaseImplementation group: 'com.squareup.leakcanary', name: 'leakcanary-android-no-op', version: "${rootProject.leakyCanaryVersion}"
+    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootProject.leakyCanaryVersion}"
+    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootProject.leakyCanaryVersion}"
+    androidTestImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootProject.leakyCanaryVersion}"
+    odkCollectReleaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootProject.leakyCanaryVersion}"
 
     // Android Architecture Components:
     implementation "android.arch.lifecycle:extensions:1.1.1"
@@ -248,14 +248,14 @@ dependencies {
     annotationProcessor "com.google.dagger:dagger-compiler:${rootProject.daggerVersion}"
 
     // RxJava 2:
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.10'
+    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
+    implementation "io.reactivex.rxjava2:rxjava:2.1.10"
 
     // Better "Subjects" for Rx:
-    implementation 'com.jakewharton.rxrelay2:rxrelay:2.0.0'
+    implementation "com.jakewharton.rxrelay2:rxrelay:2.0.0"
 
     // Android bindings for Rx:
-    implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
+    implementation "com.jakewharton.rxbinding2:rxbinding:2.0.0"
 
     // RxLifecycle (binds subscription cleanup to component lifecycle):
     implementation "com.trello.rxlifecycle2:rxlifecycle:${rootProject.rxLifecycleVersion}"
@@ -263,38 +263,34 @@ dependencies {
     implementation "com.trello.rxlifecycle2:rxlifecycle-android-lifecycle:${rootProject.rxLifecycleVersion}"
 
     // Makes binding to Views easy:
-    implementation 'com.jakewharton:butterknife:8.8.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
+    implementation "com.jakewharton:butterknife:8.8.1"
+    annotationProcessor "com.jakewharton:butterknife-compiler:8.8.1"
 
     // Used to generate documentation screenshots.
-    androidTestImplementation 'tools.fastlane:screengrab:1.1.0'
+    androidTestImplementation "tools.fastlane:screengrab:1.1.0"
 
     // Testing-only dependencies
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.8.47'
-    testImplementation group: 'org.robolectric', name: 'robolectric', version: '3.5.1'
-    testImplementation group: 'org.robolectric', name: 'shadows-multidex', version: '3.5.1'
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.mockito:mockito-core:2.8.47"
+    testImplementation "org.robolectric:robolectric:3.5.1"
+    testImplementation "org.robolectric:shadows-multidex:3.5.1"
 
     // power mock (for mocking final methods which is not handled by mockito)
-    testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '1.6.4'
-    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '1.7.3'
+    testImplementation "org.powermock:powermock-module-junit4:1.6.4"
+    testImplementation "org.powermock:powermock-api-mockito2:1.7.3"
 
-    androidTestImplementation group: 'org.mockito', name: 'mockito-android', version: '2.11.0'
-    androidTestImplementation(group: 'com.android.support.test', name: 'runner', version: '1.0.1') {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
-
-    androidTestImplementation(group: 'com.android.support.test.espresso', name: 'espresso-core', version: '3.0.1') {
+    androidTestImplementation "org.mockito:mockito-android:2.11.0"
+    androidTestImplementation("com.android.support.test:runner:1.0.1") {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    androidTestImplementation(group: 'com.android.support.test.espresso', name: 'espresso-intents', version: '3.0.1') {
+    androidTestImplementation("com.android.support.test.espresso:espresso-intents:3.0.1") {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    androidTestImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.9.0'
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:3.9.0"
 }
 
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -163,6 +163,8 @@ configurations.all {
     resolutionStrategy {
         cacheDynamicVersionsFor(0, 'seconds')
         cacheChangingModulesFor(0, 'seconds')
+
+        force('com.google.code.findbugs:jsr305:1.3.9')
     }
     transitive = true
 }

--- a/collect_app/src/debug/AndroidManifest.xml
+++ b/collect_app/src/debug/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
 
     <!-- Allows changing locales -->
-    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" tools:ignore="ProtectedPermissions" />
 
     <application
         android:name=".application.TestCollect"

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -169,7 +169,7 @@ public class DownloadFormsTask extends
                 Timber.i("No Manifest for: %s", fd.getFormName());
             }
         } catch (TaskCancelledException e) {
-            Timber.i(e.getMessage());
+            Timber.i(e);
             cleanUp(fileResult, e.file, tempMediaPath);
 
             // do not download additional forms.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,9 @@
+#Tue May 01 11:34:35 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip
 android.enableD8.desugaring=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+# Android Studio Gradle wrapper 3.1.2 doesn't support configure on demand
+org.gradle.configureondemand=false


### PR DESCRIPTION
Gradle 4.7 has been out for some time now and it's easier to do incremental updates than to do big updates less frequently.

Updates other dependencies that don't require code changes or a Play Services upgrade.

This also introduces variables for versions that are common between multiple dependencies as suggested by @jd-alexander. Not all versions are handled through variables, only the ones that are for sure always common. If someone disagrees with this decision, let's open a new issue and have a discussion there. 

The introduction of those version variables makes dependency declarations longer so I've standardized on using string notation over map notation for that reason.