### PR TITLE
Removed exclamation from sms_sending string

### DIFF
--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -640,7 +640,7 @@
     <string name="sms_last_submission_on_date_at_time">\'Last submission attempt at\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
     <plurals name="sms_sending">
         <item quantity="one">Submitting form as a single message.</item>
-        <item quantity="other">Submitting form, sending message %1$d! of %2$d</item>
+        <item quantity="other">Submitting form, sending message %1$d of %2$d</item>
     </plurals>
     <string name="sms_sent_on_date_at_time">\'Sent as SMS on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
     <string name="sms_submission_queued">Queued for submission.</string>


### PR DESCRIPTION
Removes a stray exclamation mark from one of the `sms_sending` strings. Issue was reported here https://forum.opendatakit.org/t/problem-with-sms-sending-string-translation/15355!-- 

#### What has been done to verify that this works as intended?
Currently, recreating an emulator that can verify the string still gets shown appropriately. This is a minor change that can be verified by QA.

#### Why is this the best possible solution? Were any other approaches considered?
Simplest fix. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't impact users in any way since the string is being formatted fine in previous versions and the removal of this stray character won't have any user-facing implications. 

#### Do we need any specific form for testing your changes? If so, please attach one.
SMS Test form. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)