### PR TITLE
Fixed Attempt to invoke getLocale() on null reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -101,7 +101,13 @@ public class FormEntryPromptUtils {
 
         if (data != null && data.getValue() != null && fep.getDataType() == DATATYPE_TEXT
                 && fep.getQuestion().getAdditionalAttribute(null, "query") != null) { // ItemsetWidget
-            return new ItemsetDao().getItemLabel(fep.getAnswerValue().getDisplayText(), formController.getMediaFolder().getAbsolutePath(), formController.getLanguage());
+
+            String language = "";
+            if (formController.getLanguages() != null && formController.getLanguages().length > 0) {
+                language = formController.getLanguage();
+            }
+
+            return new ItemsetDao().getItemLabel(fep.getAnswerValue().getDisplayText(), formController.getMediaFolder().getAbsolutePath(), language);
         }
 
         return fep.getAnswerText();


### PR DESCRIPTION
Closes #2402 

#### What has been done to verify that this works as intended?
I've tested a form attached by the user.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a fix. We shouldn't try to read languages if they don't exist.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
A good sample form is here https://forum.opendatakit.org/t/attempt-to-invoke-getlocale-on-null-reference/14152/5?u=grzesiek2010

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)