### PR TITLE
Display warning dialog for current() predicate

### DIFF
--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -654,4 +654,10 @@
     <string name="missing_google_account_dialog_title">Google account not set</string>
     <string name="missing_google_account_dialog_desc">To submit forms via Google Sheets you have to set up your Google account in the Server settings.</string>
     <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
+
+    <!-- Text for temporary notification of upcoming change. Please do not translate "current()". -->
+    <string name="current_predicate_warning">This question will not be compatible with future versions of ODK Collect because it uses current() in a choice filter. \n\nPlease make sure the person who made this form reads the details below and takes action.</string>
+    <string name="current_predicate_warning_title">Action needed</string>
+    <string name="current_predicate_forum">Read details</string>
+    <string name="current_predicate_continue">Continue</string>
 </resources>


### PR DESCRIPTION
Adds dialog warning users about upcoming change to `current()` in choice filters. Logs an analytics event for when the web page with details is shown so that we can track what forms have received the warning.

It would be good to get this merged soon so we can be sure translations for the most common languages make it into the release.

#### What has been done to verify that this works as intended?
Ran with [predicate-warning.xml.txt](https://github.com/opendatakit/collect/files/2359089/predicate-warning.xml.txt) ([XLSForm](https://docs.google.com/spreadsheets/d/1j3u5el6XP4_MaRfi_IWjpvL_uIVdsXdmVPgZQJ3395k/edit#gid=0)), verified that the dialogs show up on questions with predicates that have `current()` in them and that they don't show up on questions that don't.  Looked at the real time analytics console and verified that events are being sent.

#### Why is this the best possible solution? Were any other approaches considered?
- The current version looked for `current` in a predicate. This looks for `func-expr:current` because I realized `current` could be part of a question name. This avoids false positives.
- Where to show the dialog: I considered doing it at form load but then it's less clear which question is the problem and the implementation is more complex.
- What to show in the dialog: I tried to make the language precise and understandable. I considered putting a URL in the dialog text but having a "Read details" button seemed to make it easier to take action.
- How often to show the dialog: I considered adding a "don't show this again" checkbox but haven't yet because it adds complexity and may make it difficult for users to get to the information if they dismiss it and then realize they should have paid attention. I will solicit feedback on this and it's something we may want to add later.
- Implementation-wise, it's not pretty but since this is temporary, I think it's a good balance between simplicity and cleanliness. For example, the `WidgetFactory` really shouldn't be creating dialogs and it's not very nice that a method that logs analytics also returns whether the question has a predicate with `current()` in it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Because this shows a dialog for every single question with `current()` in its choice filter every single time a new form is filled, it will get annoying for enumerators. July 26 - Sept 5, 44 unique forms had this property so the impact won't be huge (4222 unique forms used choice filters without `current()`).

There should be no other change in behavior. A risk would be that select questions *without* `current()` in their predicates are affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
[predicate-warning.xml.txt](https://github.com/opendatakit/collect/files/2359110/predicate-warning.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew pmd checkstyle lintDebug spotbugsDebug testDebugUnitTest connectedDebugAndroidTest` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)