### PR TITLE
Don't allow to proceed if formController object which is a result of loading a form is null

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2519,116 +2519,122 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         dismissDialog(PROGRESS_DIALOG);
 
         final FormController formController = task.getFormController();
-        int requestCode = task.getRequestCode(); // these are bogus if
-        // pendingActivityResult is
-        // false
-        int resultCode = task.getResultCode();
-        Intent intent = task.getIntent();
+        if (formController != null) {
+            int requestCode = task.getRequestCode(); // these are bogus if
+            // pendingActivityResult is
+            // false
+            int resultCode = task.getResultCode();
+            Intent intent = task.getIntent();
 
-        formLoaderTask.setFormLoaderListener(null);
-        FormLoaderTask t = formLoaderTask;
-        formLoaderTask = null;
-        t.cancel(true);
-        t.destroy();
-        Collect.getInstance().setFormController(formController);
-        supportInvalidateOptionsMenu();
+            formLoaderTask.setFormLoaderListener(null);
+            FormLoaderTask t = formLoaderTask;
+            formLoaderTask = null;
+            t.cancel(true);
+            t.destroy();
+            Collect.getInstance().setFormController(formController);
+            supportInvalidateOptionsMenu();
 
-        Collect.getInstance().setExternalDataManager(task.getExternalDataManager());
+            Collect.getInstance().setExternalDataManager(task.getExternalDataManager());
 
-        // Set the language if one has already been set in the past
-        String[] languageTest = formController.getLanguages();
-        if (languageTest != null) {
-            String defaultLanguage = formController.getLanguage();
-            String newLanguage = FormsDaoHelper.getFormLanguage(formPath);
+            // Set the language if one has already been set in the past
+            String[] languageTest = formController.getLanguages();
+            if (languageTest != null) {
+                String defaultLanguage = formController.getLanguage();
+                String newLanguage = FormsDaoHelper.getFormLanguage(formPath);
 
-            long start = System.currentTimeMillis();
-            Timber.i("calling formController.setLanguage");
-            try {
-                formController.setLanguage(newLanguage);
-            } catch (Exception e) {
-                // if somehow we end up with a bad language, set it to the default
-                Timber.e("Ended up with a bad language. %s", newLanguage);
-                formController.setLanguage(defaultLanguage);
-            }
-            Timber.i("Done in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
-        }
-
-        boolean pendingActivityResult = task.hasPendingActivityResult();
-
-        if (pendingActivityResult) {
-            // set the current view to whatever group we were at...
-            refreshCurrentView();
-            // process the pending activity request...
-            onActivityResult(requestCode, resultCode, intent);
-            return;
-        }
-
-        // it can be a normal flow for a pending activity result to restore from
-        // a savepoint
-        // (the call flow handled by the above if statement). For all other use
-        // cases, the
-        // user should be notified, as it means they wandered off doing other
-        // things then
-        // returned to ODK Collect and chose Edit Saved Form, but that the
-        // savepoint for that
-        // form is newer than the last saved version of their form data.
-
-        boolean hasUsedSavepoint = task.hasUsedSavepoint();
-
-        if (hasUsedSavepoint) {
-            runOnUiThread(() -> ToastUtils.showLongToast(R.string.savepoint_used));
-        }
-
-        // Set saved answer path
-        if (formController.getInstanceFile() == null) {
-
-            // Create new answer folder.
-            String time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss",
-                    Locale.ENGLISH).format(Calendar.getInstance().getTime());
-            String file = formPath.substring(formPath.lastIndexOf('/') + 1,
-                    formPath.lastIndexOf('.'));
-            String path = Collect.INSTANCES_PATH + File.separator + file + "_"
-                    + time;
-            if (FileUtils.createFolder(path)) {
-                File instanceFile = new File(path + File.separator + file + "_" + time + ".xml");
-                formController.setInstanceFile(instanceFile);
+                long start = System.currentTimeMillis();
+                Timber.i("calling formController.setLanguage");
+                try {
+                    formController.setLanguage(newLanguage);
+                } catch (Exception e) {
+                    // if somehow we end up with a bad language, set it to the default
+                    Timber.e("Ended up with a bad language. %s", newLanguage);
+                    formController.setLanguage(defaultLanguage);
+                }
+                Timber.i("Done in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
             }
 
-            formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_START, 0, null, false, true);
-        } else {
-            Intent reqIntent = getIntent();
-            boolean showFirst = reqIntent.getBooleanExtra("start", false);
+            boolean pendingActivityResult = task.hasPendingActivityResult();
 
-            if (!showFirst) {
-                // we've just loaded a saved form, so start in the hierarchy view
+            if (pendingActivityResult) {
+                // set the current view to whatever group we were at...
+                refreshCurrentView();
+                // process the pending activity request...
+                onActivityResult(requestCode, resultCode, intent);
+                return;
+            }
 
-                if (!allowMovingBackwards) {
-                    FormIndex formIndex = SaveFormIndexTask.loadFormIndexFromFile();
-                    if (formIndex != null) {
-                        formController.jumpToIndex(formIndex);
-                        refreshCurrentView();
-                        return;
-                    }
+            // it can be a normal flow for a pending activity result to restore from
+            // a savepoint
+            // (the call flow handled by the above if statement). For all other use
+            // cases, the
+            // user should be notified, as it means they wandered off doing other
+            // things then
+            // returned to ODK Collect and chose Edit Saved Form, but that the
+            // savepoint for that
+            // form is newer than the last saved version of their form data.
+
+            boolean hasUsedSavepoint = task.hasUsedSavepoint();
+
+            if (hasUsedSavepoint) {
+                runOnUiThread(() -> ToastUtils.showLongToast(R.string.savepoint_used));
+            }
+
+            // Set saved answer path
+            if (formController.getInstanceFile() == null) {
+
+                // Create new answer folder.
+                String time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss",
+                        Locale.ENGLISH).format(Calendar.getInstance().getTime());
+                String file = formPath.substring(formPath.lastIndexOf('/') + 1,
+                        formPath.lastIndexOf('.'));
+                String path = Collect.INSTANCES_PATH + File.separator + file + "_"
+                        + time;
+                if (FileUtils.createFolder(path)) {
+                    File instanceFile = new File(path + File.separator + file + "_" + time + ".xml");
+                    formController.setInstanceFile(instanceFile);
                 }
 
-                String formMode = reqIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
-                if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
-                    formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_RESUME, 0, null, false, true);
-                    formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.HIERARCHY, 0, null, false, true);
-                    startActivity(new Intent(this, EditFormHierarchyActivity.class));
-                    return; // so we don't show the intro screen before jumping to the hierarchy
-                } else {
-                    if (ApplicationConstants.FormModes.VIEW_SENT.equalsIgnoreCase(formMode)) {
-                        startActivity(new Intent(this, ViewFormHierarchyActivity.class));
-                    }
-                    finish();
-                }
+                formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_START, 0, null, false, true);
             } else {
-                formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_RESUME, 0, null, false, true);
-            }
-        }
+                Intent reqIntent = getIntent();
+                boolean showFirst = reqIntent.getBooleanExtra("start", false);
 
-        refreshCurrentView();
+                if (!showFirst) {
+                    // we've just loaded a saved form, so start in the hierarchy view
+
+                    if (!allowMovingBackwards) {
+                        FormIndex formIndex = SaveFormIndexTask.loadFormIndexFromFile();
+                        if (formIndex != null) {
+                            formController.jumpToIndex(formIndex);
+                            refreshCurrentView();
+                            return;
+                        }
+                    }
+
+                    String formMode = reqIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
+                    if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
+                        formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_RESUME, 0, null, false, true);
+                        formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.HIERARCHY, 0, null, false, true);
+                        startActivity(new Intent(this, EditFormHierarchyActivity.class));
+                        return; // so we don't show the intro screen before jumping to the hierarchy
+                    } else {
+                        if (ApplicationConstants.FormModes.VIEW_SENT.equalsIgnoreCase(formMode)) {
+                            startActivity(new Intent(this, ViewFormHierarchyActivity.class));
+                        }
+                        finish();
+                    }
+                } else {
+                    formController.getTimerLogger().logTimerEvent(TimerLogger.EventTypes.FORM_RESUME, 0, null, false, true);
+                }
+            }
+
+            refreshCurrentView();
+        } else {
+            Timber.e("FormController is null");
+            ToastUtils.showLongToast(R.string.loading_form_failed);
+            finish();
+        }
     }
 
     /**

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -644,4 +644,5 @@
     <string name="seconds">Seconds</string>
     <string name="rank_items">Rank items</string>
     <string name="image_not_saved">The image can not be saved because of a problem with the corresponding instance file.</string>
+    <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
 </resources>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Just hardcoded a null value and confirmed that an activity is finished and an appropriate message is displayed.

#### Why is this the best possible solution? Were any other approaches considered?
I've been working on many issues (NullPointerExceptions) caused by a null value stored in FormController objects. We weren't able to reproduce any of those crashes so we have added many null checks across the app. I guess some of them may be caused by a null value returned from FormLoaderTask. 
I added just a null check which checks the value returned from that task and finishes an activity showing an appropriate message if needed to avoid crashes.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)