### PR TITLE
Save HttpContext between requests

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
@@ -99,12 +99,15 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     private static final int UPLOAD_CONNECTION_TIMEOUT = 60000; // it can take up to 27 seconds to spin up an Aggregate
     private static final String HTTP_CONTENT_TYPE_TEXT_XML = "text/xml";
 
-    private CredentialsProvider credentialsProvider;
-    private CookieStore cookieStore;
+    // Retain authentication and cookies between requests. Gets mutated on each call to
+    // HttpClient.execute).
+    private HttpContext httpContext;
 
     public HttpClientConnection() {
-        credentialsProvider = new AgingCredentialsProvider(7 * 60 * 1000);
-        cookieStore = new BasicCookieStore();
+        httpContext = new BasicHttpContext();
+
+        httpContext.setAttribute(HttpClientContext.COOKIE_STORE, new BasicCookieStore());
+        httpContext.setAttribute(HttpClientContext.CREDS_PROVIDER, new AgingCredentialsProvider(7 * 60 * 1000));
     }
 
     private enum ContentTypeMapping {
@@ -149,14 +152,13 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     public @NonNull
     HttpGetResult get(@NonNull URI uri, @Nullable final String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
         addCredentialsForHost(uri, credentials);
-        getCookieStore().clear();
+        clearCookieStore();
 
-        HttpContext localContext = getHttpContext();
         HttpClient httpclient = createHttpClient(CONNECTION_TIMEOUT);
 
         // if https then enable preemptive basic auth...
         if (uri.getScheme().equals("https")) {
-            enablePreemptiveBasicAuth(localContext, uri.getHost());
+            enablePreemptiveBasicAuth(uri.getHost());
         }
 
         // set up request...
@@ -165,14 +167,14 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
 
         HttpResponse response;
 
-        response = httpclient.execute(req, localContext);
+        response = httpclient.execute(req, httpContext);
         int statusCode = response.getStatusLine().getStatusCode();
 
         if (statusCode != HttpStatus.SC_OK) {
             discardEntityBytes(response);
             if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
                 // clear the cookies -- should not be necessary?
-                getCookieStore().clear();
+                clearCookieStore();
             }
             String errMsg =
                     Collect.getInstance().getString(R.string.file_fetch_failed, uri.toString(),
@@ -233,16 +235,15 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     @Override
     public @NonNull HttpHeadResult head(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
         addCredentialsForHost(uri, credentials);
-        getCookieStore().clear();
+        clearCookieStore();
 
-        HttpContext localContext = getHttpContext();
         HttpClient httpclient = createHttpClient(CONNECTION_TIMEOUT);
         HttpHead httpHead = createOpenRosaHttpHead(uri);
         Map<String, String> responseHeaders = new HashMap<>();
 
         // if https then enable preemptive basic auth...
         if (uri.getScheme() != null && uri.getScheme().equals("https")) {
-            enablePreemptiveBasicAuth(localContext, uri.getHost());
+            enablePreemptiveBasicAuth(uri.getHost());
         }
 
         final HttpResponse response;
@@ -251,11 +252,10 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
         try {
             Timber.i("Issuing HEAD request to: %s", uri.toString());
 
-            response = httpclient.execute(httpHead, localContext);
+            response = httpclient.execute(httpHead, httpContext);
             statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == HttpStatus.SC_UNAUTHORIZED) {
-                getCookieStore().clear();
-
+                clearCookieStore();
             } else if (statusCode == HttpStatus.SC_NO_CONTENT) {
                 for (Header head : response.getAllHeaders()) {
                     responseHeaders.put(head.getName(), head.getValue());
@@ -299,15 +299,13 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                                                       @NonNull URI uri,
                                                       @Nullable HttpCredentialsInterface credentials) throws IOException {
         addCredentialsForHost(uri, credentials);
-        getCookieStore().clear();
+        clearCookieStore();
 
-        // get shared HttpContext so that authentication and cookies are retained.
-        HttpContext localContext = getHttpContext();
         HttpClient httpclient = createHttpClient(UPLOAD_CONNECTION_TIMEOUT);
 
         // if https then enable preemptive basic auth...
         if (uri.getScheme().equals("https")) {
-            enablePreemptiveBasicAuth(localContext, uri.getHost());
+            enablePreemptiveBasicAuth(uri.getHost());
         }
 
         ResponseMessageParser messageParser = null;
@@ -379,7 +377,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
 
             try {
                 Timber.i("Issuing POST request to: %s", uri.toString());
-                response = httpclient.execute(httppost, localContext);
+                response = httpclient.execute(httppost, httpContext);
                 int responseCode = response.getStatusLine().getStatusCode();
                 HttpEntity httpEntity = response.getEntity();
                 Timber.i("Response code:%d", responseCode);
@@ -392,7 +390,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                 discardEntityBytes(response);
 
                 if (responseCode == HttpStatus.SC_UNAUTHORIZED) {
-                    getCookieStore().clear();
+                    clearCookieStore();
                 }
 
                 if (responseCode != HttpStatus.SC_CREATED && responseCode != HttpStatus.SC_ACCEPTED) {
@@ -423,18 +421,6 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
         if (credentials != null) {
             addCredentials(credentials.getUsername(), credentials.getPassword(), uri.getHost());
         }
-    }
-
-    private synchronized HttpContext getHttpContext() {
-
-        // context holds authentication state machine, so it cannot be
-        // shared across independent activities.
-        HttpContext localContext = new BasicHttpContext();
-
-        localContext.setAttribute(HttpClientContext.COOKIE_STORE, getCookieStore());
-        localContext.setAttribute(HttpClientContext.CREDS_PROVIDER, getCredentialsProvider());
-
-        return localContext;
     }
 
     /**
@@ -474,14 +460,12 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
 
     }
 
-    private void enablePreemptiveBasicAuth(
-            HttpContext localContext, String host) {
-        AuthCache ac = (AuthCache) localContext
-                .getAttribute(HttpClientContext.AUTH_CACHE);
+    private void enablePreemptiveBasicAuth(String host) {
+        AuthCache ac = (AuthCache) httpContext.getAttribute(HttpClientContext.AUTH_CACHE);
         HttpHost h = new HttpHost(host);
         if (ac == null) {
             ac = new BasicAuthCache();
-            localContext.setAttribute(HttpClientContext.AUTH_CACHE, ac);
+            httpContext.setAttribute(HttpClientContext.AUTH_CACHE, ac);
         }
         List<AuthScope> asList = buildAuthScopes(host);
         for (AuthScope authScope : asList) {
@@ -503,12 +487,12 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
         return asList;
     }
 
-    private CookieStore getCookieStore() {
-        return cookieStore;
+    private void clearCookieStore() {
+        ((CookieStore) httpContext.getAttribute(HttpClientContext.COOKIE_STORE)).clear();
     }
 
     private CredentialsProvider getCredentialsProvider() {
-        return credentialsProvider;
+        return (CredentialsProvider) httpContext.getAttribute(HttpClientContext.CREDS_PROVIDER);
     }
 
     public void clearHostCredentials(String host) {


### PR DESCRIPTION
Closes #2592 

Prior to #2257, an `HttpContext` object was stored in the `Application` class. In #2257, it became a local variable. That meant that authentication information was not saved between requests. Certain servers were not able to handle a retry after a 401.

#### What has been done to verify that this works as intended?
Submitted filled forms from the form described in the issue with large video (~30mb) to Ona and Aggregate 1.6.

#### Why is this the best possible solution? Were any other approaches considered?
I considered going back to something like the pre-#2257 structure but I believe that `httpContext` having the same scope as `HttpClientConnection` is sufficient because we issue `HEAD` requests before doing the `POST` regardless. That means saving credentials between activities or sessions doesn't help. Keeping everything in `HttpClientConnection` makes it easier to isolate all `httpclientandroidlib` calls.

@xsteelej You may have thoughts on whether there could be a better approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only intentional change is that an `Authorization` header should be sent with the `POST` request when submitting a filled form. There's a regression risk to all submission code but I think it's really low.

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)