### PR TITLE
Add dividers to SelectMultipleAutocompleteWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultipleAutocompleteWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultipleAutocompleteWidget.java
@@ -18,6 +18,7 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 import android.widget.CompoundButton;
+import android.widget.LinearLayout;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.AudioPlayListener;
@@ -36,6 +37,8 @@ public class SelectMultipleAutocompleteWidget extends SelectMultiWidget implemen
         for (int i = 0; i < checkBoxes.size(); i++) {
             if (tagList == null || tagList.contains(i)) {
                 answerLayout.addView(checkBoxes.get(i));
+                answerLayout.setDividerDrawable(getResources().getDrawable(themeUtils.getDivider()));
+                answerLayout.setShowDividers(LinearLayout.SHOW_DIVIDER_MIDDLE);
             }
         }
     }


### PR DESCRIPTION
Closes #2394 

#### What has been done to verify that this works as intended?
I tested the attached form.
I also added this widget to https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0

#### Why is this the best possible solution? Were any other approaches considered?
All select widgets contain dividers so it should be consistent.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
[SelectMultipleAutocomplete.xml.txt](https://github.com/opendatakit/collect/files/2214061/SelectMultipleAutocomplete.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)