### PR TITLE
Fixed null date issue and stream error handling

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -142,13 +142,16 @@ public class InstanceUploaderAdapter extends CursorAdapter {
         compositeDisposable.add(eventBus.register(SmsRxEvent.class)
                 .filter(event -> event.getInstanceId().equals(String.valueOf(instanceId)))
                 .subscribeOn(Schedulers.io())
-                .doOnError(Timber::e)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(event -> {
-                    viewHolder.progressBar.setProgressPercent((int) event.getProgress().getPercentage(), true);
-                    setSmsSubmissionStateIcons(event.getResultCode(), viewHolder);
-                    setDisplaySubTextView(event, viewHolder);
-                    setupCloseButton(viewHolder, event.getResultCode());
+                    try {
+                        viewHolder.progressBar.setProgressPercent((int) event.getProgress().getPercentage(), true);
+                        setSmsSubmissionStateIcons(event.getResultCode(), viewHolder);
+                        setDisplaySubTextView(event, viewHolder);
+                        setupCloseButton(viewHolder, event.getResultCode());
+                    } catch (Exception e) {
+                        Timber.e(e);
+                    }
                 }));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -32,6 +32,7 @@ import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
+import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.provider.InstanceProviderAPI.STATUS_SUBMISSION_FAILED;
@@ -141,6 +142,7 @@ public class InstanceUploaderAdapter extends CursorAdapter {
         compositeDisposable.add(eventBus.register(SmsRxEvent.class)
                 .filter(event -> event.getInstanceId().equals(String.valueOf(instanceId)))
                 .subscribeOn(Schedulers.io())
+                .doOnError(Timber::e)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(event -> {
                     viewHolder.progressBar.setProgressPercent((int) event.getProgress().getPercentage(), true);

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -32,7 +32,6 @@ import butterknife.ButterKnife;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
-import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.provider.InstanceProviderAPI.STATUS_SUBMISSION_FAILED;
@@ -144,14 +143,10 @@ public class InstanceUploaderAdapter extends CursorAdapter {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(event -> {
-                    try {
-                        viewHolder.progressBar.setProgressPercent((int) event.getProgress().getPercentage(), true);
-                        setSmsSubmissionStateIcons(event.getResultCode(), viewHolder);
-                        setDisplaySubTextView(event, viewHolder);
-                        setupCloseButton(viewHolder, event.getResultCode());
-                    } catch (Exception e) {
-                        Timber.e(e);
-                    }
+                    viewHolder.progressBar.setProgressPercent((int) event.getProgress().getPercentage(), true);
+                    setSmsSubmissionStateIcons(event.getResultCode(), viewHolder);
+                    setDisplaySubTextView(event, viewHolder);
+                    setupCloseButton(viewHolder, event.getResultCode());
                 }));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/events/SmsRxEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/events/SmsRxEvent.java
@@ -18,6 +18,7 @@ public class SmsRxEvent extends RxEvent {
         this.instanceId = instanceId;
         this.resultCode = resultCode;
         progress = new SmsProgress();
+        lastUpdated = new Date();
     }
 
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -390,7 +390,7 @@ public class SmsService {
                 default:
                     return new SimpleDateFormat(context.getString(R.string.sms_fatal_error), Locale.getDefault()).format(date);
             }
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
             Timber.e(e);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -366,6 +366,11 @@ public class SmsService {
     }
 
     public static String getDisplaySubtext(int resultCode, Date date, SmsProgress progress, Context context) {
+        if (date == null) {
+            Timber.e("date is null");
+            return context.getString(R.string.error_occured);
+        }
+
         try {
             switch (resultCode) {
                 case RESULT_ERROR_NO_SERVICE:
@@ -390,7 +395,7 @@ public class SmsService {
                 default:
                     return new SimpleDateFormat(context.getString(R.string.sms_fatal_error), Locale.getDefault()).format(date);
             }
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             Timber.e(e);
         }
 


### PR DESCRIPTION
Stream errors weren't being handled so a crash was being caused when an error occurs within the stream so now that is being handled and sent to Crashlytics via the Timber log. The `SmsEvent` now has a default date that can be used by events. Events without the date were causing a crash when the formatter got a null date.

Closes #2401 

#### What has been done to verify that this works as intended?
Tested the scenario described in the issue on a physical tablet and an emulator. Crash won't be caused in the event anything weird ever happens since the stream handles errors.

#### Why is this the best possible solution? Were any other approaches considered?
It's the best solution since the stream being broken by the error was causing the crash so implemented exception handling causes this to not occur.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
Use a SMS Test sample form from the server.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
N/A

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)