### PR TITLE
Fixed Attempt to invoke virtual method 'java.lang.String java.io.FilegetParent()' on a null object reference

### DIFF
--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -614,4 +614,5 @@
     <string name="hide_old_form_versions_setting_summary">Only the newest version will appear in Fill Blank Form</string>
     <string name="seconds">Seconds</string>
     <string name="double_tap_to_start">Double tap to start</string>
+    <string name="image_not_saved">The image can not be saved because of a problem with the corresponding instance file.</string>
 </resources>


### PR DESCRIPTION
Closes #2324 

#### What has been done to verify that this works as intended?
#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue it's just a null check to avoid crashes.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)