### PR TITLE
Sms Phone Number Popup Dialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/listeners/OnBackPressedListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/OnBackPressedListener.java
@@ -1,0 +1,8 @@
+package org.odk.collect.android.listeners;
+
+/***
+ * Used by components that need to get the onBackPressed events
+ */
+public interface OnBackPressedListener {
+    void doBack();
+}

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/OnBackPressedListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/OnBackPressedListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.odk.collect.android.listeners;
 
 /***

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -21,12 +21,15 @@ import android.os.Bundle;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.listeners.OnBackPressedListener;
 import org.odk.collect.android.utilities.ThemeUtils;
 
 public class PreferencesActivity extends CollectAbstractActivity {
 
     public static final String TAG = "GeneralPreferencesFragment";
     public static final String INTENT_KEY_ADMIN_MODE = "adminMode";
+
+    private OnBackPressedListener onBackPressedListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,5 +49,22 @@ public class PreferencesActivity extends CollectAbstractActivity {
     protected void onPause() {
         super.onPause();
         Collect.getInstance().initProperties();
+    }
+
+    /**
+     * If the onBackPressedListener is set then onBackPressed
+     * is delegated to it.
+     */
+    @Override
+    public void onBackPressed() {
+        if (onBackPressedListener != null) {
+            onBackPressedListener.doBack();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    public void setOnBackPressedListener(OnBackPressedListener onBackPressedListener) {
+        this.onBackPressedListener = onBackPressedListener;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -51,10 +51,7 @@ public class PreferencesActivity extends CollectAbstractActivity {
         Collect.getInstance().initProperties();
     }
 
-    /**
-     * If the onBackPressedListener is set then onBackPressed
-     * is delegated to it.
-     */
+    // If the onBackPressedListener is set then onBackPressed is delegated to it.
     @Override
     public void onBackPressed() {
         if (onBackPressedListener != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -457,10 +457,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                         .setTitle(getString(R.string.sms_invalid_phone_number))
                         .setMessage(R.string.sms_invalid_phone_number_description)
                         .setPositiveButton(getString(R.string.ok), (dialog, which) -> dialog.dismiss())
-                        .setNegativeButton(getString(R.string.exit), (dialog, id) -> {
-                            dialog.dismiss();
-                            continueOnBackPressed();
-                        }).create();
+                        .create();
 
                 showDialog(alertDialog, getActivity());
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -341,7 +341,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                     }
 
                     preference.setSummary(username);
-                    clearCachedCrendentials();
+                    clearCachedCredentials();
 
                     // To ensure we update current credentials in CredentialsProvider
                     credentialsHaveChanged = true;
@@ -358,7 +358,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                     }
 
                     maskPasswordSummary(pw);
-                    clearCachedCrendentials();
+                    clearCachedCredentials();
 
                     // To ensure we update current credentials in CredentialsProvider
                     credentialsHaveChanged = true;
@@ -407,7 +407,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                 : "");
     }
 
-    private void clearCachedCrendentials() {
+    private void clearCachedCredentials() {
         String server = (String) GeneralSharedPreferences
                 .getInstance().get(PreferenceKeys.KEY_SERVER_URL);
         Uri u = Uri.parse(server);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -17,8 +17,8 @@
 package org.odk.collect.android.preferences;
 
 import android.accounts.AccountManager;
+import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -82,9 +82,9 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
     private ExtendedPreferenceCategory smsPreferenceCategory;
 
     @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        ((PreferencesActivity) context).setOnBackPressedListener(this);
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        ((PreferencesActivity) activity).setOnBackPressedListener(this);
     }
 
     public void addAggregatePreferences() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -17,6 +17,8 @@
 package org.odk.collect.android.preferences;
 
 import android.accounts.AccountManager;
+import android.app.AlertDialog;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -39,6 +41,7 @@ import com.google.gson.reflect.TypeToken;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.listeners.OnBackPressedListener;
 import org.odk.collect.android.preferences.filters.ControlCharacterFilter;
 import org.odk.collect.android.preferences.filters.WhitespaceFilter;
 import org.odk.collect.android.utilities.AuthDialogUtility;
@@ -58,10 +61,11 @@ import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_GATEWAY
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_PREFERENCE;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_URL;
+import static org.odk.collect.android.utilities.DialogUtils.showDialog;
 import static org.odk.collect.android.utilities.gdrive.GoogleAccountsManager.REQUEST_ACCOUNT_PICKER;
 
 public class ServerPreferencesFragment extends BasePreferenceFragment implements View.OnTouchListener,
-        GoogleAccountsManager.GoogleAccountSelectionListener {
+        GoogleAccountsManager.GoogleAccountSelectionListener, OnBackPressedListener {
     private static final String KNOWN_URL_LIST = "knownUrlList";
     protected EditTextPreference serverUrlPreference;
     protected EditTextPreference usernamePreference;
@@ -76,6 +80,12 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
     private GoogleAccountsManager accountsManager;
     private ListPreference transportPreference;
     private ExtendedPreferenceCategory smsPreferenceCategory;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        ((PreferencesActivity) context).setOnBackPressedListener(this);
+    }
 
     public void addAggregatePreferences() {
         addPreferencesFromResource(R.xml.aggregate_preferences);
@@ -427,5 +437,45 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
     @Override
     public void onGoogleAccountSelected(String accountName) {
         selectedGoogleAccountPreference.setSummary(accountName);
+    }
+
+    /**
+     * Shows a dialog if SMS submission is enabled but the phone number isn't set.
+     */
+    private void runSmsPhoneNumberValidation() {
+        Transport transport = Transport.fromPreference(GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE));
+
+        if (!transport.equals(Transport.Internet)) {
+            SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getActivity());
+
+            String gateway = settings.getString(KEY_SMS_GATEWAY, null);
+
+            if (!PhoneNumberUtils.isGlobalPhoneNumber(gateway)) {
+
+                AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
+                        .setIcon(android.R.drawable.ic_dialog_info)
+                        .setTitle(getString(R.string.sms_invalid_phone_number))
+                        .setMessage(R.string.sms_invalid_phone_number_description)
+                        .setPositiveButton(getString(R.string.ok), (dialog, which) -> dialog.dismiss())
+                        .setNegativeButton(getString(R.string.exit), (dialog, id) -> {
+                            dialog.dismiss();
+                            continueOnBackPressed();
+                        }).create();
+
+                showDialog(alertDialog, getActivity());
+            }
+        } else {
+            continueOnBackPressed();
+        }
+    }
+
+    private void continueOnBackPressed() {
+        ((PreferencesActivity) getActivity()).setOnBackPressedListener(null);
+        getActivity().onBackPressed();
+    }
+
+    @Override
+    public void doBack() {
+        runSmsPhoneNumberValidation();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -463,6 +463,8 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                         }).create();
 
                 showDialog(alertDialog, getActivity());
+            } else {
+                continueOnBackPressed();
             }
         } else {
             continueOnBackPressed();

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -648,4 +648,5 @@
     <string name="rank_items">Rank items</string>
     <string name="image_not_saved">The image can not be saved because of a problem with the corresponding instance file.</string>
     <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
+    <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions.</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -648,5 +648,5 @@
     <string name="rank_items">Rank items</string>
     <string name="image_not_saved">The image can not be saved because of a problem with the corresponding instance file.</string>
     <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
-    <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions.</string>
+    <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
 </resources>


### PR DESCRIPTION
Closes #2459 
![screencast-genymotion-2018-08-11_16 45 01 722](https://user-images.githubusercontent.com/1509205/43997412-36d954f0-9da0-11e8-88d6-75e3743060eb.gif)

#### What has been done to verify that this works as intended?

- When Internet submission is enabled, the dialog does not show because the SMS submission is disabled.

- If SMS submission is enabled and the phone number field is empty then when the user presses back a dialog is presented. Pressing Yes on the dialog allows the user to set the phone number. Pressing exit removes them from the screen. 

- When the user fills in the phone number the dialog doesn't show when the user presses back. 

- Select on send and SMS are the only modes that cause the validation to occur. 

#### Why is this the best possible solution? Were any other approaches considered?
This is the best solution because `onBackPressed` is the event that notifies us that the user is done with a settings screen so utilizing it to prompt then to enter the number is best solution. The only edge case that exists is that the user can close the app and then when they send a SMS submission it would notify them that the phone number is missing. That's something we can live with because once the user has set the number once there's no way it can be empty again because if the validation fails the previous number remains.

#### Are there any risks to merging this code? If so, what are they?
No. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)