### PR TITLE
Guidance hint test fix

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
@@ -29,16 +29,19 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
 
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static junit.framework.Assert.assertFalse;
 import static org.odk.collect.android.activities.FormEntryActivity.EXTRA_TESTING_PATH;
+import static org.odk.collect.android.test.TestUtils.waitId;
 
 @RunWith(AndroidJUnit4.class)
 public class GuidanceHintFormTest {
@@ -92,6 +95,8 @@ public class GuidanceHintFormTest {
         assertFalse(TextUtils.isEmpty(guidance));
 
         Screengrab.screenshot("guidance_hint");
+
+        onView(isRoot()).perform(waitId(R.id.guidance_text_view, TimeUnit.SECONDS.toMillis(15)));
 
         onView(withId(R.id.guidance_text_view)).check(matches(withText(guidance)));
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android;
 
-
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.AssetManager;
@@ -35,7 +34,6 @@ import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
@@ -85,7 +83,7 @@ public class GuidanceHintFormTest {
 
     @Test
     public void guidanceVisibilityContentTest() {
-        GeneralSharedPreferences.getInstance().save(PreferenceKeys.KEY_GUIDANCE_HINT, GuidanceHint.YesCollapsed.toString());
+        GeneralSharedPreferences.getInstance().save(PreferenceKeys.KEY_GUIDANCE_HINT, GuidanceHint.Yes.toString());
 
         FormEntryPrompt prompt = Collect.getInstance().getFormController().getQuestionPrompt();
 
@@ -93,12 +91,9 @@ public class GuidanceHintFormTest {
 
         assertFalse(TextUtils.isEmpty(guidance));
 
-        onView(withId(R.id.help_text_view)).perform(click());
-
         Screengrab.screenshot("guidance_hint");
 
         onView(withId(R.id.guidance_text_view)).check(matches(withText(guidance)));
-
     }
 
     //region Helper methods.
@@ -107,8 +102,6 @@ public class GuidanceHintFormTest {
                 + FORMS_DIRECTORY
                 + GUIDANCE_SAMPLE_FORM;
     }
-
-
 
     //region Custom TestRule.
     private class FormEntryActivityTestRule extends IntentsTestRule<FormEntryActivity> {
@@ -128,6 +121,4 @@ public class GuidanceHintFormTest {
         }
     }
     //endregion
-
-
 }


### PR DESCRIPTION
View Action that waits to see if  the guidance text view will be drawn before proceeding with the rest of the test.
<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors so that they work with both light and dark themes.
