### PR TITLE
Catch OutOfMemoryError

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
@@ -149,9 +149,13 @@ public class ImageConverter {
     }
 
     private static void rotateBitmap(Bitmap image, int degrees, String imagePath) {
-        Matrix matrix = new Matrix();
-        matrix.postRotate(degrees);
-        image = Bitmap.createBitmap(image, 0, 0, image.getWidth(), image.getHeight(), matrix, true);
+        try {
+            Matrix matrix = new Matrix();
+            matrix.postRotate(degrees);
+            image = Bitmap.createBitmap(image, 0, 0, image.getWidth(), image.getHeight(), matrix, true);
+        } catch (OutOfMemoryError e) {
+            Timber.w(e);
+        }
         FileUtils.saveBitmapToFile(image, imagePath);
     }
 }


### PR DESCRIPTION
Closes #2421 

#### What has been done to verify that this works as intended?
I just tested `ImageWidget` and confirmed that it works well. if an OutOfMemoryError occurs its should just skip rotating an image. 

#### Why is this the best possible solution? Were any other approaches considered?
We can't do anything more here. It just may happen on older devices with low memory.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)