### PR TITLE
Strip out the search() appearance/function before identifying select appearance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
@@ -59,7 +59,7 @@ public final class ExternalDataUtil {
     public static final String EXTERNAL_DATA_TABLE_NAME = "externalData";
     public static final String SORT_COLUMN_NAME = "c_sortby";
 
-    private static final Pattern SEARCH_FUNCTION_REGEX = Pattern.compile("search\\(.+\\)");
+    public static final Pattern SEARCH_FUNCTION_REGEX = Pattern.compile("search\\(.+\\)");
     private static final String COLUMN_SEPARATOR = ",";
     private static final String FALLBACK_COLUMN_SEPARATOR = " ";
     public static final String JR_IMAGES_PREFIX = "jr://images/";

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -29,6 +29,7 @@ import org.javarosa.xpath.expr.XPathExpression;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.WebViewActivity;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.external.ExternalDataUtil;
 
 import java.util.List;
 import java.util.Locale;
@@ -64,11 +65,10 @@ public class WidgetFactory {
         // For now, all appearance tags are in English.
         appearance = appearance.toLowerCase(Locale.ENGLISH);
 
-        // The search appearance which shows a text area for filtering choices is distinct
-        // from the search() appearance/function. The two can combine but a text area should
-        // not be shown if only the appearance/function is specified.
-        boolean hasSearchAppearance = appearance.contains("search")
-                && !appearance.contains("search(") || appearance.contains("search ");
+        // Strip out the search() appearance/function which is handled in ExternalDataUtil so that
+        // it is not considered when matching other appearances. For example, a file named list.csv
+        // used as a parameter to search() should not be interpreted as a list appearance.
+        appearance = ExternalDataUtil.SEARCH_FUNCTION_REGEX.matcher(appearance).replaceAll("");
 
         final QuestionWidget questionWidget;
         switch (fep.getControlType()) {
@@ -211,7 +211,7 @@ public class WidgetFactory {
                     questionWidget = new GridWidget(context, fep, numColumns, appearance.contains("quick"));
                 } else if (appearance.contains("minimal")) {
                     questionWidget = new SpinnerWidget(context, fep, appearance.contains("quick"));
-                } else if (hasSearchAppearance || appearance.contains("autocomplete")) {
+                } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
                     questionWidget = new SelectOneSearchWidget(context, fep, appearance.contains("quick"));
                 } else if (appearance.contains("list-nolabel")) {
                     questionWidget = new ListWidget(context, fep, false, appearance.contains("quick"));
@@ -257,7 +257,7 @@ public class WidgetFactory {
                     questionWidget = new ListMultiWidget(context, fep, true);
                 } else if (appearance.startsWith("label")) {
                     questionWidget = new LabelWidget(context, fep);
-                } else if (hasSearchAppearance || appearance.contains("autocomplete")) {
+                } else if (appearance.contains("search") || appearance.contains("autocomplete")) {
                     questionWidget = new SelectMultipleAutocompleteWidget(context, fep);
                 } else if (appearance.startsWith("image-map")) {
                     questionWidget = new SelectMultiImageMapWidget(context, fep);


### PR DESCRIPTION
Closes #2590

#### What has been done to verify that this works as intended?
Tried All Widgets, form described in issue, form at https://github.com/opendatakit/collect/pull/2393, form at https://github.com/opendatakit/collect/pull/2540

#### Why is this the best possible solution? Were any other approaches considered?
This ensures that the `search()` appearance/function is considered completely separately from the other appearances. That means it's ok for user text to match one of the appearance names.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intent is to fix #2590 by allowing any appearance name (not just `search`) to be part of the `search()` appearance/function. There should be no other change in behavior. There is a regression risk around different combinations of appearances.

#### Do we need any specific form for testing your changes? If so, please attach one.
All Widgets, form described in issue, form at https://github.com/opendatakit/collect/pull/2393, form at https://github.com/opendatakit/collect/pull/2540

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)