### PR TITLE
File ContentProvider to share uris with external apps that need to read/write the respective files.

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -97,7 +97,7 @@ the specific language governing permissions and limitations under the License.
         <provider
             android:name="android.support.v4.content.FileProvider"
             android:authorities="${applicationId}.provider"
-            android:exported="true"
+            android:exported="false"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -94,6 +94,16 @@ the specific language governing permissions and limitations under the License.
             android:authorities="org.odk.collect.android.provider.odk.instances"
             android:exported="true" />
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="true"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+
         <activity
             android:name=".activities.MainMenuActivity"
             android:configChanges="locale|orientation|screenSize" />

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -139,7 +139,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
  *
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Thomas Smyth, Sassafras Tech Collective (tom@sassafrastech.com; constraint behavior
- *         option)
+ * option)
  */
 public class FormEntryActivity extends CollectAbstractActivity implements AnimationListener,
         FormLoaderListener, FormSavedListener, AdvanceToNextListener,
@@ -664,6 +664,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 // file
                 ImageConverter.execute(Collect.TMPFILE_PATH, getWidgetWaitingForBinaryData(), this);
                 File fi = new File(Collect.TMPFILE_PATH);
+
+                //revoke permissions granted to this file due it's possible usage in
+                //the camera app
+                FileUtils.revokeFileReadWritePermission(this, fi);
+
                 String instanceFolder = formController.getInstanceFile()
                         .getParent();
                 String s = instanceFolder + File.separator + System.currentTimeMillis() + ".jpg";
@@ -1012,10 +1017,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             createDeleteRepeatConfirmDialog();
         } else {
             /*
-            * We don't have the right view here, so we store the View's ID as the
-            * item ID and loop through the possible views to find the one the user
-            * clicked on.
-            */
+             * We don't have the right view here, so we store the View's ID as the
+             * item ID and loop through the possible views to find the one the user
+             * clicked on.
+             */
             boolean shouldClearDialogBeShown;
             for (QuestionWidget qw : getCurrentViewIfODKView().getWidgets()) {
                 shouldClearDialogBeShown = false;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -520,8 +520,8 @@ public class FileUtils {
      * are sharing. With this approach the access only last as long as the target activity on Api versions
      * above Kit Kat. Once you are below that you have to manually revoke the permissions.
      *
-     * @param intent
-     * @param uri
+     * @param intent that needs to have the permission flags
+     * @param uri that the permissions are being applied to
      * @return intent that has read and write permissions
      */
     public static Intent grantFilePermissions(Intent intent, Uri uri, Context context) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2012 University of Washington
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -22,14 +22,17 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
+import android.support.v4.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 import java.util.Locale;
@@ -190,7 +193,7 @@ public class AnnotateWidget extends BaseImageWidget {
                 .logInstanceAction(this, "captureButton", "click",
                         getFormEntryPrompt().getIndex());
         errorTextView.setVisibility(View.GONE);
-        Intent i = new Intent(
+        Intent intent = new Intent(
                 android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
         // We give the camera an absolute filename/path where to put the
         // picture because of bug:
@@ -200,13 +203,17 @@ public class AnnotateWidget extends BaseImageWidget {
         // images returned by the camera in 1.6 (and earlier) are ~1/4
         // the size. boo.
 
+        Uri uri = FileProvider.getUriForFile(getContext(),
+                BuildConfig.APPLICATION_ID + ".provider",
+                new File(Collect.TMPFILE_PATH));
         // if this gets modified, the onActivityResult in
         // FormEntyActivity will also need to be updated.
-        i.putExtra(android.provider.MediaStore.EXTRA_OUTPUT,
-                Uri.fromFile(new File(Collect.TMPFILE_PATH)));
+        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
+        intent = FileUtils.grantFilePermissions(intent, uri, getContext());
+
         try {
             waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
+            ((Activity) getContext()).startActivityForResult(intent,
                     RequestCodes.IMAGE_CAPTURE);
         } catch (ActivityNotFoundException e) {
             Toast.makeText(

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -18,8 +18,12 @@ package org.odk.collect.android.widgets;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
@@ -39,6 +43,7 @@ import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 
 import java.io.File;
+import java.util.List;
 
 import timber.log.Timber;
 
@@ -73,7 +78,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
         MediaManager
                 .INSTANCE
                 .markOriginalFileOrDelete(getFormEntryPrompt().getIndex().toString(),
-                getInstanceFolder() + File.separator + binaryName);
+                        getInstanceFolder() + File.separator + binaryName);
         binaryName = null;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -18,12 +18,8 @@ package org.odk.collect.android.widgets;
 
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
@@ -43,7 +39,6 @@ import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 
 import java.io.File;
-import java.util.List;
 
 import timber.log.Timber;
 

--- a/collect_app/src/main/res/xml/provider_paths.xml
+++ b/collect_app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,10 +1,6 @@
-#Tue May 01 11:34:35 PDT 2018
-
+#Fri Jun 01 19:51:59 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-android.enableD8.desugaring=true
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
-# Android Studio Gradle wrapper 3.1.2 doesn't support configure on demand
-org.gradle.configureondemand=false
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Closes #2263

This PR addresses the `FileUriExposedException` as described in the tagged issue. This PR is a precursor to the addition of camera permissions since this exception is thrown as soon as the camera is accessed on Nougat and later.

The main things that were done to address this are 

- [x] `FileProvider` from the support package was registered within the manifest to allow sharing of files with external apps.
- [x] The Annotate, Arbitrary File and Image Widgets were modified to provide an uri to the target external app that it can write/read. 
- [x] Utility functions were created to grant and revoke permissions of a specified uri. These functions have backward compat support for all versions of Android.

#### What has been done to verify that this works as intended?
Once you set the target SDK to API 24 or higher and you attempt to take a picture this exception is thrown. However when you you switch to this branch/PR and do the same the it bypasses that exception since the `FileProvider` is granting the external app i.e the camera app permission to read/write to the file. A permission denial exception is then thrown because the permission grants haven't been implemented as yet so that's the validation being used since this a WIP PR. 

#### Why is this the best possible solution? Were any other approaches considered?
While testing you can utilize Android's Strict Mode functionality to bypass this but that doesn't suit production so this approach is the best since it utilizes the ContentProvider to provide access to external apps and that's basically a default standard in Android cross app/process communication.

#### Are there any risks to merging this code? If so, what are they?
Not necessarily. We just have to verify that all functionality within the app that are sharing data with external apps are working fine on Nougat and if not then utilize this `FileProvider` approach to do so. I checked the `AboutActivity` that's performing several shares and external links and it seems to be fine; i.e those intents such as `ACTION_SEND` don't require these grants.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with image questions.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
All checks pass once the Api version is below 24. Once it's set to that or above lint complains about the permissions that haven't been implemented.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)