### PR TITLE
Fixed PxUsage lint

### DIFF
--- a/collect_app/src/main/res/layout/media_layout.xml
+++ b/collect_app/src/main/res/layout/media_layout.xml
@@ -23,7 +23,6 @@
             android:id="@+id/imageView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="2px"
             android:scaleType="fitStart"
             android:visibility="gone" />
 
@@ -31,7 +30,7 @@
             android:id="@+id/missingImage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:padding="10px"
+            android:padding="4dp"
             android:visibility="gone"
             tools:text="media missing" />
     </LinearLayout>

--- a/collect_app/src/main/res/values/style.xml
+++ b/collect_app/src/main/res/values/style.xml
@@ -37,14 +37,14 @@
 
     <style name="MediaButtonStyle">
         <item name="android:background">#ddd</item>
-        <item name="android:paddingBottom">12px</item>
-        <item name="android:paddingLeft">22px</item>
-        <item name="android:paddingRight">22px</item>
-        <item name="android:paddingTop">12px</item>
-        <item name="android:layout_marginLeft">6px</item>
-        <item name="android:layout_marginTop">0px</item>
-        <item name="android:layout_marginRight">6px</item>
-        <item name="android:layout_marginBottom">0px</item>
+        <item name="android:paddingBottom">5dp</item>
+        <item name="android:paddingLeft">9dp</item>
+        <item name="android:paddingRight">9dp</item>
+        <item name="android:paddingTop">5dp</item>
+        <item name="android:layout_marginLeft">2dp</item>
+        <item name="android:layout_marginTop">0dp</item>
+        <item name="android:layout_marginRight">2dp</item>
+        <item name="android:layout_marginBottom">0dp</item>
     </style>
 
 </resources>

--- a/config/lint.xml
+++ b/config/lint.xml
@@ -29,6 +29,7 @@
     <issue id="IconLocation" severity="error"/>
     <issue id="UnknownIdInLayout" severity="error"/>
     <issue id="IconDuplicates" severity="error"/>
+    <issue id="PxUsage" severity="error"/>
     <issue id="UnusedNamespace" severity="error">
         <ignore path="res/values*"/>
     </issue>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested a form with media files to confirm there is no big difference across various screens.

#### Why is this the best possible solution? Were any other approaches considered?
I think the lint description is a good explanation:
```
For performance reasons and to keep the code simpler, the Android system uses
pixels as the standard unit for expressing dimension or coordinate values.
That means that the dimensions of a view are always expressed in the code
using pixels, but always based on the current screen density. For instance, if
myView.getWidth() returns 10, the view is 10 pixels wide on the current
screen, but on a device with a higher density screen, the value returned might
be 15. If you use pixel values in your application code to work with bitmaps
that are not pre-scaled for the current screen density, you might need to
scale the pixel values that you use in your code to match the un-scaled bitmap
source. 
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change affects only the MediaLayout (with audio/video buttons). There may be a small difference across various screens in comparison with the master branch but it's normal using `dp` not `px` and it should be acceptable.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used the form attached here: https://github.com/opendatakit/collect/issues/2521

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)