### PR TITLE
Fixed java.lang.RuntimeException: Can't create handler inside thread that has not called Looper.prepare()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/ImageLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/ImageLoadingTask.java
@@ -61,17 +61,16 @@ public class ImageLoadingTask extends AsyncTask<Uri, Void, File> {
                         return newImage;
                     } else {
                         Timber.e("Could not receive chosen image");
-                        ToastUtils.showShortToastInMiddle(R.string.error_occured);
+                        formEntryActivity.get().runOnUiThread(() -> ToastUtils.showShortToastInMiddle(R.string.error_occured));
                         return null;
                     }
                 } catch (GDriveConnectionException e) {
-
                     Timber.e("Could not receive chosen image due to connection problem");
-                    ToastUtils.showLongToastInMiddle(R.string.gdrive_connection_exception);
+                    formEntryActivity.get().runOnUiThread(() -> ToastUtils.showLongToastInMiddle(R.string.gdrive_connection_exception));
                     return null;
                 }
             } else {
-                ToastUtils.showLongToast(R.string.image_not_saved);
+                formEntryActivity.get().runOnUiThread(() -> ToastUtils.showLongToast(R.string.image_not_saved));
                 Timber.w(formEntryActivity.get().getString(R.string.image_not_saved));
                 return null;
             }


### PR DESCRIPTION
Closes #2579 

#### What has been done to verify that this works as intended?
I added one toast in the edited class which is displayed every time we choose a photo and confirmed there is no crash.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix. We can't show toasts (and generally deal with UI) from an AsyncTask.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's safe and doesn't affect anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)