### PR TITLE
Fixed the disabled GeoWidget ImageButtons in Api21+.

### DIFF
--- a/collect_app/src/main/res/color/dark_theme_tint_list.xml
+++ b/collect_app/src/main/res/color/dark_theme_tint_list.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/darkIconColorDisabled" android:state_enabled="false" />
+    <item android:color="@color/darkIconColorEnabled" android:state_enabled="true" />
+</selector>

--- a/collect_app/src/main/res/color/light_theme_tint_list.xml
+++ b/collect_app/src/main/res/color/light_theme_tint_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/lightIconColorDisabled" android:state_enabled="false" android:tint="@color/lightIconColorDisabled" />
-    <item android:color="@color/lightIconColorEnabled" android:state_enabled="true" android:tint="@color/lightIconColorEnabled" />
+    <item android:color="@color/lightIconColorDisabled" android:state_enabled="false" />
+    <item android:color="@color/lightIconColorEnabled" android:state_enabled="true" />
 </selector>

--- a/collect_app/src/main/res/color/light_theme_tint_list.xml
+++ b/collect_app/src/main/res/color/light_theme_tint_list.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/lightIconColorDisabled" android:state_enabled="false" android:tint="@color/lightIconColorDisabled" />
+    <item android:color="@color/lightIconColorEnabled" android:state_enabled="true" android:tint="@color/lightIconColorEnabled" />
+</selector>

--- a/collect_app/src/main/res/values-v21/theme.xml
+++ b/collect_app/src/main/res/values-v21/theme.xml
@@ -3,9 +3,11 @@
 
     <style name="BaseDarkAppTheme.Collect">
         <item name="android:buttonStyle">@style/CustomButtonStyle</item>
+        <item name="imageButtonStyle">@style/CustomImageButtonDark</item>
     </style>
 
     <style name="BaseLightAppTheme.Collect">
         <item name="android:buttonStyle">@style/CustomButtonStyle</item>
+        <item name="imageButtonStyle">@style/CustomImageButtonLight</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values-v21/theme.xml
+++ b/collect_app/src/main/res/values-v21/theme.xml
@@ -3,11 +3,9 @@
 
     <style name="BaseDarkAppTheme.Collect">
         <item name="android:buttonStyle">@style/CustomButtonStyle</item>
-        <item name="imageButtonStyle">@style/CustomImageButtonDark</item>
     </style>
 
     <style name="BaseLightAppTheme.Collect">
         <item name="android:buttonStyle">@style/CustomButtonStyle</item>
-        <item name="imageButtonStyle">@style/CustomImageButtonLight</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -19,14 +19,18 @@ the License.
     <!-- Dark Theme Palette -->
     <color name="darkPrimaryTextColor">@android:color/white</color>
     <color name="darkPopupDialogColor">#3f3f3f</color>
-    <color name="darkIconColor">@android:color/white</color>
+    <color name="defaultDarkIconColor">@android:color/white</color>
     <color name="darkRankItemColor">@android:color/black</color>
+    <color name="darkIconColorDisabled">#aaaaaa</color>
+    <color name="darkIconColorEnabled">@android:color/white</color>
 
     <!-- Light Theme Palette -->
     <color name="lightPrimaryTextColor">@android:color/black</color>
-    <color name="lightIconColor">@android:color/black</color>
+    <color name="defaultLightIconColor">@android:color/black</color>
     <color name="lightRankItemColor">#EEEEEE</color>
     <color name="lightAccentColor">#2196F3</color>
+    <color name="lightIconColorDisabled">#aaaaaa</color>
+    <color name="lightIconColorEnabled">@android:color/black</color>
 
     <color name="displaySubtextColor">#4CAF50</color>
 </resources>

--- a/collect_app/src/main/res/values/style.xml
+++ b/collect_app/src/main/res/values/style.xml
@@ -7,6 +7,9 @@
         <item name="android:textAppearance">@style/TextAppearance.AppCompat</item>
     </style>
 
+    <style name="CustomImageButtonLight" parent="android:Widget.Holo.Light.ImageButton" />
+    <style name="CustomImageButtonDark" parent="android:Widget.Holo.ImageButton" />
+
     <style name="emptyViewStyle">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>

--- a/collect_app/src/main/res/values/style.xml
+++ b/collect_app/src/main/res/values/style.xml
@@ -7,6 +7,14 @@
         <item name="android:textAppearance">@style/TextAppearance.AppCompat</item>
     </style>
 
+    <style name="CustomImageButtonLight" parent="Widget.AppCompat.ImageButton">
+        <item name="android:tint">@color/light_theme_tint_list</item>
+    </style>
+
+    <style name="CustomImageButtonDark" parent="Widget.AppCompat.ImageButton">
+        <item name="android:tint">@color/dark_theme_tint_list</item>
+    </style>
+
     <style name="emptyViewStyle">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>

--- a/collect_app/src/main/res/values/style.xml
+++ b/collect_app/src/main/res/values/style.xml
@@ -7,9 +7,6 @@
         <item name="android:textAppearance">@style/TextAppearance.AppCompat</item>
     </style>
 
-    <style name="CustomImageButtonLight" parent="android:Widget.Holo.Light.ImageButton" />
-    <style name="CustomImageButtonDark" parent="android:Widget.Holo.ImageButton" />
-
     <style name="emptyViewStyle">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -20,7 +20,7 @@
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
         <item name="searchViewStyle">@style/SearchViewTheme.Dark</item>
-        <item name="iconColor">@color/darkIconColor</item>
+        <item name="iconColor">@color/defaultDarkIconColor</item>
         <item name="rankItemColor">@color/darkRankItemColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="warningColor">@color/red</item>
@@ -61,7 +61,7 @@
         <item name="android:panelBackground">@android:color/white</item>
         <item name="alertDialogTheme">@style/AlertDialogTheme.Light</item>
         <item name="searchViewStyle">@style/SearchViewTheme.Light</item>
-        <item name="iconColor">@color/lightIconColor</item>
+        <item name="iconColor">@color/defaultLightIconColor</item>
         <item name="rankItemColor">@color/lightRankItemColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="warningColor">@color/red</item>


### PR DESCRIPTION
Closes #2262 #2143 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I have tested in Android 4.4 and Android 6.0.

#### Why is this the best possible solution? Were any other approaches considered?
At first, I wanted to address this issue via `theme.xml`  using `style="@style/Widget.AppCompat.Button.Colored"`, but we have two themes, we can only set one `AccentColor` in this case. So I implemented a `GeoImageButton` and refactored the code.

Dark | Light
---- | ---
![](https://i.loli.net/2018/06/06/5b1800d1873f6.png) | ![](https://i.loli.net/2018/06/06/5b1800d179648.png)


#### Are there any risks to merging this code? If so, what are they?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)