### PR TITLE
Loading form didn't end when it contained an empty field-list group

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -502,7 +502,7 @@ public class FormController {
     public int stepToNextEvent(boolean stepIntoGroup) {
         if ((getEvent() == FormEntryController.EVENT_GROUP
                 || getEvent() == FormEntryController.EVENT_REPEAT)
-                && indexIsInFieldList() && !stepIntoGroup) {
+                && indexIsInFieldList() && getQuestionPrompts().length > 0 && !stepIntoGroup) {
             return stepOverGroup();
         } else {
             return formEntryController.stepToNextEvent();
@@ -606,8 +606,7 @@ public class FormController {
                             break group_skip;
                         case FormEntryController.EVENT_GROUP:
                         case FormEntryController.EVENT_REPEAT:
-                            if (indexIsInFieldList()
-                                    && getQuestionPrompts().length != 0) {
+                            if (indexIsInFieldList() && getQuestionPrompts().length != 0) {
                                 break group_skip;
                             }
                             // otherwise it's not a field-list group, so just skip it
@@ -801,7 +800,7 @@ public class FormController {
     public FormEntryPrompt[] getQuestionPrompts() throws RuntimeException {
         // For questions, there is only one.
         // For groups, there could be many, but we set that below
-        FormEntryPrompt[] questions = new FormEntryPrompt[1];
+        FormEntryPrompt[] questions = new FormEntryPrompt[0];
 
         IFormElement element = formEntryController.getModel().getForm().getChild(getFormIndex());
         if (element instanceof GroupDef) {
@@ -827,6 +826,7 @@ public class FormController {
             }
         } else {
             // We have a question, so just get the one prompt
+            questions = new FormEntryPrompt[1];
             questions[0] = getQuestionPrompt();
         }
 


### PR DESCRIPTION
Closes #1833 

#### What has been done to verify that this works as intended?
I tested the attached form which contains an empty field-list group and another one with an empty regular group (no appearances).

#### Why is this the best possible solution? Were any other approaches considered?
The problem was caused by two bugs:
[This line](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1833?expand=1#diff-586e0a142c0ade6fb5d285ebc8da0965R610) was never called because even if a group was empty [getQuestionPrompts()](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1833?expand=1#diff-586e0a142c0ade6fb5d285ebc8da0965R800) method returned an array with one element which was null.

The second problem was that we should call [stepOverGroup()](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-1833?expand=1#diff-586e0a142c0ade6fb5d285ebc8da0965R506) only if a group is not empty otherwise it doesn't make sense and cause problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't affect anything at all just fix the bug. It would be good to perform some regression tests here just using forms with groups: regular, regular field-list and repeated.

#### Do we need any specific form for testing your changes? If so, please attach one.
[emptyGroupFieldList.xml.txt](https://github.com/opendatakit/collect/files/2445662/emptyGroupFieldList.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)