### PR TITLE
Resolved crash when downloading forms from Google Server

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -492,17 +492,6 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
     }
 
     @Override
-    protected void onPause() {
-        if (retrieveDriveFileContentsAsyncTask != null) {
-            retrieveDriveFileContentsAsyncTask.setTaskListener(null);
-        }
-        if (getFileTask != null) {
-            getFileTask.setGoogleDriveFormDownloadListener(null);
-        }
-        super.onPause();
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
         if (retrieveDriveFileContentsAsyncTask != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -535,6 +535,24 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
         super.onStop();
     }
 
+    @Override
+    protected void onDestroy() {
+        if (retrieveDriveFileContentsAsyncTask != null) {
+            if (!retrieveDriveFileContentsAsyncTask.isCancelled()) {
+                retrieveDriveFileContentsAsyncTask.cancel(true);
+            }
+            retrieveDriveFileContentsAsyncTask.setTaskListener(null);
+        }
+        if (getFileTask != null) {
+            if (!getFileTask.isCancelled()) {
+                getFileTask.cancel(true);
+            }
+            getFileTask.setGoogleDriveFormDownloadListener(null);
+        }
+        finish();
+        super.onDestroy();
+    }
+
     public void listFiles(String dir, String query) {
         setProgressBarIndeterminateVisibility(true);
         adapter = null;


### PR DESCRIPTION
Closes #2167

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Verified on physical device running Android 7.1
#### Why is this the best possible solution? Were any other approaches considered?
In `onPause()` listeners were set to null but when form download is complete `listener.formDownloadComplete(results);` results into NPE which should not happen.
#### Are there any risks to merging this code? If so, what are they?
No
#### Do we need any specific form for testing your changes? If so, please attach one.
No
#### Does this change require updates to documentation? If so, please file an issue at [Here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors so that they work with both light and dark themes.
