### PR TITLE
Fix crash previously fixed in d14ed91. Fixes #2270

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -80,6 +80,7 @@ public abstract class FormHierarchyActivity extends CollectAbstractActivity {
         // https://github.com/opendatakit/collect/issues/998
         if (formController == null) {
             finish();
+            Timber.w("FormController is null");
             return;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ViewFormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ViewFormHierarchyActivity.java
@@ -37,6 +37,12 @@ public class ViewFormHierarchyActivity extends FormHierarchyActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // super.onCreate() can call finish() if it finds the FormController to be null
+        // in that case, we want to shortcut this method, and let the Activity finish itself
+        if (isFinishing()) {
+            return;
+        }
+
         Collect.getInstance().getFormController().stepToOuterScreenEvent();
 
         Button exitButton = findViewById(R.id.exitButton);


### PR DESCRIPTION
Closes #2270 

#### What has been done to verify that this works as intended?

I was not able to reproduce it. The only verification is the logical analysis of the code. I will test the solution once I understand the steps @grzesiek2010 performed to fix https://github.com/opendatakit/collect/issues/998

#### Why is this the best possible solution? Were any other approaches considered?

This is an unverified fix based on assumptions from changes made first in:
https://github.com/opendatakit/collect/issues/998 to fix an issue, 
and then in:
https://github.com/opendatakit/collect/pull/1038
that probably caused the issue to reemerge. 

The changes in #998 introduced a null check to make sure the `FormHierarchyActivity` is closed when FormController is null. 

#1038 created a subclass of `FormHierarchyActivity` -> `ViewFormHierarchyActivity`. This caused a reintroduction of the bug fixed in #998, as the subclass does not recheck for null in the onCreate() method.

When the same situation that caused crash fixed in #998 occurs in the ViewFormHierarchyActivity following steps will happen:

1. ViewFormHierarchyActivity will start with calling [super.onCreate()](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/ViewFormHierarchyActivity.java#L38)
2. A null check in `super.onCreate()` parent class [FormHierarchyActivity::onCreate ](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java#L81) will call shortcut the `onCreate()` method by calling return, and call `finish()` on activity. 
3. `finish()` will be scheduled to close the activity asynchronously after the `onCreate()` is finished
4. `super.onCreate()` is done, the rest of the `onCreate()` method in ViewFormHierarchyActivity will be called. The shortcut only affected stopping `super.onCraete()`, the `onCreate()` is still called.
5. `Collect.getInstance().getFormController()` will still be null. It needs to be to be shortcut again. No need to call finish() this time, as it was already called in the `super.onCreate()`.


#### Are there any risks to merging this code? If so, what are they?

No changes to business logic. The activity silently finishes instead of throwing a Null Pointer Exception. 

#### Do we need any specific form for testing your changes? If so, please attach one.

The issue should be reproduced by the same steps as described in https://github.com/opendatakit/collect/issues/998

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.