### PR TITLE
Sms error state standardization

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -99,11 +99,9 @@ public class InstanceUploaderAdapter extends CursorAdapter {
         switch (status) {
 
             case STATUS_SUBMISSION_FAILED:
-                if (isSmsSubmission) {
-                    viewHolder.statusIcon.setImageResource(R.drawable.message_alert);
-                } else {
-                    viewHolder.statusIcon.setImageResource(R.drawable.exclamation);
-                }
+
+                viewHolder.statusIcon.setImageResource(R.drawable.exclamation);
+
                 break;
 
             case STATUS_SUBMITTED:
@@ -179,7 +177,7 @@ public class InstanceUploaderAdapter extends CursorAdapter {
                 break;
 
             default:
-                viewHolder.statusIcon.setImageResource(R.drawable.message_alert);
+                viewHolder.statusIcon.setImageResource(R.drawable.exclamation);
                 break;
         }
     }

--- a/collect_app/src/main/res/drawable/message_alert.xml
+++ b/collect_app/src/main/res/drawable/message_alert.xml
@@ -1,8 +1,0 @@
-<!-- drawable/message_alert.xml -->
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path android:fillColor="@android:color/white" android:pathData="M13,10H11V6H13M13,14H11V12H13M20,2H4A2,2 0 0,0 2,4V22L6,18H20A2,2 0 0,0 22,16V4C22,2.89 21.1,2 20,2Z" />
-</vector>


### PR DESCRIPTION
Closes #2477

#### What has been done to verify that this works as intended?

- A SMS submission was made and when it failed the exclamation mark was shown instead of the message alert icon that was previously used.

- A HTTP submission that fails utilizes the same icon as well. 

#### Why is this the best possible solution? Were any other approaches considered?
Standardizing the look of these icons make it easier for the user to remember what icon represents an error in general.

#### Are there any risks to merging this code? If so, what are they?
No.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)