### PR TITLE
Forms table already exists in onCreate call

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/ActivityLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/ActivityLogger.java
@@ -95,7 +95,7 @@ public final class ActivityLogger {
     private static final String PARAM2 = "param2";
 
     private static final String DATABASE_CREATE =
-            "create table " + DATABASE_TABLE + " ("
+            "CREATE TABLE IF NOT EXISTS " + DATABASE_TABLE + " ("
                     + ID + " integer primary key autoincrement, "
                     + TIMESTAMP + " integer not null, "
                     + DEVICEID + " text not null, "

--- a/collect_app/src/main/java/org/odk/collect/android/database/ItemsetDbAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/ItemsetDbAdapter.java
@@ -30,7 +30,7 @@ public class ItemsetDbAdapter {
     private static final String KEY_PATH = "path";
 
     private static final String CREATE_ITEMSET_TABLE =
-            "create table " + ITEMSET_TABLE + " (_id integer primary key autoincrement, "
+            "CREATE TABLE IF NOT EXISTS " + ITEMSET_TABLE + " (_id integer primary key autoincrement, "
                     + KEY_ITEMSET_HASH + " text, "
                     + KEY_PATH + " text "
                     + ");";

--- a/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/helpers/FormsDatabaseHelper.java
@@ -296,7 +296,7 @@ public class FormsDatabaseHelper extends SQLiteOpenHelper {
     }
 
     private void createFormsTable(SQLiteDatabase db, String tableName) {
-        db.execSQL("CREATE TABLE " + tableName + " ("
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + tableName + " ("
                 + _ID + " integer primary key, "
                 + DISPLAY_NAME + " text not null, "
                 + DISPLAY_SUBTEXT + " text not null, "

--- a/collect_app/src/main/java/org/odk/collect/android/database/helpers/InstancesDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/helpers/InstancesDatabaseHelper.java
@@ -188,7 +188,7 @@ public class InstancesDatabaseHelper extends SQLiteOpenHelper {
     }
 
     private void createInstancesTable(SQLiteDatabase db) {
-        db.execSQL("CREATE TABLE " + INSTANCES_TABLE_NAME + " ("
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + INSTANCES_TABLE_NAME + " ("
                 + _ID + " integer primary key, "
                 + DISPLAY_NAME + " text not null, "
                 + SUBMISSION_URI + " text, "

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalSQLiteOpenHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalSQLiteOpenHelper.java
@@ -134,7 +134,7 @@ public class ExternalSQLiteOpenHelper extends SQLiteOpenHelper {
             boolean sortColumnAlreadyPresent = false;
 
             sb
-                    .append("CREATE TABLE ")
+                    .append("CREATE TABLE IF NOT EXISTS ")
                     .append(tableName)
                     .append(" ( ");
 


### PR DESCRIPTION
Closes #2412 

#### What has been done to verify that this works as intended?
I tested installing a completely new app and creating databases.

#### Why is this the best possible solution? Were any other approaches considered?
Ideally, we should avoid such concurrency maybe using a singleton to manage databases or something like that (I'll investigate it) but for now, it's a good solution we can add to a point release. 

I also added changes for other databases because I found the same issue regarding, for example, ItemsetsDB https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/5b5851036007d59fcdb12dbd?time=last-seven-days&sessionId=5B5850EA016100010980B91486D13681_DNE_1_v2

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)