### PR TITLE
Log analytics events for successful submissions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploader.java
@@ -20,6 +20,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.auth.GoogleAuthException;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.UserRecoverableAuthException;
@@ -195,6 +196,13 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                         cv.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
                         Collect.getInstance().getContentResolver().update(toUpdate, cv, null, null);
                         messagesByInstanceId.put(id, DEFAULT_SUCCESSFUL_TEXT);
+
+                        Collect.getInstance()
+                                .getDefaultTracker()
+                                .send(new HitBuilders.EventBuilder()
+                                        .setCategory("Submission")
+                                        .setAction("HTTP-Sheets")
+                                        .build());
                     } catch (UploadException e) {
                         Timber.e(e);
                         messagesByInstanceId.put(id, e.getMessage() != null ? e.getMessage() : e.getCause().getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploader.java
@@ -21,6 +21,8 @@ import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.webkit.MimeTypeMap;
 
+import com.google.android.gms.analytics.HitBuilders;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
@@ -494,6 +496,13 @@ public class InstanceServerUploader extends InstanceUploader {
 
         cv.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
         Collect.getInstance().getContentResolver().update(toUpdate, cv, null, null);
+
+        Collect.getInstance()
+                .getDefaultTracker()
+                .send(new HitBuilders.EventBuilder()
+                        .setCategory("Submission")
+                        .setAction("HTTP")
+                        .build());
         return true;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -10,8 +10,10 @@ import com.evernote.android.job.Job;
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobRequest;
 import com.evernote.android.job.util.support.PersistableBundleCompat;
+import com.google.android.gms.analytics.HitBuilders;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.events.RxEventBus;
@@ -333,6 +335,13 @@ public class SmsService {
 
         ContentValues contentValues = new ContentValues();
         contentValues.put(InstanceProviderAPI.InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
+
+        Collect.getInstance()
+                .getDefaultTracker()
+                .send(new HitBuilders.EventBuilder()
+                        .setCategory("Submission")
+                        .setAction("SMS")
+                        .build());
 
         try (Cursor cursor = instancesDao.getInstancesCursorForId(instanceId)) {
             cursor.moveToPosition(-1);


### PR DESCRIPTION
Closes #2380

#### What has been done to verify that this works as intended?
Ran a debug build, sent over HTTP and verified that the ODK Collect (Debug) Google Analytics variant saw the event. Since the gsheets and SMS are copied from there, I didn't independently verify those.

#### Why is this the best possible solution? Were any other approaches considered?
I considered logging all submission attempts but I don't think those would give us a realistic sense of how commonly the different transports are used. Someone who has a bad sheet configured to receive GSheets data could try 100 times before they get the submission through, for example. I think logging successful submissions is more telling. We could also consider logging both attempts and successes but that can come in a later PR.

#### Are there any risks to merging this code? If so, what are they?
None I can think of. There's no personal information included in the event logging. No behavior is modified.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No. We already show some info about analytics in the User and device identity settings.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)