### PR TITLE
Fetch available google spreadsheets and display in a dialog when setting fallback submission url

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/DriveHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/DriveHelper.java
@@ -41,6 +41,8 @@ import static org.odk.collect.android.tasks.InstanceGoogleSheetsUploader.GOOGLE_
 public class DriveHelper {
 
     public static final String FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+    private static final String SPREADSHEET_MIME_TYPE = "application/vnd.google-apps.spreadsheet";
+
     private final DriveService driveService;
 
     DriveHelper(@NonNull GoogleAccountCredential credential,
@@ -221,6 +223,22 @@ public class DriveHelper {
 
         String mimeType = folderName != null ? FOLDER_MIME_TYPE : null;
         String requestString = generateSearchQuery(folderName, parentId, mimeType);
+        String fields = "nextPageToken, files(modifiedTime, id, name, mimeType)";
+        Drive.Files.List request = buildRequest(requestString, fields);
+
+        if (request != null) {
+            driveService.fetchAllFiles(request, files);
+        }
+        return files;
+    }
+
+    /**
+     * Fetches the list of spreadsheets from the google drive for the associated google account
+     */
+    public List<com.google.api.services.drive.model.File> getAllSheetsFromDrive() throws IOException {
+        List<com.google.api.services.drive.model.File> files = new ArrayList<>();
+
+        String requestString = generateSearchQuery(null, null, SPREADSHEET_MIME_TYPE);
         String fields = "nextPageToken, files(modifiedTime, id, name, mimeType)";
         Drive.Files.List request = buildRequest(requestString, fields);
 

--- a/collect_app/src/main/res/xml/google_preferences.xml
+++ b/collect_app/src/main/res/xml/google_preferences.xml
@@ -6,10 +6,10 @@
         <Preference
             android:key="selected_google_account"
             android:title="@string/selected_google_account_text" />
-        <EditTextPreference
+        <ListPreference
             android:dialogTitle="@string/google_sheets_url"
-            android:inputType="textNoSuggestions"
             android:key="google_sheets_url"
+            android:enabled="false"
             android:summary="@string/google_sheets_url_hint"
             android:title="@string/google_sheets_url" />
     </PreferenceCategory>


### PR DESCRIPTION
Closes #1773 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I have verified the following cases:
 1. The user hasn't provided google drive access to the app
 2. No internet availability
 3. There is an internet connection available and the user gives access to google drive
 4. Changing the server type to `Google Drive` when there is already a Google account saved

#### Why is this the best possible solution? Were any other approaches considered?
Provides an easy and user-friendly way to set fallback submission URLs

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Yes, it changes the way the user sets a fallback submission URL. Until now, one has to manually enter the URL or copy/paste from mobile's browser/drive app. Now, all of the available sheets are shown within the app in a dialog when trying to set fallback submission URL

#### Do we need any specific form for testing your changes? If so, please attach one.
I used the All-Widgets form for testing

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Yes (waiting until the approach is accepted)

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

![device-2018-09-22-231709](https://user-images.githubusercontent.com/8918023/45920156-14649580-bebe-11e8-9ea2-0ae5db9a6d0a.gif)
![image](https://user-images.githubusercontent.com/8918023/45920155-12023b80-bebe-11e8-8526-f5cf71f659f0.png)
