### PR TITLE
Remove Firebase performance monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
         classpath 'org.ow2.asm:asm:6.0' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.0'
         classpath 'io.fabric.tools:gradle:1.25.2'
-        classpath 'com.google.firebase:firebase-plugins:1.1.5'
     }
 }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'io.fabric'
 apply from: '../config/quality.gradle'
 apply from: '../config/jacoco.gradle'
@@ -198,7 +197,6 @@ dependencies {
     implementation "com.google.android.gms:play-services-location:15.0.1"
 
     implementation "com.google.firebase:firebase-core:16.0.1"
-    implementation "com.google.firebase:firebase-perf:16.1.0"
     implementation "com.crashlytics.sdk.android:crashlytics:2.9.2"
 
     implementation("com.google.code.gson:gson:2.6.2") {


### PR DESCRIPTION
Closes #2542 

#### What has been done to verify that this works as intended?
Verified that the steps at https://firebase.google.com/docs/perf-mon/get-started-android#add-performance-monitoringto-your-app have been reversed.

#### Why is this the best possible solution? Were any other approaches considered?
I'm not completely sure I want to remove this right away and have described my thinking in the issue. If we are convinced we want to remove it, I think this is the only way. We could also revert the dependency version updates but I don't think that's necessary.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no visible change to users. It means we won't get performance log so may not be able to react to existing performance issues.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)