### PR TITLE
Remove code duplication introduced in PR 2281

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -360,21 +360,12 @@ public class FormsProvider extends ContentProvider {
                         }
                     }
 
-                    String[] newWhereArgs;
-                    if (whereArgs == null || whereArgs.length == 0) {
-                        newWhereArgs = new String[] {formId};
-                    } else {
-                        newWhereArgs = new String[(whereArgs.length + 1)];
-                        newWhereArgs[0] = formId;
-                        System.arraycopy(whereArgs, 0, newWhereArgs, 1, whereArgs.length);
-                    }
-
                     count = db.delete(
                             FORMS_TABLE_NAME,
                             FormsColumns._ID
                                     + "=?"
                                     + (!TextUtils.isEmpty(where) ? " AND (" + where
-                                    + ')' : ""), newWhereArgs);
+                                    + ')' : ""), prepareWhereArgs(whereArgs, formId));
                     break;
 
                 default:
@@ -518,22 +509,13 @@ public class FormsProvider extends ContentProvider {
                                 values.put(FormsColumns.DISPLAY_SUBTEXT, ts);
                             }
 
-                            String[] newWhereArgs;
-                            if (whereArgs == null || whereArgs.length == 0) {
-                                newWhereArgs = new String[] {formId};
-                            } else {
-                                newWhereArgs = new String[(whereArgs.length + 1)];
-                                newWhereArgs[0] = formId;
-                                System.arraycopy(whereArgs, 0, newWhereArgs, 1, whereArgs.length);
-                            }
-
                             count = db.update(
                                     FORMS_TABLE_NAME,
                                     values,
                                     FormsColumns._ID
                                             + "=?"
                                             + (!TextUtils.isEmpty(where) ? " AND ("
-                                            + where + ')' : ""), newWhereArgs);
+                                            + where + ')' : ""), prepareWhereArgs(whereArgs, formId));
                         } else {
                             Timber.e("Attempting to update row that does not exist");
                         }
@@ -552,6 +534,19 @@ public class FormsProvider extends ContentProvider {
         }
 
         return count;
+    }
+
+    @NonNull
+    private String[] prepareWhereArgs(String[] whereArgs, String formId) {
+        String[] newWhereArgs;
+        if (whereArgs == null || whereArgs.length == 0) {
+            newWhereArgs = new String[] {formId};
+        } else {
+            newWhereArgs = new String[(whereArgs.length + 1)];
+            newWhereArgs[0] = formId;
+            System.arraycopy(whereArgs, 0, newWhereArgs, 1, whereArgs.length);
+        }
+        return newWhereArgs;
     }
 
     static {


### PR DESCRIPTION
https://github.com/opendatakit/collect/pull/2281/files added a duplicated non-trivial block of code. In the interest of not increasing technical debt, I would like to extract that code into a method.

I made the change using IDEA’s Extract Method and Inline Variable refactorings, so the change should be very low risk. I haven’t tested it.