### PR TITLE
Support readOnly option in the ArbitraryWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -141,6 +141,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
         widgetLayout.setOrientation(LinearLayout.VERTICAL);
 
         chooseFileButton = getSimpleButton(getContext().getString(R.string.choose_file));
+        chooseFileButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.HORIZONTAL);


### PR DESCRIPTION
Closes #2560 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
We should support readonly option in the ArbitraryWidget.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't affect anything else. It's just an approach we use widely in all widgets with buttons.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form is attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)