### PR TITLE
Combine SelectOne widgets with quick appearance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -24,10 +24,10 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RelativeLayout;
 
@@ -103,10 +103,9 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget
     }
 
     public int getCheckedId() {
-        for (int i = 0; i < buttons.size(); ++i) {
-            RadioButton button = buttons.get(i);
+        for (RadioButton button : buttons) {
             if (button.isChecked()) {
-                return i;
+                return (int) button.getTag();
             }
         }
         return -1;
@@ -134,7 +133,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget
     @Override
     public void cancelLongPress() {
         super.cancelLongPress();
-        for (RadioButton button : this.buttons) {
+        for (RadioButton button : buttons) {
             button.cancelLongPress();
         }
     }
@@ -156,6 +155,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget
         radioButton.setId(ViewIds.generateViewId());
         radioButton.setEnabled(!getFormEntryPrompt().isReadOnly());
         radioButton.setFocusable(!getFormEntryPrompt().isReadOnly());
+        radioButton.setOnClickListener(this);
 
         //adapt radioButton text as per language direction
         if (isRTL()) {
@@ -180,23 +180,26 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget
 
         if (items != null) {
             for (int i = 0; i < items.size(); i++) {
-                @SuppressLint("InflateParams")
-                RelativeLayout thisParentLayout = (RelativeLayout) inflater.inflate(R.layout.quick_select_layout, null);
-
-                RadioButton radioButton = createRadioButton(i);
-                radioButton.setOnClickListener(this);
-
-                ImageView rightArrow = (ImageView) thisParentLayout.getChildAt(1);
-                rightArrow.setImageDrawable(autoAdvance ? AppCompatResources.getDrawable(getContext(), R.drawable.expander_ic_right) : null);
-
-                buttons.add(radioButton);
-
-                LinearLayout questionLayout = (LinearLayout) thisParentLayout.getChildAt(0);
-                questionLayout.addView(createMediaLayout(i, radioButton));
-                answerLayout.addView(thisParentLayout);
+                answerLayout.addView(createRadioButtonLayout(inflater, i));
             }
             addAnswerView(answerLayout);
         }
+    }
+
+    protected RelativeLayout createRadioButtonLayout(LayoutInflater inflater, int index) {
+        @SuppressLint("InflateParams")
+        RelativeLayout thisParentLayout = (RelativeLayout) inflater.inflate(R.layout.quick_select_layout, null);
+
+        RadioButton radioButton = createRadioButton(index);
+
+        ImageView rightArrow = (ImageView) thisParentLayout.getChildAt(1);
+        rightArrow.setImageDrawable(autoAdvance ? AppCompatResources.getDrawable(getContext(), R.drawable.expander_ic_right) : null);
+
+        buttons.add(radioButton);
+
+        ((ViewGroup) thisParentLayout.getChildAt(0)).addView(createMediaLayout(index, radioButton));
+
+        return thisParentLayout;
     }
 
     public List<RadioButton> getButtons() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ListWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ListWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatRadioButton;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
@@ -45,6 +46,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.external.ExternalSelectChoice;
+import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
@@ -68,13 +70,23 @@ import timber.log.Timber;
 @SuppressLint("ViewConstructor")
 public class ListWidget extends QuestionWidget implements MultiChoiceWidget, OnCheckedChangeListener {
 
+    @Nullable
+    private AdvanceToNextListener listener;
+
+    private final boolean autoAdvance;
+
     List<SelectChoice> items; // may take a while to compute
 
     ArrayList<RadioButton> buttons;
     View center;
 
-    public ListWidget(Context context, FormEntryPrompt prompt, boolean displayLabel) {
+    public ListWidget(Context context, FormEntryPrompt prompt, boolean displayLabel, boolean autoAdvance) {
         super(context, prompt);
+
+        this.autoAdvance = autoAdvance;
+        if (context instanceof AdvanceToNextListener) {
+            listener = (AdvanceToNextListener) context;
+        }
 
         // SurveyCTO-added support for dynamic select content (from .csv files)
         XPathFuncExpr xpathFuncExpr = ExternalDataUtil.getSearchXPathExpression(
@@ -285,6 +297,10 @@ public class ListWidget extends QuestionWidget implements MultiChoiceWidget, OnC
         }
         Collect.getInstance().getActivityLogger().logInstanceAction(this, "onCheckedChanged",
                 items.get((Integer) buttonView.getTag()).getValue(), getFormEntryPrompt().getIndex());
+
+        if (autoAdvance && listener != null) {
+            listener.advance();
+        }
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
@@ -146,7 +146,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
         }
     }
 
-    private void selectArea(String areaId) {
+    protected void selectArea(String areaId) {
         SelectChoice selectChoice = null;
         for (SelectChoice sc : items) {
             if (areaId.equalsIgnoreCase(sc.getValue())) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneImageMapWidget.java
@@ -17,20 +17,35 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.support.annotation.Nullable;
 import android.webkit.WebView;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.listeners.AdvanceToNextListener;
 
 /**
  * A widget which is responsible for multi select questions represented by
  * an svg map. You can use maps of the world, countries, human body etc.
  */
 public class SelectOneImageMapWidget extends SelectImageMapWidget {
-    public SelectOneImageMapWidget(Context context, FormEntryPrompt prompt) {
+
+    @Nullable
+    private AdvanceToNextListener listener;
+
+    private final boolean autoAdvance;
+
+    public SelectOneImageMapWidget(Context context, FormEntryPrompt prompt, boolean autoAdvance) {
         super(context, prompt);
+
+        this.autoAdvance = autoAdvance;
+
+        if (context instanceof AdvanceToNextListener) {
+            listener = (AdvanceToNextListener) context;
+        }
 
         if (prompt.getAnswerValue() != null) {
             selections.add((Selection) prompt.getAnswerValue().getValue());
@@ -49,5 +64,16 @@ public class SelectOneImageMapWidget extends SelectImageMapWidget {
     public IAnswerData getAnswer() {
         return selections.isEmpty() ? null
                 : new SelectOneData(selections.get(0));
+    }
+
+    @Override
+    protected void selectArea(String areaId) {
+        super.selectArea(areaId);
+
+        ((FormEntryActivity) getContext()).runOnUiThread(() -> {
+            if (autoAdvance && listener != null) {
+                listener.advance();
+            }
+        });
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -16,8 +16,8 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.view.LayoutInflater;
 import android.widget.CompoundButton.OnCheckedChangeListener;
-import android.widget.LinearLayout;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.AudioPlayListener;
@@ -35,18 +35,18 @@ import java.util.List;
  */
 @SuppressLint("ViewConstructor")
 public class SelectOneSearchWidget extends AbstractSelectOneWidget implements OnCheckedChangeListener, AudioPlayListener {
-    public SelectOneSearchWidget(Context context, FormEntryPrompt prompt) {
-        super(context, prompt, false);
+    public SelectOneSearchWidget(Context context, FormEntryPrompt prompt, boolean autoAdvance) {
+        super(context, prompt, autoAdvance);
         createLayout();
     }
 
     @Override
     protected void addButtonsToLayout(List<Integer> tagList) {
-        for (int i = 0; i < buttons.size(); i++) {
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        buttons.clear();
+        for (int i = 0; i < items.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
-                answerLayout.addView(buttons.get(i));
-                answerLayout.setDividerDrawable(getResources().getDrawable(themeUtils.getDivider()));
-                answerLayout.setShowDividers(LinearLayout.SHOW_DIVIDER_MIDDLE);
+                answerLayout.addView(createRadioButtonLayout(inflater, i));
             }
         }
     }
@@ -59,13 +59,6 @@ public class SelectOneSearchWidget extends AbstractSelectOneWidget implements On
     @Override
     protected void createLayout() {
         readItems();
-
-        if (items != null) {
-            for (int i = 0; i < items.size(); i++) {
-                buttons.add(createRadioButton(i));
-            }
-        }
-
         setUpSearchBox();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -35,6 +36,7 @@ import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalDataUtil;
+import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.views.ScrolledToTopSpinner;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 
@@ -53,8 +55,15 @@ public class SpinnerWidget extends QuestionWidget implements MultiChoiceWidget {
     ScrolledToTopSpinner spinner;
     String[] choices;
 
-    public SpinnerWidget(Context context, FormEntryPrompt prompt) {
+    @Nullable
+    private AdvanceToNextListener listener;
+
+    public SpinnerWidget(Context context, FormEntryPrompt prompt, boolean autoAdvance) {
         super(context, prompt);
+
+        if (context instanceof AdvanceToNextListener) {
+            listener = (AdvanceToNextListener) context;
+        }
 
         // SurveyCTO-added support for dynamic select content (from .csv files)
         XPathFuncExpr xpathFuncExpr = ExternalDataUtil.getSearchXPathExpression(
@@ -113,6 +122,10 @@ public class SpinnerWidget extends QuestionWidget implements MultiChoiceWidget {
                     Collect.getInstance().getActivityLogger().logInstanceAction(this,
                             "onCheckedChanged",
                             items.get(position).getValue(), getFormEntryPrompt().getIndex());
+
+                    if (autoAdvance && listener != null) {
+                        listener.advance();
+                    }
                 }
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -193,8 +193,8 @@ public class WidgetFactory {
                     questionWidget = new ListWidget(context, fep, true);
                 } else if (appearance.equals("label")) {
                     questionWidget = new LabelWidget(context, fep);
-                } else if (appearance.startsWith("image-map")) {
-                    questionWidget = new SelectOneImageMapWidget(context, fep);
+                } else if (appearance.contains("image-map")) {
+                    questionWidget = new SelectOneImageMapWidget(context, fep, appearance.contains("quick"));
                 } else {
                     questionWidget = new SelectOneWidget(context, fep, appearance.contains("quick"));
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -187,10 +187,10 @@ public class WidgetFactory {
                     questionWidget = new SpinnerWidget(context, fep, appearance.contains("quick"));
                 } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
                     questionWidget = new SelectOneSearchWidget(context, fep, appearance.contains("quick"));
-                } else if (appearance.equals("list-nolabel")) {
-                    questionWidget = new ListWidget(context, fep, false);
-                } else if (appearance.equals("list")) {
-                    questionWidget = new ListWidget(context, fep, true);
+                } else if (appearance.contains("list-nolabel")) {
+                    questionWidget = new ListWidget(context, fep, false, appearance.contains("quick"));
+                } else if (appearance.contains("list")) {
+                    questionWidget = new ListWidget(context, fep, true, appearance.contains("quick"));
                 } else if (appearance.equals("label")) {
                     questionWidget = new LabelWidget(context, fep);
                 } else if (appearance.contains("image-map")) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -183,8 +183,8 @@ public class WidgetFactory {
                         Timber.e("Exception parsing numColumns");
                     }
                     questionWidget = new GridWidget(context, fep, numColumns, appearance.contains("quick"));
-                } else if (appearance.startsWith("minimal")) {
-                    questionWidget = new SpinnerWidget(context, fep);
+                } else if (appearance.contains("minimal")) {
+                    questionWidget = new SpinnerWidget(context, fep, appearance.contains("quick"));
                 } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
                     questionWidget = new SelectOneSearchWidget(context, fep, appearance.contains("quick"));
                 } else if (appearance.equals("list-nolabel")) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -176,35 +176,27 @@ public class WidgetFactory {
                         String firstWord = appearance.split("\\s+")[0];
                         int idx = firstWord.indexOf('-');
                         if (idx != -1) {
-                            numColumns =
-                                    Integer.parseInt(firstWord.substring(idx + 1));
+                            numColumns = Integer.parseInt(firstWord.substring(idx + 1));
                         }
                     } catch (Exception e) {
                         // Do nothing, leave numColumns as -1
                         Timber.e("Exception parsing numColumns");
                     }
-
-                    if (appearance.startsWith("quick")) {
-                        questionWidget = new GridWidget(context, fep, numColumns, true);
-                    } else {
-                        questionWidget = new GridWidget(context, fep, numColumns, false);
-                    }
+                    questionWidget = new GridWidget(context, fep, numColumns, appearance.contains("quick"));
                 } else if (appearance.startsWith("minimal")) {
                     questionWidget = new SpinnerWidget(context, fep);
-                } else if (appearance.startsWith("quick")) {
-                    questionWidget = new SelectOneWidget(context, fep, true);
+                } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
+                    questionWidget = new SelectOneSearchWidget(context, fep, appearance.contains("quick"));
                 } else if (appearance.equals("list-nolabel")) {
                     questionWidget = new ListWidget(context, fep, false);
                 } else if (appearance.equals("list")) {
                     questionWidget = new ListWidget(context, fep, true);
                 } else if (appearance.equals("label")) {
                     questionWidget = new LabelWidget(context, fep);
-                } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
-                    questionWidget = new SelectOneSearchWidget(context, fep);
                 } else if (appearance.startsWith("image-map")) {
                     questionWidget = new SelectOneImageMapWidget(context, fep);
                 } else {
-                    questionWidget = new SelectOneWidget(context, fep, false);
+                    questionWidget = new SelectOneWidget(context, fep, appearance.contains("quick"));
                 }
                 break;
             case Constants.CONTROL_SELECT_MULTI:

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ListWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ListWidgetTest.java
@@ -13,6 +13,6 @@ public class ListWidgetTest extends GeneralSelectOneWidgetTest<ListWidget> {
     @NonNull
     @Override
     public ListWidget createWidget() {
-        return new ListWidget(RuntimeEnvironment.application, formEntryPrompt, false);
+        return new ListWidget(RuntimeEnvironment.application, formEntryPrompt, false, false);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneSearchWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneSearchWidgetTest.java
@@ -13,6 +13,6 @@ public class SelectOneSearchWidgetTest extends GeneralSelectOneWidgetTest<Select
     @NonNull
     @Override
     public SelectOneSearchWidget createWidget() {
-        return new SelectOneSearchWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new SelectOneSearchWidget(RuntimeEnvironment.application, formEntryPrompt, false);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SpinnerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SpinnerWidgetTest.java
@@ -13,6 +13,6 @@ public class SpinnerWidgetTest extends GeneralSelectOneWidgetTest<SpinnerWidget>
     @NonNull
     @Override
     public SpinnerWidget createWidget() {
-        return new SpinnerWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new SpinnerWidget(RuntimeEnvironment.application, formEntryPrompt, false);
     }
 }


### PR DESCRIPTION
Closes #1137 

- added a possibility to use `quick` appearance with `search`/`autocomplete`
- added a possibility to use `quick` appearance with `image-map`
- added a possibility to use `quick` appearance with `minimal`
- added a possibility to use `quick` appearance with `list`/`list-no-label`

#### What has been done to verify that this works as intended?
I tested the attached form and SelectOne widgets from AllWidgets form to check for regression.

#### Why is this the best possible solution? Were any other approaches considered?

#### Are there any risks to merging this code? If so, what are they?
Yes because I refactored some code so we should test all SelectOne widgets.

#### Do we need any specific form for testing your changes? If so, please attach one.
[quickSelectWidgets.xml.txt](https://github.com/opendatakit/collect/files/2213839/quickSelectWidgets.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)