### PR TITLE
Google account validation dialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -57,6 +57,7 @@ import java.util.List;
 
 import static android.app.Activity.RESULT_OK;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_FORMLIST_URL;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_PROTOCOL;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SELECTED_GOOGLE_ACCOUNT;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_GATEWAY;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_PREFERENCE;
@@ -464,8 +465,9 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
 
     private void runGoogleAccountValidation() {
         String account = (String) GeneralSharedPreferences.getInstance().get(KEY_SELECTED_GOOGLE_ACCOUNT);
+        String protocol = (String) GeneralSharedPreferences.getInstance().get(KEY_PROTOCOL);
 
-        if (TextUtils.isEmpty(account)) {
+        if (TextUtils.isEmpty(account) && protocol.equals(getString(R.string.protocol_google_sheets))) {
 
             AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
                     .setIcon(android.R.drawable.ic_dialog_info)

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -29,6 +29,7 @@ import android.preference.PreferenceManager;
 import android.support.v7.content.res.AppCompatResources;
 import android.telephony.PhoneNumberUtils;
 import android.text.InputFilter;
+import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -56,6 +57,7 @@ import java.util.List;
 
 import static android.app.Activity.RESULT_OK;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_FORMLIST_URL;
+import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SELECTED_GOOGLE_ACCOUNT;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_GATEWAY;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SMS_PREFERENCE;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
@@ -183,7 +185,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
 
     public void addGooglePreferences() {
         addPreferencesFromResource(R.xml.google_preferences);
-        selectedGoogleAccountPreference = findPreference(PreferenceKeys.KEY_SELECTED_GOOGLE_ACCOUNT);
+        selectedGoogleAccountPreference = findPreference(KEY_SELECTED_GOOGLE_ACCOUNT);
 
         EditTextPreference googleSheetsUrlPreference = (EditTextPreference) findPreference(
                 PreferenceKeys.KEY_GOOGLE_SHEETS_URL);
@@ -453,8 +455,26 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
 
                 showDialog(alertDialog, getActivity());
             } else {
-                continueOnBackPressed();
+                runGoogleAccountValidation();
             }
+        } else {
+            runGoogleAccountValidation();
+        }
+    }
+
+    private void runGoogleAccountValidation() {
+        String account = (String) GeneralSharedPreferences.getInstance().get(KEY_SELECTED_GOOGLE_ACCOUNT);
+
+        if (TextUtils.isEmpty(account)) {
+
+            AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
+                    .setIcon(android.R.drawable.ic_dialog_info)
+                    .setTitle(R.string.google_invalid_account_title)
+                    .setMessage(R.string.google_invalid_account_description)
+                    .setPositiveButton(getString(R.string.ok), (dialog, which) -> dialog.dismiss())
+                    .create();
+
+            showDialog(alertDialog, getActivity());
         } else {
             continueOnBackPressed();
         }

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -654,4 +654,6 @@
     <string name="image_not_saved">The image can not be saved because of a problem with the corresponding instance file.</string>
     <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
     <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
+    <string name="google_invalid_account_title">Google account missing!</string>
+    <string name="google_invalid_account_description">Please select a Google account or change your transport type.</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -654,6 +654,6 @@
     <string name="image_not_saved">The image can not be saved because of a problem with the corresponding instance file.</string>
     <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
     <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
-    <string name="google_invalid_account_title">Google account missing!</string>
-    <string name="google_invalid_account_description">Please select a Google account or change your transport type.</string>
+    <string name="google_invalid_account_title">Google account missing</string>
+    <string name="google_invalid_account_description">Please select a Google account or change your server type.</string>
 </resources>


### PR DESCRIPTION
Closes #2464

#### What has been done to verify that this works as intended?

- Google Sheets was selected as the transport mechanism and no account was selected. When I tried to navigate away from the Server settings page dialog popped up asking for the account to be chosen or the transport to be changed.

- When the transport is changed the dialog no longer shows.

- Once an account has been selected the dialog no longer shows as well.

#### Why is this the best possible solution? Were any other approaches considered?
This solution was used because a similar approach was taken in #2472 

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)