### PR TITLE
Fixed Attempt to invoke interface method 'int android.database.CursorgetCount()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -228,7 +228,7 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
         Cursor c = null;
         try {
             c = formsDao.getFormsCursorForFormFilePath(formDefFile.getAbsolutePath());
-            return (c.getCount() > 0);
+            return (c == null || c.getCount() > 0);
         } finally {
             if (c != null) {
                 c.close();


### PR DESCRIPTION
Closes #2439 

#### What has been done to verify that this works as intended?
#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check to avoid crashes in some very rare cases.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)