### PR TITLE
Use same click effect in reset dialog as used in other settings

### DIFF
--- a/collect_app/src/main/res/layout/reset_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/reset_dialog_layout.xml
@@ -42,6 +42,7 @@ limitations under the License.
             android:text="@string/reset_settings"
             android:padding="5dp"
             android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
@@ -52,6 +53,7 @@ limitations under the License.
             android:text="@string/reset_saved_forms"
             android:padding="5dp"
             android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
@@ -62,6 +64,7 @@ limitations under the License.
             android:text="@string/reset_blank_forms"
             android:padding="5dp"
             android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
@@ -72,6 +75,7 @@ limitations under the License.
             android:text="@string/reset_cache"
             android:padding="5dp"
             android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
@@ -82,6 +86,7 @@ limitations under the License.
             android:text="@string/reset_layers"
             android:padding="5dp"
             android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
@@ -92,6 +97,7 @@ limitations under the License.
             android:text="@string/reset_osm_tiles"
             android:padding="5dp"
             android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 


### PR DESCRIPTION
Closes #2036 

#### What has been done to verify that this works as intended?
I tested the `Reset Settings` dialog.

#### Why is this the best possible solution? Were any other approaches considered?
Because now we use the same effect for checkboxes like in other settings.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/3276264/42514600-124b567e-845a-11e8-9dc1-e43d2af60f97.gif)
