### PR TITLE
Support readOnly option in SelectMap widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
@@ -119,6 +119,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
         readItems();
 
         webView = new CustomWebView(getContext());
+
         selectedAreasLabel = getAnswerTextView();
         answerLayout.addView(webView);
         answerLayout.addView(selectedAreasLabel);
@@ -147,6 +148,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
             webView.getSettings().setUseWideViewPort(true);
             int height = (int) (getResources().getDisplayMetrics().heightPixels / 1.7); // about 60% of a screen
             webView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height));
+            webView.setOnTouchListener((v, event) -> getFormEntryPrompt().isReadOnly());
             webView.setWebViewClient(new WebViewClient() {
                 @Override
                 public void onPageFinished(WebView view, String url) {


### PR DESCRIPTION
Closes #2558 

#### What has been done to verify that this works as intended?
I tested the attached form (to the issue) and `All widgets` form.

#### Why is this the best possible solution? Were any other approaches considered?
I tried `setEnabled(false)` and `setClickable(false)` but it didn't work so I decided using `setOnTouchListener` and consuming the event if needed (what makes the job because if `isReadonly()` returns true the event is consumed and isn't propagated to the WebView).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should be safe and shouldn't affect anything else. The only change is supporting readonly option.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue and `All widgets` form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)