### PR TITLE
Signature/Annotate widget with a fixed image

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -34,12 +34,14 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.apache.commons.io.FilenameUtils;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaManager;
@@ -149,6 +151,10 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
             File f = new File(getInstanceFolder() + File.separator + binaryName);
 
+            if (!f.exists() && (this instanceof SignatureWidget || this instanceof AnnotateWidget)) {
+                f = addDefaultImageIfExists(f);
+            }
+
             Bitmap bmp = null;
             if (f.exists()) {
                 bmp = FileUtils.getBitmapScaledToDisplay(f, screenHeight, screenWidth);
@@ -170,6 +176,19 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
         answerLayout.addView(imageView);
         }
+    }
+
+    private File addDefaultImageIfExists(File f) {
+        FormController formController = Collect.getInstance().getFormController();
+        if (formController != null) {
+            File defaultFile = new File(formController.getMediaFolder() + File.separator + binaryName);
+            if (defaultFile.exists()) {
+                binaryName = System.currentTimeMillis() + "." + FilenameUtils.getExtension(defaultFile.getName());
+                FileUtils.copyFile(defaultFile, new File(getInstanceFolder() + File.separator + binaryName));
+                f = new File(getInstanceFolder() + File.separator + binaryName);
+            }
+        }
+        return f;
     }
 
     protected void setUpLayout() {


### PR DESCRIPTION
Closes #84

I have run into this issue recently and I think we can allow users to add default images to a form. I think I it would be especially useful in case of `SignatureWidget` and `AnnotateWidget`.

For example, in SigatureWidget we could add an image with any text, something like a doc document to sign:
 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3276264/43318592-a66fe622-91a1-11e8-960f-4fefb41e52e1.gif)

#### What has been done to verify that this works as intended?
I tested the attached form.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
[Downloads.zip](https://github.com/opendatakit/collect/files/2336379/Downloads.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)
