### PR TITLE
Use uri_data key in intent appearance as intent data

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -20,6 +20,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.text.method.TextKeyListener;
 import android.text.method.TextKeyListener.Capitalize;
 import android.util.TypedValue;
@@ -94,6 +95,11 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
  */
 @SuppressLint("ViewConstructor")
 public class ExStringWidget extends QuestionWidget implements BinaryWidget {
+    // If an extra with this key is specified, it will be parsed as a URI and used as intent data
+    private static final String URI_KEY = "uri_data";
+    // Placeholder URI to ensure an activity to handle the intent is found
+    private static final Uri PLACEHOLDER_URI = Uri.parse("smsto:5555555");
+
 
     protected EditText answer;
     private boolean hasExApp = true;
@@ -245,15 +251,24 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
         errorString = (v != null) ? v : getContext().getString(R.string.no_app);
 
         Intent i = new Intent(intentName);
+        if (exParams.containsKey(URI_KEY)) {
+            i.setData(PLACEHOLDER_URI);
+        }
+
         if (activityAvailability.isActivityAvailable(i)) {
             try {
                 ExternalAppsUtils.populateParameters(i, exParams,
                         getFormEntryPrompt().getIndex().getReference());
 
+                if (exParams.containsKey(URI_KEY)) {
+                    i.setData(Uri.parse(i.getStringExtra(URI_KEY)));
+                    i.removeExtra(URI_KEY);
+                }
+
                 waitForData();
                 fireActivity(i);
 
-            } catch (ExternalParamsException e) {
+            } catch (ExternalParamsException | ActivityNotFoundException e) {
                 Timber.d(e);
                 onException(e.getMessage());
             }


### PR DESCRIPTION
Closes #2350

#### What has been done to verify that this works as intended?
I tried sending text messages and emails with single and multiple recipients.

#### Why is this the best possible solution? Were any other approaches considered?
I tried to work within what exists now. It's unfortunate that intent configuration is done through an `appearance` and it would be better to introduce something like a `data` attribute on an `intent` type but that's a bigger conversation. This works for people now. Introducing a special meaning for the key `uri_data` seems safe because it's odd enough that it's unlikely to be currently in use as an extra key.

The main source of ugliness in the code is that we need to set the data before checking whether an activity is available to receive the intent. I considered pulling `populateParameters` before the `isActivityAvailable` call. I decided against it because it requires also pulling out the exception and seems like wasted effort if there's no `uri_data` and no activity available. I also considered refactoring `populateParameters` so it would return a map rather than setting the extras itself. I can either do that here or it can be left for a future PR.

I'd like some opinions from others on the current approach.

#### Are there any risks to merging this code? If so, what are they?
Slight risk that there exists a form out there that already uses `uri_data` as an extra key but that seems very unlikely. Other than that it's a very narrow change.

#### Do we need any specific form for testing your changes? If so, please attach one.
[send-sms.xml.txt](https://github.com/opendatakit/collect/files/2164427/send-sms.xml.txt) shows sending a text message or an email to a single recipient and sending a text to multiple recipients. [XLSForm](https://docs.google.com/spreadsheets/d/1hep9Ibtd2u3rtPviNn8HS0qbwjGoJy4JtZOn6xdHkMk/edit#gid=0).

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Yes, we would need to document the meaning of `uri_data`. I'd like to make sure we want to move forward with this before filing a documentation issue.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)