### PR TITLE
Fixed NullPointerException

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
@@ -21,7 +21,6 @@ import java.util.List;
 /**
  * Created by sanjeev on 17/3/17.
  */
-
 public class CustomTabHelper {
     public static final String OPEN_URL = "url";
     private static final String CUSTOM_TAB_PACKAGE_NAME = "com.android.chrome";
@@ -44,12 +43,15 @@ public class CustomTabHelper {
                 CustomTabHelper.this.customTabsClient = customTabsClient;
                 CustomTabHelper.this.customTabsClient.warmup(0L);
                 customTabsSession = CustomTabHelper.this.customTabsClient.newSession(null);
-                customTabsSession.mayLaunchUrl(getNonNullUri(url), null, null);
+                if (customTabsSession != null) {
+                    customTabsSession.mayLaunchUrl(getNonNullUri(url), null, null);
+                }
             }
 
             @Override
             public void onServiceDisconnected(ComponentName name) {
                 customTabsClient = null;
+                customTabsSession = null;
             }
         };
         CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME, serviceConnection);
@@ -61,7 +63,6 @@ public class CustomTabHelper {
      * http://stackoverflow.com/a/33281092/137744
      * https://medium.com/google-developers/best-practices-for-custom-tabs-5700e55143ee
      */
-
     private List<String> getPackageName(Context context) {
         // Get default VIEW intent handler that can view a web url.
         Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.test-url.com"));


### PR DESCRIPTION
Closes #2316 

#### What has been done to verify that this works as intended?
#### Why is this the best possible solution? Were any other approaches considered?
It is just a null check just in case of a random problem with `customTabsSession`. If `customTabsSession` is null we can just skip calling `mayLaunchUrl()` since it's not a must.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)