### PR TITLE
Hide old form versions

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/FormUtilsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.provider.BaseColumns;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.dto.Form;
+import org.odk.collect.android.provider.FormsProviderAPI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class FormUtilsTest {
+
+    @Test
+    public void removeOldFormsTest() {
+        MatrixCursor cursor = getCursor();
+        cursor.addRow(new Object[] {1, "Form1", null, "form1", null, null, null, null, null, null, 1526806800000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {2, "Form1", null, "form1", null, null, null, null, null, null, 1526803200000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {3, "Form1", null, "form1", null, null, null, null, null, null, 1526799600000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {4, "Form1", null, "form1", null, null, null, null, null, null, 1526796000000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {5, "Form2", null, "form2", null, null, null, null, null, null, 1526796180000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {6, "Form3", null, "form3", null, null, null, null, null, null, 1526810400000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {7, "Form3", null, "form3", null, null, null, null, null, null, 1526814000000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {8, "Form4", null, "form4", null, null, null, null, null, null, 1526817600000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {9, "Form4", null, "form4", null, null, null, null, null, null, 1526817000000L, null, null, null, null, null, null});
+        cursor.addRow(new Object[] {10, "Form4", null, "form4", null, null, null, null, null, null, 1526817300000L, null, null, null, null, null, null});
+
+        Cursor filteredCursor = FormUtils.removeOldForms(cursor);
+
+        assertNotNull(filteredCursor);
+        assertEquals(4, filteredCursor.getCount());
+
+        List<Form> forms = getFormsFromCursor(filteredCursor);
+
+        assertEquals(4, forms.size());
+        assertEquals(1, forms.get(0).getId());
+        assertEquals(5, forms.get(1).getId());
+        assertEquals(7, forms.get(2).getId());
+        assertEquals(8, forms.get(3).getId());
+    }
+
+    private List<Form> getFormsFromCursor(Cursor cursor) {
+        List<Form> forms = new ArrayList<>();
+        if (cursor != null && cursor.moveToFirst()) {
+            do {
+                int idColumnIndex = cursor.getColumnIndex(BaseColumns._ID);
+                int displayNameColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME);
+                int jrFormIdColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID);
+                int jrVersionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_VERSION);
+                int dateColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DATE);
+
+                Form form = new Form.Builder()
+                        .id(cursor.getInt(idColumnIndex))
+                        .displayName(cursor.getString(displayNameColumnIndex))
+                        .jrFormId(cursor.getString(jrFormIdColumnIndex))
+                        .jrVersion(cursor.getString(jrVersionColumnIndex))
+                        .date(cursor.getLong(dateColumnIndex))
+                        .build();
+
+                forms.add(form);
+            } while (cursor.moveToNext());
+        }
+        return forms;
+    }
+
+    private MatrixCursor getCursor() {
+        return new MatrixCursor(
+                new String[] {
+                        BaseColumns._ID,
+                        FormsProviderAPI.FormsColumns.DISPLAY_NAME,
+                        FormsProviderAPI.FormsColumns.DESCRIPTION,
+                        FormsProviderAPI.FormsColumns.JR_FORM_ID,
+                        FormsProviderAPI.FormsColumns.JR_VERSION,
+                        FormsProviderAPI.FormsColumns.FORM_FILE_PATH,
+                        FormsProviderAPI.FormsColumns.SUBMISSION_URI,
+                        FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY,
+                        FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT,
+                        FormsProviderAPI.FormsColumns.MD5_HASH,
+                        FormsProviderAPI.FormsColumns.DATE,
+                        FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH,
+                        FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH,
+                        FormsProviderAPI.FormsColumns.LANGUAGE,
+                        FormsProviderAPI.FormsColumns.AUTO_SEND,
+                        FormsProviderAPI.FormsColumns.AUTO_DELETE,
+                        FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH}
+        );
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -33,6 +33,8 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.listeners.DiskSyncListener;
 import org.odk.collect.android.listeners.PermissionListener;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
@@ -245,7 +247,10 @@ public class FormChooserList extends FormListActivity implements
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         hideProgressBarIfAllowed();
-        listAdapter.changeCursor(FormUtils.removeOldForms(cursor));
+        listAdapter.changeCursor(
+                GeneralSharedPreferences.getInstance().getBoolean(PreferenceKeys.KEY_HIDE_OLD_FORM_VERSIONS, false)
+                        ? FormUtils.removeOldForms(cursor)
+                        : cursor);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -36,6 +36,7 @@ import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.FormUtils;
 import org.odk.collect.android.utilities.VersionHidingCursorAdapter;
 
 import timber.log.Timber;
@@ -244,7 +245,7 @@ public class FormChooserList extends FormListActivity implements
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         hideProgressBarIfAllowed();
-        listAdapter.changeCursor(cursor);
+        listAdapter.changeCursor(FormUtils.removeOldForms(cursor));
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -171,52 +171,48 @@ public class FormsDao {
 
     public List<Form> getFormsFromCursor(Cursor cursor) {
         List<Form> forms = new ArrayList<>();
-        if (cursor != null) {
-            try {
-                while (cursor.moveToNext()) {
-                    int idColumnIndex = cursor.getColumnIndex(BaseColumns._ID);
-                    int displayNameColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME);
-                    int descriptionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DESCRIPTION);
-                    int jrFormIdColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID);
-                    int jrVersionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_VERSION);
-                    int formFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH);
-                    int submissionUriColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.SUBMISSION_URI);
-                    int base64RSAPublicKeyColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY);
-                    int displaySubtextColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT);
-                    int md5HashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MD5_HASH);
-                    int dateColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DATE);
-                    int jrCacheFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH);
-                    int formMediaPathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH);
-                    int languageColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LANGUAGE);
-                    int autoSendColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_SEND);
-                    int autoDeleteColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_DELETE);
-                    int lastDetectedFormVersionHashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH);
+        if (cursor != null && cursor.moveToFirst()) {
+            do {
+                int idColumnIndex = cursor.getColumnIndex(BaseColumns._ID);
+                int displayNameColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME);
+                int descriptionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DESCRIPTION);
+                int jrFormIdColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID);
+                int jrVersionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_VERSION);
+                int formFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH);
+                int submissionUriColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.SUBMISSION_URI);
+                int base64RSAPublicKeyColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY);
+                int displaySubtextColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT);
+                int md5HashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MD5_HASH);
+                int dateColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DATE);
+                int jrCacheFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH);
+                int formMediaPathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH);
+                int languageColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LANGUAGE);
+                int autoSendColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_SEND);
+                int autoDeleteColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_DELETE);
+                int lastDetectedFormVersionHashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH);
 
-                    Form form = new Form.Builder()
-                            .id(cursor.getInt(idColumnIndex))
-                            .displayName(cursor.getString(displayNameColumnIndex))
-                            .description(cursor.getString(descriptionColumnIndex))
-                            .jrFormId(cursor.getString(jrFormIdColumnIndex))
-                            .jrVersion(cursor.getString(jrVersionColumnIndex))
-                            .formFilePath(cursor.getString(formFilePathColumnIndex))
-                            .submissionUri(cursor.getString(submissionUriColumnIndex))
-                            .base64RSAPublicKey(cursor.getString(base64RSAPublicKeyColumnIndex))
-                            .displaySubtext(cursor.getString(displaySubtextColumnIndex))
-                            .md5Hash(cursor.getString(md5HashColumnIndex))
-                            .date(cursor.getLong(dateColumnIndex))
-                            .jrCacheFilePath(cursor.getString(jrCacheFilePathColumnIndex))
-                            .formMediaPath(cursor.getString(formMediaPathColumnIndex))
-                            .language(cursor.getString(languageColumnIndex))
-                            .autoSend(cursor.getString(autoSendColumnIndex))
-                            .autoDelete(cursor.getString(autoDeleteColumnIndex))
-                            .lastDetectedFormVersionHash(cursor.getString(lastDetectedFormVersionHashColumnIndex))
-                            .build();
+                Form form = new Form.Builder()
+                        .id(cursor.getInt(idColumnIndex))
+                        .displayName(cursor.getString(displayNameColumnIndex))
+                        .description(cursor.getString(descriptionColumnIndex))
+                        .jrFormId(cursor.getString(jrFormIdColumnIndex))
+                        .jrVersion(cursor.getString(jrVersionColumnIndex))
+                        .formFilePath(cursor.getString(formFilePathColumnIndex))
+                        .submissionUri(cursor.getString(submissionUriColumnIndex))
+                        .base64RSAPublicKey(cursor.getString(base64RSAPublicKeyColumnIndex))
+                        .displaySubtext(cursor.getString(displaySubtextColumnIndex))
+                        .md5Hash(cursor.getString(md5HashColumnIndex))
+                        .date(cursor.getLong(dateColumnIndex))
+                        .jrCacheFilePath(cursor.getString(jrCacheFilePathColumnIndex))
+                        .formMediaPath(cursor.getString(formMediaPathColumnIndex))
+                        .language(cursor.getString(languageColumnIndex))
+                        .autoSend(cursor.getString(autoSendColumnIndex))
+                        .autoDelete(cursor.getString(autoDeleteColumnIndex))
+                        .lastDetectedFormVersionHash(cursor.getString(lastDetectedFormVersionHashColumnIndex))
+                        .build();
 
-                    forms.add(form);
-                }
-            } finally {
-                cursor.close();
-            }
+                forms.add(form);
+            } while (cursor.moveToNext());
         }
         return forms;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.dao;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
+import android.provider.BaseColumns;
 import android.support.v4.content.CursorLoader;
 
 import org.odk.collect.android.application.Collect;
@@ -29,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class is used to encapsulate all access to the {@link org.odk.collect.android.provider.FormsProvider#DATABASE_NAME}
+ * This class is used to encapsulate all access to the {@link org.odk.collect.android.database.helpers.FormsDatabaseHelper#DATABASE_NAME}
  * For more information about this pattern go to https://en.wikipedia.org/wiki/Data_access_object
  */
 public class FormsDao {
@@ -42,11 +43,11 @@ public class FormsDao {
         return getFormsCursor(null, selection, selectionArgs, null);
     }
 
-    public Cursor getFormsCursor(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+    Cursor getFormsCursor(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
         return Collect.getInstance().getContentResolver().query(FormsProviderAPI.FormsColumns.CONTENT_URI, projection, selection, selectionArgs, sortOrder);
     }
 
-    public CursorLoader getFormsCursorLoader(String sortOrder) {
+    private CursorLoader getFormsCursorLoader(String sortOrder) {
         return getFormsCursorLoader(null, null, null, sortOrder);
     }
 
@@ -62,7 +63,7 @@ public class FormsDao {
         return cursorLoader;
     }
 
-    public CursorLoader getFormsCursorLoader(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+    private CursorLoader getFormsCursorLoader(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
         return new CursorLoader(Collect.getInstance(), FormsProviderAPI.FormsColumns.CONTENT_URI, projection, selection, selectionArgs, sortOrder);
     }
 
@@ -173,6 +174,7 @@ public class FormsDao {
         if (cursor != null) {
             try {
                 while (cursor.moveToNext()) {
+                    int idColumnIndex = cursor.getColumnIndex(BaseColumns._ID);
                     int displayNameColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME);
                     int descriptionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DESCRIPTION);
                     int jrFormIdColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID);
@@ -186,8 +188,12 @@ public class FormsDao {
                     int jrCacheFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH);
                     int formMediaPathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH);
                     int languageColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LANGUAGE);
+                    int autoSendColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_SEND);
+                    int autoDeleteColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_DELETE);
+                    int lastDetectedFormVersionHashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH);
 
                     Form form = new Form.Builder()
+                            .id(cursor.getInt(idColumnIndex))
                             .displayName(cursor.getString(displayNameColumnIndex))
                             .description(cursor.getString(descriptionColumnIndex))
                             .jrFormId(cursor.getString(jrFormIdColumnIndex))
@@ -201,6 +207,9 @@ public class FormsDao {
                             .jrCacheFilePath(cursor.getString(jrCacheFilePathColumnIndex))
                             .formMediaPath(cursor.getString(formMediaPathColumnIndex))
                             .language(cursor.getString(languageColumnIndex))
+                            .autoSend(cursor.getString(autoSendColumnIndex))
+                            .autoDelete(cursor.getString(autoDeleteColumnIndex))
+                            .lastDetectedFormVersionHash(cursor.getString(lastDetectedFormVersionHashColumnIndex))
                             .build();
 
                     forms.add(form);

--- a/collect_app/src/main/java/org/odk/collect/android/dto/Form.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dto/Form.java
@@ -18,11 +18,12 @@ package org.odk.collect.android.dto;
 
 /**
  * This class represents a single row from the forms table which is located in
- * {@link org.odk.collect.android.provider.FormsProvider#DATABASE_NAME}
+ * {@link org.odk.collect.android.database.helpers.FormsDatabaseHelper#DATABASE_NAME}
  * For more information about this pattern go to https://en.wikipedia.org/wiki/Data_transfer_object
  * Objects of this class are created using builder pattern: https://en.wikipedia.org/wiki/Builder_pattern
  */
 public class Form {
+    private int id;
     private String displayName;
     private String description;
     private String jrFormId;
@@ -36,8 +37,12 @@ public class Form {
     private String jrCacheFilePath;
     private String formMediaPath;
     private String language;
+    private String autoSend;
+    private String autoDelete;
+    private String lastDetectedFormVersionHash;
 
     private Form(Form.Builder builder) {
+        id = builder.id;
         displayName = builder.displayName;
         description = builder.description;
         jrFormId = builder.jrFormId;
@@ -51,9 +56,13 @@ public class Form {
         jrCacheFilePath = builder.jrCacheFilePath;
         formMediaPath = builder.formMediaPath;
         language = builder.language;
+        autoSend = builder.autoSend;
+        autoDelete = builder.autoDelete;
+        lastDetectedFormVersionHash = builder.lastDetectedFormVersionHash;
     }
 
     public static class Builder {
+        private int id;
         private String displayName;
         private String description;
         private String jrFormId;
@@ -67,6 +76,14 @@ public class Form {
         private String jrCacheFilePath;
         private String formMediaPath;
         private String language;
+        private String autoSend;
+        private String autoDelete;
+        private String lastDetectedFormVersionHash;
+
+        public Builder id(int id) {
+            this.id = id;
+            return this;
+        }
 
         public Builder displayName(String displayName) {
             this.displayName = displayName;
@@ -135,9 +152,28 @@ public class Form {
             return this;
         }
 
+        public Builder autoSend(String autoSend) {
+            this.autoSend = autoSend;
+            return this;
+        }
+
+        public Builder autoDelete(String autoDelete) {
+            this.autoDelete = autoDelete;
+            return this;
+        }
+
+        public Builder lastDetectedFormVersionHash(String lastDetectedFormVersionHash) {
+            this.lastDetectedFormVersionHash = lastDetectedFormVersionHash;
+            return this;
+        }
+
         public Form build() {
             return new Form(this);
         }
+    }
+
+    public int getId() {
+        return id;
     }
 
     public String getDisplayName() {
@@ -190,5 +226,17 @@ public class Form {
 
     public String getLanguage() {
         return language;
+    }
+
+    public String getAutoSend() {
+        return autoSend;
+    }
+
+    public String getAutoDelete() {
+        return autoDelete;
+    }
+
+    public String getLastDetectedFormVersionHash() {
+        return lastDetectedFormVersionHash;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
@@ -41,6 +41,7 @@ public final class AdminKeys {
     // client
     private static final String KEY_PERIODIC_FORM_UPDATES_CHECK = "periodic_form_updates_check";
     private static final String KEY_AUTOMATIC_UPDATE            = "automatic_update";
+    private static final String KEY_HIDE_OLD_FORM_VERSIONS      = "hide_old_form_versions";
     private static final String KEY_CHANGE_FONT_SIZE            = "change_font_size";
     private static final String KEY_DEFAULT_TO_FINALIZED        = "default_to_finalized";
     private static final String KEY_HIGH_RESOLUTION             = "high_resolution";
@@ -75,6 +76,7 @@ public final class AdminKeys {
 
             ag(KEY_PERIODIC_FORM_UPDATES_CHECK, PreferenceKeys.KEY_PERIODIC_FORM_UPDATES_CHECK),
             ag(KEY_AUTOMATIC_UPDATE,           PreferenceKeys.KEY_AUTOMATIC_UPDATE),
+            ag(KEY_HIDE_OLD_FORM_VERSIONS,     PreferenceKeys.KEY_HIDE_OLD_FORM_VERSIONS),
             ag(KEY_CHANGE_FONT_SIZE,           PreferenceKeys.KEY_FONT_SIZE),
             ag(KEY_APP_LANGUAGE,               PreferenceKeys.KEY_APP_LANGUAGE),
             ag(KEY_DEFAULT_TO_FINALIZED,       PreferenceKeys.KEY_COMPLETED_DEFAULT),
@@ -127,6 +129,7 @@ public final class AdminKeys {
     static Collection<String> formManagementKeys = Arrays.asList(
             KEY_PERIODIC_FORM_UPDATES_CHECK,
             KEY_AUTOMATIC_UPDATE,
+            KEY_HIDE_OLD_FORM_VERSIONS,
             KEY_AUTOSEND,
             KEY_DELETE_AFTER_SEND,
             KEY_DEFAULT_TO_FINALIZED,

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -25,6 +25,7 @@ public final class PreferenceKeys {
     public static final String KEY_INSTANCE_SYNC            = "instance_sync";
     public static final String KEY_PERIODIC_FORM_UPDATES_CHECK = "periodic_form_updates_check";
     public static final String KEY_AUTOMATIC_UPDATE         = "automatic_update";
+    static final String KEY_HIDE_OLD_FORM_VERSIONS          = "hide_old_form_versions";
 
     // form_metadata_preferences.xml
     public static final String KEY_METADATA_USERNAME        = "metadata_username";
@@ -91,6 +92,7 @@ public final class PreferenceKeys {
         hashMap.put(KEY_INSTANCE_SYNC,              true);
         hashMap.put(KEY_PERIODIC_FORM_UPDATES_CHECK, "never");
         hashMap.put(KEY_AUTOMATIC_UPDATE,           false);
+        hashMap.put(KEY_HIDE_OLD_FORM_VERSIONS,     true);
         // form_metadata_preferences.xml
         hashMap.put(KEY_METADATA_USERNAME,          "");
         hashMap.put(KEY_METADATA_PHONENUMBER,       "");

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -25,7 +25,7 @@ public final class PreferenceKeys {
     public static final String KEY_INSTANCE_SYNC            = "instance_sync";
     public static final String KEY_PERIODIC_FORM_UPDATES_CHECK = "periodic_form_updates_check";
     public static final String KEY_AUTOMATIC_UPDATE         = "automatic_update";
-    static final String KEY_HIDE_OLD_FORM_VERSIONS          = "hide_old_form_versions";
+    public static final String KEY_HIDE_OLD_FORM_VERSIONS   = "hide_old_form_versions";
 
     // form_metadata_preferences.xml
     public static final String KEY_METADATA_USERNAME        = "metadata_username";

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
@@ -34,7 +34,7 @@ public class FormUtils {
 
     /**
      * Keep only newest form versions, that means if you have more than one form with given formId
-     * and version number, only the newest one should be displayed.
+     * only the newest one should be displayed.
      */
     public static Cursor removeOldForms(Cursor cursor) {
         List<Form> forms = new FormsDao().getFormsFromCursor(cursor);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
@@ -44,7 +44,9 @@ public class FormUtils {
                         _ID,
                         FormsProviderAPI.FormsColumns.DISPLAY_NAME,
                         FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT,
-                        FormsProviderAPI.FormsColumns.JR_VERSION
+                        FormsProviderAPI.FormsColumns.JR_FORM_ID,
+                        FormsProviderAPI.FormsColumns.JR_VERSION,
+                        FormsProviderAPI.FormsColumns.DATE
                 }
         );
 
@@ -54,7 +56,9 @@ public class FormUtils {
                         form.getId(),
                         form.getDisplayName(),
                         form.getDisplaySubtext(),
+                        form.getJrFormId(),
                         form.getJrVersion(),
+                        form.getDate()
                 });
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.database.Cursor;
+import android.database.MatrixCursor;
+
+import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.dto.Form;
+import org.odk.collect.android.provider.FormsProviderAPI;
+
+import java.util.List;
+
+import static android.provider.BaseColumns._ID;
+
+public class FormUtils {
+
+    private FormUtils() {
+    }
+
+    /**
+     * Keep only newest form versions, that means if you have more than one form with given formId
+     * and version number, only the newest one should be displayed.
+     */
+    public static Cursor removeOldForms(Cursor cursor) {
+        List<Form> forms = new FormsDao().getFormsFromCursor(cursor);
+
+        MatrixCursor filteredCursor = new MatrixCursor(
+                new String[] {
+                        _ID,
+                        FormsProviderAPI.FormsColumns.DISPLAY_NAME,
+                        FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT,
+                        FormsProviderAPI.FormsColumns.JR_VERSION
+                }
+        );
+
+        for (Form form : forms) {
+            if (isThisFormTheNewestOne(forms, form)) {
+                filteredCursor.addRow(new Object[] {
+                        form.getId(),
+                        form.getDisplayName(),
+                        form.getDisplaySubtext(),
+                        form.getJrVersion(),
+                });
+            }
+        }
+
+        return filteredCursor;
+    }
+
+    private static boolean isThisFormTheNewestOne(List<Form> forms, Form formForChecking) {
+        for (Form form : forms) {
+            if (form.getJrFormId().equals(formForChecking.getJrFormId()) && !form.equals(formForChecking)) {
+                if (form.getDate() > formForChecking.getDate()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -610,5 +610,5 @@
     <string name="location_metadata">Satellites available: %1$d/24\n\nTime elapsed: %2$s</string>
     <string name="instance_upload_cancelled">Instance upload canceled</string>
     <string name="hide_old_form_versions_setting_title">Hide old form versions</string>
-    <string name="hide_old_form_versions_setting_summary">Only the newest form versions will be available in form list</string>
+    <string name="hide_old_form_versions_setting_summary">Only the newest version will appear in Fill Blank Form</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -609,4 +609,6 @@
     <string name="not_a_directory">%s exists, but is not a directory</string>
     <string name="location_metadata">Satellites available: %1$d/24\n\nTime elapsed: %2$s</string>
     <string name="instance_upload_cancelled">Instance upload canceled</string>
+    <string name="hide_old_form_versions_setting_title">Hide old form versions</string>
+    <string name="hide_old_form_versions_setting_summary">Only the newest form versions will be available in form list</string>
 </resources>

--- a/collect_app/src/main/res/xml/form_management_preferences.xml
+++ b/collect_app/src/main/res/xml/form_management_preferences.xml
@@ -13,6 +13,10 @@
             android:key="automatic_update"
             android:summary="@string/automatic_download_summary"
             android:title="@string/automatic_download" />
+        <CheckBoxPreference
+            android:key="hide_old_form_versions"
+            android:title="@string/hide_old_form_versions_setting_title"
+            android:summary="@string/hide_old_form_versions_setting_summary" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="form_submission"

--- a/collect_app/src/main/res/xml/user_settings_access_preferences.xml
+++ b/collect_app/src/main/res/xml/user_settings_access_preferences.xml
@@ -35,6 +35,9 @@
             android:key="automatic_update"
             android:title="@string/automatic_download" />
         <CheckBoxPreference
+            android:key="hide_old_form_versions"
+            android:title="@string/hide_old_form_versions_setting_title" />
+        <CheckBoxPreference
             android:key="default_to_finalized"
             android:title="@string/default_completed" />
         <CheckBoxPreference


### PR DESCRIPTION
Closes #1694 

#### What has been done to verify that this works as intended?
I tested the solution on a real device and I also wrote an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
Hiding old forms is better than removing them because thanks to this approach we can still edit old saved forms.

#### Are there any risks to merging this code? If so, what are they?
We only hide old forms keeping them in the database. That means old saved forms are still available what makes this change less risky. I wrote an automated test so I think it's not risky and we hide old forms in an appropriate way. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
https://github.com/opendatakit/docs/issues/710

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)