### PR TITLE
Fade red highlight to background color rather than text color on Android 4.1

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -486,15 +486,17 @@ public class ODKView extends ScrollView implements OnLongClickListener {
                 ValueAnimator va = new ValueAnimator();
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
                     // only for kitkat and newer versions
-                    va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
+                    va.setIntValues(getResources().getColor(R.color.red),
+                            getDrawingCacheBackgroundColor());
                     } else {
-                    TypedValue a = new TypedValue();
-                    getContext().getTheme().resolveAttribute(android.R.attr.windowBackground, a, true);
-                    if (a.type >= TypedValue.TYPE_FIRST_COLOR_INT && a.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                    TypedValue typedValue = new TypedValue();
+                    getContext().getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true);
+                    if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
                         // windowBackground is a color
-                        va.setIntValues(getResources().getColor(R.color.red), a.data);
+                        va.setIntValues(getResources().getColor(R.color.red), typedValue.data);
                         } else {
-                        va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
+                        va.setIntValues(getResources().getColor(R.color.red),
+                                getDrawingCacheBackgroundColor());
                     }
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -485,18 +485,16 @@ public class ODKView extends ScrollView implements OnLongClickListener {
 
                 ValueAnimator va = new ValueAnimator();
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
-                    // only for kitkat and newer versions
-                    va.setIntValues(getResources().getColor(R.color.red),
-                            getDrawingCacheBackgroundColor());
-                    } else {
+
+                    va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
+                } else {
                     TypedValue typedValue = new TypedValue();
                     getContext().getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true);
                     if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
-                        // windowBackground is a color
+
                         va.setIntValues(getResources().getColor(R.color.red), typedValue.data);
-                        } else {
-                        va.setIntValues(getResources().getColor(R.color.red),
-                                getDrawingCacheBackgroundColor());
+                    } else {
+                        va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
                     }
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -485,13 +485,12 @@ public class ODKView extends ScrollView implements OnLongClickListener {
 
                 ValueAnimator va = new ValueAnimator();
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
-
                     va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
                 } else {
+                    // Avoid fading to black on certain devices and Android versions that may not support transparency
                     TypedValue typedValue = new TypedValue();
                     getContext().getTheme().resolveAttribute(android.R.attr.windowBackground, typedValue, true);
                     if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
-
                         va.setIntValues(getResources().getColor(R.color.red), typedValue.data);
                     } else {
                         va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -483,7 +484,20 @@ public class ODKView extends ScrollView implements OnLongClickListener {
                 scrollTo(0, qw.getTop());
 
                 ValueAnimator va = new ValueAnimator();
-                va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
+                    // only for kitkat and newer versions
+                    va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
+                    } else {
+                    TypedValue a = new TypedValue();
+                    getContext().getTheme().resolveAttribute(android.R.attr.windowBackground, a, true);
+                    if (a.type >= TypedValue.TYPE_FIRST_COLOR_INT && a.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                        // windowBackground is a color
+                        va.setIntValues(getResources().getColor(R.color.red), a.data);
+                        } else {
+                        va.setIntValues(getResources().getColor(R.color.red), getDrawingCacheBackgroundColor());
+                    }
+                }
+
                 va.setEvaluator(new ArgbEvaluator());
                 va.addUpdateListener(valueAnimator -> qw.setBackgroundColor((int) valueAnimator.getAnimatedValue()));
                 va.setDuration(2500);


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested it on API level 5.0 and 4.1.

#### Why is this the best possible solution? Were any other approaches considered?
It uses Value Animator to flash red background colour on API level 21 and higher while on lower API, after flashing red background colour, it then, sets the background colour to the current theme background colour, so, it works just fine in both light and dark themes.

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)