### PR TITLE
Reduced level of spotbugs detector to medium

### DIFF
--- a/config/findbugs-filter.xml
+++ b/config/findbugs-filter.xml
@@ -51,16 +51,129 @@
         <Class name="~.*ViewBinding\$.*" />
     </Match>
 
+    <!-- Internationalization -->
     <Match>
         <Bug pattern="DM_DEFAULT_ENCODING" />
     </Match>
 
+    <!-- Bad practice -->
+    <Match>
+        <Bug pattern="DE_MIGHT_IGNORE" />
+    </Match>
+    <Match>
+        <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS" />
+    </Match>
+    <Match>
+        <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE" />
+    </Match>
+    <Match>
+        <Bug pattern="OS_OPEN_STREAM" />
+    </Match>
+    <Match>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+    </Match>
+    <Match>
+        <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE" />
+    </Match>
+
+    <!-- Correctness -->
+    <Match>
+        <Bug pattern="NP_NULL_ON_SOME_PATH" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_NULL_PARAM_DEREF" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED" />
+    </Match>
+
+    <!-- Experimental -->
+    <Match>
+        <Bug pattern="OBL_UNSATISFIED_OBLIGATION" />
+    </Match>
+    <Match>
+        <Bug pattern="OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE" />
+    </Match>
+
+    <!-- Malicious code vulnerability -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Bug pattern="MS_CANNOT_BE_FINAL" />
+    </Match>
+    <Match>
+        <Bug pattern="MS_PKGPROTECT" />
+    </Match>
+
+    <!-- Multithreaded correctness -->
+    <Match>
+        <Bug pattern="IS2_INCONSISTENT_SYNC" />
+    </Match>
+
+    <!-- Performance Warnings -->
+    <Match>
+        <Bug pattern="SBSC_USE_STRINGBUFFER_CONCATENATION" />
+    </Match>
+    <Match>
+        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
+    </Match>
+    <Match>
+        <Bug pattern="URF_UNREAD_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="UUF_UNUSED_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
+    </Match>
+
+
+    <!-- Dodgy code Warnings -->
     <Match>
         <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
     </Match>
-
     <Match>
         <Bug pattern="INT_BAD_REM_BY_1" />
+    </Match>
+    <Match>
+        <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+    </Match>
+    <Match>
+        <Bug pattern="DMI_THREAD_PASSED_WHERE_RUNNABLE_EXPECTED" />
+    </Match>
+    <Match>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="SF_SWITCH_NO_DEFAULT" />
+    </Match>
+    <Match>
+        <Bug pattern="UC_USELESS_OBJECT" />
+    </Match>
+    <Match>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="SF_SWITCH_FALLTHROUGH" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="REC_CATCH_EXCEPTION" />
     </Match>
 
 </FindBugsFilter>

--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -41,7 +41,7 @@ android.applicationVariants.all { variant ->
         effort = 'max'       // Search better
 
         // Reporting only high priority problems {Possible reportLevels: 'high', 'medium', 'low'}
-        reportLevel = 'high'
+        reportLevel = 'medium'
 
         excludeFilter = new File("$configDir/findbugs-filter.xml")
         classes = fileTree("build/intermediates/classes/${variant.flavorName}/${variant.buildType.name}/")


### PR DESCRIPTION
Spotbugs was set to detect only high priority bugs which overlook many performance related issues. The purpose of the PR is just to reduce the scan level to `medium` from `high` and exclude all the detected issues as of now. Later, those can be fixed one at a time like it is done for other code quality tools.  

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
This is a pure configuration change and does not affect the application's functionality in any way

#### Why is this the best possible solution? Were any other approaches considered?
This further adds a good list of checks for improving the code quality a bit further

#### Are there any risks to merging this code? If so, what are they?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)