### PR TITLE
Capitalize 'gps' in user-facing notifications. Closes #2156.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -29,6 +29,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
+import org.odk.collect.android.utilities.GeoPointUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.GeoPointWidget;
 
@@ -255,7 +256,7 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
     }
 
     public String getProviderAccuracyMessage(@NonNull Location location) {
-        return getString(R.string.location_provider_accuracy, location.getProvider(), truncateDouble(location.getAccuracy()));
+        return getString(R.string.location_provider_accuracy, GeoPointUtils.capitalizeGps(location.getProvider()), truncateDouble(location.getAccuracy()));
     }
 
     public String getResultStringForLocation(@NonNull Location location) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -44,6 +44,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
 import org.odk.collect.android.spatial.MapHelper;
+import org.odk.collect.android.utilities.GeoPointUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.GeoPointWidget;
 
@@ -583,7 +584,7 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
     }
 
     public String getAccuracyStringForLocation(Location location) {
-        return getString(R.string.location_provider_accuracy, location.getProvider(),
+        return getString(R.string.location_provider_accuracy, GeoPointUtils.capitalizeGps(location.getProvider()),
                 truncateFloat(location.getAccuracy()));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -36,6 +36,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
 import org.odk.collect.android.spatial.MapHelper;
+import org.odk.collect.android.utilities.GeoPointUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.GeoPointWidget;
 import org.osmdroid.events.MapEventsReceiver;
@@ -427,7 +428,7 @@ public class GeoPointOsmMapActivity extends CollectAbstractActivity implements L
                     foundFirstLocation = true;
                 }
                 locationStatus.setText(
-                        getString(R.string.location_provider_accuracy, this.location.getProvider(),
+                        getString(R.string.location_provider_accuracy, GeoPointUtils.capitalizeGps(this.location.getProvider()),
                                 truncateFloat(this.location.getAccuracy())));
             } else {
                 // Prevent from forever increasing

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/GeoPointUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/GeoPointUtils.java
@@ -1,0 +1,15 @@
+package org.odk.collect.android.utilities;
+
+public class GeoPointUtils {
+
+    private GeoPointUtils() {
+
+    }
+
+    /**
+     * Corrects location provider names so "gps" displays as "GPS" in user-facing messaging.
+     */
+    public static String capitalizeGps(String locationProvider) {
+        return "gps".equals(locationProvider) ? "GPS" : locationProvider;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/GeoPointUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/GeoPointUtilsTest.java
@@ -1,0 +1,20 @@
+package org.odk.collect.android.utilities;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class GeoPointUtilsTest {
+    @Test
+    public void capitalizesGps() {
+        String input = "gps";
+        assertEquals("GPS", GeoPointUtils.capitalizeGps(input));
+
+        String locationProvider = "network";
+        assertEquals("network", GeoPointUtils.capitalizeGps(locationProvider));
+
+        String nullLocationProvider = null;
+        assertNull(GeoPointUtils.capitalizeGps(nullLocationProvider));
+    }
+}


### PR DESCRIPTION
When using location-related form widgets like geopoints, users will see a message like 'Using gps. Accuracy is 10 m.' while Collect poinpoints their location. Since GPS is a standardized acronym, this commit changes occurrences of the term in these notifications to properly say 'Using GPS' instead.

Three classes - GeoPointActivity, GeoPointMapActivity and GeoPointsOsmMapActivity - use the Android Location.getProvider() call to build strings in this way. Since they all inherit from CollectAbstractActivity, this commit creates an abstract LocationActivity superclass for those three classes. The LocationActivity class contains just a single method, which, given a string, returns 'GPS' if the parameter is 'gps' and otherwise just returns the parameter untouched.

This lets the three location classes inherit from LocationActivity and simply slightly tweak their accuracy-generating methods to capitalize GPS for the user.

Closes #2156 

#### What has been done to verify that this works as intended?

Ran the Gradle test suite and found my original approach caused a failed GeoPointActivity test due to a NullPointerException. It appears the testLocationClientLifecycle() test at one point passes `null` to the activity as a location. 

This has been resolved - should the superclass's capitalization method receive null instead of a string, it simply returns null instead of trying to work with it. (It appears this is what would happen if the location was ever really null and we added it to our user-facing string).

I also ran my changes on an Android and verified the user now sees "Using GPS" instead of "using gps" when pinpointing location with any of the three affected widgets/activities.

#### Why is this the best possible solution? Were any other approaches considered?

Rather than hard-coding the check for `"gps"` in the capitalization method, I considered whether it might be better to use a string resource instead. A little bit of looking around online tells me GPS seems to be known as GPS everywhere and thus wouldn't require translation. However, I'm curious if the team thinks we should use a string resource instead - and I'm happy to make the change if so.

@dcbriccetti was extremely helpful and suggested creating a new abstract parent for the three activities - the only other way I could think of would require duplicating the check for the string `"gps" across all three classes, but I'd be curious as to the team's thoughts.

#### Are there any risks to merging this code? If so, what are they?

None that I can think of, other than it adding another abstract class and whether we want to take on that weight.

#### Do we need any specific form for testing your changes? If so, please attach one.

Nope!

#### Does this change require updates to documentation? If so, please file an issue at [Here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Nope!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors so that they work with both light and dark themes.
