### PR TITLE
Adjust font size in NumberPicker

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/CustomNumberPicker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/CustomNumberPicker.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.NumberPicker;
+
+import org.odk.collect.android.application.Collect;
+
+public class CustomNumberPicker extends NumberPicker {
+
+    public CustomNumberPicker(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public void addView(View view) {
+        super.addView(view);
+        updateView(view);
+    }
+
+    @Override
+    public void addView(View view, int index, android.view.ViewGroup.LayoutParams params) {
+        super.addView(view, index, params);
+        updateView(view);
+    }
+
+    @Override
+    public void addView(View view, android.view.ViewGroup.LayoutParams params) {
+        super.addView(view, params);
+        updateView(view);
+    }
+
+    private void updateView(View view) {
+        if (view instanceof EditText) {
+            ((EditText) view).setTextSize(Collect.getQuestionFontsize());
+        }
+    }
+}

--- a/collect_app/src/main/res/layout/number_picker_dialog.xml
+++ b/collect_app/src/main/res/layout/number_picker_dialog.xml
@@ -13,11 +13,11 @@ limitations under the License.
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
-    <NumberPicker
+    <org.odk.collect.android.views.CustomNumberPicker
         android:id="@+id/number_picker"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:descendantFocusability="blocksDescendants"
         android:layout_gravity="center_horizontal">
-    </NumberPicker>
+    </org.odk.collect.android.views.CustomNumberPicker>
 </FrameLayout>


### PR DESCRIPTION
Closes #2481 

#### What has been done to verify that this works as intended?
Tested `RanegWidget` with `picker` appearance from `AllWidgets` form.
Before:
![screenshot_1535062406](https://user-images.githubusercontent.com/3276264/44554774-91bbaf80-a732-11e8-8d30-0b00e2253164.png)

After:
![screenshot_1535059957](https://user-images.githubusercontent.com/3276264/44554375-00980900-a731-11e8-9762-6e2575e6e3ba.png)

#### Why is this the best possible solution? Were any other approaches considered?
Ws should use the same font size we use for other questions.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)