### PR TITLE
Hide "Submission transport" server settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
@@ -36,6 +36,7 @@ public final class AdminKeys {
     static final String KEY_CHANGE_ADMIN_PASSWORD               = "admin_password";
     static final String KEY_IMPORT_SETTINGS                     = "import_settings";
     private static final String KEY_CHANGE_SERVER               = "change_server";
+    private static final String KEY_CHANGE_SUBMISSION_TRANSPORT = "change_submission_transport";
     private static final String KEY_CHANGE_FORM_METADATA        = "change_form_metadata";
 
     // client
@@ -72,6 +73,8 @@ public final class AdminKeys {
     static AdminAndGeneralKeys[] adminToGeneral = new AdminAndGeneralKeys[] {
 
             ag(KEY_CHANGE_SERVER,              PreferenceKeys.KEY_PROTOCOL),
+            ag(KEY_CHANGE_SUBMISSION_TRANSPORT, PreferenceKeys.KEY_TRANSPORT_PREFERENCE),
+            ag(KEY_CHANGE_SUBMISSION_TRANSPORT, PreferenceKeys.KEY_SMS_PREFERENCE),
             ag(KEY_CHANGE_FORM_METADATA,       PreferenceKeys.KEY_FORM_METADATA),
 
             ag(KEY_PERIODIC_FORM_UPDATES_CHECK, PreferenceKeys.KEY_PERIODIC_FORM_UPDATES_CHECK),

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
@@ -23,7 +23,13 @@ public class BasePreferenceFragment extends PreferenceFragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
 
         initToolbar(getPreferenceScreen(), view);
+        removeDisabledPrefs();
 
+
+        super.onViewCreated(view, savedInstanceState);
+    }
+
+    void removeDisabledPrefs() {
         // removes disabled preferences if in general settings
         if (getActivity() instanceof PreferencesActivity) {
             Bundle args = getArguments();
@@ -36,8 +42,6 @@ public class BasePreferenceFragment extends PreferenceFragment {
                 removeAllDisabledPrefs();
             }
         }
-
-        super.onViewCreated(view, savedInstanceState);
     }
 
     // inflates toolbar in the preference fragments

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ExtendedCheckboxPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ExtendedCheckboxPreference.java
@@ -1,0 +1,71 @@
+package org.odk.collect.android.preferences;
+
+import android.content.Context;
+import android.preference.CheckBoxPreference;
+import android.support.v4.content.ContextCompat;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+import org.odk.collect.android.utilities.ThemeUtils;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * A Checkbox preference that allows the title to have the disabled look when the
+ * dependency it references gets disabled.
+ */
+public class ExtendedCheckboxPreference extends CheckBoxPreference {
+
+    private Boolean shouldDisableDependents;
+
+    @BindView(android.R.id.title)
+    TextView title;
+    @BindView(android.R.id.checkbox)
+    CheckBox checkBox;
+
+    public ExtendedCheckboxPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public ExtendedCheckboxPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ExtendedCheckboxPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void onBindView(View view) {
+        super.onBindView(view);
+
+        ButterKnife.bind(this, view);
+
+        //the title's color is only modified if the checkbox is disabled which means the parent
+        //Server setting was disabled since shouldDisableDependents gets set in multiple places.
+        if (!checkBox.isEnabled()) {
+            if (!shouldDisableDependents) {
+                ThemeUtils themeUtils = new ThemeUtils(getContext());
+
+                if (themeUtils.isDarkTheme()) {
+                    int darkEnabledSummaryColor = ContextCompat.getColor(getContext(), android.R.color.white);
+                    title.setTextColor(darkEnabledSummaryColor);
+                } else {
+                    int lightEnabledSummaryColor = -16777216;
+                    title.setTextColor(lightEnabledSummaryColor);
+                }
+            } else {
+                title.setTextColor(ContextCompat.getColor(getContext(), android.R.color.secondary_text_dark));
+            }
+        }
+    }
+
+    @Override
+    public boolean shouldDisableDependents() {
+        shouldDisableDependents = super.shouldDisableDependents();
+        return shouldDisableDependents;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferenceKeys.java
@@ -48,6 +48,8 @@ public final class PreferenceKeys {
     public static final String KEY_PROTOCOL                 = "protocol";
     public static final String KEY_SMS_GATEWAY              = "sms_gateway";
     public static final String KEY_SUBMISSION_TRANSPORT_TYPE = "submission_transport_type";
+    public static final String KEY_TRANSPORT_PREFERENCE      = "submission_transport_preference";
+    public static final String KEY_SMS_PREFERENCE            = "sms_preference";
 
     // user_interface_preferences.xml
     public static final String KEY_APP_THEME                = "appTheme";

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferences.java
@@ -82,6 +82,7 @@ public class ServerPreferences extends ServerPreferencesFragment {
                 if (!newValue.equals(oldValue)) {
                     removeTypeSettings();
                     initProtocolPrefs();
+                    removeDisabledPrefs();
                 }
             }
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -54,6 +54,7 @@ import java.util.List;
 import static android.app.Activity.RESULT_OK;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_FORMLIST_URL;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_GATEWAY;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_PREFERENCE;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_URL;
 import static org.odk.collect.android.utilities.gdrive.GoogleAccountsManager.REQUEST_ACCOUNT_PICKER;
@@ -125,7 +126,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
         transportPreference.setOnPreferenceChangeListener(createTransportChangeListener());
         transportPreference.setSummary(transportPreference.getEntry());
 
-        smsPreferenceCategory = (ExtendedPreferenceCategory) findPreference(getString(R.string.sms_submission_preference_key));
+        smsPreferenceCategory = (ExtendedPreferenceCategory) findPreference(KEY_SMS_PREFERENCE);
 
         smsGatewayPreference = (ExtendedEditTextPreference) findPreference(KEY_SMS_GATEWAY);
 

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -523,6 +523,7 @@
     <string name="invalid_email_address">Invalid email address!</string>
     <string name="sort_by">Sort by</string>
     <string name="server">Server</string>
+    <string name="submission_transport_admin_setting">Submission transport</string>
     <string name="select_value">Select value</string>
     <string name="edit_value">Edit value</string>
     <string name="no_value_selected">No value selected</string>

--- a/collect_app/src/main/res/values/untranslated.xml
+++ b/collect_app/src/main/res/values/untranslated.xml
@@ -14,7 +14,6 @@ the specific language governing permissions and limitations under the License. -
     <string name="default_server_url" translatable="false">https://opendatakit.appspot.com</string>
     <string name="default_odk_formlist" translatable="false">/formList</string>
     <string name="default_odk_submission" translatable="false">/submission</string>
-    <string name="sms_submission_preference_key" translatable="false">sms_preference</string>
     <string name="transport_type_value_internet" translatable="false">internet</string>
     <string name="transport_type_value_sms" translatable="false">sms</string>
     <string name="app_url" translatable="false">http://opendatakit.org</string>

--- a/collect_app/src/main/res/xml/aggregate_preferences.xml
+++ b/collect_app/src/main/res/xml/aggregate_preferences.xml
@@ -20,6 +20,7 @@
             android:title="@string/password" />
     </PreferenceCategory>
     <PreferenceCategory
+        android:key="submission_transport_preference"
         android:title="@string/submission_transport">
         <ListPreference
             android:dialogTitle="@string/submission_transport_types_title"
@@ -29,7 +30,7 @@
             android:title="@string/submission_transport_types_title" />
     </PreferenceCategory>
     <org.odk.collect.android.preferences.ExtendedPreferenceCategory
-        android:key="@string/sms_submission_preference_key"
+        android:key="sms_preference"
         android:title="@string/sms_submission_preferences">
         <org.odk.collect.android.preferences.ExtendedEditTextPreference
             android:dialogTitle="@string/sms_pref_dialog_title"

--- a/collect_app/src/main/res/xml/google_preferences.xml
+++ b/collect_app/src/main/res/xml/google_preferences.xml
@@ -14,6 +14,7 @@
             android:title="@string/google_sheets_url" />
     </PreferenceCategory>
     <PreferenceCategory
+        android:key="submission_transport_preference"
         android:title="@string/submission_transport">
         <ListPreference
             android:dialogTitle="@string/submission_transport_types_title"
@@ -23,7 +24,7 @@
             android:title="@string/submission_transport_types_title" />
     </PreferenceCategory>
     <org.odk.collect.android.preferences.ExtendedPreferenceCategory
-        android:key="@string/sms_submission_preference_key"
+        android:key="sms_preference"
         android:title="@string/sms_submission_preferences">
         <org.odk.collect.android.preferences.ExtendedEditTextPreference
             android:dialogTitle="@string/sms_pref_dialog_title"

--- a/collect_app/src/main/res/xml/user_settings_access_preferences.xml
+++ b/collect_app/src/main/res/xml/user_settings_access_preferences.xml
@@ -4,6 +4,11 @@
         <CheckBoxPreference
             android:key="change_server"
             android:title="@string/server" />
+        <org.odk.collect.android.preferences.ExtendedCheckboxPreference
+            android:key="change_submission_transport"
+            android:title="@string/submission_transport_admin_setting"
+            android:dependency="change_server"
+            />
         <CheckBoxPreference
             android:key="change_form_metadata"
             android:title="@string/form_metadata" />


### PR DESCRIPTION
Closes #2374 

![screencast-genymotion-2018-07-26_23 08 42 841](https://user-images.githubusercontent.com/1509205/43312028-bbb1e670-9151-11e8-99b5-3e7f3d3e93f1.gif)

#### What has been done to verify that this works as intended?
I navigated to Admin Settings -> User Settings -> and I enabled/disabled `Submission transport`. Then I tested the effect of this action by going to the Server Settings and checked to ensure that the visibility of all the SMS Submission preferences matched the state.

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution due to overall depth of this implementation. 

1) A custom `CheckboxPreference` was created to display a full on`disabled` state. By default when the preference is disabled it just disables the checkbox but that might not be enough for the user since they are used the entire item being greyed out so this component accomplishes that. 

2) the `Submission transport` setting was bounded to the `Server` setting as a dependency so once the `Server` is disabled it automatically gets that state. That behaviour was then used to toggle the disabled state of the new `CheckboxPreference`. I opted for showing the disabled state instead of making the item invisible because Android's dependency functionality does the disabling by default.

3) Also this approach and the research done for the custom components will be a great example for other settings that will be child settings.

#### Are there any risks to merging this code? If so, what are they?
No, we just have to ensure that no regression has taken place. The main functionality that was impacted by this change is the `Submission transport (advanced)` group of settings in the Server section for both Aggregate and Google Drive so we just have to verify that toggling between those two causes no issues and that screen is reacting well to the setting changes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)