### PR TITLE
App crashes when the user tries to open `Admin Settings` if targetSdkVersion is set to 24

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -71,7 +71,7 @@ android {
     defaultConfig {
         applicationId('org.odk.collect.android')
         minSdkVersion(16)
-        targetSdkVersion(23)
+        targetSdkVersion(24)
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('android.support.test.runner.AndroidJUnitRunner')

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesFragment.java
@@ -21,7 +21,6 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
-import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.text.InputType;
 import android.view.LayoutInflater;
@@ -39,7 +38,6 @@ import org.odk.collect.android.fragments.dialogs.SimpleDialog;
 import org.odk.collect.android.utilities.ToastUtils;
 
 import static android.content.Context.MODE_PRIVATE;
-import static android.content.Context.MODE_WORLD_READABLE;
 import static org.odk.collect.android.fragments.dialogs.MovingBackwardsDialog.MOVING_BACKWARDS_DIALOG_TAG;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_ADMIN_PW;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_CHANGE_ADMIN_PASSWORD;
@@ -58,9 +56,7 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        PreferenceManager prefMgr = getPreferenceManager();
-        prefMgr.setSharedPreferencesName(ADMIN_PREFERENCES);
-        prefMgr.setSharedPreferencesMode(MODE_WORLD_READABLE);
+        getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
         addPreferencesFromResource(R.xml.admin_preferences);
 
@@ -173,9 +169,7 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-            PreferenceManager prefMgr = getPreferenceManager();
-            prefMgr.setSharedPreferencesName(ADMIN_PREFERENCES);
-            prefMgr.setSharedPreferencesMode(MODE_WORLD_READABLE);
+            getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
             addPreferencesFromResource(R.xml.main_menu_access_preferences);
             findPreference(KEY_EDIT_SAVED).setEnabled((Boolean) AdminSharedPreferences.getInstance().get(ALLOW_OTHER_WAYS_OF_EDITING_FORM));
@@ -201,9 +195,7 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-            PreferenceManager prefMgr = getPreferenceManager();
-            prefMgr.setSharedPreferencesName(ADMIN_PREFERENCES);
-            prefMgr.setSharedPreferencesMode(MODE_WORLD_READABLE);
+            getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
             addPreferencesFromResource(R.xml.user_settings_access_preferences);
         }
@@ -227,9 +219,7 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
-            PreferenceManager prefMgr = getPreferenceManager();
-            prefMgr.setSharedPreferencesName(ADMIN_PREFERENCES);
-            prefMgr.setSharedPreferencesMode(MODE_WORLD_READABLE);
+            getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
             addPreferencesFromResource(R.xml.form_entry_access_preferences);
 


### PR DESCRIPTION
Closes #2525 

I think it would be better to merge this pr after the upcoming release since it bumps targetSdkVersion.

#### What has been done to verify that this works as intended?
I tested AdminPreferences. I also bumped targetSdkVersion to 24 since this issue is the only one we noticed in API 24.

#### Why is this the best possible solution? Were any other approaches considered?
MODE_WORLD_READABLE is no longer supported. There is no need to set setSharedPreferencesMode there so I just removed those lines.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't affect anything.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)