### PR TITLE
Auto-send with SMS 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -51,6 +51,7 @@ import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.AutoSendPreferenceMigrator;
 import org.odk.collect.android.preferences.FormMetadataMigrator;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.tasks.sms.SmsService;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.PRNGFixes;
@@ -116,6 +117,8 @@ public class Collect extends Application implements HasActivityInjector {
 
     @Inject
     DispatchingAndroidInjector<Activity> androidInjector;
+    @Inject
+    SmsService smsService;
 
     public static Collect getInstance() {
         return singleton;
@@ -295,6 +298,8 @@ public class Collect extends Application implements HasActivityInjector {
         }
 
         setupLeakCanary();
+
+        smsService.autoSendForms();
     }
 
     protected RefWatcher setupLeakCanary() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AutoSendPreferenceMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AutoSendPreferenceMigrator.java
@@ -3,11 +3,15 @@ package org.odk.collect.android.preferences;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND_MIGRATED;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND_NETWORK;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND_WIFI;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_MULTI_AUTOSEND;
 
 /**
  * Migrates existing autosend_wifi and autosend_network preference values to autosend
@@ -77,5 +81,47 @@ public class AutoSendPreferenceMigrator {
 
         //save to shared preferences
         GeneralSharedPreferences.getInstance().save(KEY_AUTOSEND, autoSend);
+
+        migrateToMultiListPreferences();
+    }
+
+    /**
+     * Migrates the auto-send options to the multi-auto-send schema
+     *
+     * This involves checking the AUTO_SEND key for the current value and comparing it
+     * with the values from the previous array that represented it's option.
+     * Once that's done, the MULTI_AUTOSEND is populated with the selected options based on how
+     * it correlates to the current options for the multi-select list.
+     */
+    private static void migrateToMultiListPreferences() {
+
+        boolean migrated = GeneralSharedPreferences.getInstance().getBoolean(KEY_AUTOSEND_MIGRATED, false);
+
+        if (migrated) {
+            return;
+        }
+
+        GeneralSharedPreferences.getInstance().save(KEY_AUTOSEND_MIGRATED, true);
+
+        String autoSend = (String) GeneralSharedPreferences.getInstance().get(KEY_AUTOSEND);
+
+        Set<String> multiAutoSend = new HashSet<>();
+
+        switch (autoSend) {
+            case "wifi_only":
+                multiAutoSend.add("wifi");
+                break;
+
+            case "cellular_only":
+                multiAutoSend.add("cellular");
+                break;
+
+            case "wifi_and_cellular":
+                multiAutoSend.add("wifi");
+                multiAutoSend.add("cellular");
+                break;
+        }
+
+        GeneralSharedPreferences.getInstance().save(KEY_MULTI_AUTOSEND, multiAutoSend);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AutoSendPreferenceMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AutoSendPreferenceMigrator.java
@@ -81,20 +81,18 @@ public class AutoSendPreferenceMigrator {
 
         //save to shared preferences
         GeneralSharedPreferences.getInstance().save(KEY_AUTOSEND, autoSend);
-
         migrateToMultiListPreferences();
     }
 
     /**
      * Migrates the auto-send options to the multi-auto-send schema
-     *
+     * <p>
      * This involves checking the AUTO_SEND key for the current value and comparing it
      * with the values from the previous array that represented it's option.
      * Once that's done, the MULTI_AUTOSEND is populated with the selected options based on how
      * it correlates to the current options for the multi-select list.
      */
     private static void migrateToMultiListPreferences() {
-
         boolean migrated = GeneralSharedPreferences.getInstance().getBoolean(KEY_AUTOSEND_MIGRATED, false);
 
         if (migrated) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -91,7 +91,6 @@ public class FormManagementPreferences extends BasePreferenceFragment {
     }
 
     private void setMultiListPreferenceSummary(MultiSelectListPreference preference, Set<String> values) {
-
         if (values.isEmpty()) {
             preference.setSummary(getString(R.string.off));
         } else {
@@ -102,7 +101,6 @@ public class FormManagementPreferences extends BasePreferenceFragment {
             }
 
             String summary = TextUtils.join(", ", selectedEntries);
-
             preference.setSummary(summary);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -16,19 +16,24 @@ package org.odk.collect.android.preferences;
 
 import android.os.Bundle;
 import android.preference.ListPreference;
+import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.view.View;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.tasks.ServerPollingJob;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.odk.collect.android.preferences.AdminKeys.ALLOW_OTHER_WAYS_OF_EDITING_FORM;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOMATIC_UPDATE;
-import static org.odk.collect.android.preferences.PreferenceKeys.KEY_AUTOSEND;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_CONSTRAINT_BEHAVIOR;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_GUIDANCE_HINT;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_IMAGE_SIZE;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_MULTI_AUTOSEND;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_PERIODIC_FORM_UPDATES_CHECK;
 
 public class FormManagementPreferences extends BasePreferenceFragment {
@@ -39,9 +44,9 @@ public class FormManagementPreferences extends BasePreferenceFragment {
         addPreferencesFromResource(R.xml.form_management_preferences);
 
         initListPref(KEY_PERIODIC_FORM_UPDATES_CHECK);
-        initPref(KEY_AUTOMATIC_UPDATE);  
+        initPref(KEY_AUTOMATIC_UPDATE);
         initListPref(KEY_CONSTRAINT_BEHAVIOR);
-        initListPref(KEY_AUTOSEND);
+        initMultiSelectListPref(KEY_MULTI_AUTOSEND);
         initListPref(KEY_IMAGE_SIZE);
         initGuidancePrefs();
     }
@@ -57,6 +62,48 @@ public class FormManagementPreferences extends BasePreferenceFragment {
         super.onDetach();
         if (toolbar != null) {
             toolbar.setTitle(R.string.general_preferences);
+        }
+    }
+
+    private void initMultiSelectListPref(String key) {
+        final MultiSelectListPreference preference = (MultiSelectListPreference) findPreference(key);
+
+        if (preference == null) {
+            return;
+        }
+
+        Set<String> currentValues = (Set<String>) GeneralSharedPreferences.getInstance().get(key);
+
+        preference.setValues(currentValues);
+        setMultiListPreferenceSummary(preference, currentValues);
+
+        preference.setOnPreferenceChangeListener((currentPref, newValue) -> {
+
+            Set<String> selectedValues = (Set<String>) newValue;
+            ((MultiSelectListPreference) currentPref).setValues(selectedValues);
+
+            setMultiListPreferenceSummary(preference, selectedValues);
+
+            GeneralSharedPreferences.getInstance().save(key, selectedValues);
+
+            return false;
+        });
+    }
+
+    private void setMultiListPreferenceSummary(MultiSelectListPreference preference, Set<String> values) {
+
+        if (values.isEmpty()) {
+            preference.setSummary(getString(R.string.off));
+        } else {
+            Set<CharSequence> selectedEntries = new HashSet<>();
+            for (String value : values) {
+                int index = preference.findIndexOfValue(value);
+                selectedEntries.add(preference.getEntries()[index]);
+            }
+
+            String summary = TextUtils.join(", ", selectedEntries);
+
+            preference.setSummary(summary);
         }
     }
 
@@ -106,14 +153,11 @@ public class FormManagementPreferences extends BasePreferenceFragment {
         }
 
         guidance.setSummary(guidance.getEntry());
-        guidance.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object newValue) {
-                int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
-                String entry = (String) ((ListPreference) preference).getEntries()[index];
-                preference.setSummary(entry);
-                return true;
-            }
+        guidance.setOnPreferenceChangeListener((preference, newValue) -> {
+            int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+            String entry = (String) ((ListPreference) preference).getEntries()[index];
+            preference.setSummary(entry);
+            return true;
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralSharedPreferences.java
@@ -64,6 +64,8 @@ public class GeneralSharedPreferences {
             value = sharedPreferences.getInt(key, (Integer) defaultValue);
         } else if (defaultValue instanceof Float) {
             value = sharedPreferences.getFloat(key, (Float) defaultValue);
+        } else if (defaultValue instanceof Set) {
+            value = sharedPreferences.getStringSet(key, (Set<String>) defaultValue);
         }
         return value;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -18,6 +18,9 @@ public final class PreferenceKeys {
     // form_management_preferences.xml
     public static final String KEY_AUTOSEND                 = "autosend";
     public static final String KEY_MULTI_AUTOSEND           = "multi_autosend";
+    public static final String KEY_AUTOSEND_MIGRATED        = "autosend_migrated";
+    public static final String KEY_AUTOSEND_WIFI            = "autosend_wifi";
+    public static final String KEY_AUTOSEND_NETWORK         = "autosend_network";
     public static final String KEY_DELETE_AFTER_SEND        = "delete_send";
     public static final String KEY_COMPLETED_DEFAULT        = "default_completed";
     public static final String KEY_CONSTRAINT_BEHAVIOR      = "constraint_behavior";
@@ -67,8 +70,6 @@ public final class PreferenceKeys {
     public static final String KEY_FIRST_RUN                = "firstRun";
     /** Whether any existing username and email values have been migrated to form metadata */
     static final String KEY_METADATA_MIGRATED               = "metadata_migrated";
-    static final String KEY_AUTOSEND_WIFI                   = "autosend_wifi";
-    static final String KEY_AUTOSEND_NETWORK                = "autosend_network";
 
     // values
     public static final String NAVIGATION_SWIPE             = "swipe";
@@ -89,6 +90,7 @@ public final class PreferenceKeys {
         // form_management_preferences.xml
         hashMap.put(KEY_AUTOSEND,                   AUTOSEND_OFF);
         hashMap.put(KEY_MULTI_AUTOSEND,             new HashSet<>());
+        hashMap.put(KEY_AUTOSEND_MIGRATED,          false);
         hashMap.put(KEY_GUIDANCE_HINT,              GUIDANCE_HINT_OFF);
         hashMap.put(KEY_DELETE_AFTER_SEND,          false);
         hashMap.put(KEY_COMPLETED_DEFAULT,          true);
@@ -141,5 +143,4 @@ public final class PreferenceKeys {
     private PreferenceKeys() {
 
     }
-
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -6,6 +6,7 @@ import org.odk.collect.android.application.Collect;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 
 public final class PreferenceKeys {
 
@@ -16,6 +17,7 @@ public final class PreferenceKeys {
 
     // form_management_preferences.xml
     public static final String KEY_AUTOSEND                 = "autosend";
+    public static final String KEY_MULTI_AUTOSEND           = "multi_autosend";
     public static final String KEY_DELETE_AFTER_SEND        = "delete_send";
     public static final String KEY_COMPLETED_DEFAULT        = "default_completed";
     public static final String KEY_CONSTRAINT_BEHAVIOR      = "constraint_behavior";
@@ -86,6 +88,7 @@ public final class PreferenceKeys {
         hashMap.put(KEY_USERNAME,                   "");
         // form_management_preferences.xml
         hashMap.put(KEY_AUTOSEND,                   AUTOSEND_OFF);
+        hashMap.put(KEY_MULTI_AUTOSEND,             new HashSet<>());
         hashMap.put(KEY_GUIDANCE_HINT,              GUIDANCE_HINT_OFF);
         hashMap.put(KEY_DELETE_AFTER_SEND,          false);
         hashMap.put(KEY_COMPLETED_DEFAULT,          true);

--- a/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
@@ -78,17 +78,24 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
 
     private boolean isFormAutoSendOptionEnabled(NetworkInfo currentNetworkInfo) {
         // make sure autosend is enabled on the given connected interface
-        String autosend = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_AUTOSEND);
-        boolean sendwifi = autosend.equals("wifi_only");
-        boolean sendnetwork = autosend.equals("cellular_only");
-        if (autosend.equals("wifi_and_cellular")) {
-            sendwifi = true;
-            sendnetwork = true;
+        Set<String> multiAutoSend = (Set<String>) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_MULTI_AUTOSEND);
+        boolean sendWifi = false;
+        boolean sendNetwork = false;
+
+        for (String option : multiAutoSend) {
+
+            if (option.equals("wifi")) {
+                sendWifi = true;
+            }
+
+            if (option.equals("cellular")) {
+                sendNetwork = true;
+            }
         }
 
         return (currentNetworkInfo.getType() == ConnectivityManager.TYPE_WIFI
-                && sendwifi || currentNetworkInfo.getType() == ConnectivityManager.TYPE_MOBILE
-                && sendnetwork);
+                && sendWifi || currentNetworkInfo.getType() == ConnectivityManager.TYPE_MOBILE
+                && sendNetwork);
     }
 
     /**
@@ -166,7 +173,7 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
      *                                    <p>
      *                                    If the form explicitly sets the auto-send property, then it overrides the preferences.
      */
-    private boolean isFormAutoSendEnabled(String jrFormId, boolean isFormAutoSendOptionEnabled) {
+    public static boolean isFormAutoSendEnabled(String jrFormId, boolean isFormAutoSendOptionEnabled) {
         Cursor cursor = new FormsDao().getFormsCursorForFormId(jrFormId);
         String autoSend = null;
         if (cursor != null && cursor.moveToFirst()) {

--- a/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
@@ -43,7 +43,6 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
     // turning on wifi often gets two CONNECTED events. we only want to run one thread at a time
     public static boolean running;
     InstanceServerUploader instanceServerUploader;
-
     InstanceGoogleSheetsUploader instanceGoogleSheetsUploader;
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -134,7 +134,6 @@ public class SmsService {
      * background job.
      */
     public boolean submitForm(String instanceId, FormInfo info, String displayName, boolean autoSend) {
-
         String text;
 
         if (formsDao.isFormEncrypted(info.getFormID(), info.getFormVersion())) {
@@ -167,7 +166,6 @@ public class SmsService {
         try {
             text = getFileContents(smsFile);
         } catch (IOException e) {
-
             SmsRxEvent event = new SmsRxEvent(instanceId, RESULT_FILE_ERROR);
             updateInstanceStatusFailedText(instanceId, event);
             rxEventBus.post(event);
@@ -253,7 +251,6 @@ public class SmsService {
      * @param instanceId id from instanceDao
      */
     public boolean cancelFormSubmission(String instanceId) {
-
         SmsSubmission model = smsSubmissionManager.getSubmissionModel(instanceId);
 
         if (model == null) {
@@ -280,7 +277,6 @@ public class SmsService {
      * This function then determines the next action to perform based on the result it receives.
      */
     void processMessageSentResult(String instanceId, int messageId, int resultCode) {
-
         String log = String.format(Locale.getDefault(), "Received result from broadcast receiver of instance id %s with message id of %d", instanceId, messageId);
         Timber.i(log);
 
@@ -324,7 +320,6 @@ public class SmsService {
      * @param instanceId from instanceDao
      */
     protected void startSendMessagesJob(String instanceId) {
-
         PersistableBundleCompat extras = new PersistableBundleCompat();
         extras.putString(SmsSenderJob.INSTANCE_ID, instanceId);
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -21,6 +21,7 @@ import org.odk.collect.android.logic.FormInfo;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.receivers.NetworkReceiver;
 import org.odk.collect.android.tasks.InstanceUploader;
 import org.odk.collect.android.tasks.sms.contracts.SmsSubmissionManagerContract;
 import org.odk.collect.android.tasks.sms.models.Message;
@@ -36,6 +37,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -44,6 +46,7 @@ import timber.log.Timber;
 import static android.app.Activity.RESULT_OK;
 import static android.telephony.SmsManager.RESULT_ERROR_NO_SERVICE;
 import static android.telephony.SmsManager.RESULT_ERROR_RADIO_OFF;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.tasks.sms.SmsNotificationReceiver.SMS_NOTIFICATION_ACTION;
 import static org.odk.collect.android.tasks.sms.SmsSender.SMS_INSTANCE_ID;
 import static org.odk.collect.android.tasks.sms.SmsSender.SMS_MESSAGE_ID;
@@ -121,12 +124,16 @@ public class SmsService {
         }
     }
 
+    public boolean submitForm(String instanceId, FormInfo info, String displayName) {
+        return submitForm(instanceId, info, displayName, false);
+    }
+
     /**
      * Responsible for fetching the saved form that adheres to the SMS spec and
      * persisting the form as a group of messages so that they can be sent via a
      * background job.
      */
-    public boolean submitForm(String instanceId, FormInfo info, String displayName) {
+    public boolean submitForm(String instanceId, FormInfo info, String displayName, boolean autoSend) {
 
         String text;
 
@@ -139,13 +146,21 @@ public class SmsService {
 
         File smsFile = new File(getSmsInstancePath(info.getInstancePath()));
 
-        /**
+        /*
          * No instance.txt file is generated if a form doesn't have sms tags.
          */
         if (!smsFile.exists()) {
-            SmsRxEvent event = new SmsRxEvent(instanceId, RESULT_NO_MESSAGE);
-            updateInstanceStatusFailedText(instanceId, event);
-            rxEventBus.post(event);
+
+            /*
+             * When in auto send mode an instance that doesn't have sms tags should fail silently,
+             * rather than displaying a notification or updating the status field.
+             * */
+            if (!autoSend) {
+                SmsRxEvent event = new SmsRxEvent(instanceId, RESULT_NO_MESSAGE);
+                updateInstanceStatusFailedText(instanceId, event);
+                rxEventBus.post(event);
+            }
+
             return false;
         }
 
@@ -399,5 +414,60 @@ public class SmsService {
         }
 
         return "";
+    }
+
+    /**
+     * Automatically submits finalized instances that have sms tags.
+     * Before submission there are checks to see if
+     *
+     * 1) The transport is set to SMS
+     * 2) SMS auto send is enabled.
+     * 3) The form's auto send option isn't overriding the app settings.
+     * 4) SMS tags are included in the form submission.
+     */
+    public void autoSendForms() {
+        String transport = (String) GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE);
+        boolean smsTransportEnabled = transport.equalsIgnoreCase(context.getString(R.string.transport_type_value_sms));
+
+        if (!smsTransportEnabled) {
+            return;
+        }
+
+        boolean autoSend = false;
+        Set<String> multiAutoSend = (Set<String>) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_MULTI_AUTOSEND);
+
+        for (String option : multiAutoSend) {
+
+            if (option.equals("sms")) {
+                autoSend = true;
+                break;
+            }
+        }
+
+        try (Cursor results = new InstancesDao().getFinalizedInstancesCursor()) {
+            if (results.getCount() > 0) {
+                results.moveToPosition(-1);
+                while (results.moveToNext()) {
+
+                    String formId = results.getString(results.getColumnIndex(InstanceProviderAPI.InstanceColumns.JR_FORM_ID));
+
+                    boolean shouldSend = NetworkReceiver.isFormAutoSendEnabled(formId, autoSend);
+
+                    if (!shouldSend) {
+                        continue;
+                    }
+
+                    String filePath = results.getString(results
+                            .getColumnIndex(InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH));
+                    String instanceId = results.getString(results.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID));
+                    String displayName = results.getString(results.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_NAME));
+                    String formVersion = results.getString(results.getColumnIndex(InstanceProviderAPI.InstanceColumns.JR_VERSION));
+
+                    FormInfo info = new FormInfo(filePath, formId, formVersion);
+
+                    submitForm(instanceId, info, displayName, false);
+                }
+            }
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -465,7 +465,7 @@ public class SmsService {
 
                     FormInfo info = new FormInfo(filePath, formId, formVersion);
 
-                    submitForm(instanceId, info, displayName, false);
+                    submitForm(instanceId, info, displayName, true);
                 }
             }
         }

--- a/collect_app/src/main/res/values-ar/strings.xml
+++ b/collect_app/src/main/res/values-ar/strings.xml
@@ -458,8 +458,7 @@
   <string name="off">مغلق</string>
   <string name="wifi_autosend">ارسال تلقائي عبر Wifi</string>
   <string name="cellular_autosend">ارسال تلقائي عبر شبكة الاتصال</string>
-  <string name="wifi_cellular_autosend">ارسال تلقائي عبر Wifi و شبكة الاتصال</string>
-  <string name="map_basemap_behavior_title">الخريطة</string>
+    <string name="map_basemap_behavior_title">الخريطة</string>
   <string name="form_management_preferences">إعدادات ادارة الاستمارة</string>
   <string name="form_submission_category">خيارات الارسال</string>
   <string name="form_filling_category">تعبئة الاستمارة</string>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -487,8 +487,7 @@
   <string name="guidance_yes_collapsed">Ja - ausgeblendet</string>
   <string name="wifi_autosend">Nur WLAN</string>
   <string name="cellular_autosend">Nur Mobilfunk</string>
-  <string name="wifi_cellular_autosend">WLAN oder Mobilfunk</string>
-  <string name="map_basemap_behavior_title">Basiskarte</string>
+    <string name="map_basemap_behavior_title">Basiskarte</string>
   <string name="form_management_preferences">Formularverwaltung</string>
   <string name="form_submission_category">Formulareinsendung</string>
   <string name="form_filling_category">Formulareingabe</string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -489,8 +489,7 @@
   <string name="guidance_yes_collapsed">Si - Colapsado</string>
   <string name="wifi_autosend">Solo con WIFI</string>
   <string name="cellular_autosend">Solo con Datos Móviles</string>
-  <string name="wifi_cellular_autosend">Wifi o Datos Móviles</string>
-  <string name="map_basemap_behavior_title">Mapa Base</string>
+    <string name="map_basemap_behavior_title">Mapa Base</string>
   <string name="form_management_preferences">Gestión de formulario</string>
   <string name="form_submission_category">Enviar formulario</string>
   <string name="form_filling_category">Llenado de Formularios</string>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -487,8 +487,7 @@
   <string name="guidance_yes_collapsed">Kyllä - tiivistettynä</string>
   <string name="wifi_autosend">Vain Wifi</string>
   <string name="cellular_autosend">Vain puhelinverkko</string>
-  <string name="wifi_cellular_autosend">Wifi tai puhelinverkko</string>
-  <string name="map_basemap_behavior_title">Peruskartta</string>
+    <string name="map_basemap_behavior_title">Peruskartta</string>
   <string name="form_management_preferences">Lomakkeen hallinta</string>
   <string name="form_submission_category">Lomakkeen lähetys</string>
   <string name="form_filling_category">Lomakkeen täyttö</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -487,8 +487,7 @@
   <string name="guidance_yes_collapsed">Oui - Echoué</string>
   <string name="wifi_autosend">Seulement Wifi</string>
   <string name="cellular_autosend">Seulement Cellulaire</string>
-  <string name="wifi_cellular_autosend">Wifi ou Cellulaire</string>
-  <string name="map_basemap_behavior_title">Fonds de carte</string>
+    <string name="map_basemap_behavior_title">Fonds de carte</string>
   <string name="form_management_preferences">Gestion de formulaire</string>
   <string name="form_submission_category">Soumission de formulaire</string>
   <string name="form_filling_category">Remplissage de formulaire</string>

--- a/collect_app/src/main/res/values-hi/strings.xml
+++ b/collect_app/src/main/res/values-hi/strings.xml
@@ -462,8 +462,7 @@
   <string name="guidance_no">नहीं</string>
   <string name="wifi_autosend">केवल वाई-फाई </string>
   <string name="cellular_autosend"> केवल सेलुलर</string>
-  <string name="wifi_cellular_autosend">वाई-फाई या सेलुलर</string>
-  <string name="map_basemap_behavior_title">बेसमैप</string>
+    <string name="map_basemap_behavior_title">बेसमैप</string>
   <string name="form_management_preferences">फॉर्म मैनेजमेंट</string>
   <string name="form_submission_category">फॉर्म भेजना</string>
   <string name="form_filling_category">फॉर्म भरना</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -465,8 +465,7 @@
   <string name="guidance_no">Tidak</string>
   <string name="wifi_autosend">Hanya Wifi</string>
   <string name="cellular_autosend">Hanya Selular</string>
-  <string name="wifi_cellular_autosend">Wifi atau selular</string>
-  <string name="map_basemap_behavior_title">Peta dasar</string>
+    <string name="map_basemap_behavior_title">Peta dasar</string>
   <string name="form_management_preferences">Manajemen Formulir</string>
   <string name="form_submission_category">Pengiriman Formulir</string>
   <string name="form_filling_category">Mengisi Formulir</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -482,8 +482,7 @@
   <string name="guidance_no">いいえ</string>
   <string name="wifi_autosend">Wifi のみ</string>
   <string name="cellular_autosend">データ通信のみ</string>
-  <string name="wifi_cellular_autosend">Wifi またはデータ通信</string>
-  <string name="map_basemap_behavior_title">基本地図</string>
+    <string name="map_basemap_behavior_title">基本地図</string>
   <string name="form_management_preferences">フォーム管理</string>
   <string name="form_submission_category">フォーム送信</string>
   <string name="form_filling_category">フォーム入力</string>

--- a/collect_app/src/main/res/values-km/strings.xml
+++ b/collect_app/src/main/res/values-km/strings.xml
@@ -486,8 +486,7 @@
   <string name="guidance_yes_collapsed">បាទ - បញ្ចូលគ្នា</string>
   <string name="wifi_autosend">តែ Wifi ប៉ុណ្ណោះ</string>
   <string name="cellular_autosend">តែ Cellular ប៉ុណ្ណោះ</string>
-  <string name="wifi_cellular_autosend">Wifi ឬ Cellular</string>
-  <string name="map_basemap_behavior_title">ផែនទីមូលដ្ឋាន</string>
+    <string name="map_basemap_behavior_title">ផែនទីមូលដ្ឋាន</string>
   <string name="form_management_preferences">ការគ្រប់គ្រងទម្រង់</string>
   <string name="form_submission_category">ការដាក់ស្នើរទម្រង់</string>
   <string name="form_filling_category">ការបំពេញទម្រង់</string>

--- a/collect_app/src/main/res/values-mr/strings.xml
+++ b/collect_app/src/main/res/values-mr/strings.xml
@@ -451,8 +451,7 @@
   <string name="off">बंद</string>
   <string name="wifi_autosend">केवळ Wifi</string>
   <string name="cellular_autosend">केवळ सेल्यूलर</string>
-  <string name="wifi_cellular_autosend">वायफाय किंवा सेल्यूलर</string>
-  <string name="map_basemap_behavior_title">बेसमॅप</string>
+    <string name="map_basemap_behavior_title">बेसमॅप</string>
   <string name="form_management_preferences">फॉर्म व्यवस्थापन</string>
   <string name="form_submission_category">फॉर्म सबमिशन</string>
   <string name="form_filling_category">फॉर्म भरणे</string>

--- a/collect_app/src/main/res/values-ne-rNP/strings.xml
+++ b/collect_app/src/main/res/values-ne-rNP/strings.xml
@@ -388,8 +388,7 @@
   <string name="guidance_no">होइन</string>
   <string name="wifi_autosend">Wifi मात्र</string>
   <string name="cellular_autosend">मोबाईल ईन्टरनेट मात्र</string>
-  <string name="wifi_cellular_autosend">Wifi वा मोबाईल ईन्टरनेट</string>
-  <string name="form_management_preferences">फारम व्यवस्थापन</string>
+    <string name="form_management_preferences">फारम व्यवस्थापन</string>
   <string name="form_submission_category">फारम बुझाउँदा</string>
   <string name="form_filling_category">फारम भर्दा</string>
   <string name="high_resolution_title">ठुलो साइजको भिडियो</string>

--- a/collect_app/src/main/res/values-ru/strings.xml
+++ b/collect_app/src/main/res/values-ru/strings.xml
@@ -484,8 +484,7 @@
   <string name="guidance_no">Нет</string>
   <string name="wifi_autosend">Только Wi-Fi</string>
   <string name="cellular_autosend">Только сотовая связь</string>
-  <string name="wifi_cellular_autosend">Wi-Fi или сотовая связь</string>
-  <string name="map_basemap_behavior_title">Базовый слой</string>
+    <string name="map_basemap_behavior_title">Базовый слой</string>
   <string name="form_management_preferences">Управление формами</string>
   <string name="form_submission_category">Отправка формы</string>
   <string name="form_filling_category">Заполнение формы</string>

--- a/collect_app/src/main/res/values-sq/strings.xml
+++ b/collect_app/src/main/res/values-sq/strings.xml
@@ -417,8 +417,7 @@
   <string name="off">Fikur</string>
   <string name="wifi_autosend">Vetëm wifi</string>
   <string name="cellular_autosend">Vetëm celular</string>
-  <string name="wifi_cellular_autosend">Wifi ose celular</string>
-  <string name="map_basemap_behavior_title">Harta bazë</string>
+    <string name="map_basemap_behavior_title">Harta bazë</string>
   <string name="form_management_preferences">Administrimi i formularëve</string>
   <string name="form_submission_category">Dërgimi i formularëve</string>
   <string name="form_filling_category">Plotësimi i formularëve</string>

--- a/collect_app/src/main/res/values-sv-rSE/strings.xml
+++ b/collect_app/src/main/res/values-sv-rSE/strings.xml
@@ -465,8 +465,7 @@
   <string name="guidance_no">Nej</string>
   <string name="wifi_autosend">Endast WiFi</string>
   <string name="cellular_autosend">Endast mobilt nätverk</string>
-  <string name="wifi_cellular_autosend">WiFi eller mobilt nätverk</string>
-  <string name="map_basemap_behavior_title">Grundkarta</string>
+    <string name="map_basemap_behavior_title">Grundkarta</string>
   <string name="form_management_preferences">Formulärhantering</string>
   <string name="form_submission_category">Formulärinskickning</string>
   <string name="form_filling_category">Formulärifyllnad</string>

--- a/collect_app/src/main/res/values-uk/strings.xml
+++ b/collect_app/src/main/res/values-uk/strings.xml
@@ -487,8 +487,7 @@
   <string name="guidance_yes_collapsed">Так - згорнуті</string>
   <string name="wifi_autosend">Тільки Wi-Fi</string>
   <string name="cellular_autosend">Тільки мобільна мережа</string>
-  <string name="wifi_cellular_autosend">Wi-Fi або мобільна мережа</string>
-  <string name="map_basemap_behavior_title">Базова мапа</string>
+    <string name="map_basemap_behavior_title">Базова мапа</string>
   <string name="form_management_preferences">Управління анкетою</string>
   <string name="form_submission_category">Відправка анкети</string>
   <string name="form_filling_category">Заповнення анкети</string>

--- a/collect_app/src/main/res/values/arrays.xml
+++ b/collect_app/src/main/res/values/arrays.xml
@@ -137,16 +137,14 @@ the specific language governing permissions and limitations under the License. -
         <item>@string/minutes</item>
     </string-array>
     <string-array name="autosend_selector_entries">
-        <item>@string/off</item>
         <item>@string/wifi_autosend</item>
         <item>@string/cellular_autosend</item>
-        <item>@string/wifi_cellular_autosend</item>
+        <item>@string/sms_autosend</item>
     </string-array>
     <string-array name="autosend_selector_entries_values" translatable="false">
-        <item>off</item>
-        <item>wifi_only</item>
-        <item>cellular_only</item>
-        <item>wifi_and_cellular</item>
+        <item>wifi</item>
+        <item>cellular</item>
+        <item>sms</item>
     </string-array>
     <string-array name="guidance_hint_selector_entries">
         <item>@string/guidance_no</item>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -502,9 +502,9 @@
     <string name="guidance_no">No</string>
     <string name="guidance_yes">Yes - always shown</string>
     <string name="guidance_yes_collapsed">Yes - collapsed</string>
-    <string name="wifi_autosend">Wifi only</string>
-    <string name="cellular_autosend">Cellular only</string>
-    <string name="wifi_cellular_autosend">Wifi or cellular</string>
+    <string name="wifi_autosend">Wifi</string>
+    <string name="cellular_autosend">Cellular</string>
+    <string name="sms_autosend">SMS</string>
     <string name="map_basemap_behavior_title">Basemap</string>
     <string name="form_management_preferences">Form management</string>
     <string name="form_submission_category">Form submission</string>

--- a/collect_app/src/main/res/xml/form_management_preferences.xml
+++ b/collect_app/src/main/res/xml/form_management_preferences.xml
@@ -21,11 +21,11 @@
     <PreferenceCategory
         android:key="form_submission"
         android:title="@string/form_submission_category">
-        <ListPreference
+        <MultiSelectListPreference
             android:dialogTitle="@string/autosend_selector_title"
             android:entries="@array/autosend_selector_entries"
             android:entryValues="@array/autosend_selector_entries_values"
-            android:key="autosend"
+            android:key="multi_autosend"
             android:title="@string/autosend" />
         <CheckBoxPreference
             android:key="delete_send"


### PR DESCRIPTION
Closes #2370 

![webp net-resizeimage](https://user-images.githubusercontent.com/1509205/42742862-332b889a-8884-11e8-8802-9df9ba1fd2d3.png)


#### What has been done to verify that this works as intended?
The different options within the auto-send multi-select list options were selected and when the auto-send functionality was triggered submissions took place for both internet and SMS.

#### Why is this the best possible solution? Were any other approaches considered?
This was the best approach because based on the variety of auto-send options available. Putting them within a multi-select list just seemed right.

#### Are there any risks to merging this code? If so, what are they?
The risks I can see are just verifying that the migration is being done smoothly. i.e verifying the upgrading/downgrading of the app to ensure that in all cases the auto-send functionality stays intact.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)