### PR TITLE
Dark theme is not applied to the main menu when user load settings from collect.settings file

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -252,6 +252,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             if (success) {
                 ToastUtils.showLongToast(R.string.settings_successfully_loaded_file_notification);
                 j.delete();
+                recreate();
 
                 // Delete settings file to prevent overwrite of settings from JSON file on next startup
                 if (f.exists()) {
@@ -265,6 +266,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             if (success) {
                 ToastUtils.showLongToast(R.string.settings_successfully_loaded_file_notification);
                 f.delete();
+                recreate();
             } else {
                 ToastUtils.showLongToast(R.string.corrupt_settings_file_notification);
             }


### PR DESCRIPTION
Closes #2244 

#### What has been done to verify that this works as intended?
I've tested the attached settings file.

#### Why is this the best possible solution? Were any other approaches considered?
The activity should be recreated after loading new settings.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)