### PR TITLE
Fixed: attempt to re-open an already-closed object

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -247,7 +247,7 @@ public class InstanceChooserList extends InstanceListActivity implements
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         hideProgressBarIfAllowed();
-        listAdapter.changeCursor(cursor);
+        listAdapter.swapCursor(cursor);
     }
 
     @Override


### PR DESCRIPTION
Closes #2583 

#### What has been done to verify that this works as intended?
I just confirmed the `InstanceChooserList` works without any change.

#### Why is this the best possible solution? Were any other approaches considered?
It's a rare but longstanding issue. We can't reproduce it. I guess is it's a race condition problem. I decided to replace `changeCursor()` with `swapCursor()` because the second method doesn't close an old cursor what I guess may be a cause of the crash. Also, we use `swapCursor()` in other places.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
`changeCursor()` and `swapCursor()` work in the same way the only difference is that the first one closes an old cursor. This change shouldn't affect anything.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)