### PR TITLE
Resolved SMS/internet submission status issue

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsNotificationReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsNotificationReceiver.java
@@ -54,6 +54,7 @@ public class SmsNotificationReceiver extends BroadcastReceiver {
         notificationManager = NotificationManagerCompat.from(context);
 
         sendBundledNotification();
+        deleteIfSubmissionCompleted();
     }
 
     void sendBundledNotification() {
@@ -100,6 +101,16 @@ public class SmsNotificationReceiver extends BroadcastReceiver {
                 .setGroup(SMS_NOTIFICATION_GROUP)
                 .setGroupSummary(true)
                 .build();
+    }
+
+    /**
+     * Once the submission is completed, it's deleted here since this is the final point
+     * at which it's data is needed.
+     */
+    private void deleteIfSubmissionCompleted() {
+        if (smsSubmission.isSubmissionComplete()) {
+            submissionManagerContract.forgetSubmission(smsSubmission.getInstanceId());
+        }
     }
 
     private String getContentText() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsSender.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsSender.java
@@ -27,7 +27,7 @@ public class SmsSender {
     private final String instanceId;
 
     public static final String SMS_SEND_ACTION = "org.odk.collect.android.COLLECT_SMS_SEND_ACTION";
-    static final String SMS_INSTANCE_ID = "COLLECT_SMS_INSTANCE_ID";
+    public static final String SMS_INSTANCE_ID = "COLLECT_SMS_INSTANCE_ID";
     static final String SMS_MESSAGE_ID = "COLLECT_SMS_MESSAGE_ID";
     static final String SMS_RESULT_CODE = "COLLECT_SMS_RESULT_CODE";
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -162,15 +162,6 @@ public class SmsService {
         SmsSubmission model = smsSubmissionManager.getSubmissionModel(instanceId);
 
         /*
-         * Checks to see if a previous instance was sent successfully. If so
-         * remove that instance so a new one can be sent.
-         * */
-        if (model != null && model.isSubmissionComplete()) {
-            model = null;
-            smsSubmissionManager.forgetSubmission(instanceId);
-        }
-
-        /*
          * If the model exists that means this instance was probably sent in the past.
          */
         if (model != null) {


### PR DESCRIPTION
Closes #2372

#### What has been done to verify that this works as intended?
Submissions were done via SMS and then using the internet. When the submission via the internet was completed the status was updated.

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution because at the moment the `SmsSubmissionManager` is used to store the progress and state of submissions being sent over SMS so if that state isn't supposed to be displayed then submissions have to be flagged so when a user is switching between transport types the upload list reacts accordingly.

#### Are there any risks to merging this code? If so, what are they?
No risks are associated. The behavior just needs to be verified.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. Just use the `SMS test` form that's provided via the default Aggregate server.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)