### PR TITLE
Choice filter analytics

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -16,9 +16,19 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 
-import org.javarosa.core.model.Constants;
-import org.javarosa.form.api.FormEntryPrompt;
+import com.google.android.gms.analytics.HitBuilders;
 
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.ItemsetBinding;
+import org.javarosa.core.model.QuestionDef;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.javarosa.xpath.expr.XPathExpression;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.utilities.FileUtils;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
 import java.util.Locale;
 
 import timber.log.Timber;
@@ -207,6 +217,9 @@ public class WidgetFactory {
                 } else {
                     questionWidget = new SelectOneWidget(context, fep, false);
                 }
+
+                logChoiceFilterAnalytics(fep.getQuestion());
+
                 break;
             case Constants.CONTROL_SELECT_MULTI:
                 // search() appearance/function (not part of XForms spec) added by SurveyCTO gets
@@ -261,12 +274,60 @@ public class WidgetFactory {
                         questionWidget = new StringWidget(context, fep, readOnlyOverride);
                         break;
                 }
+
+                logChoiceFilterAnalytics(fep.getQuestion());
+
                 break;
             default:
                 questionWidget = new StringWidget(context, fep, readOnlyOverride);
                 break;
         }
         return questionWidget;
+    }
+
+    /**
+     * Log analytics event each time a question with a choice filter is accessed, identifying
+     * choice filters with relative expressions. This will inform communication around the fix
+     * for a long-standing bug in JavaRosa: https://github.com/opendatakit/javarosa/issues/293
+     */
+    private static void logChoiceFilterAnalytics(QuestionDef question) {
+        ItemsetBinding itemsetBinding = question.getDynamicChoices();
+
+        if (itemsetBinding != null && itemsetBinding.nodesetRef != null) {
+            if (itemsetBinding.nodesetRef.hasPredicates()) {
+                for (int level = 0; level < itemsetBinding.nodesetRef.size(); level++) {
+                    List<XPathExpression> predicates = itemsetBinding.nodesetRef.getPredicate(level);
+
+                    if (predicates != null) {
+                        // Log a hash of the form title and id joined by a space. This
+                        // will allow us to know a rough count of unique forms that use
+                        // current() in a predicate without compromising user privacy.
+                        String formIdentifier = "";
+                        FormController formController = Collect.getInstance().getFormController();
+                        if (formController != null) {
+                            String formID = formController.getFormDef().getMainInstance()
+                                    .getRoot().getAttributeValue("", "id");
+                            formIdentifier = formController.getFormTitle() + " " + formID;
+                        }
+
+                        String formIdentifierHash = FileUtils.getMd5Hash(
+                                new ByteArrayInputStream(formIdentifier.getBytes()));
+
+                        for (XPathExpression predicate : predicates) {
+                            String actionName = predicate.toString().contains("current") ?
+                                    "CurrentPredicate" : "NonCurrentPredicate";
+
+                            Collect.getInstance().getDefaultTracker()
+                                    .send(new HitBuilders.EventBuilder()
+                                    .setCategory("Itemset")
+                                    .setAction(actionName)
+                                    .setLabel(formIdentifierHash)
+                                    .build());
+                        }
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -168,8 +168,9 @@ public class WidgetFactory {
                 questionWidget = new VideoWidget(context, fep);
                 break;
             case Constants.CONTROL_SELECT_ONE:
-                // SurveyCTO-revised support for dynamic select content (from .csv files)
-                // consider traditional ODK appearance to be first word in appearance string
+                // search() appearance/function (not part of XForms spec) added by SurveyCTO gets
+                // considered in each widget by calls to ExternalDataUtil.getSearchXPathExpression.
+                // This means normal appearances should be put before search().
                 if (appearance.startsWith("compact") || appearance.startsWith("quickcompact")) {
                     int numColumns = -1;
                     try {
@@ -208,8 +209,9 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_SELECT_MULTI:
-                // SurveyCTO-revised support for dynamic select content (from .csv files)
-                // consider traditional ODK appearance to be first word in appearance string
+                // search() appearance/function (not part of XForms spec) added by SurveyCTO gets
+                // considered in each widget by calls to ExternalDataUtil.getSearchXPathExpression.
+                // This means normal appearances should be put before search().
                 if (appearance.startsWith("compact")) {
                     int numColumns = -1;
                     try {


### PR DESCRIPTION
Add analytics events for choice filters with `current()` to inform communication around https://github.com/opendatakit/javarosa/issues/293. If we see a lot of unique forms use `current()` choice filters, we need to be very careful with the change. If we see very few, we can move forward without too much concern.

This should go in the 1.16.1 patch release so we can start collecting data right away. @ggalmazor, you probably have the most context to verify this! It's in Collect but really the addition is entirely dealing with JR classes.

The first commit is fixing a comment that didn't provide enough context.

#### What has been done to verify that this works as intended?
Ran with https://github.com/lognaturel/javarosa/blob/20e357fca5b3497a4f9fa5f7138e8f08922c7034/resources/org/javarosa/xpath/expr/relative-current-ref.xml (itemset with choice filter that uses `current()`) and with the All Widgets select examples which don't use dynamic itemsets (or choice filters because they're not possible).

#### Why is this the best possible solution? Were any other approaches considered?
I decided to log the hash of the predicate `toString` to get a sense of unique usages without compromising user privacy. I also considered just logging an event without it but then we might not be able to interpret a high number (is it just one person swiping back and forth a million times?).

I decided to also log predicates without `current()` to have a sense of how common choice filters are in general and be able to compare that with how many use `current()`. I think this will give us actionable information.

The logging happens on question rendering which isn't ideal because the same question could be rendered multiple times in the same form-filling session. I couldn't come up with a better place to put it but am open to suggestions.

#### Are there any risks to merging this code? If so, what are they?
I think the highest risk is that I didn't consider a null case or other state that leads to an exception. This would then lead to a crash which would be shown to the user. 

#### Do we need any specific form for testing your changes? If so, please attach one.
https://github.com/lognaturel/javarosa/blob/20e357fca5b3497a4f9fa5f7138e8f08922c7034/resources/org/javarosa/xpath/expr/relative-current-ref.xml, All Widgets

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)