### PR TITLE
Show form version and form id when deleting blank forms #2173

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -101,7 +101,8 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
     }
 
     private void setupAdapter() {
-        String[] data = new String[]{FormsColumns.DISPLAY_NAME, FormsColumns.DISPLAY_SUBTEXT, FormsColumns.JR_VERSION};
+        String[] data = new String[]{FormsColumns.DISPLAY_NAME, FormsColumns.DISPLAY_SUBTEXT, FormsColumns.JR_VERSION,
+                                        FormsColumns.JR_FORM_ID};
         int[] view = new int[]{R.id.text1, R.id.text2, R.id.text3};
 
         listAdapter = new VersionHidingCursorAdapter(

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/VersionHidingCursorAdapter.java
@@ -54,9 +54,8 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                     v.setVisibility(View.GONE);
                     if (version != null) {
                         v.append(String.format(ctxt.getString(R.string.version_number), version));
+                        v.append(" ");
                         v.setVisibility(View.VISIBLE);
-                    } else {
-                        v.append("");
                     }
                     if (from.length > 3) {
                         int idColumnIndex = cursor.getColumnIndex(from[3]);
@@ -64,8 +63,6 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                         if (id != null) {
                             v.append(String.format(ctxt.getString(R.string.id_number), id));
                             v.setVisibility(View.VISIBLE);
-                        } else {
-                            v.append("");
                         }
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/VersionHidingCursorAdapter.java
@@ -50,12 +50,23 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                 } else {
                     String version = cursor.getString(columnIndex);
                     TextView v = (TextView) view;
+                    v.setText("");
+                    v.setVisibility(View.GONE);
                     if (version != null) {
-                        v.setText(String.format(ctxt.getString(R.string.version_number), version));
+                        v.append(String.format(ctxt.getString(R.string.version_number), version));
                         v.setVisibility(View.VISIBLE);
                     } else {
-                        v.setText(null);
-                        v.setVisibility(View.GONE);
+                        v.append("");
+                    }
+                    if (from.length > 3) {
+                        int idColumnIndex = cursor.getColumnIndex(from[3]);
+                        String id = cursor.getString(idColumnIndex);
+                        if (id != null) {
+                            v.append(String.format(ctxt.getString(R.string.id_number), id));
+                            v.setVisibility(View.VISIBLE);
+                        } else {
+                            v.append("");
+                        }
                     }
                 }
                 return true;

--- a/collect_app/src/main/res/layout/two_item_multiple_choice.xml
+++ b/collect_app/src/main/res/layout/two_item_multiple_choice.xml
@@ -39,12 +39,22 @@ the specific language governing permissions and limitations under the License. -
             tools:text="text1" />
 
         <TextView
-            android:id="@+id/text2"
+            android:id="@+id/text3"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:layout_below="@+id/text1"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/text2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_below="@+id/text3"
             android:layout_toLeftOf="@+id/checkbox"
             android:layout_toStartOf="@+id/checkbox"
             android:gravity="center_vertical"

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -381,6 +381,7 @@
     <string name="parser_exception">XPathParser Exception: \"%s\"</string>
     <string name="selected_answer">Selected: %s</string>
     <string name="version_number">Version: %s</string>
+    <string name="id_number">ID: %s</string>
     <string name="odk_website">Visit the ODK website</string>
     <string name="odk_website_summary">Open Data Kit (ODK) is used to collect data for social good in challenging environments.</string>
     <string name="odk_forum">Join the ODK forum</string>


### PR DESCRIPTION
Closes #2173 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it.

#### Why is this the best possible solution? Were any other approaches considered?
I used VersionHidingCursorAdapter instead of using SimpleCursorAdapter and incorporated a small piece of code for showing ID number of forms. As VersionHidinCursorAdapter is working fine for Fill Blank Form page, it must work out fine here too.

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
The forms which have both version and id like All Widgets form, CascadingSelect Form, Cascading Triple Select Form

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)