### PR TITLE
App crashes on Selfie video widget if microphone permissions are not set

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivityNewApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivityNewApi.java
@@ -26,7 +26,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.Camera2VideoFragment;
 import org.odk.collect.android.utilities.ToastUtils;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfCameraPermissionGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.checkIfCameraAndRecordAudioPermissionsGranted;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class CaptureSelfieVideoActivityNewApi extends Activity {
@@ -35,7 +35,7 @@ public class CaptureSelfieVideoActivityNewApi extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!checkIfCameraPermissionGranted(this)) {
+        if (!checkIfCameraAndRecordAudioPermissionsGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -190,6 +190,39 @@ public class PermissionUtils {
                 .check();
     }
 
+    public static void requestCameraAndRecordAudioPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+        MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
+            @Override
+            public void onPermissionsChecked(MultiplePermissionsReport report) {
+                if (report.areAllPermissionsGranted()) {
+                    action.granted();
+                } else {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Light_Dialog);
+
+                    builder.setTitle(R.string.camera_runtime_permission_denied_title)
+                            .setMessage(R.string.camera_runtime_permission_denied_desc)
+                            .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> action.denied())
+                            .setCancelable(false)
+                            .setIcon(R.drawable.ic_photo_camera)
+                            .show();
+                }
+            }
+
+            @Override
+            public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {
+                token.continuePermissionRequest();
+            }
+        };
+
+        Dexter.withActivity(activity)
+                .withPermissions(
+                        Manifest.permission.CAMERA,
+                        Manifest.permission.RECORD_AUDIO
+                ).withListener(multiplePermissionsListener)
+                .withErrorListener(error -> Timber.i(error.name()))
+                .check();
+    }
+
     public static void requestGetAccountsPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
@@ -310,6 +343,14 @@ public class PermissionUtils {
 
         return accessFineLocation == PackageManager.PERMISSION_GRANTED
                 && accessCoarseLocation == PackageManager.PERMISSION_GRANTED;
+    }
+
+    public static boolean checkIfCameraAndRecordAudioPermissionsGranted(Context context) {
+        int cameraPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA);
+        int recordAudioPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO);
+
+        return cameraPermission == PackageManager.PERMISSION_GRANTED
+                && recordAudioPermission == PackageManager.PERMISSION_GRANTED;
     }
 
     public static boolean checkIfGetAccountsPermissionGranted(Context context) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -58,6 +58,7 @@ import timber.log.Timber;
 
 import static android.os.Build.MODEL;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.PermissionUtils.requestCameraAndRecordAudioPermissions;
 import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 
 /**
@@ -321,16 +322,29 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
     public void onButtonClick(int id) {
         switch (id) {
             case R.id.capture_video:
-                requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
-                    @Override
-                    public void granted() {
-                        captureVideo();
-                    }
+                if (selfie) {
+                    requestCameraAndRecordAudioPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+                        @Override
+                        public void granted() {
+                            captureVideo();
+                        }
 
-                    @Override
-                    public void denied() {
-                    }
-                });
+                        @Override
+                        public void denied() {
+                        }
+                    });
+                } else {
+                    requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                        @Override
+                        public void granted() {
+                            captureVideo();
+                        }
+
+                        @Override
+                        public void denied() {
+                        }
+                    });
+                }
                 break;
             case R.id.choose_video:
                 chooseVideo();


### PR DESCRIPTION
Closes #2565 

#### What has been done to verify that this works as intended?
I tested the `VideoWidget` with `selfie` appearance.

#### Why is this the best possible solution? Were any other approaches considered?
Using `VideoWidget` we use an external camera app and in that case, we need to grant only the CAMERA permission but if we use `VideoWidget` with `selfie` appearance we use our own implementation ([Camera2VideoFragment](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java)) and then both the CAMERA and the RECORD_AUDIO permissions are needed.

It's because external apps ask us for RECORD_AUDIO if that permission is not granted so in the first case we don't need to care about it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't affect anything else. We can just confirm that it fixes the bug and the VideoWidget works well as before (the VideoWidget without any appearance).

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with the `VideoWidget` with `selfie` appearance (eg `All Widgets` form).

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)