### PR TITLE
Revert resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,13 @@ references:
   ## Docker image configurations
 
   android_config: &android_config
-    resource_class: large
     working_directory: *workspace
     docker:
       - image: circleci/android:api-26-alpha
+    environment:
+        # Least invasive change to resolve out-of-memory error
+        # https://discuss.circleci.com/t/11207/9
+        _JAVA_OPTIONS: "-Xmx1024m"
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:


### PR DESCRIPTION
Although this worked well on CircleCI on the project's master, forks on users' github accounts can't access that larger resource class and so this makes all PRs fail.