### PR TITLE
Fixed issue taking place with guidanceVisibilityContentTest

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android;
 
-
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.AssetManager;
@@ -35,7 +34,6 @@ import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
@@ -85,7 +83,7 @@ public class GuidanceHintFormTest {
 
     @Test
     public void guidanceVisibilityContentTest() {
-        GeneralSharedPreferences.getInstance().save(PreferenceKeys.KEY_GUIDANCE_HINT, GuidanceHint.YesCollapsed.toString());
+        GeneralSharedPreferences.getInstance().save(PreferenceKeys.KEY_GUIDANCE_HINT, GuidanceHint.Yes.toString());
 
         FormEntryPrompt prompt = Collect.getInstance().getFormController().getQuestionPrompt();
 
@@ -93,12 +91,9 @@ public class GuidanceHintFormTest {
 
         assertFalse(TextUtils.isEmpty(guidance));
 
-        onView(withId(R.id.help_text_view)).perform(click());
-
         Screengrab.screenshot("guidance_hint");
 
         onView(withId(R.id.guidance_text_view)).check(matches(withText(guidance)));
-
     }
 
     //region Helper methods.
@@ -107,8 +102,6 @@ public class GuidanceHintFormTest {
                 + FORMS_DIRECTORY
                 + GUIDANCE_SAMPLE_FORM;
     }
-
-
 
     //region Custom TestRule.
     private class FormEntryActivityTestRule extends IntentsTestRule<FormEntryActivity> {
@@ -128,6 +121,4 @@ public class GuidanceHintFormTest {
         }
     }
     //endregion
-
-
 }


### PR DESCRIPTION
The action of the tests was checking to see if a guidance hint would be displayed if the help text layout was clicked. A failure occurred because the animation that's being used to animate the expansion of the hint guidance layout would cause issues if an IdlingResource isn't used and it's generally recommended not to use animations during tests. To resolve the issue I simply tested the use case where the hint guidance is set to Yes, so it's just shown once the question has been rendered.


<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Ran the test locally and it passed.

#### Why is this the best possible solution? Were any other approaches considered?
N/A

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
Form with a hint guidance.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors so that they work with both light and dark themes.
