### PR TITLE
Closes #2012: Used X-OpenRosa-Accept-Content-Length header

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
@@ -102,6 +102,8 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     private CredentialsProvider credentialsProvider;
     private CookieStore cookieStore;
 
+    private long contentLength = 10000000;
+
     public HttpClientConnection() {
         credentialsProvider = new AgingCredentialsProvider(7 * 60 * 1000);
         cookieStore = new BasicCookieStore();
@@ -290,6 +292,11 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
             throw new Exception("Generic Exception: " + msg);
         }
 
+        Header[] headers = response.getHeaders("X-OpenRosa-Accept-Content-Length");
+        if (headers.length > 0) {
+            contentLength = Long.parseLong(headers[0].getValue());
+        }
+
         return new HttpHeadResult(statusCode, responseHeaders);
     }
 
@@ -355,7 +362,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                 // we've added at least one attachment to the request...
                 if (fileIndex + 1 < fileList.size()) {
                     if ((fileIndex - lastFileIndex + 1 > 100) || (byteCount + fileList.get(fileIndex + 1).length()
-                            > 10000000L)) {
+                            > contentLength)) {
                         // the next file would exceed the 10MB threshold...
                         Timber.i("Extremely long post is being split into multiple posts");
                         try {


### PR DESCRIPTION
Closes #2012 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it by sending a form, and displaying the value of content length that it uses now.

#### Why is this the best possible solution? Were any other approaches considered?
It fetches the value of OpenRosa Content length from the header of Http response and then uses it to decide the maximum size of a file to be sent in a single post. 

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)