### PR TITLE
Connectivity check & toast only occurs with internet submissions.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -149,7 +149,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
     @OnClick({R.id.upload_button, R.id.sms_upload_button})
     public void onUploadButtonsClicked(Button button) {
         Transport transport = Transport.fromPreference(GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE));
-        if (transport.equals(Transport.Internet) || button.getId() == R.id.upload_button) {
+        if (!transport.equals(Transport.Sms) && button.getId() == R.id.upload_button) {
 
             ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(
                     Context.CONNECTIVITY_SERVICE);


### PR DESCRIPTION
Closes #2478
![screencast-genymotion-2018-08-14_17 09 48 875](https://user-images.githubusercontent.com/1509205/44121410-80153200-9fe5-11e8-8311-bfc19e7da05f.gif)

#### What has been done to verify that this works as intended?

- The transport was set to `SMS Submission` and when an instance was submitted while on airplane mode the network connectivity toast did not show. The list item updated with the `Failed due to airplane mode` message. 

- The transport mode was set to `Select on send`. When the `Send (Internet)` button was pressed the toast `no network available` toast was shown. When the `Send (SMS)` button was pressed the list item was updated with the failed messaging. 

- The transport mode was set to the default `Wifi/Cellular` and that gave the network connectivity toast when a submission was attempted.

- Once the airplane mode was disabled both transport types performed submissions normally.

#### Why is this the best possible solution? Were any other approaches considered?
Because the code changes basically optimized the conditions used to enable the network check. Once that's done the functionality is the same as before.

#### Are there any risks to merging this code? If so, what are they?
No. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)