### PR TITLE
Add permission checks in FormDownloadList & InstanceUploaderActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -169,7 +169,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     Collect.createODKDirs();
                     Collect.getInstance().getActivityLogger().open();
                 } catch (RuntimeException e) {
-                    DialogUtils.createErrorDialog(FormDownloadList.this, e.getMessage(), EXIT);
+                    DialogUtils.showDialog(DialogUtils.createErrorDialog(FormDownloadList.this, e.getMessage(), EXIT), FormDownloadList.this);
                     return;
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -42,11 +42,13 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.http.HttpCredentialsInterface;
 import org.odk.collect.android.listeners.DownloadFormsTaskListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
+import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
+import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
@@ -65,6 +67,7 @@ import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_AUTH_REQUIRED;
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_ERROR_MSG;
+import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying, adding and deleting all the valid forms in the forms directory. One
@@ -157,6 +160,31 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         getComponent().inject(this);
         setTitle(getString(R.string.get_forms));
 
+        // This activity is accessed directly externally
+        requestStoragePermissions(this, new PermissionListener() {
+            @Override
+            public void granted() {
+                // must be at the beginning of any activity that can be called from an external intent
+                try {
+                    Collect.createODKDirs();
+                    Collect.getInstance().getActivityLogger().open();
+                } catch (RuntimeException e) {
+                    DialogUtils.createErrorDialog(FormDownloadList.this, e.getMessage(), EXIT);
+                    return;
+                }
+
+                init(savedInstanceState);
+            }
+
+            @Override
+            public void denied() {
+                // The activity has to finish because ODK Collect cannot function without these permissions.
+                finish();
+            }
+        });
+    }
+
+    private void init(Bundle savedInstanceState) {
         formsFound = new ArrayList<>();
         formResult = new HashMap<>();
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -26,11 +26,13 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.fragments.dialogs.SimpleDialog;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
+import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceServerUploader;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ArrayUtils;
 import org.odk.collect.android.utilities.AuthDialogUtility;
+import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
 
 import java.util.ArrayList;
@@ -40,6 +42,8 @@ import java.util.Iterator;
 import java.util.Set;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Activity to upload completed forms.
@@ -54,6 +58,8 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
     private static final String AUTH_URI = "auth";
     private static final String ALERT_MSG = "alertmsg";
     private static final String TO_SEND = "tosend";
+
+    private static final boolean EXIT = true;
 
     private ProgressDialog progressDialog;
 
@@ -71,12 +77,39 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
     private String username;
     private String password;
     private Boolean deleteInstanceAfterUpload;
+    private boolean waitingForPermissions = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Timber.i("onCreate: %s", savedInstanceState == null ? "creating" : "re-initializing");
 
+        // This activity is accessed directly externally
+        requestStoragePermissions(this, new PermissionListener() {
+            @Override
+            public void granted() {
+                // must be at the beginning of any activity that can be called from an external intent
+                try {
+                    Collect.createODKDirs();
+                    Collect.getInstance().getActivityLogger().open();
+                } catch (RuntimeException e) {
+                    DialogUtils.createErrorDialog(InstanceUploaderActivity.this, e.getMessage(), EXIT);
+                    return;
+                }
+
+                init(savedInstanceState);
+            }
+
+            @Override
+            public void denied() {
+                // The activity has to finish because ODK Collect cannot function without these permissions.
+                finish();
+            }
+        });
+
+    }
+
+    private void init(Bundle savedInstanceState) {
         alertMsg = getString(R.string.please_wait);
 
         uploadedInstances = new HashMap<String, String>();
@@ -185,7 +218,9 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
 
     @Override
     protected void onResume() {
-        Timber.i("onResume: Resuming upload of %d instances!", instancesToSend.length);
+        if (instancesToSend != null) {
+            Timber.i("onResume: Resuming upload of %d instances!", instancesToSend.length);
+        }
         if (instanceServerUploader != null) {
             instanceServerUploader.setUploaderListener(this);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -77,7 +77,6 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
     private String username;
     private String password;
     private Boolean deleteInstanceAfterUpload;
-    private boolean waitingForPermissions = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -92,7 +92,8 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
                     Collect.createODKDirs();
                     Collect.getInstance().getActivityLogger().open();
                 } catch (RuntimeException e) {
-                    DialogUtils.createErrorDialog(InstanceUploaderActivity.this, e.getMessage(), EXIT);
+                    DialogUtils.showDialog(DialogUtils.createErrorDialog(InstanceUploaderActivity.this,
+                            e.getMessage(), EXIT), InstanceUploaderActivity.this);
                     return;
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -15,8 +15,6 @@
 package org.odk.collect.android.activities;
 
 import android.app.Activity;
-import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -67,7 +67,8 @@ public class SplashScreenActivity extends Activity {
                     Collect.createODKDirs();
                     Collect.getInstance().getActivityLogger().open();
                 } catch (RuntimeException e) {
-                    DialogUtils.createErrorDialog(SplashScreenActivity.this, e.getMessage(), EXIT);
+                    DialogUtils.showDialog(DialogUtils.createErrorDialog(SplashScreenActivity.this,
+                            e.getMessage(), EXIT), SplashScreenActivity.this);
                     return;
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -36,6 +36,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
+import org.odk.collect.android.utilities.DialogUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -68,7 +69,7 @@ public class SplashScreenActivity extends Activity {
                     Collect.createODKDirs();
                     Collect.getInstance().getActivityLogger().open();
                 } catch (RuntimeException e) {
-                    createErrorDialog(e.getMessage(), EXIT);
+                    DialogUtils.createErrorDialog(SplashScreenActivity.this, e.getMessage(), EXIT);
                     return;
                 }
 
@@ -209,30 +210,6 @@ public class SplashScreenActivity extends Activity {
             }
         };
         t.start();
-    }
-
-    private void createErrorDialog(String errorMsg, final boolean shouldExit) {
-        Collect.getInstance().getActivityLogger().logAction(this, "createErrorDialog", "show");
-        AlertDialog alertDialog = new AlertDialog.Builder(this).create();
-        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
-        alertDialog.setMessage(errorMsg);
-        DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int i) {
-                switch (i) {
-                    case DialogInterface.BUTTON_POSITIVE:
-                        Collect.getInstance().getActivityLogger().logAction(this,
-                                "createErrorDialog", "OK");
-                        if (shouldExit) {
-                            finish();
-                        }
-                        break;
-                }
-            }
-        };
-        alertDialog.setCancelable(false);
-        alertDialog.setButton(getString(R.string.ok), errorListener);
-        alertDialog.show();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -105,8 +105,8 @@ public final class DialogUtils {
     /**
      * Creates an error dialog on an activity
      *
-     * @param errorMsg
-     * @param shouldExit
+     * @param errorMsg The message to show on the dialog box
+     * @param shouldExit Finish the activity if Ok is clicked
      */
     public static void createErrorDialog(@NonNull Activity activity, String errorMsg, final boolean shouldExit) {
         Collect.getInstance().getActivityLogger().logAction(activity, "createErrorDialog", "show");

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -108,7 +108,7 @@ public final class DialogUtils {
      * @param errorMsg The message to show on the dialog box
      * @param shouldExit Finish the activity if Ok is clicked
      */
-    public static void createErrorDialog(@NonNull Activity activity, String errorMsg, final boolean shouldExit) {
+    public static Dialog createErrorDialog(@NonNull Activity activity, String errorMsg, final boolean shouldExit) {
         Collect.getInstance().getActivityLogger().logAction(activity, "createErrorDialog", "show");
         AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
@@ -129,6 +129,7 @@ public final class DialogUtils {
         };
         alertDialog.setCancelable(false);
         alertDialog.setButton(activity.getString(R.string.ok), errorListener);
-        alertDialog.show();
+
+        return alertDialog;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -17,14 +17,17 @@
 package org.odk.collect.android.utilities;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.support.annotation.NonNull;
 import android.widget.ListView;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 
 import timber.log.Timber;
 
@@ -97,5 +100,35 @@ public final class DialogUtils {
         } catch (Exception e) {
             Timber.e(e);
         }
+    }
+
+    /**
+     * Creates an error dialog on an activity
+     *
+     * @param errorMsg
+     * @param shouldExit
+     */
+    public static void createErrorDialog(@NonNull Activity activity, String errorMsg, final boolean shouldExit) {
+        Collect.getInstance().getActivityLogger().logAction(activity, "createErrorDialog", "show");
+        AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
+        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
+        alertDialog.setMessage(errorMsg);
+        DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int i) {
+                switch (i) {
+                    case DialogInterface.BUTTON_POSITIVE:
+                        Collect.getInstance().getActivityLogger().logAction(this,
+                                "createErrorDialog", "OK");
+                        if (shouldExit) {
+                            activity.finish();
+                        }
+                        break;
+                }
+            }
+        };
+        alertDialog.setCancelable(false);
+        alertDialog.setButton(activity.getString(R.string.ok), errorListener);
+        alertDialog.show();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -20,8 +20,10 @@ import com.karumi.dexter.listener.multi.MultiplePermissionsListener;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.activities.FormChooserList;
+import org.odk.collect.android.activities.FormDownloadList;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.InstanceChooserList;
+import org.odk.collect.android.activities.InstanceUploaderActivity;
 import org.odk.collect.android.activities.InstanceUploaderList;
 import org.odk.collect.android.activities.SplashScreenActivity;
 import org.odk.collect.android.listeners.PermissionListener;
@@ -324,6 +326,8 @@ public class PermissionUtils {
         activities.add(FormChooserList.class);
         activities.add(InstanceUploaderList.class);
         activities.add(SplashScreenActivity.class);
+        activities.add(FormDownloadList.class);
+        activities.add(InstanceUploaderActivity.class);
 
         for (Class<?> act : activities) {
             if (activity.getClass().equals(act)) {


### PR DESCRIPTION
Closes #2603

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

This PR adds permission checks on two entry activities - `InstanceUploaderActivity` and `InstanceUploaderActivity`

This fixes crashes experienced when starting ODK Collect from external apps

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It does not.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)