### PR TITLE
Implemented RecyclerView to improve selectOne widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -152,7 +152,7 @@ public class SelectOneListAdapter extends RecyclerView.Adapter<SelectOneListAdap
         radioButton.setTag(items.indexOf(filteredItems.get(index)));
         radioButton.setEnabled(!widget.getFormEntryPrompt().isReadOnly());
         radioButton.setGravity(isRTL() ? Gravity.END : Gravity.START);
-        radioButton.setOnLongClickListener((ODKView) widget.getParent().getParent());
+        radioButton.setOnLongClickListener((ODKView) widget.getParent().getParent().getParent());
         radioButton.setOnClickListener(this);
         radioButton.setOnCheckedChangeListener(this);
 

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.adapters;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.AppCompatRadioButton;
+import android.support.v7.widget.RecyclerView;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CompoundButton;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.FrameLayout;
+import android.widget.RadioButton;
+import android.widget.RelativeLayout;
+
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.utilities.TextUtils;
+import org.odk.collect.android.views.ODKView;
+import org.odk.collect.android.widgets.AbstractSelectOneWidget;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.odk.collect.android.widgets.QuestionWidget.isRTL;
+
+public class SelectOneListAdapter extends RecyclerView.Adapter<SelectOneListAdapter.ViewHolder>
+        implements View.OnClickListener, CompoundButton.OnCheckedChangeListener, Filterable {
+
+    private final List<SelectChoice> items;
+    private final AbstractSelectOneWidget widget;
+    private String selectedValue;
+    private RadioButton selectedRadioButton;
+    private List<SelectChoice> filteredItems;
+
+    public SelectOneListAdapter(List<SelectChoice> items,
+                                String selectedValue,
+                                AbstractSelectOneWidget widget) {
+        this.items = items;
+        this.selectedValue = selectedValue;
+        this.widget = widget;
+        filteredItems = items;
+    }
+
+    @Override
+    public SelectOneListAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        return new ViewHolder(new FrameLayout(widget.getContext()));
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int index) {
+        holder.bind(index);
+    }
+
+    @Override
+    public int getItemCount() {
+        return filteredItems.size();
+    }
+
+    @Override
+    public void onClick(View v) {
+        widget.onClick();
+    }
+
+    @Override
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        if (isChecked) {
+            if (selectedRadioButton != null && buttonView != selectedRadioButton) {
+                selectedRadioButton.setChecked(false);
+                widget.clearNextLevelsOfCascadingSelect();
+            }
+            selectedRadioButton = (RadioButton) buttonView;
+            selectedValue = items.get((int) selectedRadioButton.getTag()).getValue();
+        }
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder {
+        FrameLayout container;
+
+        ViewHolder(View v) {
+            super(v);
+            container = (FrameLayout) v;
+        }
+
+        void bind(final int index) {
+            container.removeAllViews();
+            container.addView(createRadioButtonLayout(index));
+        }
+    }
+
+    @Override
+    public Filter getFilter() {
+        return new Filter() {
+            @Override
+            protected FilterResults performFiltering(CharSequence charSequence) {
+                String searchStr = charSequence.toString().toLowerCase(Locale.US);
+                if (searchStr.isEmpty()) {
+                    filteredItems = items;
+                } else {
+                    List<SelectChoice> filteredList = new ArrayList<>();
+                    FormEntryPrompt formEntryPrompt = widget.getFormEntryPrompt();
+                    for (SelectChoice item : items) {
+                        if (formEntryPrompt.getSelectChoiceText(item).toLowerCase(Locale.US).contains(searchStr)) {
+                            filteredList.add(item);
+                        }
+                    }
+
+                    filteredItems = filteredList;
+                }
+
+                FilterResults filterResults = new FilterResults();
+                filterResults.values = filteredItems;
+                return filterResults;
+            }
+
+            @Override
+            protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
+                filteredItems = (List<SelectChoice>) filterResults.values;
+                notifyDataSetChanged();
+            }
+        };
+    }
+
+    private RelativeLayout createRadioButtonLayout(int index) {
+        RelativeLayout parentLayout = (RelativeLayout) LayoutInflater.from(widget.getContext()).inflate(R.layout.quick_select_layout, null);
+
+        parentLayout.findViewById(R.id.auto_advance_icon).setVisibility(widget.isAutoAdvance() ? View.VISIBLE : View.GONE);
+        ((FrameLayout) parentLayout.findViewById(R.id.container)).addView(widget.createMediaLayout(index, createRadioButton(index)));
+
+        return parentLayout;
+    }
+
+    private RadioButton createRadioButton(final int index) {
+        AppCompatRadioButton radioButton = new AppCompatRadioButton(widget.getContext());
+        radioButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, Collect.getQuestionFontsize());
+        radioButton.setText(getItemText(index));
+        radioButton.setTag(items.indexOf(filteredItems.get(index)));
+        radioButton.setEnabled(!widget.getFormEntryPrompt().isReadOnly());
+        radioButton.setGravity(isRTL() ? Gravity.END : Gravity.START);
+        radioButton.setOnLongClickListener((ODKView) widget.getParent().getParent());
+        radioButton.setOnClickListener(this);
+        radioButton.setOnCheckedChangeListener(this);
+
+        if (filteredItems.get(index).getValue().equals(selectedValue)) {
+            radioButton.setChecked(true);
+        }
+
+        return radioButton;
+    }
+
+    private String getItemText(int index) {
+        String choiceName = widget.getFormEntryPrompt().getSelectChoiceText(filteredItems.get(index));
+        return choiceName != null ? TextUtils.textToHtml(choiceName).toString() : "";
+    }
+
+    public void clearAnswer() {
+        if (selectedRadioButton != null) {
+            selectedRadioButton.setChecked(false);
+        }
+        selectedValue = null;
+        widget.clearNextLevelsOfCascadingSelect();
+    }
+
+    public SelectChoice getSelectedItem() {
+        if (selectedValue != null) {
+            for (SelectChoice item : items) {
+                if (selectedValue.equalsIgnoreCase(item.getValue())) {
+                    return item;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -27,15 +27,15 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.Filter;
 import android.widget.Filterable;
-import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.RadioButton;
-import android.widget.RelativeLayout;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.TextUtils;
+import org.odk.collect.android.views.MediaLayout;
 import org.odk.collect.android.views.ODKView;
 import org.odk.collect.android.widgets.AbstractSelectOneWidget;
 
@@ -65,7 +65,7 @@ public class SelectOneListAdapter extends RecyclerView.Adapter<SelectOneListAdap
 
     @Override
     public SelectOneListAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new ViewHolder(new FrameLayout(widget.getContext()));
+        return new ViewHolder(LayoutInflater.from(widget.getContext()).inflate(R.layout.quick_select_layout, null));
     }
 
     @Override
@@ -96,16 +96,19 @@ public class SelectOneListAdapter extends RecyclerView.Adapter<SelectOneListAdap
     }
 
     class ViewHolder extends RecyclerView.ViewHolder {
-        FrameLayout container;
+        ImageView autoAdvanceIcon;
+        MediaLayout mediaLayout;
 
         ViewHolder(View v) {
             super(v);
-            container = (FrameLayout) v;
+            autoAdvanceIcon = v.findViewById(R.id.auto_advance_icon);
+            autoAdvanceIcon.setVisibility(widget.isAutoAdvance() ? View.VISIBLE : View.GONE);
+            mediaLayout = v.findViewById(R.id.mediaLayout);
+            widget.initMediaLayoutSetUp(mediaLayout);
         }
 
         void bind(final int index) {
-            container.removeAllViews();
-            container.addView(createRadioButtonLayout(index));
+            widget.setUpAVT(mediaLayout, index, createRadioButton(index));
         }
     }
 
@@ -140,15 +143,6 @@ public class SelectOneListAdapter extends RecyclerView.Adapter<SelectOneListAdap
                 notifyDataSetChanged();
             }
         };
-    }
-
-    private RelativeLayout createRadioButtonLayout(int index) {
-        RelativeLayout parentLayout = (RelativeLayout) LayoutInflater.from(widget.getContext()).inflate(R.layout.quick_select_layout, null);
-
-        parentLayout.findViewById(R.id.auto_advance_icon).setVisibility(widget.isAutoAdvance() ? View.VISIBLE : View.GONE);
-        ((FrameLayout) parentLayout.findViewById(R.id.container)).addView(widget.createMediaLayout(index, createRadioButton(index)));
-
-        return parentLayout;
     }
 
     private RadioButton createRadioButton(final int index) {

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -108,7 +108,7 @@ public class SelectOneListAdapter extends RecyclerView.Adapter<SelectOneListAdap
         }
 
         void bind(final int index) {
-            widget.setUpAVT(mediaLayout, index, createRadioButton(index));
+            widget.addMediaFromChoice(mediaLayout, index, createRadioButton(index));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -23,6 +23,7 @@ import android.graphics.Color;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.support.v7.widget.AppCompatImageButton;
+import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.CheckBox;
@@ -87,6 +88,20 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
 
     public MediaLayout(Context context) {
         super(context);
+
+        View.inflate(context, R.layout.media_layout, this);
+        ButterKnife.bind(this);
+    }
+
+    public MediaLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        View.inflate(context, R.layout.media_layout, this);
+        ButterKnife.bind(this);
+    }
+
+    public MediaLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
 
         View.inflate(context, R.layout.media_layout, this);
         ButterKnife.bind(this);
@@ -235,6 +250,7 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
             }
         }
 
+        flContainer.removeAllViews();
         flContainer.addView(viewText);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -100,13 +100,6 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
         ButterKnife.bind(this);
     }
 
-    public MediaLayout(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-
-        View.inflate(context, R.layout.media_layout, this);
-        ButterKnife.bind(this);
-    }
-
     /**
      * For stubbing during unit testing
      */

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -25,6 +25,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.v4.widget.NestedScrollView;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -32,7 +33,6 @@ import android.view.View;
 import android.view.View.OnLongClickListener;
 import android.widget.Button;
 import android.widget.LinearLayout;
-import android.widget.ScrollView;
 import android.widget.TableLayout;
 import android.widget.TextView;
 
@@ -74,7 +74,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
  * @author carlhartung
  */
 @SuppressLint("ViewConstructor")
-public class ODKView extends ScrollView implements OnLongClickListener {
+public class ODKView extends NestedScrollView implements OnLongClickListener {
 
     private final LinearLayout view;
     private final LinearLayout.LayoutParams layout;

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -32,6 +32,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnLongClickListener;
 import android.widget.Button;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
@@ -74,7 +75,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
  * @author carlhartung
  */
 @SuppressLint("ViewConstructor")
-public class ODKView extends NestedScrollView implements OnLongClickListener {
+public class ODKView extends FrameLayout implements OnLongClickListener {
 
     private final LinearLayout view;
     private final LinearLayout.LayoutParams layout;
@@ -85,6 +86,8 @@ public class ODKView extends NestedScrollView implements OnLongClickListener {
     public ODKView(Context context, final FormEntryPrompt[] questionPrompts,
             FormEntryCaption[] groups, boolean advancingPage) {
         super(context);
+
+        inflate(getContext(), R.layout.nested_scroll_view, this); // keep in an xml file to enable the vertical scrollbar
 
         widgets = new ArrayList<>();
 
@@ -207,7 +210,7 @@ public class ODKView extends NestedScrollView implements OnLongClickListener {
             view.addView(qw, layout);
         }
 
-        addView(view);
+        ((NestedScrollView) findViewById(R.id.odk_view_container)).addView(view);
 
         // see if there is an autoplay option.
         // Only execute it during forward swipes through the form

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -17,34 +17,28 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.support.annotation.Nullable;
-import android.support.v7.content.res.AppCompatResources;
-import android.support.v7.widget.AppCompatRadioButton;
-import android.text.method.LinkMovementMethod;
-import android.util.TypedValue;
-import android.view.Gravity;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.CompoundButton;
-import android.widget.CompoundButton.OnCheckedChangeListener;
-import android.widget.ImageView;
+import android.support.v7.widget.DividerItemDecoration;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.DisplayMetrics;
 import android.widget.RadioButton;
-import android.widget.RelativeLayout;
 
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.R;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.adapters.SelectOneListAdapter;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
-import org.odk.collect.android.listeners.AudioPlayListener;
-import org.odk.collect.android.utilities.TextUtils;
-import org.odk.collect.android.utilities.ViewIds;
+import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 
-import java.util.ArrayList;
-import java.util.List;
+import timber.log.Timber;
 
 /**
  * SelectOneWidgets handles select-one fields using radio buttons.
@@ -53,20 +47,17 @@ import java.util.List;
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
 @SuppressLint("ViewConstructor")
-public abstract class AbstractSelectOneWidget extends SelectTextWidget
-        implements OnCheckedChangeListener, AudioPlayListener, MultiChoiceWidget, View.OnClickListener {
+public abstract class AbstractSelectOneWidget extends SelectTextWidget implements MultiChoiceWidget {
 
     @Nullable
     private AdvanceToNextListener listener;
 
-    protected List<RadioButton> buttons;
-    protected String selectedValue;
-
+    private String selectedValue;
     private final boolean autoAdvance;
+    protected SelectOneListAdapter adapter;
 
     public AbstractSelectOneWidget(Context context, FormEntryPrompt prompt, boolean autoAdvance) {
         super(context, prompt);
-        buttons = new ArrayList<>();
 
         if (prompt.getAnswerValue() != null) {
             if (this instanceof ItemsetWidget) {
@@ -85,148 +76,101 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget
 
     @Override
     public void clearAnswer() {
-        for (RadioButton button : this.buttons) {
-            if (button.isChecked()) {
-                button.setChecked(false);
-                clearNextLevelsOfCascadingSelect();
-                break;
-            }
+        if (adapter != null) {
+            adapter.clearAnswer();
         }
     }
 
     @Override
     public IAnswerData getAnswer() {
-        int i = getCheckedId();
+        SelectChoice selectChoice =  adapter.getSelectedItem();
 
-        return i == -1 ? null :
-                (this instanceof ItemsetWidget ? new StringData(items.get(i).getValue()) : new SelectOneData(new Selection(items.get(i))));
-    }
-
-    public int getCheckedId() {
-        for (RadioButton button : buttons) {
-            if (button.isChecked()) {
-                return (int) button.getTag();
-            }
-        }
-        return -1;
-    }
-
-    @Override
-    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        if (isChecked) {
-            for (RadioButton button : buttons) {
-                if (button.isChecked() && buttonView != button) {
-                    button.setChecked(false);
-                    clearNextLevelsOfCascadingSelect();
-                }
-            }
-        }
-    }
-
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        for (RadioButton r : buttons) {
-            r.setOnLongClickListener(l);
-        }
-    }
-
-    @Override
-    public void cancelLongPress() {
-        super.cancelLongPress();
-        for (RadioButton button : buttons) {
-            button.cancelLongPress();
-        }
-    }
-
-    protected RadioButton createRadioButton(int index) {
-        String choiceName = getFormEntryPrompt().getSelectChoiceText(items.get(index));
-        CharSequence choiceDisplayName;
-        if (choiceName != null) {
-            choiceDisplayName = TextUtils.textToHtml(choiceName);
-        } else {
-            choiceDisplayName = "";
-        }
-
-        AppCompatRadioButton radioButton = new AppCompatRadioButton(getContext());
-        radioButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, getAnswerFontSize());
-        radioButton.setText(choiceDisplayName);
-        radioButton.setMovementMethod(LinkMovementMethod.getInstance());
-        radioButton.setTag(index);
-        radioButton.setId(ViewIds.generateViewId());
-        radioButton.setEnabled(!getFormEntryPrompt().isReadOnly());
-        radioButton.setFocusable(!getFormEntryPrompt().isReadOnly());
-        radioButton.setOnClickListener(this);
-
-        //adapt radioButton text as per language direction
-        if (isRTL()) {
-            radioButton.setGravity(Gravity.END);
-        } else {
-            radioButton.setGravity(Gravity.START);
-        }
-
-        if (items.get(index).getValue().equals(selectedValue)) {
-            radioButton.setChecked(true);
-        }
-
-        radioButton.setOnCheckedChangeListener(this);
-
-        return radioButton;
+        return selectChoice == null
+                ? null
+                : this instanceof ItemsetWidget
+                    ? new StringData(selectChoice.getValue())
+                    : new SelectOneData(new Selection(selectChoice));
     }
 
     protected void createLayout() {
         readItems();
 
-        LayoutInflater inflater = LayoutInflater.from(getContext());
+        adapter = new SelectOneListAdapter(items, selectedValue, this);
 
         if (items != null) {
-            for (int i = 0; i < items.size(); i++) {
-                answerLayout.addView(createRadioButtonLayout(inflater, i));
+            RecyclerView recyclerView = new RecyclerView(getContext());
+            recyclerView.setHasFixedSize(true);
+            recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+            recyclerView.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
+            recyclerView.setAdapter(adapter);
+            answerLayout.addView(recyclerView);
+
+            /*
+            It's not a very elegant solution but the only one we were able to come up with.
+            In case of many items we need to set the height of our RecyclerView in order to speed up loading.
+            Ideally we should do that only if our items take more place than our screen has.
+            Unfortunately there is no easy way to determine when it's going to happen (for how many items).
+            30 elements is an estimated number.
+             */
+            if (adapter.getItemCount() > 30) {
+                // Only let the RecyclerView take up 100% of the screen height in order to speed up loading if there are many items
+                DisplayMetrics displayMetrics = new DisplayMetrics();
+                ((FormEntryActivity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+                recyclerView.getLayoutParams().height = displayMetrics.heightPixels;
+            } else {
+                recyclerView.setNestedScrollingEnabled(false);
             }
             addAnswerView(answerLayout);
         }
     }
 
-    protected RelativeLayout createRadioButtonLayout(LayoutInflater inflater, int index) {
-        @SuppressLint("InflateParams")
-        RelativeLayout thisParentLayout = (RelativeLayout) inflater.inflate(R.layout.quick_select_layout, null);
+    /**
+     * It's needed only for external choices. Everything works well and
+     * out of the box when we use internal choices instead
+     */
+    public void clearNextLevelsOfCascadingSelect() {
+        FormController formController = Collect.getInstance().getFormController();
+        if (formController == null) {
+            return;
+        }
 
-        RadioButton radioButton = createRadioButton(index);
-
-        ImageView rightArrow = (ImageView) thisParentLayout.getChildAt(1);
-        rightArrow.setImageDrawable(autoAdvance ? AppCompatResources.getDrawable(getContext(), R.drawable.expander_ic_right) : null);
-
-        buttons.add(radioButton);
-
-        ((ViewGroup) thisParentLayout.getChildAt(0)).addView(createMediaLayout(index, radioButton));
-
-        return thisParentLayout;
+        if (formController.currentCaptionPromptIsQuestion()) {
+            try {
+                FormIndex startFormIndex = formController.getQuestionPrompt().getIndex();
+                formController.stepToNextScreenEvent();
+                while (formController.currentCaptionPromptIsQuestion()
+                        && formController.getQuestionPrompt().getFormElement().getAdditionalAttribute(null, "query") != null) {
+                    formController.saveAnswer(formController.getQuestionPrompt().getIndex(), null);
+                    formController.stepToNextScreenEvent();
+                }
+                formController.jumpToIndex(startFormIndex);
+            } catch (JavaRosaException e) {
+                Timber.d(e);
+            }
+        }
     }
 
-    public List<RadioButton> getButtons() {
-        return buttons;
+    public void onClick() {
+        if (autoAdvance && listener != null) {
+            listener.advance();
+        }
+    }
+
+    public boolean isAutoAdvance() {
+        return autoAdvance;
     }
 
     @Override
     public int getChoiceCount() {
-        return buttons.size();
+        return adapter.getItemCount();
     }
 
     @Override
     public void setChoiceSelected(int choiceIndex, boolean isSelected) {
-        for (RadioButton button : buttons) {
-            button.setChecked(false);
-        }
-
-        RadioButton button = buttons.get(choiceIndex);
+        RadioButton button = new RadioButton(getContext());
+        button.setTag(choiceIndex);
         button.setChecked(isSelected);
 
-        onCheckedChanged(button, isSelected);
-    }
-
-    @Override
-    public void onClick(View view) {
-        if (autoAdvance && listener != null) {
-            listener.advance();
-        }
+        adapter.onCheckedChanged(button, isSelected);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -52,7 +52,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
     /**
      * An estimated max number of elements for whom we don't need to resize a RecyclerView
      */
-    private static final int MAX_ITEMS_WITHOUT_SCREEN_BOUND = 30;
+    private static final int MAX_ITEMS_WITHOUT_SCREEN_BOUND = 40;
 
     @Nullable
     private AdvanceToNextListener listener;
@@ -118,10 +118,10 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
             MAX_ITEMS_WITHOUT_SCREEN_BOUND elements is an estimated number.
              */
             if (adapter.getItemCount() > MAX_ITEMS_WITHOUT_SCREEN_BOUND) {
-                // Only let the RecyclerView take up 100% of the screen height in order to speed up loading if there are many items
+                // Only let the RecyclerView take up 80% of the screen height in order to speed up loading if there are many items
                 DisplayMetrics displayMetrics = new DisplayMetrics();
                 ((FormEntryActivity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
-                recyclerView.getLayoutParams().height = displayMetrics.heightPixels;
+                recyclerView.getLayoutParams().height = (int) (displayMetrics.heightPixels * 0.8);
             } else {
                 recyclerView.setNestedScrollingEnabled(false);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -49,6 +49,11 @@ import timber.log.Timber;
 @SuppressLint("ViewConstructor")
 public abstract class AbstractSelectOneWidget extends SelectTextWidget implements MultiChoiceWidget {
 
+    /**
+     * An estimated max number of elements for whom we don't need to resize a RecyclerView
+     */
+    private static final int MAX_ITEMS_WITHOUT_SCREEN_BOUND = 30;
+
     @Nullable
     private AdvanceToNextListener listener;
 
@@ -110,9 +115,9 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
             In case of many items we need to set the height of our RecyclerView in order to speed up loading.
             Ideally we should do that only if our items take more place than our screen has.
             Unfortunately there is no easy way to determine when it's going to happen (for how many items).
-            30 elements is an estimated number.
+            MAX_ITEMS_WITHOUT_SCREEN_BOUND elements is an estimated number.
              */
-            if (adapter.getItemCount() > 30) {
+            if (adapter.getItemCount() > MAX_ITEMS_WITHOUT_SCREEN_BOUND) {
                 // Only let the RecyclerView take up 100% of the screen height in order to speed up loading if there are many items
                 DisplayMetrics displayMetrics = new DisplayMetrics();
                 ((FormEntryActivity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -50,7 +50,11 @@ import timber.log.Timber;
 public abstract class AbstractSelectOneWidget extends SelectTextWidget implements MultiChoiceWidget {
 
     /**
-     * An estimated max number of elements for whom we don't need to resize a RecyclerView
+     * A list of choices can have thousands of items. To increase loading and scrolling performance,
+     * a RecyclerView is used. Because it is nested inside a ScrollView, by default, all of
+     * the RecyclerView's items are loaded and there is no performance benefit over a ListView.
+     * This constant is used to bound the number of items loaded. The value 40 was chosen because
+     * it is around the maximum number of elements that can be shown on a large tablet.
      */
     private static final int MAX_ITEMS_WITHOUT_SCREEN_BOUND = 40;
 
@@ -110,13 +114,6 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
             recyclerView.setAdapter(adapter);
             answerLayout.addView(recyclerView);
 
-            /*
-            It's not a very elegant solution but the only one we were able to come up with.
-            In case of many items we need to set the height of our RecyclerView in order to speed up loading.
-            Ideally we should do that only if our items take more place than our screen has.
-            Unfortunately there is no easy way to determine when it's going to happen (for how many items).
-            MAX_ITEMS_WITHOUT_SCREEN_BOUND elements is an estimated number.
-             */
             if (adapter.getItemCount() > MAX_ITEMS_WITHOUT_SCREEN_BOUND) {
                 // Only let the RecyclerView take up 80% of the screen height in order to speed up loading if there are many items
                 DisplayMetrics displayMetrics = new DisplayMetrics();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -45,7 +45,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.ActivityLogger;
-import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
@@ -573,32 +572,6 @@ public abstract class QuestionWidget
         imageView.setAdjustViewBounds(true);
         imageView.setImageBitmap(bitmap);
         return imageView;
-    }
-
-    /**
-     * It's needed only for external choices. Everything works well and
-     * out of the box when we use internal choices instead
-     */
-    protected void clearNextLevelsOfCascadingSelect() {
-        FormController formController = Collect.getInstance().getFormController();
-        if (formController == null) {
-            return;
-        }
-
-        if (formController.currentCaptionPromptIsQuestion()) {
-            try {
-                FormIndex startFormIndex = formController.getQuestionPrompt().getIndex();
-                formController.stepToNextScreenEvent();
-                while (formController.currentCaptionPromptIsQuestion()
-                        && formController.getQuestionPrompt().getFormElement().getAdditionalAttribute(null, "query") != null) {
-                    formController.saveAnswer(formController.getQuestionPrompt().getIndex(), null);
-                    formController.stepToNextScreenEvent();
-                }
-                formController.jumpToIndex(startFormIndex);
-            } catch (JavaRosaException e) {
-                Timber.d(e);
-            }
-        }
     }
 
     //region Data waiting

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneSearchWidget.java
@@ -16,14 +16,10 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.view.LayoutInflater;
-import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
-
-import java.util.List;
 
 /**
  * SelectOneSearchWidget allows the user to enter a value in an editable text box and based on
@@ -34,31 +30,22 @@ import java.util.List;
  * @author Raghu Mittal (raghu.mittal@handsrel.com)
  */
 @SuppressLint("ViewConstructor")
-public class SelectOneSearchWidget extends AbstractSelectOneWidget implements OnCheckedChangeListener, AudioPlayListener {
+public class SelectOneSearchWidget extends AbstractSelectOneWidget implements AudioPlayListener {
     public SelectOneSearchWidget(Context context, FormEntryPrompt prompt, boolean autoAdvance) {
         super(context, prompt, autoAdvance);
         createLayout();
+        setUpSearchBox();
     }
 
     @Override
-    protected void addButtonsToLayout(List<Integer> tagList) {
-        LayoutInflater inflater = LayoutInflater.from(getContext());
-        buttons.clear();
-        for (int i = 0; i < items.size(); i++) {
-            if (tagList == null || tagList.contains(i)) {
-                answerLayout.addView(createRadioButtonLayout(inflater, i));
-            }
+    protected void doSearch(String searchStr) {
+        if (adapter != null) {
+            adapter.getFilter().filter(searchStr);
         }
     }
 
     @Override
     public void setFocus(Context context) {
         SoftKeyboardUtils.showSoftKeyboard(searchStr);
-    }
-
-    @Override
-    protected void createLayout() {
-        readItems();
-        setUpSearchBox();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectTextWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectTextWidget.java
@@ -64,7 +64,11 @@ public abstract class SelectTextWidget extends SelectWidget {
         params.setMargins(7, 5, 7, 5);
         searchStr.setLayoutParams(params);
         setupChangeListener();
-        answerLayout.addView(searchStr, 0);
+        if (this instanceof SelectOneSearchWidget) {
+            answerLayout.addView(searchStr, 0);
+        } else {
+            addAnswerView(searchStr);
+        }
 
         String searchText = null;
         if (getState() != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectTextWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectTextWidget.java
@@ -64,7 +64,7 @@ public abstract class SelectTextWidget extends SelectWidget {
         params.setMargins(7, 5, 7, 5);
         searchStr.setLayoutParams(params);
         setupChangeListener();
-        addAnswerView(searchStr);
+        answerLayout.addView(searchStr, 0);
 
         String searchText = null;
         if (getState() != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -127,6 +127,25 @@ public abstract class SelectWidget extends QuestionWidget {
     }
 
     public MediaLayout createMediaLayout(int index, TextView textView) {
+        MediaLayout mediaLayout = new MediaLayout(getContext());
+
+        initMediaLayoutSetUp(mediaLayout);
+        setUpAVT(mediaLayout, index, textView);
+
+        if (index != items.size() - 1) {
+            mediaLayout.addDivider();
+        }
+
+        return mediaLayout;
+    }
+
+    public void initMediaLayoutSetUp(MediaLayout mediaLayout) {
+        mediaLayout.setAudioListener(this);
+        mediaLayout.setPlayTextColor(getPlayColor());
+        playList.add(mediaLayout);
+    }
+
+    public void setUpAVT(MediaLayout mediaLayout, int index, TextView textView) {
         String audioURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
 
         String imageURI;
@@ -140,17 +159,7 @@ public abstract class SelectWidget extends QuestionWidget {
         String videoURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "video");
         String bigImageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "big-image");
 
-        MediaLayout mediaLayout = new MediaLayout(getContext());
         mediaLayout.setAVT(getFormEntryPrompt().getIndex(), "." + Integer.toString(index), textView, audioURI,
                 imageURI, videoURI, bigImageURI, getPlayer());
-        mediaLayout.setAudioListener(this);
-        mediaLayout.setPlayTextColor(getPlayColor());
-        playList.add(mediaLayout);
-
-        if (index != items.size() - 1) {
-            mediaLayout.addDivider();
-        }
-
-        return mediaLayout;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -126,7 +126,7 @@ public abstract class SelectWidget extends QuestionWidget {
         }
     }
 
-    protected MediaLayout createMediaLayout(int index, TextView textView) {
+    public MediaLayout createMediaLayout(int index, TextView textView) {
         String audioURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
 
         String imageURI;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -130,7 +130,7 @@ public abstract class SelectWidget extends QuestionWidget {
         MediaLayout mediaLayout = new MediaLayout(getContext());
 
         initMediaLayoutSetUp(mediaLayout);
-        setUpAVT(mediaLayout, index, textView);
+        addMediaFromChoice(mediaLayout, index, textView);
 
         if (index != items.size() - 1) {
             mediaLayout.addDivider();
@@ -145,7 +145,10 @@ public abstract class SelectWidget extends QuestionWidget {
         playList.add(mediaLayout);
     }
 
-    public void setUpAVT(MediaLayout mediaLayout, int index, TextView textView) {
+    /**
+     * Pull media from the current item and add it to the media layout.
+     */
+    public void addMediaFromChoice(MediaLayout mediaLayout, int index, TextView textView) {
         String audioURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
 
         String imageURI;

--- a/collect_app/src/main/res/layout/nested_scroll_view.xml
+++ b/collect_app/src/main/res/layout/nested_scroll_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Nafundi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<android.support.v4.widget.NestedScrollView
+    android:id="@+id/odk_view_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:scrollbars="vertical">
+
+</android.support.v4.widget.NestedScrollView>

--- a/collect_app/src/main/res/layout/quick_select_layout.xml
+++ b/collect_app/src/main/res/layout/quick_select_layout.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal" >
+    android:orientation="horizontal">
 
-    <LinearLayout
+    <FrameLayout
+        android:id="@+id/container"
         android:orientation="horizontal"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -12,11 +15,13 @@
         android:layout_alignParentLeft="true" />
 
     <ImageView
+        android:id="@+id/auto_advance_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
-        android:contentDescription="@string/select_answer" />
+        android:contentDescription="@string/select_answer"
+        app:srcCompat="@drawable/expander_ic_right"/>
 
 </RelativeLayout>

--- a/collect_app/src/main/res/layout/quick_select_layout.xml
+++ b/collect_app/src/main/res/layout/quick_select_layout.xml
@@ -6,8 +6,8 @@
     android:layout_height="match_parent"
     android:orientation="horizontal">
 
-    <FrameLayout
-        android:id="@+id/container"
+    <org.odk.collect.android.views.MediaLayout
+        android:id="@+id/mediaLayout"
         android:orientation="horizontal"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"


### PR DESCRIPTION
Closes #2494 

#### What has been done to verify that this works as intended?
I tested forms attached below. I don't have any form with more than 1k items I could share but I'll add once I create it.

#### Why is this the best possible solution? Were any other approaches considered?
RecyclerView is the fastest way and now loading a select_one widget with more than 1k items takes less than one second on my Samsung Galaxy S4 Android 5.

#### Are there any risks to merging this code? If so, what are they?
Yes, all select_one widgets should be tested to avoid regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used:
AllWidgets form

[SelectOneInFieldList.xml.txt](https://github.com/opendatakit/collect/files/2331764/SelectOneInFieldList.xml.txt)
[SelectOneInFieldList_manyItems.xml.txt](https://github.com/opendatakit/collect/files/2331766/SelectOneInFieldList_manyItems.xml.txt)

https://drive.google.com/file/d/1jZg3ye-27zkZeBhxUIzDNyoAusjt2UeF/view?usp=sharing

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)