### PR TITLE
Revert Google Cloud SDK to v216 to fix gcloud crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ references:
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:
-      - image: google/cloud-sdk:latest
+      - image: google/cloud-sdk:216.0.0
 
 jobs:
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I ran a version of this PR with v216 as the Docker image and a `.circleci/config.yml` with the branch filters removed. While I was not able to get a successful build, I can confirm that the `gcloud firebase test android run` command that was failing due to `gcloud crashed (TypeError): expected string or buffer` runs without a crash. 

#### Why is this the best possible solution? Were any other approaches considered?
It may not even be the solution, but this is a lot faster to try than setting up Firebase on my personal account.