### PR TITLE
Check for null because servers may not provide text

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
@@ -58,7 +58,7 @@ public class InstanceUploaderUtils {
     }
 
     private static String localizeDefaultAggregateSuccessfulText(String text) {
-        if (text.equals(DEFAULT_SUCCESSFUL_TEXT)) {
+        if (text != null && text.equals(DEFAULT_SUCCESSFUL_TEXT)) {
             text = Collect.getInstance().getString(R.string.success);
         }
         return text;


### PR DESCRIPTION
Closes #2413

#### What has been done to verify that this works as intended?
Visual inspection.

#### Why is this the best possible solution? Were any other approaches considered?
I considered doing something more elaborate like setting a blank string when text is null but this is a very unusual case that probably just affects one custom server somewhere so I didn't want to spend any time on it.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)