### PR TITLE
Read only is ignored for rank

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -170,6 +170,7 @@ public class RankingWidget extends QuestionWidget implements BinaryWidget {
         widgetLayout = new LinearLayout(getContext());
         widgetLayout.setOrientation(LinearLayout.VERTICAL);
         showRankingDialogButton = getSimpleButton(getContext().getString(R.string.rank_items));
+        showRankingDialogButton.setEnabled(!getFormEntryPrompt().isReadOnly());
         widgetLayout.addView(showRankingDialogButton);
         widgetLayout.addView(setUpAnswerTextView());
 


### PR DESCRIPTION
Closes #2551

#### What has been done to verify that this works as intended?
I tested the for attached to the issue and confirmed that the behavior is consistent with other readonly questions.

#### Why is this the best possible solution? Were any other approaches considered?
If a question is readonly we shouldn't allow editing its value.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There is no risk here. The only change I made is disabling `Rank items` button if a question is readonly.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)