### PR TITLE
Remove toast informing about spaces in underlying values

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -24,9 +24,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.TextUtils;
-import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
@@ -45,11 +43,9 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
     protected final List<CheckBox> checkBoxes = new ArrayList<>();
     private boolean checkboxInit = true;
     private final List<Selection> ve;
-    private final Context context;
 
     public SelectMultiWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
-        this.context = context;
         //noinspection unchecked
         ve = getFormEntryPrompt().getAnswerValue() == null ? new ArrayList<>() :
                 (List<Selection>) getFormEntryPrompt().getAnswerValue().getValue();
@@ -118,12 +114,6 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
         checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (!checkboxInit && getFormEntryPrompt().isReadOnly()) {
                 buttonView.setChecked(!buttonView.isChecked());
-            }
-
-            // show warning when selected choice value has spaces
-            String value = items.get((int) checkBox.getTag()).getValue();
-            if (isChecked && value != null && value.contains(" ")) {
-                ToastUtils.showLongToast(context.getString(R.string.invalid_space_in_answer_singular, value));
             }
         });
 


### PR DESCRIPTION
A warning about spaces in underlying values is displayed in the question widget. There is no need for additional toast. 

Closes #2284.

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested on own device. Pixel gen 1 Android 9.0 beta

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
Use form provided in https://github.com/opendatakit/collect/issues/1964

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)