### PR TITLE
Non-question object at form index when rank questions are in field-list

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
@@ -26,6 +26,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.RankingListAdapter.ItemViewHolder;
@@ -40,11 +41,11 @@ import java.util.List;
 public class RankingListAdapter extends Adapter<ItemViewHolder> {
 
     private final List<String> values;
-    private final FormController formController;
+    private final FormIndex formIndex;
 
-    public RankingListAdapter(List<String> values) {
+    public RankingListAdapter(List<String> values, FormIndex formIndex) {
         this.values = new ArrayList<>(values);
-        formController = Collect.getInstance().getFormController();
+        this.formIndex = formIndex;
     }
 
     @NonNull
@@ -55,14 +56,15 @@ public class RankingListAdapter extends Adapter<ItemViewHolder> {
 
     @Override
     public void onBindViewHolder(@NonNull final ItemViewHolder holder, int position) {
+        FormController formController = Collect.getInstance().getFormController();
         String itemName = formController != null
-                ? formController.getQuestionPrompt().getSelectChoiceText(getItem(values.get(position)))
+                ? formController.getQuestionPrompt(formIndex).getSelectChoiceText(getItem(formController, values.get(position)))
                 : values.get(position);
         holder.textView.setText(itemName);
     }
 
-    private SelectChoice getItem(String value) {
-        for (SelectChoice item : formController.getQuestionPrompt().getSelectChoices()) {
+    private SelectChoice getItem(FormController formController, String value) {
+        for (SelectChoice item : formController.getQuestionPrompt(formIndex).getSelectChoices()) {
             if (item.getValue().equals(value)) {
                 return item;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
@@ -33,6 +33,7 @@ import android.widget.LinearLayout.LayoutParams;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import org.javarosa.core.model.FormIndex;
 import org.odk.collect.android.R;
 import org.odk.collect.android.R.string;
 import org.odk.collect.android.adapters.RankingListAdapter;
@@ -45,20 +46,23 @@ import java.util.List;
 public class RankingWidgetDialog extends DialogFragment {
 
     private static final String VALUES = "values";
+    private static final String FORM_INDEX = "form_index";
 
     private RankingListener listener;
 
     private RankingListAdapter rankingListAdapter;
     private List<String> values;
+    private FormIndex formIndex;
 
     public interface RankingListener {
         void onRankingChanged(List<String> values);
     }
 
-    public static RankingWidgetDialog newInstance(List<String> values) {
+    public static RankingWidgetDialog newInstance(List<String> values, FormIndex formIndex) {
         RankingWidgetDialog dialog = new RankingWidgetDialog();
         Bundle bundle = new Bundle();
         bundle.putSerializable(VALUES, (Serializable) values);
+        bundle.putSerializable(FORM_INDEX, formIndex);
         dialog.setArguments(bundle);
 
         return dialog;
@@ -78,12 +82,15 @@ public class RankingWidgetDialog extends DialogFragment {
         values = (List<String>) (savedInstanceState == null
                         ? getArguments().getSerializable(VALUES)
                         : savedInstanceState.getSerializable(VALUES));
+        formIndex = (FormIndex) (savedInstanceState == null
+                        ? getArguments().getSerializable(FORM_INDEX)
+                        : savedInstanceState.getSerializable(FORM_INDEX));
     }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         return new Builder(getActivity())
-                .setView(setUpRankingLayout(values))
+                .setView(setUpRankingLayout(values, formIndex))
                 .setPositiveButton(string.ok, (dialog, id) -> {
                     listener.onRankingChanged(rankingListAdapter.getValues());
                     dismiss();
@@ -98,11 +105,11 @@ public class RankingWidgetDialog extends DialogFragment {
         super.onSaveInstanceState(outState);
     }
 
-    private ScrollView setUpRankingLayout(List<String> values) {
+    private ScrollView setUpRankingLayout(List<String> values, FormIndex formIndex) {
         LinearLayout rankingLayout = new LinearLayout(getContext());
         rankingLayout.setOrientation(LinearLayout.HORIZONTAL);
         rankingLayout.addView(setUpPositionsLayout(values));
-        rankingLayout.addView(setUpRecyclerView(values));
+        rankingLayout.addView(setUpRecyclerView(values, formIndex));
         rankingLayout.setPadding(10, 0, 10, 0);
 
         ScrollView scrollView = new ScrollView(getContext());
@@ -129,8 +136,8 @@ public class RankingWidgetDialog extends DialogFragment {
         return positionsLayout;
     }
 
-    private RecyclerView setUpRecyclerView(List<String> values) {
-        rankingListAdapter = new RankingListAdapter(values);
+    private RecyclerView setUpRecyclerView(List<String> values, FormIndex formIndex) {
+        rankingListAdapter = new RankingListAdapter(values, formIndex);
 
         RecyclerView recyclerView = new RecyclerView(getContext());
         recyclerView.setHasFixedSize(true);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -96,11 +96,11 @@ public class RankingWidget extends QuestionWidget implements BinaryWidget {
     public void onButtonClick(int buttonId) {
         FormController formController = Collect.getInstance().getFormController();
         if (formController != null) {
-            formController.setIndexWaitingForData(formController.getFormIndex());
+            formController.setIndexWaitingForData(getFormEntryPrompt().getIndex());
         }
         RankingWidgetDialog rankingWidgetDialog = RankingWidgetDialog.newInstance(savedItems == null
                 ? getValues(originalItems)
-                : getValues(savedItems));
+                : getValues(savedItems), getFormEntryPrompt().getIndex());
         rankingWidgetDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), "RankingDialog");
     }
 


### PR DESCRIPTION
Closes #2552 

#### What has been done to verify that this works as intended?
I tested the ranking widget:
- normal question
- multiple questions on one page

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix. We use a formIndex of a question to get choices but if we use field-list default formIndex is an index of a group what caused the problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a bug fix. I can't see any risk here and it shouldn't affect anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)