### PR TITLE
GeoPointMapActivity crash when map isn't ready resolved

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -131,18 +131,8 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         isMapReady = false;
         ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map)).getMapAsync(googleMap -> {
             setupMap(googleMap);
-            locationClient.setListener(getActivity());
+            locationClient.setListener(GeoPointMapActivity.this);
         });
-    }
-
-    /**
-     * Utilizing GeoPointMapActivity.this for the current activity instance causes
-     * PMD to fail so this method prevents that.
-     *
-     * @return an instance of this activity
-     */
-    private GeoPointMapActivity getActivity() {
-        return this;
     }
 
     @Override
@@ -251,7 +241,7 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
 
         // Menu Layer Toggle
         ImageButton layers = findViewById(R.id.layer_menu);
-        layers.setOnClickListener(v -> helper.showLayersDialog(getActivity()));
+        layers.setOnClickListener(v -> helper.showLayersDialog(GeoPointMapActivity.this));
         zoomDialogView = getLayoutInflater().inflate(R.layout.geo_zoom_dialog, null);
         zoomLocationButton = zoomDialogView.findViewById(R.id.zoom_location);
         zoomLocationButton.setOnClickListener(v -> {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.activities;
 
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
 import android.location.Location;
@@ -33,7 +32,6 @@ import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMap.OnMapLongClickListener;
 import com.google.android.gms.maps.GoogleMap.OnMarkerDragListener;
-import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
@@ -131,12 +129,9 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         locationClient = LocationClients.clientForContext(this);
 
         isMapReady = false;
-        ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map)).getMapAsync(new OnMapReadyCallback() {
-            @Override
-            public void onMapReady(GoogleMap googleMap) {
-                setupMap(googleMap);
-                locationClient.setListener(GeoPointMapActivity.this);
-            }
+        ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map)).getMapAsync(googleMap -> {
+            setupMap(googleMap);
+            locationClient.setListener(GeoPointMapActivity.this);
         });
     }
 
@@ -219,89 +214,67 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         });
 
         reloadLocation.setEnabled(false);
-        reloadLocation.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (marker != null) {
-                    marker.remove();
-                }
-                latLng = null;
-                marker = null;
-                setClear = false;
-                latLng = new LatLng(location.getLatitude(), location.getLongitude());
-                markerOptions.position(latLng);
-                if (marker == null) {
-                    marker = map.addMarker(markerOptions);
-                    if (draggable && !readOnly) {
-                        marker.setDraggable(true);
-                    }
-                }
-                captureLocation = true;
-                isDragged = false;
-                zoomToPoint();
+        reloadLocation.setOnClickListener(v -> {
+            if (marker != null) {
+                marker.remove();
             }
+            latLng = null;
+            marker = null;
+            setClear = false;
+            latLng = new LatLng(location.getLatitude(), location.getLongitude());
+            markerOptions.position(latLng);
+            if (marker == null) {
+                marker = map.addMarker(markerOptions);
+                if (draggable && !readOnly) {
+                    marker.setDraggable(true);
+                }
+            }
+            captureLocation = true;
+            isDragged = false;
+            zoomToPoint();
         });
 
         // Focuses on marked location
         //showLocation.setClickable(false);
         showLocation.setEnabled(false);
-        showLocation.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showZoomDialog();
-            }
-        });
+        showLocation.setOnClickListener(v -> showZoomDialog());
 
         // Menu Layer Toggle
         ImageButton layers = findViewById(R.id.layer_menu);
-        layers.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                helper.showLayersDialog(GeoPointMapActivity.this);
-            }
-        });
+        layers.setOnClickListener(v -> helper.showLayersDialog(GeoPointMapActivity.this));
         zoomDialogView = getLayoutInflater().inflate(R.layout.geo_zoom_dialog, null);
         zoomLocationButton = zoomDialogView.findViewById(R.id.zoom_location);
-        zoomLocationButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                zoomToLocation();
-                zoomDialog.dismiss();
-            }
+        zoomLocationButton.setOnClickListener(v -> {
+            zoomToLocation();
+            zoomDialog.dismiss();
         });
 
         zoomPointButton = zoomDialogView.findViewById(R.id.zoom_saved_location);
-        zoomPointButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                zoomToPoint();
-                zoomDialog.dismiss();
-            }
+        zoomPointButton.setOnClickListener(v -> {
+            zoomToPoint();
+            zoomDialog.dismiss();
         });
 
         ImageButton clearPointButton = findViewById(R.id.clear);
-        clearPointButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (marker != null) {
-                    marker.remove();
-                }
-                if (location != null) {
-                    reloadLocation.setEnabled(true);
-                    // locationStatus.setVisibility(View.VISIBLE);
-                }
-                // reloadLocation.setEnabled(true);
-                locationInfo.setVisibility(View.VISIBLE);
-                locationStatus.setVisibility(View.VISIBLE);
-                latLng = null;
-                marker = null;
-                setClear = true;
-                isDragged = false;
-                captureLocation = false;
-                draggable = intentDraggable;
-                locationFromIntent = false;
-                overlayMyLocationLayers();
+        clearPointButton.setOnClickListener(v -> {
+            if (marker != null) {
+                marker.remove();
             }
+            if (location != null) {
+                reloadLocation.setEnabled(true);
+                // locationStatus.setVisibility(View.VISIBLE);
+            }
+            // reloadLocation.setEnabled(true);
+            locationInfo.setVisibility(View.VISIBLE);
+            locationStatus.setVisibility(View.VISIBLE);
+            latLng = null;
+            marker = null;
+            setClear = true;
+            isDragged = false;
+            captureLocation = false;
+            draggable = intentDraggable;
+            locationFromIntent = false;
+            overlayMyLocationLayers();
         });
 
         Intent intent = getIntent();
@@ -477,17 +450,10 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.setTitle(getString(R.string.zoom_to_where));
             builder.setView(zoomDialogView)
-                    .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int id) {
-                            dialog.cancel();
-                        }
-                    })
-                    .setOnCancelListener(new DialogInterface.OnCancelListener() {
-                        @Override
-                        public void onCancel(DialogInterface dialog) {
-                            dialog.cancel();
-                            zoomDialog.dismiss();
-                        }
+                    .setNegativeButton(R.string.cancel, (dialog, id) -> dialog.cancel())
+                    .setOnCancelListener(dialog -> {
+                        dialog.cancel();
+                        zoomDialog.dismiss();
                     });
             zoomDialog = builder.create();
         }
@@ -523,20 +489,16 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         alertDialogBuilder.setMessage(getString(R.string.gps_enable_message))
                 .setCancelable(false)
                 .setPositiveButton(getString(R.string.enable_gps),
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                startActivityForResult(
-                                        new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS), 0);
-                                errorDialog = null;
-                            }
+                        (dialog, id) -> {
+                            startActivityForResult(
+                                    new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS), 0);
+                            errorDialog = null;
                         });
 
         alertDialogBuilder.setNegativeButton(getString(R.string.cancel),
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        dialog.cancel();
-                        errorDialog = null;
-                    }
+                (dialog, id) -> {
+                    dialog.cancel();
+                    errorDialog = null;
                 });
 
         errorDialog = alertDialogBuilder.create();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -131,8 +131,18 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         isMapReady = false;
         ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map)).getMapAsync(googleMap -> {
             setupMap(googleMap);
-            locationClient.setListener(GeoPointMapActivity.this);
+            locationClient.setListener(getActivity());
         });
+    }
+
+    /**
+     * Utilizing GeoPointMapActivity.this for the current activity instance causes
+     * PMD to fail so this method prevents that.
+     *
+     * @return an instance of this activity
+     */
+    private GeoPointMapActivity getActivity() {
+        return this;
     }
 
     @Override
@@ -241,7 +251,7 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
 
         // Menu Layer Toggle
         ImageButton layers = findViewById(R.id.layer_menu);
-        layers.setOnClickListener(v -> helper.showLayersDialog(GeoPointMapActivity.this));
+        layers.setOnClickListener(v -> helper.showLayersDialog(getActivity()));
         zoomDialogView = getLayoutInflater().inflate(R.layout.geo_zoom_dialog, null);
         zoomLocationButton = zoomDialogView.findViewById(R.id.zoom_location);
         zoomLocationButton.setOnClickListener(v -> {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -129,13 +129,13 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         showLocation = findViewById(R.id.show_location);
 
         locationClient = LocationClients.clientForContext(this);
-        locationClient.setListener(this);
 
         isMapReady = false;
         ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map)).getMapAsync(new OnMapReadyCallback() {
             @Override
             public void onMapReady(GoogleMap googleMap) {
                 setupMap(googleMap);
+                locationClient.setListener(GeoPointMapActivity.this);
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClient.java
@@ -6,7 +6,6 @@ import android.support.annotation.Nullable;
 
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
-import com.google.android.gms.maps.OnMapReadyCallback;
 
 /**
  * An interface for classes that allow monitoring and retrieving the User's Location.

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClient.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.maps.OnMapReadyCallback;
 
 /**
  * An interface for classes that allow monitoring and retrieving the User's Location.

--- a/config/pmd-ruleset.xml
+++ b/config/pmd-ruleset.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<!--
+<?xml version="1.0"?><!--
   ~ Copyright 2015 Vincent Brison.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +14,7 @@
   ~ limitations under the License.
   -->
 
-<ruleset
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Android Application Rules"
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Android Application Rules"
     xmlns="http://pmd.sf.net/ruleset/1.0.0"
     xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd"
     xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd">
@@ -26,14 +24,14 @@
     <exclude-pattern>.*/R.java</exclude-pattern>
     <exclude-pattern>.*/gen/.*</exclude-pattern>
 
-    <rule ref="rulesets/java/android.xml"/>
-    <rule ref="rulesets/java/clone.xml"/>
-    <rule ref="rulesets/java/finalizers.xml"/>
+    <rule ref="rulesets/java/android.xml" />
+    <rule ref="rulesets/java/clone.xml" />
+    <rule ref="rulesets/java/finalizers.xml" />
     <rule ref="rulesets/java/imports.xml">
-        <exclude name="TooManyStaticImports"/>
+        <exclude name="TooManyStaticImports" />
     </rule>
-    <rule ref="rulesets/java/logging-java.xml"/>
-    <rule ref="rulesets/java/braces.xml"/>
+    <rule ref="rulesets/java/logging-java.xml" />
+    <rule ref="rulesets/java/braces.xml" />
     <rule ref="rulesets/java/strings.xml">
         <exclude name="AvoidDuplicateLiterals" />
         <exclude name="InefficientEmptyStringCheck" />
@@ -51,15 +49,15 @@
         <exclude name="ReturnFromFinallyBlock" />
     </rule>
     <rule ref="rulesets/java/naming.xml">
-        <exclude name="AbstractNaming"/>
-        <exclude name="LongVariable"/>
-        <exclude name="ShortMethodName"/>
-        <exclude name="ShortVariable"/>
-        <exclude name="VariableNamingConventions"/>
-        <exclude name="AvoidFieldNameMatchingMethodName"/>
-        <exclude name="ShortClassName"/>
-        <exclude name="MethodNamingConventions"/>
-        <exclude name="AvoidFieldNameMatchingTypeName"/>
+        <exclude name="AbstractNaming" />
+        <exclude name="LongVariable" />
+        <exclude name="ShortMethodName" />
+        <exclude name="ShortVariable" />
+        <exclude name="VariableNamingConventions" />
+        <exclude name="AvoidFieldNameMatchingMethodName" />
+        <exclude name="ShortClassName" />
+        <exclude name="MethodNamingConventions" />
+        <exclude name="AvoidFieldNameMatchingTypeName" />
     </rule>
     <rule ref="rulesets/java/design.xml">
         <exclude name="ConfusingTernary" />
@@ -115,13 +113,14 @@
         <exclude name="AvoidCatchingNPE" />
         <exclude name="AvoidCatchingThrowable" />
     </rule>
-    <rule ref="rulesets/java/typeresolution.xml" >
+    <rule ref="rulesets/java/typeresolution.xml">
         <exclude name="SignatureDeclareThrowsException" />
         <exclude name="LooseCoupling" />
     </rule>
-    <rule ref="rulesets/java/unnecessary.xml" >
+    <rule ref="rulesets/java/unnecessary.xml">
         <!-- Decided not to use in #1519 -->
         <exclude name="UselessParentheses" />
+        <exclude name="UselessQualifiedThis" />
     </rule>
     <rule ref="rulesets/java/codesize.xml">
         <exclude name="CyclomaticComplexity" />


### PR DESCRIPTION
Closes #2291

#### What has been done to verify that this works as intended?
The 	`GeoPointMapActivity` was opened and location events were received when the `onMapReady` functionality wasn't triggered and no crash occurred because the `locationClient` only registers a listener when the map is ready.

#### Why is this the best possible solution? Were any other approaches considered?
This is best solution because the code inside `onLocationChanged` relies on the map being available.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
The default widget forms can test this. Just navigate to the GeoPoint Widget question.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)