### PR TITLE
Resolved error that caused FormEntryActivity to go to the FormChooser List

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -136,6 +136,8 @@ public class FormChooserList extends FormListActivity implements
                 intent.putExtra(ApplicationConstants.BundleKeys.FORM_MODE, ApplicationConstants.FormModes.EDIT_SAVED);
                 startActivity(intent);
             }
+            
+            finish();
         }
     }
 


### PR DESCRIPTION
Added `finish` to `OnItemClicked` listener code that triggers the FormEntryActivity to be opened. This was accidentally removed when the `FormChooserList` was being refactored to support storage permissions. The denied function of the permissions listener is utilizing a method called `finishActivities` to clear the entire stack instead of finish to just do so for the current activity, so while removing the finish method this was one was removed as well and the FormChooserList was still on the activity stack so when the FormEntryActivity was finished after saving it would navigate back to it.

Closes #2229
<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I opened a form and once I saved it or ignored the changes the app navigates back to the main screen. 

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
No.
#### Do we need any specific form for testing your changes? If so, please attach one.
Any form works.
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)