### PR TITLE
Exclude slf4j from javarosa import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,13 @@ references:
   ## Docker image configurations
 
   android_config: &android_config
-    resource_class: large
     working_directory: *workspace
     docker:
       - image: circleci/android:api-26-alpha
+    environment:
+        # Least invasive change to resolve out-of-memory error
+        # https://discuss.circleci.com/t/11207/9
+        _JAVA_OPTIONS: "-Xmx1024m"
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -212,6 +212,7 @@ dependencies {
     implementation "net.sf.opencsv:opencsv:2.3"
     implementation("org.opendatakit:opendatakit-javarosa:2.10.0-SNAPSHOT") {
         exclude module: 'joda-time'
+        exclude group: 'org.slf4j'
     }
     implementation "com.karumi:dexter:4.2.0"
     implementation "org.osmdroid:osmdroid-android:5.6.4"

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -211,7 +211,6 @@ dependencies {
     implementation "net.sf.kxml:kxml2:2.3.0"
     implementation "net.sf.opencsv:opencsv:2.3"
     implementation("org.opendatakit:opendatakit-javarosa:2.10.0-SNAPSHOT") {
-        exclude module: 'joda-time'
         exclude group: 'org.slf4j'
     }
     implementation "com.karumi:dexter:4.2.0"


### PR DESCRIPTION
SLF4J is already imported by Collect. Exclude it from the JR import.