### PR TITLE
Fixed the title of the Open source licenses page under About section.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/WebViewActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/WebViewActivity.java
@@ -65,6 +65,7 @@ public class WebViewActivity extends CollectAbstractActivity {
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
                 progressBar.setVisibility(View.GONE);
+                getSupportActionBar().setTitle("Open Source Licenses");
             }
 
             @Override


### PR DESCRIPTION
Closes #2397

#### What has been done to verify that this works as intended?

I tested it by opening the Open Source Licenses page under the About section. It is showing the title as intended.

 #### Why is this the best possible solution? Were any other approaches considered?

It's a one-line and only solution for this issue.   

#### Are there any risks to merging this code? If so, what are they?

No.

#### Do we need any specific form for testing your changes? If so, please attach one.

No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)