### PR TITLE
Lighten the color of popup dialog of Spinner widget for dark theme

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -80,7 +80,7 @@ public final class ThemeUtils {
         return isDarkTheme() ? 0 : 1;
     }
 
-    private boolean isDarkTheme() {
+    public boolean isDarkTheme() {
         String theme = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_APP_THEME);
         return theme.equals(context.getString(R.string.app_theme_dark));
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
@@ -211,6 +211,10 @@ public class SpinnerWidget extends QuestionWidget implements MultiChoiceWidget {
             tv.setTextSize(textUnit, textSize);
             tv.setPadding(20, 10, 10, 10);
 
+            if (themeUtils.isDarkTheme()) {
+                convertView.setBackgroundColor(getResources().getColor(R.color.darkPopupDialogColor));
+            }
+
             if (position == items.length - 1) {
                 tv.setText(parent.getContext().getString(R.string.clear_answer));
             } else {

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -16,6 +16,7 @@ the License.
 <resources>
     <!-- Dark Theme Palette -->
     <color name="darkPrimaryTextColor">@android:color/white</color>
+    <color name="darkPopupDialogColor">#3f3f3f</color>
     <color name="darkIconColor">@android:color/white</color>
     <color name="darkTintColor">#2196F3</color>
 


### PR DESCRIPTION
Closes #2213 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Verified manually with both the themes

#### Why is this the best possible solution? Were any other approaches considered?
This is the most appropriate solution which is in line with the already implemented approach

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with spinner widget

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

![issue-2213](https://user-images.githubusercontent.com/8918023/40218868-b7f513a6-5a90-11e8-9f12-c1ddd8637641.png)
