### PR TITLE
Add custom google analytics event for activity logger tracking

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/ActivityLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/ActivityLogger.java
@@ -22,15 +22,20 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
 
+import com.google.android.gms.analytics.HitBuilders;
+
 import org.javarosa.core.model.FormIndex;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 
 import java.io.File;
 import java.util.Calendar;
 import java.util.LinkedList;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.preferences.PreferenceKeys.ACTIVITY_LOGGER_ANALYTICS;
 
 /**
  * Log all user interface activity into a SQLite database. Logging is disabled by default.
@@ -115,7 +120,29 @@ public final class ActivityLogger {
     public ActivityLogger(String deviceId) {
         this.deviceId = deviceId;
         loggingEnabled = new File(Collect.LOG_PATH, ENABLE_LOGGING).exists();
-        open();
+
+        if (loggingEnabled) {
+            open();
+
+            if (isFirstTime()) {
+                sendAnalyticsEvent();
+                GeneralSharedPreferences.getInstance().save(ACTIVITY_LOGGER_ANALYTICS, false);
+            }
+        }
+    }
+
+    private void sendAnalyticsEvent() {
+        Collect.getInstance()
+                .getDefaultTracker()
+                .send(new HitBuilders.EventBuilder()
+                        .setCategory("ActivityLogger")
+                        .setAction("Enabled")
+                        .setLabel("ActivityLogger is enabled")
+                        .build());
+    }
+
+    private boolean isFirstTime() {
+        return GeneralSharedPreferences.getInstance().getBoolean(ACTIVITY_LOGGER_ANALYTICS, true);
     }
 
     public boolean isOpen() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -57,6 +57,7 @@ public final class PreferenceKeys {
     public static final String KEY_MAP_BASEMAP              = "map_basemap_behavior";
 
     // other keys
+    public static final String ACTIVITY_LOGGER_ANALYTICS    = "activity_logger_event";
     public static final String KEY_LAST_VERSION             = "lastVersion";
     public static final String KEY_FIRST_RUN                = "firstRun";
     /** Whether any existing username and email values have been migrated to form metadata */
@@ -122,7 +123,8 @@ public final class PreferenceKeys {
             KEY_FIRST_RUN,
             KEY_METADATA_MIGRATED,
             KEY_AUTOSEND_WIFI,
-            KEY_AUTOSEND_NETWORK
+            KEY_AUTOSEND_NETWORK,
+            ACTIVITY_LOGGER_ANALYTICS
     );
 
     public static final HashMap<String, Object> GENERAL_KEYS = getHashMap();


### PR DESCRIPTION
Closes #2109 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I don't know if this works as intended as I don't have access to the analytics account so I will need help of someone with the access to the account to verify if an event is registered.

#### Why is this the best possible solution? Were any other approaches considered?
An event with label "Activity logger is enabled" is sent only if the log path is found for the first time.
I followd the official [docs](https://developers.google.com/analytics/devguides/collection/android/v4/events) for the implementation so it is the standard solution. 

#### Are there any risks to merging this code? If so, what are they?
No 

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)