### PR TITLE
Provide ways to clear out shared preferences representing SMS state

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTestCase.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTestCase.java
@@ -32,6 +32,7 @@ import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.tasks.sms.SmsSubmissionManager;
 import org.odk.collect.android.utilities.ResetUtility;
 import org.osmdroid.config.Configuration;
 
@@ -44,25 +45,34 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.odk.collect.android.tasks.sms.SmsSubmissionManager.KEY_SUBMISSION;
 
 @RunWith(AndroidJUnit4.class)
 public class ResetAppStateTestCase {
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
         resetAppState(Arrays.asList(
-                ResetUtility.ResetAction.RESET_PREFERENCES, ResetUtility.ResetAction.RESET_INSTANCES,
-                ResetUtility.ResetAction.RESET_FORMS, ResetUtility.ResetAction.RESET_LAYERS,
-                ResetUtility.ResetAction.RESET_CACHE, ResetUtility.ResetAction.RESET_OSM_DROID
+                ResetUtility.ResetAction.RESET_PREFERENCES,
+                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY,
+                ResetUtility.ResetAction.RESET_INSTANCES,
+                ResetUtility.ResetAction.RESET_FORMS,
+                ResetUtility.ResetAction.RESET_LAYERS,
+                ResetUtility.ResetAction.RESET_CACHE,
+                ResetUtility.ResetAction.RESET_OSM_DROID
         ));
     }
 
     @After
-    public void tearDown() throws IOException {
+    public void tearDown() {
         resetAppState(Arrays.asList(
-                ResetUtility.ResetAction.RESET_PREFERENCES, ResetUtility.ResetAction.RESET_INSTANCES,
-                ResetUtility.ResetAction.RESET_FORMS, ResetUtility.ResetAction.RESET_LAYERS,
-                ResetUtility.ResetAction.RESET_CACHE, ResetUtility.ResetAction.RESET_OSM_DROID
+                ResetUtility.ResetAction.RESET_PREFERENCES,
+                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY,
+                ResetUtility.ResetAction.RESET_INSTANCES,
+                ResetUtility.ResetAction.RESET_FORMS,
+                ResetUtility.ResetAction.RESET_LAYERS,
+                ResetUtility.ResetAction.RESET_CACHE,
+                ResetUtility.ResetAction.RESET_OSM_DROID
         ));
     }
 
@@ -81,6 +91,13 @@ public class ResetAppStateTestCase {
     }
 
     @Test
+    public void resetSMSSubmissionsHistoryTest() {
+        setupTestSMSSubmissionHistory();
+        resetAppState(Collections.singletonList(ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY));
+        assertEquals(0, new SmsSubmissionManager(InstrumentationRegistry.getTargetContext()).getAll().size());
+    }
+
+    @Test
     public void resetFormsTest() throws IOException {
         saveTestFormFiles();
         setupTestFormsDatabase();
@@ -91,7 +108,7 @@ public class ResetAppStateTestCase {
     }
 
     @Test
-    public void resetInstancesTest() throws IOException {
+    public void resetInstancesTest() {
         saveTestInstanceFiles();
         setupTestInstancesDatabase();
         resetAppState(Collections.singletonList(ResetUtility.ResetAction.RESET_INSTANCES));
@@ -147,6 +164,14 @@ public class ResetAppStateTestCase {
         assertTrue(new File(Collect.SETTINGS).exists() || new File(Collect.SETTINGS).mkdir());
         assertTrue(new File(Collect.SETTINGS + "/collect.settings").createNewFile());
         assertTrue(new File(Collect.ODK_ROOT + "/collect.settings").createNewFile());
+    }
+
+    private void setupTestSMSSubmissionHistory() {
+        SmsSubmissionManager smsSubmissionManager = new SmsSubmissionManager(InstrumentationRegistry.getTargetContext());
+        smsSubmissionManager.savePreference(KEY_SUBMISSION + "1", "displayName\":\"SMS Test\",\"instanceId\":\"1\",\"lastUpdated\":\"Jul 30, 2018 11:28:52 PM\",\"messages\":[{\"text\":\"SMS-TEST \",\"id\":612174895,\"partNumber\":1,\"resultCode\":106}],\"jobId\":6,\"notificationId\":719983413}");
+        smsSubmissionManager.savePreference(KEY_SUBMISSION + "2", "displayName\":\"SMS Test\",\"instanceId\":\"2\",\"lastUpdated\":\"Jul 30, 2018 11:29:52 PM\",\"messages\":[{\"text\":\"SMS-TEST \",\"id\":612174896,\"partNumber\":1,\"resultCode\":106}],\"jobId\":6,\"notificationId\":719983414}");
+        smsSubmissionManager.savePreference(KEY_SUBMISSION + "3", "displayName\":\"SMS Test\",\"instanceId\":\"3\",\"lastUpdated\":\"Jul 30, 2018 11:30:52 PM\",\"messages\":[{\"text\":\"SMS-TEST \",\"id\":612174897,\"partNumber\":1,\"resultCode\":106}],\"jobId\":6,\"notificationId\":719983415}");
+        assertEquals(3, smsSubmissionManager.getAll().size());
     }
 
     private void setupTestFormsDatabase() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTestCase.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTestCase.java
@@ -54,12 +54,12 @@ public class ResetAppStateTestCase {
     public void setUp() {
         resetAppState(Arrays.asList(
                 ResetUtility.ResetAction.RESET_PREFERENCES,
-                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY,
                 ResetUtility.ResetAction.RESET_INSTANCES,
                 ResetUtility.ResetAction.RESET_FORMS,
                 ResetUtility.ResetAction.RESET_LAYERS,
                 ResetUtility.ResetAction.RESET_CACHE,
-                ResetUtility.ResetAction.RESET_OSM_DROID
+                ResetUtility.ResetAction.RESET_OSM_DROID,
+                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY
         ));
     }
 
@@ -67,12 +67,12 @@ public class ResetAppStateTestCase {
     public void tearDown() {
         resetAppState(Arrays.asList(
                 ResetUtility.ResetAction.RESET_PREFERENCES,
-                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY,
                 ResetUtility.ResetAction.RESET_INSTANCES,
                 ResetUtility.ResetAction.RESET_FORMS,
                 ResetUtility.ResetAction.RESET_LAYERS,
                 ResetUtility.ResetAction.RESET_CACHE,
-                ResetUtility.ResetAction.RESET_OSM_DROID
+                ResetUtility.ResetAction.RESET_OSM_DROID,
+                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY
         ));
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
@@ -302,12 +302,12 @@ public class FormsDaoTest {
     private void resetAppState() {
         List<Integer> resetActions = Arrays.asList(
                 ResetUtility.ResetAction.RESET_PREFERENCES,
-                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY,
                 ResetUtility.ResetAction.RESET_INSTANCES,
                 ResetUtility.ResetAction.RESET_FORMS,
                 ResetUtility.ResetAction.RESET_LAYERS,
                 ResetUtility.ResetAction.RESET_CACHE,
-                ResetUtility.ResetAction.RESET_OSM_DROID
+                ResetUtility.ResetAction.RESET_OSM_DROID,
+                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY
         );
 
         List<Integer> failedResetActions = new ResetUtility().reset(InstrumentationRegistry.getTargetContext(), resetActions);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/dao/FormsDaoTest.java
@@ -301,9 +301,13 @@ public class FormsDaoTest {
 
     private void resetAppState() {
         List<Integer> resetActions = Arrays.asList(
-                ResetUtility.ResetAction.RESET_PREFERENCES, ResetUtility.ResetAction.RESET_INSTANCES,
-                ResetUtility.ResetAction.RESET_FORMS, ResetUtility.ResetAction.RESET_LAYERS,
-                ResetUtility.ResetAction.RESET_CACHE, ResetUtility.ResetAction.RESET_OSM_DROID
+                ResetUtility.ResetAction.RESET_PREFERENCES,
+                ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY,
+                ResetUtility.ResetAction.RESET_INSTANCES,
+                ResetUtility.ResetAction.RESET_FORMS,
+                ResetUtility.ResetAction.RESET_LAYERS,
+                ResetUtility.ResetAction.RESET_CACHE,
+                ResetUtility.ResetAction.RESET_OSM_DROID
         );
 
         List<Integer> failedResetActions = new ResetUtility().reset(InstrumentationRegistry.getTargetContext(), resetActions);

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppComponent.java
@@ -21,6 +21,7 @@ import org.odk.collect.android.tasks.sms.SmsService;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DownloadFormListUtils;
 import org.odk.collect.android.utilities.FormDownloader;
+import org.odk.collect.android.utilities.ResetUtility;
 
 import dagger.BindsInstance;
 import dagger.Component;
@@ -82,4 +83,6 @@ public interface AppComponent {
     void inject(AuthDialogUtility authDialogUtility);
   
     void inject(FormDownloadList formDownloadList);
+
+    void inject(ResetUtility resetUtility);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppModule.java
@@ -33,7 +33,12 @@ public class AppModule {
     }
 
     @Provides
-    SmsSubmissionManagerContract provideSmsSubmissionManager(Application application) {
+    SmsSubmissionManagerContract provideSmsSubmissionManagerContract(Application application) {
+        return new SmsSubmissionManager(application);
+    }
+
+    @Provides
+    SmsSubmissionManager provideSmsSubmissionManager(Application application) {
         return new SmsSubmissionManager(application);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
@@ -43,12 +43,13 @@ import static org.odk.collect.android.utilities.ResetUtility.ResetAction.RESET_S
 
 public class ResetDialogPreference extends DialogPreference implements CompoundButton.OnCheckedChangeListener {
     private CheckBox preferences;
-    private CheckBox smsSubmissionsHistory;
     private CheckBox instances;
     private CheckBox forms;
     private CheckBox layers;
     private CheckBox cache;
     private CheckBox osmDroid;
+    private CheckBox smsSubmissionsHistory;
+
     private ProgressDialog progressDialog;
 
     public ResetDialogPreference(Context context, AttributeSet attrs) {
@@ -59,7 +60,6 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
     @Override
     public void onBindDialogView(View view) {
         preferences = view.findViewById(R.id.preferences);
-        smsSubmissionsHistory = view.findViewById(R.id.sms_submissions_history);
         instances = view.findViewById(R.id.instances);
         forms = view.findViewById(R.id.forms);
         layers = view.findViewById(R.id.layers);
@@ -72,6 +72,7 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
         layers.setOnCheckedChangeListener(this);
         cache.setOnCheckedChangeListener(this);
         osmDroid.setOnCheckedChangeListener(this);
+        smsSubmissionsHistory = view.findViewById(R.id.sms_submissions_history);
 
         super.onBindDialogView(view);
     }
@@ -95,9 +96,6 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
         if (preferences.isChecked()) {
             resetActions.add(RESET_PREFERENCES);
         }
-        if (smsSubmissionsHistory.isChecked()) {
-            resetActions.add(RESET_SMS_SUBMISSIONS_HISTORY);
-        }
         if (instances.isChecked()) {
             resetActions.add(ResetUtility.ResetAction.RESET_INSTANCES);
         }
@@ -113,15 +111,15 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
         if (osmDroid.isChecked()) {
             resetActions.add(ResetUtility.ResetAction.RESET_OSM_DROID);
         }
+        if (smsSubmissionsHistory.isChecked()) {
+            resetActions.add(RESET_SMS_SUBMISSIONS_HISTORY);
+        }
         if (!resetActions.isEmpty()) {
             showProgressDialog();
-            Runnable runnable = new Runnable() {
-                @Override
-                public void run() {
-                    List<Integer> failedResetActions = new ResetUtility().reset(getContext(), resetActions);
-                    hideProgressDialog();
-                    handleResult(resetActions, failedResetActions);
-                }
+            Runnable runnable = () -> {
+                List<Integer> failedResetActions = new ResetUtility().reset(getContext(), resetActions);
+                hideProgressDialog();
+                handleResult(resetActions, failedResetActions);
             };
             new Thread(runnable).start();
         }
@@ -148,15 +146,6 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
                                 getContext().getString(R.string.error_occured)));
                     } else {
                         resultMessage.append(String.format(getContext().getString(R.string.reset_settings_result),
-                                getContext().getString(R.string.success)));
-                    }
-                    break;
-                case RESET_SMS_SUBMISSIONS_HISTORY:
-                    if (failedResetActions.contains(action)) {
-                        resultMessage.append(String.format(getContext().getString(R.string.reset_sms_submissions_history_result),
-                                getContext().getString(R.string.error_occured)));
-                    } else {
-                        resultMessage.append(String.format(getContext().getString(R.string.reset_sms_submissions_history_result),
                                 getContext().getString(R.string.success)));
                     }
                     break;
@@ -205,6 +194,15 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
                                 getContext().getString(R.string.success)));
                     }
                     break;
+                case RESET_SMS_SUBMISSIONS_HISTORY:
+                    if (failedResetActions.contains(action)) {
+                        resultMessage.append(String.format(getContext().getString(R.string.reset_sms_submissions_history_result),
+                                getContext().getString(R.string.error_occured)));
+                    } else {
+                        resultMessage.append(String.format(getContext().getString(R.string.reset_sms_submissions_history_result),
+                                getContext().getString(R.string.success)));
+                    }
+                    break;
             }
             if (resetActions.indexOf(action) < resetActions.size() - 1) {
                 resultMessage.append("\n\n");
@@ -231,8 +229,8 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
     }
 
     private void adjustResetButtonAccessibility() {
-        if (preferences.isChecked() || smsSubmissionsHistory.isChecked() || instances.isChecked() || forms.isChecked()
-                || layers.isChecked() || cache.isChecked() || osmDroid.isChecked()) {
+        if (preferences.isChecked() || instances.isChecked() || forms.isChecked()
+                || layers.isChecked() || cache.isChecked() || osmDroid.isChecked() || smsSubmissionsHistory.isChecked()) {
             ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
             ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE)
                     .setTextColor(((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_NEGATIVE).getCurrentTextColor());

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
@@ -65,14 +65,15 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
         layers = view.findViewById(R.id.layers);
         cache = view.findViewById(R.id.cache);
         osmDroid = view.findViewById(R.id.osmdroid);
+        smsSubmissionsHistory = view.findViewById(R.id.sms_submissions_history);
+
         preferences.setOnCheckedChangeListener(this);
-        smsSubmissionsHistory.setOnCheckedChangeListener(this);
         instances.setOnCheckedChangeListener(this);
         forms.setOnCheckedChangeListener(this);
         layers.setOnCheckedChangeListener(this);
         cache.setOnCheckedChangeListener(this);
         osmDroid.setOnCheckedChangeListener(this);
-        smsSubmissionsHistory = view.findViewById(R.id.sms_submissions_history);
+        smsSubmissionsHistory.setOnCheckedChangeListener(this);
 
         super.onBindDialogView(view);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
@@ -39,9 +39,11 @@ import timber.log.Timber;
 
 import static org.odk.collect.android.fragments.dialogs.ResetSettingsResultDialog.RESET_SETTINGS_RESULT_DIALOG_TAG;
 import static org.odk.collect.android.utilities.ResetUtility.ResetAction.RESET_PREFERENCES;
+import static org.odk.collect.android.utilities.ResetUtility.ResetAction.RESET_SMS_SUBMISSIONS_HISTORY;
 
 public class ResetDialogPreference extends DialogPreference implements CompoundButton.OnCheckedChangeListener {
     private CheckBox preferences;
+    private CheckBox smsSubmissionsHistory;
     private CheckBox instances;
     private CheckBox forms;
     private CheckBox layers;
@@ -57,12 +59,14 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
     @Override
     public void onBindDialogView(View view) {
         preferences = view.findViewById(R.id.preferences);
+        smsSubmissionsHistory = view.findViewById(R.id.sms_submissions_history);
         instances = view.findViewById(R.id.instances);
         forms = view.findViewById(R.id.forms);
         layers = view.findViewById(R.id.layers);
         cache = view.findViewById(R.id.cache);
         osmDroid = view.findViewById(R.id.osmdroid);
         preferences.setOnCheckedChangeListener(this);
+        smsSubmissionsHistory.setOnCheckedChangeListener(this);
         instances.setOnCheckedChangeListener(this);
         forms.setOnCheckedChangeListener(this);
         layers.setOnCheckedChangeListener(this);
@@ -90,6 +94,9 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
 
         if (preferences.isChecked()) {
             resetActions.add(RESET_PREFERENCES);
+        }
+        if (smsSubmissionsHistory.isChecked()) {
+            resetActions.add(RESET_SMS_SUBMISSIONS_HISTORY);
         }
         if (instances.isChecked()) {
             resetActions.add(ResetUtility.ResetAction.RESET_INSTANCES);
@@ -141,6 +148,15 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
                                 getContext().getString(R.string.error_occured)));
                     } else {
                         resultMessage.append(String.format(getContext().getString(R.string.reset_settings_result),
+                                getContext().getString(R.string.success)));
+                    }
+                    break;
+                case RESET_SMS_SUBMISSIONS_HISTORY:
+                    if (failedResetActions.contains(action)) {
+                        resultMessage.append(String.format(getContext().getString(R.string.reset_sms_submissions_history_result),
+                                getContext().getString(R.string.error_occured)));
+                    } else {
+                        resultMessage.append(String.format(getContext().getString(R.string.reset_sms_submissions_history_result),
                                 getContext().getString(R.string.success)));
                     }
                     break;
@@ -215,7 +231,7 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
     }
 
     private void adjustResetButtonAccessibility() {
-        if (preferences.isChecked() || instances.isChecked() || forms.isChecked()
+        if (preferences.isChecked() || smsSubmissionsHistory.isChecked() || instances.isChecked() || forms.isChecked()
                 || layers.isChecked() || cache.isChecked() || osmDroid.isChecked()) {
             ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
             ((AlertDialog) getDialog()).getButton(AlertDialog.BUTTON_POSITIVE)

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -61,6 +61,8 @@ import static org.odk.collect.android.utilities.FileUtil.getSmsInstancePath;
  */
 public class SmsService {
 
+    private static List<String> formsToSend = new ArrayList<>();
+
     private final SmsManager smsManager;
     private final SmsSubmissionManagerContract smsSubmissionManager;
     private final Context context;
@@ -118,6 +120,7 @@ public class SmsService {
 
                     FormInfo info = new FormInfo(filePath, formId, formVersion);
 
+                    formsToSend.add(instanceId);
                     submitForm(instanceId, info, displayName);
                 }
             }
@@ -246,6 +249,7 @@ public class SmsService {
 
         rxEventBus.post(event);
 
+        formsToSend.remove(instanceId);
         return true;
     }
 
@@ -289,6 +293,8 @@ public class SmsService {
         } else if (resultCode != RESULT_OK && resultCode != RESULT_OK_OTHERS_PENDING) {
             updateInstanceStatusFailedText(instanceId, event);
         }
+
+        formsToSend.remove(instanceId);
     }
 
     /***
@@ -407,5 +413,9 @@ public class SmsService {
         }
 
         return "";
+    }
+
+    public static boolean isRunning() {
+        return !formsToSend.isEmpty();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsSubmissionManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsSubmissionManager.java
@@ -120,7 +120,7 @@ public class SmsSubmissionManager implements SmsSubmissionManagerContract {
     }
 
     public void clearSubmissions() {
-        preferences.edit().clear().apply();
+        editor.clear().apply();
     }
 
     public Map<String, ?> getAll() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsSubmissionManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsSubmissionManager.java
@@ -15,6 +15,7 @@ import org.odk.collect.android.tasks.sms.models.SmsSubmission;
 import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class SmsSubmissionManager implements SmsSubmissionManagerContract {
     private static SharedPreferences preferences;
@@ -110,12 +111,20 @@ public class SmsSubmissionManager implements SmsSubmissionManagerContract {
         }.getType();
 
         String data = new Gson().toJson(model, submissionModel);
-        editor.putString(KEY_SUBMISSION + model.getInstanceId(), data);
+        savePreference(KEY_SUBMISSION + model.getInstanceId(), data);
+    }
+
+    public void savePreference(String key, String data) {
+        editor.putString(key, data);
         editor.commit();
     }
 
     public void clearSubmissions() {
         preferences.edit().clear().apply();
+    }
+
+    public Map<String, ?> getAll() {
+        return preferences.getAll();
     }
 
     public int checkNextMessageResultCode(String instanceId) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
@@ -24,6 +24,7 @@ import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.database.ItemsetDbAdapter;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.tasks.sms.SmsService;
 import org.odk.collect.android.tasks.sms.SmsSubmissionManager;
 import org.osmdroid.config.Configuration;
 
@@ -104,8 +105,10 @@ public class ResetUtility {
     }
 
     private void resetSMSSubmissionsHistory() {
-        smsSubmissionManager.clearSubmissions();
-        failedResetActions.remove(failedResetActions.indexOf(ResetAction.RESET_SMS_SUBMISSIONS_HISTORY));
+        if (!SmsService.isRunning()) {
+            smsSubmissionManager.clearSubmissions();
+            failedResetActions.remove(failedResetActions.indexOf(ResetAction.RESET_SMS_SUBMISSIONS_HISTORY));
+        }
     }
 
     private void resetInstances() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
@@ -24,15 +24,25 @@ import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.database.ItemsetDbAdapter;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.tasks.sms.SmsSubmissionManager;
 import org.osmdroid.config.Configuration;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 public class ResetUtility {
 
+    @Inject
+    SmsSubmissionManager smsSubmissionManager;
+
     private List<Integer> failedResetActions;
+
+    public ResetUtility() {
+        Collect.getInstance().getComponent().inject(this);
+    }
 
     public List<Integer> reset(Context context, List<Integer> resetActions) {
 
@@ -43,6 +53,9 @@ public class ResetUtility {
             switch (action) {
                 case ResetAction.RESET_PREFERENCES:
                     resetPreferences(context);
+                    break;
+                case ResetAction.RESET_SMS_SUBMISSIONS_HISTORY:
+                    resetSMSSubmissionsHistory();
                     break;
                 case ResetAction.RESET_INSTANCES:
                     resetInstances();
@@ -90,6 +103,11 @@ public class ResetUtility {
         Collect.getInstance().initProperties();
     }
 
+    private void resetSMSSubmissionsHistory() {
+        smsSubmissionManager.clearSubmissions();
+        failedResetActions.remove(failedResetActions.indexOf(ResetAction.RESET_SMS_SUBMISSIONS_HISTORY));
+    }
+
     private void resetInstances() {
         new InstancesDao().deleteInstancesDatabase();
 
@@ -132,10 +150,11 @@ public class ResetUtility {
 
     public static class ResetAction {
         public static final int RESET_PREFERENCES = 0;
-        public static final int RESET_INSTANCES = 1;
-        public static final int RESET_FORMS = 2;
-        public static final int RESET_LAYERS = 3;
-        public static final int RESET_CACHE = 4;
-        public static final int RESET_OSM_DROID = 5;
+        public static final int RESET_SMS_SUBMISSIONS_HISTORY = 1;
+        public static final int RESET_INSTANCES = 2;
+        public static final int RESET_FORMS = 3;
+        public static final int RESET_LAYERS = 4;
+        public static final int RESET_CACHE = 5;
+        public static final int RESET_OSM_DROID = 6;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
@@ -54,9 +54,6 @@ public class ResetUtility {
                 case ResetAction.RESET_PREFERENCES:
                     resetPreferences(context);
                     break;
-                case ResetAction.RESET_SMS_SUBMISSIONS_HISTORY:
-                    resetSMSSubmissionsHistory();
-                    break;
                 case ResetAction.RESET_INSTANCES:
                     resetInstances();
                     break;
@@ -77,6 +74,9 @@ public class ResetUtility {
                     if (deleteFolderContents(Configuration.getInstance().getOsmdroidTileCache().getPath())) {
                         failedResetActions.remove(failedResetActions.indexOf(ResetAction.RESET_OSM_DROID));
                     }
+                    break;
+                case ResetAction.RESET_SMS_SUBMISSIONS_HISTORY:
+                    resetSMSSubmissionsHistory();
                     break;
             }
         }
@@ -150,11 +150,11 @@ public class ResetUtility {
 
     public static class ResetAction {
         public static final int RESET_PREFERENCES = 0;
-        public static final int RESET_SMS_SUBMISSIONS_HISTORY = 1;
-        public static final int RESET_INSTANCES = 2;
-        public static final int RESET_FORMS = 3;
-        public static final int RESET_LAYERS = 4;
-        public static final int RESET_CACHE = 5;
-        public static final int RESET_OSM_DROID = 6;
+        public static final int RESET_INSTANCES = 1;
+        public static final int RESET_FORMS = 2;
+        public static final int RESET_LAYERS = 3;
+        public static final int RESET_CACHE = 4;
+        public static final int RESET_OSM_DROID = 5;
+        public static final int RESET_SMS_SUBMISSIONS_HISTORY = 6;
     }
 }

--- a/collect_app/src/main/res/layout/reset_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/reset_dialog_layout.xml
@@ -47,17 +47,6 @@ limitations under the License.
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
         <CheckBox
-            android:id="@+id/sms_submissions_history"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/reset_sms_submissions_history"
-            android:padding="5dp"
-            android:button="@null"
-            android:background="?android:attr/selectableItemBackground"
-            android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
-            android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
-
-        <CheckBox
             android:id="@+id/instances"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -106,6 +95,17 @@ limitations under the License.
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/reset_osm_tiles"
+            android:padding="5dp"
+            android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
+            android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
+            android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
+
+        <CheckBox
+            android:id="@+id/sms_submissions_history"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/reset_sms_submissions_history"
             android:padding="5dp"
             android:button="@null"
             android:background="?android:attr/selectableItemBackground"

--- a/collect_app/src/main/res/layout/reset_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/reset_dialog_layout.xml
@@ -47,6 +47,17 @@ limitations under the License.
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
         <CheckBox
+            android:id="@+id/sms_submissions_history"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/reset_sms_submissions_history"
+            android:padding="5dp"
+            android:button="@null"
+            android:background="?android:attr/selectableItemBackground"
+            android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
+            android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
+
+        <CheckBox
             android:id="@+id/instances"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -418,6 +418,7 @@
     <string name="select_all">Select All</string>
     <string name="clear_all">Clear All</string>
     <string name="reset_settings">All settings (internal settings, saved settings)</string>
+    <string name="reset_sms_submissions_history">SMS submissions history</string>
     <string name="reset_saved_forms">Saved forms (instances folder, instances database)</string>
     <string name="reset_blank_forms">Blank forms (forms folder, forms database, itemsets database)</string>
     <string name="reset_layers">Map layers (layers folder)</string>
@@ -430,6 +431,7 @@
     <string name="reset_app_state_result">Reset results</string>
     <string name="reset_app_state_warning">All selected data will be deleted permanently. There is no undo.</string>
     <string name="reset_settings_result">All settings :: %s</string>
+    <string name="reset_sms_submissions_history_result">SMS submissions history :: %s</string>
     <string name="reset_saved_forms_result">Saved forms :: %s</string>
     <string name="reset_blank_forms_result">Blank forms :: %s</string>
     <string name="reset_layers_result">Map layers :: %s</string>

--- a/collect_app/src/test/java/org/odk/collect/android/injection/TestModule.java
+++ b/collect_app/src/test/java/org/odk/collect/android/injection/TestModule.java
@@ -40,7 +40,12 @@ public class TestModule {
     }
 
     @Provides
-    SmsSubmissionManagerContract provideSmsSubmissionManager(Application application) {
+    SmsSubmissionManagerContract provideSmsSubmissionManagerContract(Application application) {
+        return new SmsSubmissionManager(application);
+    }
+
+    @Provides
+    SmsSubmissionManager provideSmsSubmissionManager(Application application) {
         return new SmsSubmissionManager(application);
     }
 


### PR DESCRIPTION
Closes #2410 

#### What has been done to verify that this works as intended?
I added automated tests and also performed manual tests.

#### Why is this the best possible solution? Were any other approaches considered?
I added clearing sms shared prefs as requested. I used a separate option because I think it's the best solution since those prefs aren't similar to any other we can clear using `ResetDialog`,

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)