### PR TITLE
Fixed AudioController

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
@@ -74,6 +74,7 @@ public class AudioController implements SeekBar.OnSeekBarChangeListener {
                     updateTimer();
                     seekHandler.postDelayed(this, 100);
                 } else {
+                    seekBar.setProgress(mediaPlayer.getDuration());
                     seekHandler.removeCallbacks(updateTimeTask);
                 }
             } catch (IllegalStateException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
@@ -72,8 +72,10 @@ public class AudioController implements SeekBar.OnSeekBarChangeListener {
             try {
                 if (mediaPlayer.isPlaying()) {
                     updateTimer();
+                    seekHandler.postDelayed(this, 100);
+                } else {
+                    seekHandler.removeCallbacks(updateTimeTask);
                 }
-                seekHandler.postDelayed(this, 100);
             } catch (IllegalStateException e) {
                 seekHandler.removeCallbacks(updateTimeTask);
                 Timber.i(e, "Attempting to update timer when player is stopped");

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
@@ -202,6 +202,11 @@ public class AudioController implements SeekBar.OnSeekBarChangeListener {
                         formEntryPrompt.getIndex());
 
         playButton.setImageResource(R.drawable.ic_pause_24dp);
+
+        if (seekBar.getProgress() == mediaPlayer.getDuration()) {
+            seekBar.setProgress(0);
+        }
+
         mediaPlayer.start();
         updateProgressBar();
     }


### PR DESCRIPTION
Closes #2355

#### What has been done to verify that this works as intended?
I tested the AudioWidget.

#### Why is this the best possible solution? Were any other approaches considered?
We just need to update the seekBar once an audio finishes. 
I also fixed `updateTimeTask` to stop it once an audio file finishes (the first commit) because before it was running all the time.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lint findbugs` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)