### PR TITLE
Closes #2057: Created MockBearingWidgetClass to test bearing widget, irrespective of whether sensors are available or not.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -50,7 +50,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
 public class BearingWidget extends QuestionWidget implements BinaryWidget {
     private final Button getBearingButton;
     private final boolean isSensorAvailable;
-    private final EditText answer;
+    protected final EditText answer;
     private final Drawable textBackground;
 
     public BearingWidget(Context context, FormEntryPrompt prompt) {
@@ -77,12 +77,17 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
         String s = prompt.getAnswerText();
         if (s != null && !s.equals("")) {
             getBearingButton.setText(getContext().getString(R.string.replace_bearing));
-            if (!isSensorAvailable && answer != null) {
-                answer.setText(s);
-            }
+            setAnswer(s);
             setBinaryData(s);
         }
         addAnswerView(answerLayout);
+    }
+
+    public void setAnswer(String s) {
+        if (!isSensorAvailable && answer != null) {
+            answer.setText(s);
+        }
+
     }
 
     @Override
@@ -124,7 +129,7 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
         answer.cancelLongPress();
     }
 
-    private boolean checkForRequiredSensors() {
+    public boolean checkForRequiredSensors() {
 
         boolean isAccelerometerSensorAvailable = false;
         boolean isMagneticFieldSensorAvailable = false;

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
@@ -26,11 +26,12 @@ public class BearingWidgetTest extends BinaryWidgetTest<BearingWidget, StringDat
 
         @Override
         public boolean checkForRequiredSensors() {
-            return false;
+            return true;
         }
 
         @Override
         public void setAnswer(String s) {
+            s = RandomString.make();
             if (answer != null) {
                 answer.setText(s);
             }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
@@ -1,10 +1,12 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.RuntimeEnvironment;
@@ -16,10 +18,29 @@ public class BearingWidgetTest extends BinaryWidgetTest<BearingWidget, StringDat
 
     private String barcodeData;
 
+    public class MockBearingWidget extends BearingWidget {
+
+        public MockBearingWidget(Context context, FormEntryPrompt prompt) {
+            super(context, prompt);
+        }
+
+        @Override
+        public boolean checkForRequiredSensors() {
+            return false;
+        }
+
+        @Override
+        public void setAnswer(String s) {
+            if (answer != null) {
+                answer.setText(s);
+            }
+        }
+    }
+
     @NonNull
     @Override
     public BearingWidget createWidget() {
-        return new BearingWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new MockBearingWidget(RuntimeEnvironment.application, formEntryPrompt);
     }
 
     @Override


### PR DESCRIPTION
Closes #2057 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it.

#### Why is this the best possible solution? Were any other approaches considered?
I created `MockBearingWidget` class as suggested by @xsteelej, and also just for testing purposes, it sets the answer in the EditText, without checking for the value of `isSensorAvailable`.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms having Bearing widget.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)