### PR TITLE
Fixed the orientation bug in Android 8.1

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -122,9 +122,7 @@ the specific language governing permissions and limitations under the License.
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:taskAffinity="" />
-        <activity
-            android:name=".activities.DrawActivity"
-            android:screenOrientation="landscape" />
+        <activity android:name=".activities.DrawActivity" />
         <activity
             android:name=".activities.GoogleDriveActivity"
             android:configChanges="orientation|screenSize"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -17,7 +17,6 @@ package org.odk.collect.android.activities;
 
 import android.app.Activity;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -151,6 +150,9 @@ public class DrawActivity extends CollectAbstractActivity {
             savepointImage.delete();
             output = new File(Collect.TMPFILE_PATH);
         } else {
+            if (extras.getInt(SCREEN_ORIENTATION) == 1) {
+                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+            }
             loadOption = extras.getString(OPTION);
             if (loadOption == null) {
                 loadOption = OPTION_DRAW;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -53,8 +53,6 @@ import java.util.List;
 
 import timber.log.Timber;
 
-import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
-
 /**
  * Modified from the FingerPaint example found in The Android Open Source
  * Project.
@@ -70,7 +68,6 @@ public class DrawActivity extends CollectAbstractActivity {
     public static final String SCREEN_ORIENTATION = "screenOrientation";
     public static final String EXTRA_OUTPUT = android.provider.MediaStore.EXTRA_OUTPUT;
     public static final String SAVEPOINT_IMAGE = "savepointImage"; // during
-    public static final String PRECIOUS_SCREEN_ORIENTATION = "preciousOrientation";
     // restore
 
     private FloatingActionButton fabActions;
@@ -154,12 +151,6 @@ public class DrawActivity extends CollectAbstractActivity {
             savepointImage.delete();
             output = new File(Collect.TMPFILE_PATH);
         } else {
-            if (isPreviousPortrait(false) && !(extras.getInt(SCREEN_ORIENTATION) == 1)) {
-                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-            }
-            if (extras.getInt(SCREEN_ORIENTATION) == 1) {
-                setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-            }
             loadOption = extras.getString(OPTION);
             if (loadOption == null) {
                 loadOption = OPTION_DRAW;
@@ -381,16 +372,6 @@ public class DrawActivity extends CollectAbstractActivity {
         }
     }
 
-    public boolean isPreviousPortrait(boolean isPrevious) {
-        if (isPrevious) {
-            Intent i = getIntent();
-            int previousOrientation = i.getIntExtra(PRECIOUS_SCREEN_ORIENTATION, ORIENTATION_PORTRAIT);
-            return previousOrientation == ORIENTATION_PORTRAIT;
-        } else {
-            return this.getResources().getConfiguration().orientation == ORIENTATION_PORTRAIT;
-        }
-    }
-
     public boolean isApiBiggerThanO() {
         return android.os.Build.VERSION.SDK_INT >= 27;
     }
@@ -398,12 +379,13 @@ public class DrawActivity extends CollectAbstractActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        if (isApiBiggerThanO() && isPreviousPortrait(true)
+        if (isApiBiggerThanO()
                 && !(getIntent().getIntExtra(SCREEN_ORIENTATION, 0) == 1)) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
         }
 
-        if (isApiBiggerThanO() && getIntent().getIntExtra(SCREEN_ORIENTATION, 0) == 1) {
+        if (isApiBiggerThanO()
+                && getIntent().getIntExtra(SCREEN_ORIENTATION, 0) == 1) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         }
     }
@@ -411,20 +393,6 @@ public class DrawActivity extends CollectAbstractActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        if (isApiBiggerThanO() && isPreviousPortrait(true)
-                && !(getIntent().getIntExtra(SCREEN_ORIENTATION, 0) == 1)) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
-        }
-
-        if (isApiBiggerThanO() && getIntent().getIntExtra(SCREEN_ORIENTATION, 0) == 1
-                && !isPreviousPortrait(true)) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
-        }
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -273,7 +273,6 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
             }
             i.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
             i = addExtrasToIntent(i);
-            i.putExtra(DrawActivity.PRECIOUS_SCREEN_ORIENTATION, getContext().getResources().getConfiguration().orientation);
             launchActivityForResult(i, requestCode, stringResourceId);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -273,6 +273,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
             }
             i.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
             i = addExtrasToIntent(i);
+            i.putExtra(DrawActivity.PRECIOUS_SCREEN_ORIENTATION, getContext().getResources().getConfiguration().orientation);
             launchActivityForResult(i, requestCode, stringResourceId);
         }
     }


### PR DESCRIPTION
Closes #2211 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested in my Nexus 6P (Android 8.1) and custom phone (Android 6.0, no regression), using `Draw widget` , `Annotate widget (markup picture)` and `Signature widget`.
#### Why is this the best possible solution? Were any other approaches considered?
It's an Android system bug, I think it's a good option for us to address it like this.
#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
Forms with `Draw widget` , `Annotate widget` and `Signature widget`.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors so that they work with both light and dark themes.
