### PR TITLE
Set memory limit of unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ references:
     working_directory: *workspace
     docker:
       - image: circleci/android:api-26-alpha
-    resource_class: large
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -155,6 +155,11 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
+            all {
+                // https://discuss.circleci.com/t/11207/24
+                // it seems any number works, but 1024 - 2048 seem reasonable 
+                maxHeapSize = "2048M"
+            }
         }
     }
 }


### PR DESCRIPTION
* Remove `resource_class` because that is on paid accounts only
* Set memory limit of unit test based on https://discuss.circleci.com/t/11207/24