### PR TITLE
Hide buttons if a question is readonly

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractDateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractDateWidget.java
@@ -118,7 +118,6 @@ public abstract class AbstractDateWidget extends QuestionWidget implements Binar
 
     private void createDateButton() {
         dateButton = getSimpleButton(getContext().getString(R.string.select_date));
-        dateButton.setEnabled(!getFormEntryPrompt().isReadOnly());
     }
 
     private void addViews() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -83,20 +83,13 @@ public class AlignedImageWidget extends BaseImageWidget {
         }
 
         captureButton = getSimpleButton(getContext().getString(R.string.capture_image), R.id.capture_image);
-        captureButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         chooseButton = getSimpleButton(getContext().getString(R.string.choose_image), R.id.choose_image);
-        chooseButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         answerLayout.addView(captureButton);
         answerLayout.addView(chooseButton);
         answerLayout.addView(errorTextView);
 
-        // and hide the capture and choose button if read-only
-        if (getFormEntryPrompt().isReadOnly()) {
-            captureButton.setVisibility(View.GONE);
-            chooseButton.setVisibility(View.GONE);
-        }
         errorTextView.setVisibility(View.GONE);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -68,19 +68,14 @@ public class AnnotateWidget extends BaseImageWidget {
     protected void setUpLayout() {
         super.setUpLayout();
         captureButton = getSimpleButton(getContext().getString(R.string.capture_image), R.id.capture_image);
-        captureButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         chooseButton = getSimpleButton(getContext().getString(R.string.choose_image), R.id.choose_image);
-        chooseButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         annotateButton = getSimpleButton(getContext().getString(R.string.markup_image), R.id.markup_image);
-        annotateButton.setEnabled(!(binaryName == null || getFormEntryPrompt().isReadOnly()));
-        annotateButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                imageClickHandler.clickImage("annotateButton");
-            }
-        });
+        if (binaryName == null) {
+            annotateButton.setEnabled(false);
+        }
+        annotateButton.setOnClickListener(v -> imageClickHandler.clickImage("annotateButton"));
 
         answerLayout.addView(captureButton);
         answerLayout.addView(chooseButton);
@@ -100,9 +95,7 @@ public class AnnotateWidget extends BaseImageWidget {
     @Override
     public void clearAnswer() {
         super.clearAnswer();
-        if (!getFormEntryPrompt().isReadOnly()) {
-            annotateButton.setEnabled(false);
-        }
+        annotateButton.setEnabled(false);
 
         // reset buttons
         captureButton.setText(getContext().getString(R.string.capture_image));
@@ -146,11 +139,7 @@ public class AnnotateWidget extends BaseImageWidget {
     }
 
     private void hideButtonsIfNeeded() {
-        if (getFormEntryPrompt().isReadOnly()) {
-            captureButton.setVisibility(View.GONE);
-            chooseButton.setVisibility(View.GONE);
-            annotateButton.setVisibility(View.GONE);
-        } else if (getFormEntryPrompt().getAppearanceHint() != null
+        if (getFormEntryPrompt().getAppearanceHint() != null
                 && getFormEntryPrompt().getAppearanceHint().toLowerCase(Locale.ENGLISH).contains("new")) {
             chooseButton.setVisibility(View.GONE);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -83,10 +83,8 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
         this.audioController = audioController;
 
         captureButton = getSimpleButton(getContext().getString(R.string.capture_audio), R.id.capture_audio);
-        captureButton.setEnabled(!prompt.isReadOnly());
 
         chooseButton = getSimpleButton(getContext().getString(R.string.choose_sound), R.id.choose_sound);
-        chooseButton.setEnabled(!prompt.isReadOnly());
 
         audioController.init(context, getPlayer(), getFormEntryPrompt());
 
@@ -197,10 +195,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
     }
 
     private void hideButtonsIfNeeded() {
-        if (getFormEntryPrompt().isReadOnly()) {
-            captureButton.setVisibility(View.GONE);
-            chooseButton.setVisibility(View.GONE);
-        } else if (getFormEntryPrompt().getAppearanceHint() != null
+        if (getFormEntryPrompt().getAppearanceHint() != null
                 && getFormEntryPrompt().getAppearanceHint().toLowerCase(Locale.ENGLISH).contains("new")) {
             chooseButton.setVisibility(View.GONE);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -49,7 +49,6 @@ public class BarcodeWidget extends QuestionWidget implements BinaryWidget {
         super(context, prompt);
 
         getBarcodeButton = getSimpleButton(getContext().getString(R.string.get_barcode));
-        getBarcodeButton.setEnabled(!prompt.isReadOnly());
 
         stringAnswer = getCenteredAnswerTextView();
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -24,7 +24,6 @@ import android.hardware.SensorManager;
 import android.text.InputType;
 import android.text.method.DigitsKeyListener;
 import android.util.TypedValue;
-import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -66,10 +65,6 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
         answer.setBackground(null);
 
         getBearingButton = getSimpleButton(getContext().getString(R.string.get_bearing));
-        getBearingButton.setEnabled(!prompt.isReadOnly());
-        if (prompt.isReadOnly()) {
-            getBearingButton.setVisibility(View.GONE);
-        }
 
         answerLayout.addView(getBearingButton);
         answerLayout.addView(answer);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
@@ -47,14 +47,10 @@ public class DrawWidget extends BaseImageWidget {
     protected void setUpLayout() {
         super.setUpLayout();
         drawButton = getSimpleButton(getContext().getString(R.string.draw_image));
-        drawButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         answerLayout.addView(drawButton);
         answerLayout.addView(errorTextView);
 
-        if (getFormEntryPrompt().isReadOnly()) {
-            drawButton.setVisibility(View.GONE);
-        }
         errorTextView.setVisibility(View.GONE);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
@@ -124,10 +124,6 @@ public class ExPrinterWidget extends QuestionWidget implements BinaryWidget {
         String buttonText = (v != null) ? v : context.getString(R.string.launch_printer);
         launchIntentButton = getSimpleButton(buttonText);
 
-        if (prompt.isReadOnly()) {
-            launchIntentButton.setEnabled(false);
-        }
-
         // finish complex layout
         LinearLayout printLayout = new LinearLayout(getContext());
         printLayout.setOrientation(LinearLayout.VERTICAL);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -145,7 +145,6 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
         String buttonText = (v != null) ? v : context.getString(R.string.launch_app);
 
         launchIntentButton = getSimpleButton(buttonText);
-        launchIntentButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         // finish complex layout
         LinearLayout answerLayout = new LinearLayout(getContext());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -111,7 +111,6 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
         viewButton = getSimpleButton(getContext().getString(R.string.get_point), R.id.get_point);
 
         getLocationButton = getSimpleButton(R.id.get_location);
-        getLocationButton.setEnabled(!prompt.isReadOnly());
 
         // finish complex layout
         // control what gets shown with setVisibility(View.GONE)
@@ -138,8 +137,6 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
         // for maps, we show the view button.
 
         if (useMapsV2 && useMaps) {
-            // show the GetLocation button
-            getLocationButton.setVisibility(View.VISIBLE);
             // hide the view button
             viewButton.setVisibility(View.GONE);
             if (readOnly) {
@@ -155,11 +152,7 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
                 }
             }
         } else {
-            // if it is read-only, hide the get-location button...
-            if (readOnly) {
-                getLocationButton.setVisibility(View.GONE);
-            } else {
-                getLocationButton.setVisibility(View.VISIBLE);
+            if (!readOnly) {
                 getLocationButton.setText(getContext().getString(
                         dataAvailable ? R.string.change_location : R.string.get_point));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -64,10 +64,6 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
 
         createShapeButton = getSimpleButton(getContext().getString(R.string.get_shape));
 
-        if (prompt.isReadOnly()) {
-            createShapeButton.setEnabled(false);
-        }
-
         LinearLayout answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(createShapeButton);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -72,10 +72,6 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
 
         createTraceButton = getSimpleButton(getContext().getString(R.string.get_trace));
 
-        if (prompt.isReadOnly()) {
-            createTraceButton.setEnabled(false);
-        }
-
         LinearLayout answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(createTraceButton);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -85,10 +85,8 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
         errorTextView.setText(R.string.selected_invalid_image);
 
         captureButton = getSimpleButton(getContext().getString(R.string.capture_image), R.id.capture_image);
-        captureButton.setEnabled(!prompt.isReadOnly());
 
         chooseButton = getSimpleButton(getContext().getString(R.string.choose_image), R.id.choose_image);
-        chooseButton.setEnabled(!prompt.isReadOnly());
 
         // finish complex layout
         LinearLayout answerLayout = new LinearLayout(getContext());
@@ -97,11 +95,6 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
         answerLayout.addView(chooseButton);
         answerLayout.addView(errorTextView);
 
-        // and hide the capture and choose button if read-only
-        if (prompt.isReadOnly()) {
-            captureButton.setVisibility(View.GONE);
-            chooseButton.setVisibility(View.GONE);
-        }
         errorTextView.setVisibility(View.GONE);
 
         // retrieve answer from data model and update ui

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -68,10 +68,8 @@ public class ImageWidget extends BaseImageWidget {
                 || appearance.equalsIgnoreCase("new-front"));
 
         captureButton = getSimpleButton(getContext().getString(R.string.capture_image), R.id.capture_image);
-        captureButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         chooseButton = getSimpleButton(getContext().getString(R.string.choose_image), R.id.choose_image);
-        chooseButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         answerLayout.addView(captureButton);
         answerLayout.addView(chooseButton);
@@ -137,10 +135,7 @@ public class ImageWidget extends BaseImageWidget {
     }
 
     private void hideButtonsIfNeeded(String appearance) {
-        if (getFormEntryPrompt().isReadOnly()) {
-            captureButton.setVisibility(View.GONE);
-            chooseButton.setVisibility(View.GONE);
-        } else if (selfie || ((appearance != null
+        if (selfie || ((appearance != null
                 && appearance.toLowerCase(Locale.ENGLISH).contains("new")))) {
             chooseButton.setVisibility(View.GONE);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -101,7 +101,6 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
         } else {
             launchOpenMapKitButton.setText(getContext().getString(R.string.capture_osm));
         }
-        launchOpenMapKitButton.setEnabled(!prompt.isReadOnly());
 
         osmFileNameHeaderTextView = new TextView(context);
         osmFileNameHeaderTextView.setId(ViewIds.generateViewId());
@@ -133,10 +132,6 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
         answerLayout.addView(osmFileNameTextView);
         addAnswerView(answerLayout);
 
-        // Hide Launch button if read-only
-        if (prompt.isReadOnly()) {
-            launchOpenMapKitButton.setVisibility(View.GONE);
-        }
         errorTextView.setVisibility(View.GONE);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -510,27 +510,28 @@ public abstract class QuestionWidget
     }
 
     protected Button getSimpleButton(String text, @IdRes final int withId) {
-        final QuestionWidget questionWidget = this;
         final Button button = new Button(getContext());
 
-        button.setId(withId);
-        button.setText(text);
-        button.setTextSize(TypedValue.COMPLEX_UNIT_DIP, getAnswerFontSize());
-        button.setPadding(20, 20, 20, 20);
+        if (getFormEntryPrompt().isReadOnly()) {
+            button.setVisibility(GONE);
+        } else {
+            button.setId(withId);
+            button.setText(text);
+            button.setTextSize(TypedValue.COMPLEX_UNIT_DIP, getAnswerFontSize());
+            button.setPadding(20, 20, 20, 20);
 
-        TableLayout.LayoutParams params = new TableLayout.LayoutParams();
-        params.setMargins(7, 5, 7, 5);
+            TableLayout.LayoutParams params = new TableLayout.LayoutParams();
+            params.setMargins(7, 5, 7, 5);
 
-        button.setLayoutParams(params);
+            button.setLayoutParams(params);
 
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
+            button.setOnClickListener(v -> {
                 if (Collect.allowClick()) {
-                    ((ButtonWidget) questionWidget).onButtonClick(withId);
+                    ((ButtonWidget) this).onButtonClick(withId);
                 }
-            }
-        });
+            });
+        }
+
         return button;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
@@ -76,12 +76,8 @@ public abstract class RangeWidget extends QuestionWidget implements ButtonWidget
         setUpWidgetParameters();
         setUpAppearance();
 
-        if (prompt.isReadOnly()) {
-            if (isPickerAppearance) {
-                pickerButton.setEnabled(false);
-            } else {
-                seekBar.setEnabled(false);
-            }
+        if (prompt.isReadOnly() && !isPickerAppearance) {
+            seekBar.setEnabled(false);
         }
 
         addAnswerView(view);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
@@ -45,15 +45,10 @@ public class SignatureWidget extends BaseImageWidget {
     protected void setUpLayout() {
         super.setUpLayout();
         signButton = getSimpleButton(getContext().getString(R.string.sign_button));
-        signButton.setEnabled(!getFormEntryPrompt().isReadOnly());
 
         answerLayout.addView(signButton);
         answerLayout.addView(errorTextView);
 
-        // and hide the sign button if read-only
-        if (getFormEntryPrompt().isReadOnly()) {
-            signButton.setVisibility(View.GONE);
-        }
         errorTextView.setVisibility(View.GONE);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -96,10 +96,6 @@ public class SpinnerMultiWidget extends QuestionWidget implements ButtonWidget, 
         selectionText = getAnswerTextView();
         selectionText.setVisibility(View.GONE);
 
-        if (prompt.isReadOnly()) {
-            button.setEnabled(false);
-        }
-
         // Fill in previous answers
         List<Selection> ve = new ArrayList<>();
         if (prompt.getAnswerValue() != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -104,7 +104,6 @@ public class TimeWidget extends QuestionWidget implements ButtonWidget, TimePick
 
     private void createTimeButton() {
         timeButton = getSimpleButton(getContext().getString(R.string.select_time));
-        timeButton.setEnabled(!getFormEntryPrompt().isReadOnly());
     }
 
     private void addViews() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -47,7 +47,6 @@ public class UrlWidget extends QuestionWidget implements ButtonWidget {
         super(context, prompt);
 
         openUrlButton = getSimpleButton(context.getString(R.string.open_url));
-        openUrlButton.setEnabled(!prompt.isReadOnly());
 
         stringAnswer = getCenteredAnswerTextView();
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -105,10 +105,8 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         selfie = appearance != null && (appearance.equalsIgnoreCase("selfie") || appearance.equalsIgnoreCase("new-front"));
 
         captureButton = getSimpleButton(getContext().getString(R.string.capture_video), R.id.capture_video);
-        captureButton.setEnabled(!prompt.isReadOnly());
 
         chooseButton = getSimpleButton(getContext().getString(R.string.choose_video), R.id.choose_video);
-        chooseButton.setEnabled(!prompt.isReadOnly());
 
         playButton = getSimpleButton(getContext().getString(R.string.play_video), R.id.play_video);
 
@@ -283,10 +281,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
     }
 
     private void hideButtonsIfNeeded() {
-        if (getFormEntryPrompt().isReadOnly()) {
-            captureButton.setVisibility(View.GONE);
-            chooseButton.setVisibility(View.GONE);
-        } else if (selfie || (getFormEntryPrompt().getAppearanceHint() != null
+        if (selfie || (getFormEntryPrompt().getAppearanceHint() != null
                 && getFormEntryPrompt().getAppearanceHint().toLowerCase(Locale.ENGLISH).contains("new"))) {
             chooseButton.setVisibility(View.GONE);
         }


### PR DESCRIPTION
Closes #2562 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue and the original all widgets form.

#### Why is this the best possible solution? Were any other approaches considered?
It doesn't make sense to display a button if a question is readonly. We decided to hide them in such a case and in all widgets to be consistent.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
this change causes that buttons in widgets are hidden if a question is readonly. I can't see any risk here we just need to use the form attached to the issue and the original all widgets form and confirm that everything works as expected.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)