### PR TITLE
Fix double instantiation of widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -443,9 +443,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             saveToDiskTask = (SaveToDiskTask) data;
         } else if (data == null) {
             if (!newForm) {
-                if (getFormController(true) != null) {
-                    refreshCurrentView();
-                } else {
+                if (getFormController(true) == null) {
                     Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath);
                     showFormLoadingDialogFragment();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -230,6 +230,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     private static final int SAVING_DIALOG = 2;
 
+    public boolean isSavingMedia;
+
     private boolean autoSaved;
     private boolean allowMovingBackwards;
 
@@ -729,7 +731,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     getCurrentViewIfODKView().setBinaryData(sb);
                 }
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
-                refreshCurrentView();
                 return;
             }
         }
@@ -838,6 +839,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 ProgressDialogFragment.newInstance(getString(R.string.please_wait))
                         .show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
 
+                isSavingMedia = true;
                 mediaLoadingFragment.beginMediaLoadingTask(intent.getData());
 
                 break;
@@ -916,9 +918,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 // We may have jumped to a new index in hierarchy activity, so
                 // refresh
                 break;
-
         }
-        refreshCurrentView();
+
+        // Now, onResume() gets called and calls refreshCurrentView() to reload the current widget.
+        // But if media is being loaded on a background thread,
+        // then the refresh will be postponed until the media fully loads
     }
 
     public QuestionWidget getWidgetWaitingForBinaryData() {
@@ -2190,7 +2194,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 startActivity(new Intent(this, MainMenuActivity.class));
                 finish();
                 return;
-            } else {
+            } else if (!isSavingMedia) {
                 refreshCurrentView();
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -98,5 +98,6 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
 
         formEntryActivity.get().saveAnswersForCurrentScreen(FormEntryActivity.DO_NOT_EVALUATE_CONSTRAINTS);
         formEntryActivity.get().refreshCurrentView();
+        formEntryActivity.get().isSavingMedia = false;
     }
 }


### PR DESCRIPTION
Closes #2537 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Added logs at the widget creation point to verify that only one instance is being generated when opening the form for the first time or returning from FormHierarchy Screen.

Test Cases verified:
 - Opening a fresh form
 - Opening a saved form
 - Opening a form > Goto > Choosing a widget
 - Opening a form > General Settings > Back
 - Opening a form > General Settings > Navigation changed to button > Back > Button visible

#### Why is this the best possible solution? Were any other approaches considered?
This is the only approach I considered since it seemed logical to me

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Does not change any behavior for the user. But it might speed up the response time after coming back from a hierarchy screen.

#### Do we need any specific form for testing your changes? If so, please attach one.
I tested with the All-Widgets form provided on the Aggregate server

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)