### PR TITLE
An audio file should be played immediately after clicking on an audio button

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/AudioButton.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/AudioButton.java
@@ -39,10 +39,14 @@ import timber.log.Timber;
  */
 public class AudioButton extends AppCompatImageButton {
 
+    private static int lastPlayedAudioId;
+    private static FormIndex lastPlayedWidgetIndex;
+
     private AudioHandler handler;
     private MediaPlayer player;
     private Bitmap bitmapPlay;
     private Bitmap bitmapStop;
+    private FormIndex formIndex;
 
     public AudioButton(Context context) {
         super(context);
@@ -63,6 +67,7 @@ public class AudioButton extends AppCompatImageButton {
 
     public void init(FormIndex index, String selectionDesignator, String uri, MediaPlayer player) {
         this.player = player;
+        formIndex = index;
         handler = new AudioHandler(index, selectionDesignator, uri, player);
     }
 
@@ -71,6 +76,8 @@ public class AudioButton extends AppCompatImageButton {
     }
 
     public void playAudio() {
+        lastPlayedAudioId = (int) getTag();
+        lastPlayedWidgetIndex = formIndex;
         handler.playAudio(getContext());
         setImageBitmap(bitmapStop);
     }
@@ -79,6 +86,14 @@ public class AudioButton extends AppCompatImageButton {
         if (player.isPlaying()) {
             player.stop();
             resetBitmap();
+
+            /*
+            It's the case when we click on an audio button while another audio file
+            (from another audio button but from the same question) is playing.
+             */
+            if (lastPlayedAudioId != (int) getTag() && lastPlayedWidgetIndex.equals(formIndex)) {
+                playAudio();
+            }
         } else {
             playAudio();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -190,6 +190,7 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
             audioButton.setVisibility(VISIBLE);
             audioButton.init(index, selectionDesignator, audioURI, player);
             audioButton.setOnClickListener(this);
+            audioButton.setTag(ViewIds.generateViewId());
         }
 
         // Setup video button


### PR DESCRIPTION
Closes #2521 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
If we click on another audio button the file should be played immediately it's the natural and expected behavior.

#### Are there any risks to merging this code? If so, what are they?
A case if we have more than one widget on one page may be tricky. Here is an example:
https://drive.google.com/file/d/1cHy-PzJsn3um3xpMs1hK1t5J5TjOP7aQ/view?usp=sharing
In such a case we allow playing multiple audio files at the same time so it's ok and nothing should change here.

#### Do we need any specific form for testing your changes? If so, please attach one.
A form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)