### PR TITLE
Display warning about spaces in underlying values for multiple selection questions. Fixes #1964

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/UnderlyingValuesConcat.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/UnderlyingValuesConcat.java
@@ -1,0 +1,19 @@
+package org.odk.collect.android.utilities;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.FluentIterable;
+
+import org.javarosa.core.model.SelectChoice;
+
+import java.util.List;
+
+public class UnderlyingValuesConcat {
+    public String asString(List<SelectChoice> items) {
+        return Joiner
+                .on(", ")
+                .join(FluentIterable
+                        .from(items)
+                        .transform((item -> item.getValue()))
+                );
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
@@ -49,6 +49,7 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.views.AudioButton.AudioHandler;
 import org.odk.collect.android.views.ExpandedHeightGridView;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -346,6 +347,8 @@ public class GridMultiWidget extends QuestionWidget implements MultiChoiceWidget
         ImageAdapter ia = new ImageAdapter(choices);
         gridview.setAdapter(ia);
         addAnswerView(gridview);
+
+        SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/LabelWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/LabelWidget.java
@@ -40,6 +40,7 @@ import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.external.ExternalSelectChoice;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ViewIds;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.io.File;
 import java.util.List;
@@ -195,6 +196,8 @@ public class LabelWidget extends QuestionWidget {
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
         params.addRule(RelativeLayout.RIGHT_OF, center.getId());
         addView(buttonLayout, params);
+
+        SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -84,6 +84,7 @@ public abstract class QuestionWidget
     private final View helpTextLayout;
     private final View guidanceTextLayout;
     private final View textLayout;
+    private final TextView warningText;
     private static final String GUIDANCE_EXPANDED_STATE = "expanded_state";
     private AtomicBoolean expanded;
     private Bundle state;
@@ -134,6 +135,7 @@ public abstract class QuestionWidget
         helpTextLayout = createHelpTextLayout();
         guidanceTextLayout = helpTextLayout.findViewById(R.id.guidance_text_layout);
         textLayout = helpTextLayout.findViewById(R.id.text_layout);
+        warningText = helpTextLayout.findViewById(R.id.warning_text);
         helpTextView = setupHelpText(helpTextLayout.findViewById(R.id.help_text_view), prompt);
         guidanceTextView = setupGuidanceTextAndLayout(helpTextLayout.findViewById(R.id.guidance_text_view), prompt);
 
@@ -485,6 +487,11 @@ public abstract class QuestionWidget
 
     public void resetAudioButtonImage() {
         getQuestionMediaLayout().resetAudioButtonBitmap();
+    }
+
+    public void showWarning(String warningBody) {
+        warningText.setVisibility(View.VISIBLE);
+        warningText.setText(warningBody);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiImageMapWidget.java
@@ -23,6 +23,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.List;
 
@@ -38,6 +39,7 @@ public class SelectMultiImageMapWidget extends SelectImageMapWidget {
             selections = (List<Selection>) getFormEntryPrompt().getAnswerValue().getValue();
             refreshSelectedItemsLabel();
         }
+        SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -19,13 +19,7 @@ import android.content.Context;
 import android.support.v7.widget.AppCompatCheckBox;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
-import android.view.View;
 import android.widget.CheckBox;
-import android.widget.TextView;
-
-import com.google.common.base.Joiner;
-
-import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
@@ -35,6 +29,7 @@ import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -140,10 +135,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
 
         if (items != null) {
             // check if any values have spaces
-            String valuesWithSpaces = getValuesWithSpaces();
-            if (valuesWithSpaces != null) {
-                answerLayout.addView(createWarning(valuesWithSpaces));
-            }
+            new SpacesInUnderlyingValuesWarning().renderWarningIfNecessary(items, answerLayout);
 
             for (int i = 0; i < items.size(); i++) {
                 CheckBox checkBox = createCheckBox(i);
@@ -153,27 +145,6 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
             addAnswerView(answerLayout);
         }
         checkboxInit = false;
-    }
-
-    private View createWarning(String valuesWithSpaces) {
-        TextView warning = new TextView(getContext());
-
-        warning.setText(getContext().getResources().getString((valuesWithSpaces.contains(",") ?
-                R.string.invalid_space_in_answer_plural : R.string.invalid_space_in_answer_singular), valuesWithSpaces));
-
-        warning.setPadding(10, 10, 10, 10);
-        return warning;
-    }
-
-    private String getValuesWithSpaces() {
-        final List<String> valuesWithSpaces = new ArrayList<>();
-        for (SelectChoice selectChoice : items) {
-            String value = selectChoice.getValue();
-            if (value.contains(" ")) {
-                valuesWithSpaces.add(value);
-            }
-        }
-        return valuesWithSpaces.isEmpty() ? null : Joiner.on(", ").join(valuesWithSpaces);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -135,7 +135,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
 
         if (items != null) {
             // check if any values have spaces
-            new SpacesInUnderlyingValuesWarning().renderWarningIfNecessary(items, answerLayout);
+            SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
 
             for (int i = 0; i < items.size(); i++) {
                 CheckBox checkBox = createCheckBox(i);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultipleAutocompleteWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultipleAutocompleteWidget.java
@@ -22,6 +22,7 @@ import android.widget.CompoundButton;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.List;
 
@@ -49,6 +50,7 @@ public class SelectMultipleAutocompleteWidget extends SelectMultiWidget implemen
         readItems();
 
         if (items != null) {
+            SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
             for (int i = 0; i < items.size(); i++) {
                 checkBoxes.add(createCheckBox(i));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,6 +127,8 @@ public class SpinnerMultiWidget extends QuestionWidget implements ButtonWidget, 
         answerLayout.addView(button);
         answerLayout.addView(selectionText);
         addAnswerView(answerLayout);
+
+        SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarning.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarning.java
@@ -1,0 +1,70 @@
+package org.odk.collect.android.widgets.warnings;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
+import org.javarosa.core.model.SelectChoice;
+import org.odk.collect.android.R;
+import org.odk.collect.android.utilities.UnderlyingValuesConcat;
+
+import java.util.List;
+
+public class SpacesInUnderlyingValuesWarning {
+
+    private final SpacesInUnderlyingValues valuesChecker = new SpacesInUnderlyingValues();
+    private final UnderlyingValuesConcat formatter = new UnderlyingValuesConcat();
+
+    public void renderWarningIfNecessary(List<SelectChoice> items, LinearLayout answerLayout) {
+
+        valuesChecker.check(items);
+
+        if (valuesChecker.hasInvalidValues()) {
+            answerLayout.addView(createWarning(valuesChecker.getInvalidValues(), answerLayout.getContext()));
+        }
+    }
+
+    private View createWarning(List<SelectChoice> invalidValues, Context context) {
+        TextView warning = new TextView(context);
+
+        warning.setText(warning.getContext().getResources().getString(
+                invalidValues.size() > 1 ? R.string.invalid_space_in_answer_plural : R.string.invalid_space_in_answer_singular,
+                formatter.asString(invalidValues)));
+
+        warning.setPadding(10, 10, 10, 10);
+        return warning;
+    }
+
+    public static class SpacesInUnderlyingValues {
+
+        private List<SelectChoice> invalidValues = Lists.newArrayList();
+        private boolean checked = false;
+
+        public void check(List<SelectChoice> items) {
+            invalidValues = FluentIterable
+                    .from(items)
+                    .filter(item -> item.getValue() != null && item.getValue().contains(" "))
+                    .toList();
+            checked = true;
+        }
+
+        public boolean hasInvalidValues() {
+            checkInitialization();
+            return !invalidValues.isEmpty();
+        }
+
+        public List<SelectChoice> getInvalidValues() {
+            checkInitialization();
+            return invalidValues;
+        }
+
+        private void checkInitialization() {
+            if (!checked) {
+                throw new IllegalStateException("check() must be called before other methods first");
+            }
+        }
+    }
+
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarning.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarning.java
@@ -11,6 +11,32 @@ import org.odk.collect.android.widgets.QuestionWidget;
 
 import java.util.List;
 
+/*
+ * For questions with multiple selection, the responses chosen by the user are stored
+ * as a space-separated list of the response values. Most form builders either warn
+ * or error when a user tries to build a form with multiple selection questions
+ * that have values with spaces but it's possible to include them when writing
+ * XML by hand or using external choices.
+ *
+ * This class is responsible for checking if the underlying values in the set of answers
+ * contain spaces. If the values contain spaces, the warning is rendered in QuestionWidget.
+ *
+ * The class is composed of 2 ingredients:
+ * - SpacesInUnderlyingValues: check if the underlying values contain spaces
+ * - WarningRenderer: create and display the warning text
+ *
+ * Both classes are combined in the {@link #renderWarningIfNecessary(List)}
+ * that is responsible for applying the checker to values, and rendering warning if checker
+ * detects an issue.
+ *
+ * The class can be extended to render warnings into other widgets or in other way.
+ * To do that one should implement a new WarningRenderer, and create a new static
+ * initializer that initializes SpacesInUnderlyingValuesWarning with the new renderer
+ * as in {@link ##forQuestionWidget(QuestionWidget)}
+ *
+ * Created as fix for https://github.com/opendatakit/collect/issues/1964
+ *
+ */
 public class SpacesInUnderlyingValuesWarning {
 
     private final UnderlyingValuesChecker valuesChecker;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarning.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarning.java
@@ -1,47 +1,76 @@
 package org.odk.collect.android.widgets.warnings;
 
 import android.content.Context;
-import android.view.View;
-import android.widget.LinearLayout;
-import android.widget.TextView;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import org.javarosa.core.model.SelectChoice;
 import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.UnderlyingValuesConcat;
+import org.odk.collect.android.widgets.QuestionWidget;
 
 import java.util.List;
 
 public class SpacesInUnderlyingValuesWarning {
 
-    private final SpacesInUnderlyingValues valuesChecker = new SpacesInUnderlyingValues();
-    private final UnderlyingValuesConcat formatter = new UnderlyingValuesConcat();
+    private final UnderlyingValuesChecker valuesChecker;
+    private final WarningRenderer warningRenderer;
 
-    public void renderWarningIfNecessary(List<SelectChoice> items, LinearLayout answerLayout) {
+    public static SpacesInUnderlyingValuesWarning forQuestionWidget(QuestionWidget questionWidget) {
+        WarningRenderer renderer = new RenderIntoQuestionWidget(questionWidget);
+        UnderlyingValuesChecker valuesChecker = new SpacesInUnderlyingValues();
+        return new SpacesInUnderlyingValuesWarning(valuesChecker, renderer);
+    }
 
+    @VisibleForTesting
+    SpacesInUnderlyingValuesWarning(UnderlyingValuesChecker valuesChecker, WarningRenderer warningRenderer) {
+        this.valuesChecker = valuesChecker;
+        this.warningRenderer = warningRenderer;
+    }
+
+
+    public void renderWarningIfNecessary(List<SelectChoice> items) {
         valuesChecker.check(items);
 
         if (valuesChecker.hasInvalidValues()) {
-            answerLayout.addView(createWarning(valuesChecker.getInvalidValues(), answerLayout.getContext()));
+            warningRenderer.render(valuesChecker.getInvalidValues());
         }
     }
 
-    private View createWarning(List<SelectChoice> invalidValues, Context context) {
-        TextView warning = new TextView(context);
-
-        warning.setText(warning.getContext().getResources().getString(
-                invalidValues.size() > 1 ? R.string.invalid_space_in_answer_plural : R.string.invalid_space_in_answer_singular,
-                formatter.asString(invalidValues)));
-
-        warning.setPadding(10, 10, 10, 10);
-        return warning;
+    interface WarningRenderer {
+        void render(List<SelectChoice> items);
     }
 
-    public static class SpacesInUnderlyingValues {
+    private static class RenderIntoQuestionWidget implements WarningRenderer {
+
+        private QuestionWidget questionWidget;
+        private final WarningTextCreator warningCreator;
+
+        RenderIntoQuestionWidget(QuestionWidget questionWidget) {
+            this.questionWidget = questionWidget;
+            warningCreator = new SpacesInUnderlyingValuesTextCreator();
+        }
+
+        @Override
+        public void render(List<SelectChoice> invalidItems) {
+            questionWidget.showWarning(warningCreator.create(invalidItems, questionWidget.getContext()));
+        }
+    }
+
+    interface UnderlyingValuesChecker {
+        void check(List<SelectChoice> items);
+
+        boolean hasInvalidValues();
+
+        List<SelectChoice> getInvalidValues();
+    }
+
+    public static class SpacesInUnderlyingValues implements UnderlyingValuesChecker {
 
         private List<SelectChoice> invalidValues = Lists.newArrayList();
         private boolean checked = false;
 
+        @Override
         public void check(List<SelectChoice> items) {
             invalidValues = FluentIterable
                     .from(items)
@@ -50,11 +79,13 @@ public class SpacesInUnderlyingValuesWarning {
             checked = true;
         }
 
+        @Override
         public boolean hasInvalidValues() {
             checkInitialization();
             return !invalidValues.isEmpty();
         }
 
+        @Override
         public List<SelectChoice> getInvalidValues() {
             checkInitialization();
             return invalidValues;
@@ -67,4 +98,19 @@ public class SpacesInUnderlyingValuesWarning {
         }
     }
 
+    public interface WarningTextCreator {
+        String create(List<SelectChoice> invalidValues, Context context);
+    }
+
+    private static class SpacesInUnderlyingValuesTextCreator implements WarningTextCreator {
+
+        private UnderlyingValuesConcat formatter = new UnderlyingValuesConcat();
+
+        @Override
+        public String create(List<SelectChoice> invalidValues, Context context) {
+            return context.getResources().getString(
+                    invalidValues.size() > 1 ? R.string.invalid_space_in_answer_plural : R.string.invalid_space_in_answer_singular,
+                    formatter.asString(invalidValues));
+        }
+    }
 }

--- a/collect_app/src/main/res/layout/help_text_layout.xml
+++ b/collect_app/src/main/res/layout/help_text_layout.xml
@@ -49,4 +49,10 @@
             android:layout_below="@id/help_text_view"
             tools:text="This is also a very long guidance that will accompany the longest hint because we are about going the extra mile." />
     </LinearLayout>
+    <TextView
+            android:id="@+id/warning_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            tools:text="Warning Text" />
 </LinearLayout>

--- a/collect_app/src/main/res/layout/help_text_layout.xml
+++ b/collect_app/src/main/res/layout/help_text_layout.xml
@@ -46,7 +46,6 @@
             android:id="@+id/guidance_text_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/help_text_view"
             tools:text="This is also a very long guidance that will accompany the longest hint because we are about going the extra mile." />
     </LinearLayout>
     <TextView

--- a/collect_app/src/main/res/layout/help_text_layout.xml
+++ b/collect_app/src/main/res/layout/help_text_layout.xml
@@ -53,5 +53,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone"
+            android:textColor="?warningColor"
             tools:text="Warning Text" />
 </LinearLayout>

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -3,5 +3,6 @@
     <declare-styleable name="Collect">
         <attr name="primaryTextColor" format="color" />
         <attr name="iconColor" format="color" />
+        <attr name="warningColor" format="color" />
     </declare-styleable>
 </resources>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -20,6 +20,7 @@
         <item name="searchViewStyle">@style/SearchViewTheme.Dark</item>
         <item name="iconColor">@color/darkIconColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
+        <item name="warningColor">@color/red</item>
     </style>
 
     <style name="AlertDialogTheme.Dark" parent="Theme.AppCompat.Dialog.Alert">
@@ -58,6 +59,7 @@
         <item name="searchViewStyle">@style/SearchViewTheme.Light</item>
         <item name="iconColor">@color/lightIconColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
+        <item name="warningColor">@color/red</item>
     </style>
 
     <style name="AlertDialogTheme.Light" parent="Theme.AppCompat.Light.Dialog.Alert">

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesTest.java
@@ -1,0 +1,92 @@
+package org.odk.collect.android.widgets.warnings;
+
+import com.google.common.collect.Lists;
+import org.javarosa.core.model.SelectChoice;
+import org.junit.Before;
+import org.junit.Test;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.SpacesInUnderlyingValues;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.SpacesInUnderlyingValuesImpl;
+
+public class SpacesInUnderlyingValuesTest {
+
+    private SpacesInUnderlyingValues subject;
+
+    @Before
+    public void setUp() {
+        subject = new SpacesInUnderlyingValues();
+    }
+
+    @Test
+    public void doesNotDetectErrorWhenThereIsNone() {
+        List<SelectChoice> items = Lists.newArrayList(
+                new SelectChoice("label", "no_space")
+        );
+
+        subject.check(items);
+        assertEquals(subject.hasInvalidValues(), false);
+    }
+
+    @Test
+    public void doesNotDetectErrorInEmptySet() {
+        List<SelectChoice> items = Lists.newArrayList();
+
+        subject.check(items);
+        assertEquals(subject.hasInvalidValues(), false);
+    }
+
+    @Test
+    public void doesDetectSingleSpaceError() {
+        List<SelectChoice> items = Lists.newArrayList(
+                new SelectChoice("label", "with space")
+        );
+
+        subject.check(items);
+        assertEquals(subject.hasInvalidValues(), true);
+    }
+
+    @Test
+    public void detectsMultipleErrors() {
+        List<SelectChoice> items = Lists.newArrayList(
+                new SelectChoice("label", "with space"),
+                new SelectChoice("label2", "with space2")
+        );
+
+        subject.check(items);
+        assertEquals(subject.hasInvalidValues(), true);
+    }
+
+    @Test
+    public void returnsInvalidValues() {
+        List<SelectChoice> items = Lists.newArrayList(
+                new SelectChoice("label", "with space"),
+                new SelectChoice("label2", "with space2")
+        );
+
+        subject.check(items);
+        assertEquals(subject.getInvalidValues().size(), 2);
+    }
+
+    @Test
+    public void detectsSpaceInTheBeginningOfUnderlyingValue() {
+        List<SelectChoice> items = Lists.newArrayList(
+                new SelectChoice("label", " before")
+        );
+
+        subject.check(items);
+        assertEquals(subject.hasInvalidValues(), true);
+    }
+
+    @Test
+    public void detectsSpaceInTheEndOfUnderlyingValue() {
+        List<SelectChoice> items = Lists.newArrayList(
+                new SelectChoice("label", "after ")
+        );
+
+        subject.check(items);
+        assertEquals(subject.hasInvalidValues(), true);
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesTest.java
@@ -4,16 +4,16 @@ import com.google.common.collect.Lists;
 import org.javarosa.core.model.SelectChoice;
 import org.junit.Before;
 import org.junit.Test;
-import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.SpacesInUnderlyingValues;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.UnderlyingValuesChecker;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.SpacesInUnderlyingValuesImpl;
+import static org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.SpacesInUnderlyingValues;
 
 public class SpacesInUnderlyingValuesTest {
 
-    private SpacesInUnderlyingValues subject;
+    private UnderlyingValuesChecker subject;
 
     @Before
     public void setUp() {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarningTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/warnings/SpacesInUnderlyingValuesWarningTest.java
@@ -1,0 +1,53 @@
+package org.odk.collect.android.widgets.warnings;
+
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.UnderlyingValuesChecker;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning.WarningRenderer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SpacesInUnderlyingValuesWarningTest {
+
+    SpacesInUnderlyingValuesWarning subject;
+
+    @Mock
+    UnderlyingValuesChecker checker;
+
+    @Mock
+    WarningRenderer renderer;
+
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        subject = new SpacesInUnderlyingValuesWarning(checker, renderer);
+    }
+
+    @Test
+    public void renderWarningWhenHasInvalidValues() {
+        when(checker.hasInvalidValues()).thenReturn(true);
+
+        subject.renderWarningIfNecessary(Lists.newArrayList());
+
+        verify(renderer, times(1)).render(any());
+    }
+
+    @Test
+    public void doesNotRenderWhenNoInvalidValuesDetected() {
+        when(checker.hasInvalidValues()).thenReturn(false);
+
+        subject.renderWarningIfNecessary(Lists.newArrayList());
+
+        verify(renderer, never()).render(any());
+    }
+
+
+}


### PR DESCRIPTION
Closes  #1964 

#### What has been done to verify that this works as intended?
Tested with [this form](https://www.dropbox.com/s/ebs4uub4k4qiaxd/multi-warning.xml?dl=0)

<img src="https://user-images.githubusercontent.com/721925/40590898-8ab563b8-6207-11e8-8ae0-49447c823e82.png" width="180" height="320"> <img src="https://user-images.githubusercontent.com/721925/40590899-8adb87f0-6207-11e8-9650-ce2d45a6b2a3.png" width="180" height="320"> <img src="https://user-images.githubusercontent.com/721925/40590900-8b0e19cc-6207-11e8-82ee-b89506d91319.png" width="180" height="320"> <img src="https://user-images.githubusercontent.com/721925/40590901-8b2a86fc-6207-11e8-9ea8-a49f0dca0e2f.png" width="180" height="320"> <img src="https://user-images.githubusercontent.com/721925/40590902-8b48c9fa-6207-11e8-872c-4311234db47c.png" width="180" height="320"> <img src="https://user-images.githubusercontent.com/721925/40590903-8b6575a0-6207-11e8-8cd3-051b7248a8cd.png" width="180" height="320">


#### Why is this the best possible solution? Were any other approaches considered?
The solution generalises solution from https://github.com/opendatakit/collect/pull/2024
It adds a TextView in help text layout, and uses it to display a warning.

#### Are there any risks to merging this code? If so, what are they?
The solution can be used to displayed any warning, but is not good for displaying multiple unrelated warnings, as it will always replace previously set warning with a new one. 
