### PR TITLE
Issue #2264 None translatable string-array time_scale in GeoTrace

### DIFF
--- a/collect_app/src/main/res/values/arrays.xml
+++ b/collect_app/src/main/res/values/arrays.xml
@@ -124,8 +124,8 @@ the specific language governing permissions and limitations under the License. -
         <item>30</item>
     </string-array>
     <string-array name="time_scale" translatable="false">
-        <item>Seconds</item>
-        <item>Minutes</item>
+        <item>@string/seconds</item>
+        <item>@string/minutes</item>
     </string-array>
     <string-array name="autosend_selector_entries">
         <item>@string/off</item>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -612,4 +612,5 @@
     <string name="instance_upload_cancelled">Instance upload canceled</string>
     <string name="hide_old_form_versions_setting_title">Hide old form versions</string>
     <string name="hide_old_form_versions_setting_summary">Only the newest version will appear in Fill Blank Form</string>
+    <string name="seconds">Seconds</string>
 </resources>


### PR DESCRIPTION
Closes #2264 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it.
Android v7.1.1
#### Why is this the best possible solution? Were any other approaches considered?
I added translations for Minutes and Seconds strings in almost all languages. We manually have to add translations because the Minutes and Seconds come from the String-Array time_scale which is marked as not translatable.
#### Are there any risks to merging this code? If so, what are they?
No
#### Do we need any specific form for testing your changes? If so, please attach one.
No
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)