### PR TITLE
Fixed Attempt to invoke virtual method 'int java.lang.Integer.intValue()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SortDialogAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SortDialogAdapter.java
@@ -30,6 +30,8 @@ import org.odk.collect.android.listeners.RecyclerViewClickListener;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ThemeUtils;
 
+import timber.log.Timber;
+
 public class SortDialogAdapter extends RecyclerView.Adapter<SortDialogAdapter.ViewHolder> {
     private final RecyclerViewClickListener listener;
     private final int selectedSortingOrder;
@@ -56,12 +58,15 @@ public class SortDialogAdapter extends RecyclerView.Adapter<SortDialogAdapter.Vi
     @Override
     public void onBindViewHolder(@NonNull ViewHolder viewHolder, int position) {
         viewHolder.txtViewTitle.setText(sortList[position]);
-        viewHolder.imgViewIcon.setImageResource(ApplicationConstants.getSortLabelToIconMap().get(sortList[position]));
-        viewHolder.imgViewIcon.setImageDrawable(DrawableCompat.wrap(viewHolder.imgViewIcon.getDrawable()).mutate());
-
         int color = position == selectedSortingOrder ? themeUtils.getAccentColor() : themeUtils.getPrimaryTextColor();
         viewHolder.txtViewTitle.setTextColor(color);
-        DrawableCompat.setTintList(viewHolder.imgViewIcon.getDrawable(), position == selectedSortingOrder ? ColorStateList.valueOf(color) : null);
+        try {
+            viewHolder.imgViewIcon.setImageResource(ApplicationConstants.getSortLabelToIconMap().get(sortList[position]));
+            viewHolder.imgViewIcon.setImageDrawable(DrawableCompat.wrap(viewHolder.imgViewIcon.getDrawable()).mutate());
+            DrawableCompat.setTintList(viewHolder.imgViewIcon.getDrawable(), position == selectedSortingOrder ? ColorStateList.valueOf(color) : null);
+        } catch (NullPointerException e) {
+            Timber.i(e);
+        }
     }
 
     // Return the size of your itemsData (invoked by the layout manager)
@@ -92,10 +97,13 @@ public class SortDialogAdapter extends RecyclerView.Adapter<SortDialogAdapter.Vi
         public void updateItemColor(int selectedSortingOrder) {
             ViewHolder previousHolder = (ViewHolder) recyclerView.findViewHolderForAdapterPosition(selectedSortingOrder);
             previousHolder.txtViewTitle.setTextColor(themeUtils.getPrimaryTextColor());
-            DrawableCompat.setTintList(previousHolder.imgViewIcon.getDrawable(), null);
-
             txtViewTitle.setTextColor(themeUtils.getAccentColor());
-            DrawableCompat.setTint(imgViewIcon.getDrawable(), themeUtils.getAccentColor());
+            try {
+                DrawableCompat.setTintList(previousHolder.imgViewIcon.getDrawable(), null);
+                DrawableCompat.setTint(imgViewIcon.getDrawable(), themeUtils.getAccentColor());
+            } catch (NullPointerException e) {
+                Timber.i(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #2327

#### What has been done to verify that this works as intended?
I confirmed that sorting option works well like before it's just a null check.

#### Why is this the best possible solution? Were any other approaches considered?
I don't understand what is the root cause here it's really strange because logs indicate that values in this HashMap https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java#L42 might be nulls, R.drawable may return nulls. So there is nothing we can do instead of catching exceptions like I did.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)