### PR TITLE
Fixed save icon color

### DIFF
--- a/collect_app/src/main/res/drawable/ic_save_black.xml
+++ b/collect_app/src/main/res/drawable/ic_save_black.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"
-      android:fillColor="#000000"/>
+      android:fillColor="?attr/colorControlNormal"/>
 </vector>


### PR DESCRIPTION
Closes #2193 

#### What has been done to verify that this works as intended?
I tested Import/Export settings in both themes.

#### Why is this the best possible solution? Were any other approaches considered?
It's the same approach use for other vectors.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors so that they work with both light and dark themes.
