### PR TITLE
Added Java version introduction in the troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ implementation (project(path: ':javarosa-master')) {
 	```gradle
 	compile files('/path/to/javarosa/build/libs/opendatakit-javarosa-x.y.z-SNAPSHOT.jar')
 	```
-
+ 
 ## Contributing code
 Any and all contributions to the project are welcome. ODK Collect is used across the world primarily by organizations with a social purpose so you can have real impact!
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ implementation (project(path: ':javarosa-master')) {
 	```gradle
 	compile files('/path/to/javarosa/build/libs/opendatakit-javarosa-x.y.z-SNAPSHOT.jar')
 	```
- 
+
 ## Contributing code
 Any and all contributions to the project are welcome. ODK Collect is used across the world primarily by organizations with a social purpose so you can have real impact!
 
@@ -198,3 +198,8 @@ You may have a mismatch between the embedded Android SDK Java and the JDK instal
 `
 
 Note that this change might cause problems with other Java-based applications (e.g., if you uninstall Android Studio).
+
+#### gradlew Failure: `java.lang.NullPointerException (no error message).`
+If you encounter the `java.lang.NullPointerException (no error message).` when running `gradlew`, please make sure your Java version for this project is Java 8. You can reinstall Java or set a specific JDK version for the project like this:
+1. run `run /usr/libexec/java_home -v 1.8` in terminal to get your JDK location.
+2. use `cmd` + `;` for Mac or `Ctrl` + `Alt` + `Shift` + `S` for Windows/Linux to pull up the Project Structure dialog. In there, you can set the JDK location as well as the Android SDK location.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ implementation (project(path: ':javarosa-master')) {
 	```gradle
 	compile files('/path/to/javarosa/build/libs/opendatakit-javarosa-x.y.z-SNAPSHOT.jar')
 	```
- 
+
 ## Contributing code
 Any and all contributions to the project are welcome. ODK Collect is used across the world primarily by organizations with a social purpose so you can have real impact!
 
@@ -200,6 +200,4 @@ You may have a mismatch between the embedded Android SDK Java and the JDK instal
 Note that this change might cause problems with other Java-based applications (e.g., if you uninstall Android Studio).
 
 #### gradlew Failure: `java.lang.NullPointerException (no error message).`
-If you encounter the `java.lang.NullPointerException (no error message).` when running `gradlew`, please make sure your Java version for this project is Java 8. You can reinstall Java or set a specific JDK version for the project like this:
-1. run `run /usr/libexec/java_home -v 1.8` in terminal to get your JDK location.
-2. use `cmd` + `;` for Mac or `Ctrl` + `Alt` + `Shift` + `S` for Windows/Linux to pull up the Project Structure dialog. In there, you can set the JDK location as well as the Android SDK location.
+If you encounter the `java.lang.NullPointerException (no error message).` when running `gradlew`, please make sure your Java version for this project is Java 8.


### PR DESCRIPTION
Closes #2504 

For `java.lang.NullPointerException (no error message)` caused by the JDK version when using `gradlew`, I added it to the troubleshooting section in README.

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->



#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)