### PR TITLE
Fixed attempt to invoke interface method 'int android.database.CursorgetCount()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploader.java
@@ -89,7 +89,7 @@ public abstract class InstanceUploader extends AsyncTask<Long, Integer, Instance
                             results =
                                     new InstancesDao().getInstancesCursor(selection.toString(),
                                             selectionArgs);
-                            if (results.getCount() > 0) {
+                            if (results != null && results.getCount() > 0) {
                                 List<Long> toDelete = new ArrayList<>();
                                 results.moveToPosition(-1);
 


### PR DESCRIPTION
Closes #2407 

#### What has been done to verify that this works as intended?
It's just an obvious null check so I didn't test anything.

#### Why is this the best possible solution? Were any other approaches considered?
We should check if a cursor object is null before we use it.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)