### PR TITLE
Calculate the amount of time used to fast forward and rewind based on a sound duration

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioController.java
@@ -45,9 +45,6 @@ import static android.view.View.GONE;
 
 public class AudioController implements SeekBar.OnSeekBarChangeListener {
 
-    private static final int SEEK_FORWARD_TIME = 5000; // 5 seconds
-    private static final int SEEK_BACKWARD_TIME = 5000; // 5 seconds
-
     @BindView(R.id.currentDuration)
     TextView currentDurationLabel;
     @BindView(R.id.totalDuration)
@@ -103,12 +100,16 @@ public class AudioController implements SeekBar.OnSeekBarChangeListener {
 
     @OnClick(R.id.fastForwardBtn)
     void fastForwardMedia() {
-        seekTo(mediaPlayer.getCurrentPosition() + SEEK_FORWARD_TIME);
+        seekTo(mediaPlayer.getCurrentPosition() + seekMoveTime());
     }
 
     @OnClick(R.id.fastRewindBtn)
     void rewindMedia() {
-        seekTo(mediaPlayer.getCurrentPosition() - SEEK_BACKWARD_TIME);
+        seekTo(mediaPlayer.getCurrentPosition() - seekMoveTime());
+    }
+
+    private int seekMoveTime() {
+        return mediaPlayer.getDuration() / 5;
     }
 
     /**


### PR DESCRIPTION
Closes #2596 

#### What has been done to verify that this works as intended?
I tested fast forward and rewind options in AudioWidget.

#### Why is this the best possible solution? Were any other approaches considered?
As I described in the issue: we should calculate an amount of time used to fast forward and rewind based on a sound duration because using a constant value causes not expected behavior in case of short and long sounds.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pull request should only affect fast forward and rewind options (in the described way) in AudioWidget. That's all. Nothing else is changed.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `AudioWidget`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)