### PR TITLE
Move duplicate code for starting an intent and setting/canceling wait calls to QuestionWIdget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -165,7 +165,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
                 ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*"); // all file types
-        startActivityForResult(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER, -1);
+        startActivityForResultOrDoNothing(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
     }
 
     private String getSourcePathFromUri(@NonNull Uri uri) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -34,7 +34,6 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FileUtils;
@@ -92,7 +91,6 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        waitForData();
         performFileSearch();
     }
 
@@ -167,7 +165,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
                 ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*"); // all file types
-        ((FormEntryActivity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
+        startActivityForResult(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER, -1);
     }
 
     private String getSourcePathFromUri(@NonNull Uri uri) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -248,13 +248,13 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
                 android.provider.MediaStore.EXTRA_OUTPUT,
                 android.provider.MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
                         .toString());
-        startActivityForResult(i, RequestCodes.AUDIO_CAPTURE, R.string.capture_audio);
+        startActivityForResultOrShowErrorToast(i, RequestCodes.AUDIO_CAPTURE, R.string.capture_audio);
     }
 
     private void chooseSound() {
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.setType("audio/*");
-        startActivityForResult(i, RequestCodes.AUDIO_CHOOSER, R.string.choose_audio);
+        startActivityForResultOrShowErrorToast(i, RequestCodes.AUDIO_CHOOSER, R.string.choose_audio);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -15,8 +15,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
@@ -26,7 +24,6 @@ import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
-import android.widget.Toast;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -251,34 +248,13 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
                 android.provider.MediaStore.EXTRA_OUTPUT,
                 android.provider.MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
                         .toString());
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.AUDIO_CAPTURE);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(
-                    getContext(),
-                    getContext().getString(R.string.activity_not_found,
-                            getContext().getString(R.string.capture_audio)), Toast.LENGTH_SHORT)
-                    .show();
-            cancelWaitingForData();
-        }
+        startActivityForResult(i, RequestCodes.AUDIO_CAPTURE, R.string.capture_audio);
     }
 
     private void chooseSound() {
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.setType("audio/*");
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.AUDIO_CHOOSER);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(
-                    getContext(),
-                    getContext().getString(R.string.activity_not_found,
-                            getContext().getString(R.string.choose_audio)), Toast.LENGTH_SHORT).show();
-            cancelWaitingForData();
-        }
+        startActivityForResult(i, RequestCodes.AUDIO_CHOOSER, R.string.choose_audio);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -296,6 +296,6 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
      * @param errorStringResource - String resource for error toast
      */
     protected void launchActivityForResult(Intent intent, final int resourceCode, final int errorStringResource) {
-        startActivityForResult(intent, resourceCode, errorStringResource);
+        startActivityForResultOrShowErrorToast(intent, resourceCode, errorStringResource);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -16,7 +16,6 @@
 
 package org.odk.collect.android.widgets;
 
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.ContentValues;
 import android.content.Context;
@@ -297,14 +296,6 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
      * @param errorStringResource - String resource for error toast
      */
     protected void launchActivityForResult(Intent intent, final int resourceCode, final int errorStringResource) {
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(intent, resourceCode);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(getContext(),
-                    getContext().getString(R.string.activity_not_found, getContext().getString(errorStringResource)),
-                    Toast.LENGTH_SHORT).show();
-            cancelWaitingForData();
-        }
+        startActivityForResult(intent, resourceCode, errorStringResource);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -152,7 +152,7 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
     public void onButtonClick(int buttonId) {
         if (isSensorAvailable) {
             Intent i = new Intent(getContext(), BearingActivity.class);
-            startActivityForResult(i, RequestCodes.BEARING_CAPTURE, -1);
+            startActivityForResultOrDoNothing(i, RequestCodes.BEARING_CAPTURE);
         } else {
             getBearingButton.setEnabled(false);
             ToastUtils.showLongToast(R.string.bearing_lack_of_sensors);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
@@ -153,9 +152,7 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
     public void onButtonClick(int buttonId) {
         if (isSensorAvailable) {
             Intent i = new Intent(getContext(), BearingActivity.class);
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.BEARING_CAPTURE);
+            startActivityForResult(i, RequestCodes.BEARING_CAPTURE, -1);
         } else {
             getBearingButton.setEnabled(false);
             ToastUtils.showLongToast(R.string.bearing_lack_of_sensors);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -26,6 +26,7 @@ import android.text.method.DigitsKeyListener;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.external.ExternalAppsUtils;
 
 import java.text.NumberFormat;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -319,6 +319,6 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
         i.putExtra(DRAGGABLE_ONLY, draggable);
         i.putExtra(ACCURACY_THRESHOLD, accuracyThreshold);
 
-        startActivityForResult(i, RequestCodes.LOCATION_CAPTURE, -1);
+        startActivityForResultOrDoNothing(i, RequestCodes.LOCATION_CAPTURE);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
@@ -320,8 +319,6 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
         i.putExtra(DRAGGABLE_ONLY, draggable);
         i.putExtra(ACCURACY_THRESHOLD, accuracyThreshold);
 
-        waitForData();
-
-        ((Activity) getContext()).startActivityForResult(i, RequestCodes.LOCATION_CAPTURE);
+        startActivityForResult(i, RequestCodes.LOCATION_CAPTURE, -1);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -86,7 +86,7 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
         Intent intent = new Intent(getContext(), GeoShapeActivity.class)
             .putExtra(SHAPE_LOCATION, answerDisplay.getText().toString())
             .putExtra(PreferenceKeys.KEY_MAP_SDK, mapSDK);
-        startActivityForResult(intent, RequestCodes.GEOSHAPE_CAPTURE, -1);
+        startActivityForResultOrDoNothing(intent, RequestCodes.GEOSHAPE_CAPTURE);
     }
 
     private void updateButtonLabelsAndVisibility(boolean dataAvailable) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -14,7 +14,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -87,7 +86,7 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
         Intent intent = new Intent(getContext(), GeoShapeActivity.class)
             .putExtra(SHAPE_LOCATION, answerDisplay.getText().toString())
             .putExtra(PreferenceKeys.KEY_MAP_SDK, mapSDK);
-        ((Activity) getContext()).startActivityForResult(intent, RequestCodes.GEOSHAPE_CAPTURE);
+        startActivityForResult(intent, RequestCodes.GEOSHAPE_CAPTURE, -1);
     }
 
     private void updateButtonLabelsAndVisibility(boolean dataAvailable) {
@@ -131,7 +130,6 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
         requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
-                waitForData();
                 startGeoShapeActivity();
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -93,7 +92,7 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
         Intent intent = new Intent(getContext(), GeoTraceActivity.class)
             .putExtra(TRACE_LOCATION, answerDisplay.getText().toString())
             .putExtra(PreferenceKeys.KEY_MAP_SDK, mapSDK);
-        ((Activity) getContext()).startActivityForResult(intent, RequestCodes.GEOTRACE_CAPTURE);
+        startActivityForResult(intent, RequestCodes.GEOTRACE_CAPTURE, -1);
     }
 
     private void updateButtonLabelsAndVisibility(boolean dataAvailable) {
@@ -135,7 +134,6 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
         requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
-                waitForData();
                 startGeoTraceActivity();
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -92,7 +92,7 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
         Intent intent = new Intent(getContext(), GeoTraceActivity.class)
             .putExtra(TRACE_LOCATION, answerDisplay.getText().toString())
             .putExtra(PreferenceKeys.KEY_MAP_SDK, mapSDK);
-        startActivityForResult(intent, RequestCodes.GEOTRACE_CAPTURE, -1);
+        startActivityForResultOrDoNothing(intent, RequestCodes.GEOTRACE_CAPTURE);
     }
 
     private void updateButtonLabelsAndVisibility(boolean dataAvailable) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -302,13 +302,13 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
         // FormEntyActivity will also need to be updated.
         i.putExtra(android.provider.MediaStore.EXTRA_OUTPUT,
                 Uri.fromFile(new File(Collect.TMPFILE_PATH)));
-        startActivityForResult(i, RequestCodes.IMAGE_CAPTURE, R.string.capture_image);
+        startActivityForResultOrShowErrorToast(i, RequestCodes.IMAGE_CAPTURE, R.string.capture_image);
     }
 
     private void chooseImage() {
         errorTextView.setVisibility(View.GONE);
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.setType("image/*");
-        startActivityForResult(i, RequestCodes.IMAGE_CHOOSER, R.string.choose_image);
+        startActivityForResultOrShowErrorToast(i, RequestCodes.IMAGE_CHOOSER, R.string.choose_image);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -15,8 +15,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
@@ -33,7 +31,6 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.android.gms.analytics.HitBuilders;
 
@@ -305,35 +302,13 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
         // FormEntyActivity will also need to be updated.
         i.putExtra(android.provider.MediaStore.EXTRA_OUTPUT,
                 Uri.fromFile(new File(Collect.TMPFILE_PATH)));
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.IMAGE_CAPTURE);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(
-                    getContext(),
-                    getContext().getString(R.string.activity_not_found,
-                            getContext().getString(R.string.capture_image)), Toast.LENGTH_SHORT)
-                    .show();
-            cancelWaitingForData();
-        }
+        startActivityForResult(i, RequestCodes.IMAGE_CAPTURE, R.string.capture_image);
     }
 
     private void chooseImage() {
         errorTextView.setVisibility(View.GONE);
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
         i.setType("image/*");
-
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.IMAGE_CHOOSER);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(
-                    getContext(),
-                    getContext().getString(R.string.activity_not_found,
-                            getContext().getString(R.string.choose_image)), Toast.LENGTH_SHORT).show();
-            cancelWaitingForData();
-        }
+        startActivityForResult(i, RequestCodes.IMAGE_CHOOSER, R.string.choose_image);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -168,7 +168,7 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
 
             //launch activity if it is safe
             if (isIntentSafe) {
-                startActivityForResult(launchIntent, RequestCodes.OSM_CAPTURE, -1);
+                startActivityForResultOrDoNothing(launchIntent, RequestCodes.OSM_CAPTURE);
             } else {
                 errorTextView.setVisibility(View.VISIBLE);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -1,7 +1,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -169,11 +168,7 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
 
             //launch activity if it is safe
             if (isIntentSafe) {
-                // notify that the form is waiting for data
-                waitForData();
-
-                // launch
-                ((Activity) ctx).startActivityForResult(launchIntent, RequestCodes.OSM_CAPTURE);
+                startActivityForResult(launchIntent, RequestCodes.OSM_CAPTURE, -1);
             } else {
                 errorTextView.setVisibility(View.VISIBLE);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -14,7 +14,10 @@
 
 package org.odk.collect.android.widgets;
 
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -25,6 +28,7 @@ import android.media.MediaPlayer.OnCompletionListener;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -37,6 +41,7 @@ import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -668,5 +673,21 @@ public abstract class QuestionWidget
 
     public int getPlayColor() {
         return playColor;
+    }
+
+    protected void startActivityForResult(Intent intent, int requestCode, @StringRes int errorRes) {
+        try {
+            waitForData();
+            ((Activity) getContext()).startActivityForResult(intent, requestCode);
+        } catch (ActivityNotFoundException e) {
+            if (errorRes != -1) {
+                Toast.makeText(
+                        getContext(),
+                        getContext().getString(R.string.activity_not_found,
+                                getContext().getString(errorRes)), Toast.LENGTH_SHORT)
+                        .show();
+            }
+            cancelWaitingForData();
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -387,7 +387,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         if (highResolution) {
             i.putExtra(android.provider.MediaStore.EXTRA_VIDEO_QUALITY, 1);
         }
-        startActivityForResult(i, RequestCodes.VIDEO_CAPTURE, R.string.capture_video);
+        startActivityForResultOrShowErrorToast(i, RequestCodes.VIDEO_CAPTURE, R.string.capture_video);
     }
 
     private void chooseVideo() {
@@ -396,7 +396,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         // Intent i =
         // new Intent(Intent.ACTION_PICK,
         // android.provider.MediaStore.Video.Media.EXTERNAL_CONTENT_URI);
-        startActivityForResult(i, RequestCodes.VIDEO_CHOOSER, R.string.choose_video);
+        startActivityForResultOrShowErrorToast(i, RequestCodes.VIDEO_CHOOSER, R.string.choose_video);
     }
 
     private void playVideoFile() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.ContentValues;
 import android.content.Context;
@@ -388,18 +387,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         if (highResolution) {
             i.putExtra(android.provider.MediaStore.EXTRA_VIDEO_QUALITY, 1);
         }
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.VIDEO_CAPTURE);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(
-                    getContext(),
-                    getContext().getString(R.string.activity_not_found,
-                            getContext().getString(R.string.capture_video)), Toast.LENGTH_SHORT)
-                    .show();
-            cancelWaitingForData();
-        }
+        startActivityForResult(i, RequestCodes.VIDEO_CAPTURE, R.string.capture_video);
     }
 
     private void chooseVideo() {
@@ -408,19 +396,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         // Intent i =
         // new Intent(Intent.ACTION_PICK,
         // android.provider.MediaStore.Video.Media.EXTERNAL_CONTENT_URI);
-        try {
-            waitForData();
-            ((Activity) getContext()).startActivityForResult(i,
-                    RequestCodes.VIDEO_CHOOSER);
-        } catch (ActivityNotFoundException e) {
-            Toast.makeText(
-                    getContext(),
-                    getContext().getString(R.string.activity_not_found,
-                            getContext().getString(R.string.choose_video)), Toast.LENGTH_SHORT)
-                    .show();
-
-            cancelWaitingForData();
-        }
+        startActivityForResult(i, RequestCodes.VIDEO_CHOOSER, R.string.choose_video);
     }
 
     private void playVideoFile() {


### PR DESCRIPTION

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

> If there are structural changes that group well with this change and make it clearer what's going on, I think it's a good idea to do them here. #2535 is massive, risky, and very difficult to review. If you can pull out some parts of it into smaller PRs, that will de-risk it.

@lognaturel This is in reference to your comment on PR #2538. It aims at pulling out some code modified in #2535  

#### What has been done to verify that this works as intended?
This does not change the behavior in any way. Pure refactor

#### Why is this the best possible solution? Were any other approaches considered?
Pulls common code into `QuestionWidget` and removes code duplicacy.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)