### PR TITLE
Separate out search and search() appearances

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -59,13 +59,19 @@ public class WidgetFactory {
     public static QuestionWidget createWidgetFromPrompt(FormEntryPrompt fep, Context context,
                                                         boolean readOnlyOverride) {
 
-        // get appearance hint and clean it up so it is lower case and never null...
+        // Get appearance hint and clean it up so it is lower case and never null.
         String appearance = fep.getAppearanceHint();
         if (appearance == null) {
             appearance = "";
         }
-        // for now, all appearance tags are in english...
+        // For now, all appearance tags are in English.
         appearance = appearance.toLowerCase(Locale.ENGLISH);
+
+        // The search appearance which shows a text area for filtering choices is distinct
+        // from the search() appearance/function. The two can combine but a text area should
+        // not be shown if only the appearance/function is specified.
+        boolean hasSearchAppearance = appearance.contains("search")
+                && !appearance.contains("search(") || appearance.contains("search ");
 
         final QuestionWidget questionWidget;
         switch (fep.getControlType()) {
@@ -201,7 +207,7 @@ public class WidgetFactory {
                     questionWidget = new GridWidget(context, fep, numColumns, appearance.contains("quick"));
                 } else if (appearance.contains("minimal")) {
                     questionWidget = new SpinnerWidget(context, fep, appearance.contains("quick"));
-                } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
+                } else if (hasSearchAppearance || appearance.contains("autocomplete")) {
                     questionWidget = new SelectOneSearchWidget(context, fep, appearance.contains("quick"));
                 } else if (appearance.contains("list-nolabel")) {
                     questionWidget = new ListWidget(context, fep, false, appearance.contains("quick"));
@@ -247,7 +253,7 @@ public class WidgetFactory {
                     questionWidget = new ListMultiWidget(context, fep, true);
                 } else if (appearance.startsWith("label")) {
                     questionWidget = new LabelWidget(context, fep);
-                } else if (appearance.contains("autocomplete")) {
+                } else if (hasSearchAppearance || appearance.contains("autocomplete")) {
                     questionWidget = new SelectMultipleAutocompleteWidget(context, fep);
                 } else if (appearance.startsWith("image-map")) {
                     questionWidget = new SelectMultiImageMapWidget(context, fep);


### PR DESCRIPTION
A search textbox should not be displayed if the search() appearance/function is used. The search appearance should alias to autocomplete for multiple selects.

Closes #2501 and Closes #2502

#### What has been done to verify that this works as intended?
I used [different-search-appearances.zip](https://github.com/opendatakit/collect/files/2312405/different-search-appearances.zip) to make sure that each combination of appearances has the intended behavior.

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change I could think of. Other options would include splitting appearances into a list to do more sophisticated comparisons but that didn't seem necessary.

Instead of just looking for matches with `search`, I changed the test to `appearance.contains("search") && !appearance.contains("search(") || appearance.contains("search ")`. The first part before the `||` addresses the case where only `search` or only `search()` is included in the appearance list. The second part after the `||` addresses the case where the two combine. Since "normal" appearances must appear before the search() appearance/function, searching for `search` followed by a space is sufficient.

I decided to introduce a boolean variable so I could explain the check in a comment.

I considered issuing two different PRs but really there's just one change here so doing it as one commit made the most sense to me.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

When the `search()` appearance is used, a search textbox will no longer be shown. This could be undesirable for users that have grown used to this behavior. There is regression risk around select questions.

#### Do we need any specific form for testing your changes? If so, please attach one.
[different-search-appearances.zip](https://github.com/opendatakit/collect/files/2312405/different-search-appearances.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
I don't think so. This just makes it true that all appearances can combine with `search()`.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)