### PR TITLE
Use FileProvider to access video files

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -27,6 +27,7 @@ import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore.Video;
 import android.support.annotation.NonNull;
+import android.support.v4.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -35,6 +36,7 @@ import android.widget.Toast;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CaptureSelfieVideoActivity;
 import org.odk.collect.android.activities.CaptureSelfieVideoActivityNewApi;
@@ -44,6 +46,7 @@ import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.FileUtil;
+import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtil;
 import org.odk.collect.android.utilities.ToastUtils;
@@ -438,12 +441,16 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
                 .getActivityLogger()
                 .logInstanceAction(this, "playButton",
                         "click", getFormEntryPrompt().getIndex());
-        Intent i = new Intent("android.intent.action.VIEW");
-        File f = new File(getInstanceFolder() + File.separator
-                + binaryName);
-        i.setDataAndType(Uri.fromFile(f), "video/*");
+        Intent intent = new Intent("android.intent.action.VIEW");
+        File file = new File(getInstanceFolder() + File.separator + binaryName);
+
+        Uri uri =
+                FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", file);
+
+        FileUtils.grantFileReadPermissions(intent, uri, getContext());
+        intent.setDataAndType(uri, "video/*");
         try {
-            getContext().startActivity(i);
+            getContext().startActivity(intent);
         } catch (ActivityNotFoundException e) {
             Toast.makeText(
                     getContext(),


### PR DESCRIPTION
Closes #2599 

#### What has been done to verify that this works as intended?
I tested opening a recorded video file using `VideoWidget`.

#### Why is this the best possible solution? Were any other approaches considered?
If your targetSdkVersion >= 24, then we have to use FileProvider class to give access to the particular file or folder to make them accessible for other apps.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I implemented changes only in a method that is responsible for opening a recorded video so if there is any regression it's only there. Nothing else is changed and there shouldn't be any change when it comes to behavior.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `VideoWidget` eg `AllWidgets` form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)