### PR TITLE
SelfieImageWidget and SelfieVideoWIdget crashes after multitapping (a few quick taps)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
@@ -44,7 +44,7 @@ public class CaptureSelfieActivity extends CollectAbstractActivity {
                 .LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
         setContentView(R.layout.activity_capture_selfie);
-        FrameLayout preview = findViewById(R.id.camera_preview);
+        FrameLayout previewLayout = findViewById(R.id.camera_preview);
 
         try {
             cameraId = CameraUtils.getFrontCameraId();
@@ -53,12 +53,13 @@ public class CaptureSelfieActivity extends CollectAbstractActivity {
             Timber.e(e);
         }
 
-        this.preview = new CameraPreview(this, camera);
-        preview.addView(this.preview);
+        preview = new CameraPreview(this, camera);
+        previewLayout.addView(preview);
 
-        this.preview.setOnClickListener(new View.OnClickListener() {
+        preview.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                preview.setEnabled(false);
                 camera.takePicture(null, null, picture);
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -856,6 +856,7 @@ public class Camera2Fragment extends Fragment
     public void onClick(View view) {
         switch (view.getId()) {
             case R.id.texture: {
+                textureView.setClickable(false);
                 takePicture();
                 break;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -56,6 +56,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.fragments.dialogs.ErrorDialog;
 import org.odk.collect.android.utilities.ToastUtils;
 
@@ -308,10 +309,13 @@ public class Camera2VideoFragment extends Fragment
     @Override
     public void onClick(View view) {
         if (view.getId() == R.id.texture) {
-            if (isRecordingVideo) {
-                stopRecordingVideo();
-            } else {
-                startRecordingVideo();
+            if (Collect.allowClick()) { // avoid multiple quick taps that may cause various problems
+                if (isRecordingVideo) {
+                    textureView.setClickable(false);
+                    stopRecordingVideo();
+                } else {
+                    startRecordingVideo();
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #2360 

#### What has been done to verify that this works as intended?
I tested multi-tapping using Android 6, 7 and 8 with both SelfieImageWidget and SelfieVideoWIdget.

#### Why is this the best possible solution? Were any other approaches considered?
I decided to block clicking after taking a photo/stooping video because allowing that doesn't make sense and causes problems. Additionally, I disabled super quick tapping in SelfieVideoWIdget to avoid various problems that may cause.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
`All Widgets` form contains both needed widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)