### PR TITLE
Fixed Attempt to invoke interface method 'int android.database.CursorgetColumnIndex(java.lang.String)' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -938,8 +938,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * @see android.content.ContentResolver
      */
     private String getFileExtensionFromUri(Uri fileUri) {
-        try (Cursor returnCursor =
-                     getContentResolver().query(fileUri, null, null, null, null)) {
+        Cursor returnCursor =
+                getContentResolver().query(fileUri, null, null, null, null);
+        try {
+            if (returnCursor == null) {
+                return "";
+            }
             int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
             returnCursor.moveToFirst();
             String filename = returnCursor.getString(nameIndex);
@@ -950,6 +954,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 // I found some mp3 files' name don't contain extension, but can be played as Audio
                 // So I write so, but I still there are some way to get its extension
                 return "";
+            }
+        } finally {
+            if (returnCursor != null) {
+                returnCursor.close();
             }
         }
     }


### PR DESCRIPTION
Closes #2418 

#### What has been done to verify that this works as intended?
I confirmed that downloading files from GD (which uses the edited method) works well.

#### Why is this the best possible solution? Were any other approaches considered?
We should always check if a cursor object is null before we try to use it. I also added closing the cursor.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)