### PR TITLE
Use FileProvider to open image/video in MediaLayout

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -22,6 +22,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.support.v4.content.FileProvider;
 import android.support.v7.widget.AppCompatImageButton;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
@@ -36,6 +37,7 @@ import android.widget.TextView;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
+import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.AudioPlayListener;
@@ -172,7 +174,10 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
         }
 
         Intent intent = new Intent("android.intent.action.VIEW");
-        intent.setDataAndType(Uri.fromFile(videoFile), "video/*");
+        Uri uri =
+                FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", videoFile);
+        FileUtils.grantFileReadPermissions(intent, uri, getContext());
+        intent.setDataAndType(uri, "video/*");
         if (intent.resolveActivity(getContext().getPackageManager()) != null) {
             getContext().startActivity(intent);
         } else {
@@ -275,7 +280,10 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
             try {
                 File bigImage = new File(referenceManager.DeriveReference(bigImageURI).getLocalURI());
                 Intent intent = new Intent("android.intent.action.VIEW");
-                intent.setDataAndType(Uri.fromFile(bigImage), "image/*");
+                Uri uri =
+                        FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", bigImage);
+                FileUtils.grantFileReadPermissions(intent, uri, getContext());
+                intent.setDataAndType(uri, "image/*");
                 getContext().startActivity(intent);
             } catch (InvalidReferenceException e) {
                 Timber.e(e, "Invalid image reference due to %s ", e.getMessage());


### PR DESCRIPTION
Closes #2604 

#### What has been done to verify that this works as intended?
I tested opening images and playing videos in MediaLayout using the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
If your targetSdkVersion >= 24, then we have to use FileProvider class to give access to the particular file or folder to make them accessible for other apps.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The behavior shouldn't be changed. The changes I implemented are only in two methods:
-the first one is responsible for opening images in MediaLayout
-the second one is responsible for playing videos.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)