### PR TITLE
Fixed Attempt to invoke virtual method 'boolean android.app.Dialog.isShowing()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -894,7 +894,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
         cleanUpWebCredentials();
 
-        if (cancelDialog.isShowing()) {
+        if (cancelDialog != null && cancelDialog.isShowing()) {
             cancelDialog.dismiss();
         }
 


### PR DESCRIPTION
Closes #2586 

#### What has been done to verify that this works as intended?
It's a rare crash and I'm not able to reproduce it so I just added a null check which is safe and doesn't require any testing.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't affect anything.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)