### PR TITLE
Added logs in widgts we want to deprecate

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -21,6 +21,8 @@ import android.content.Intent;
 import android.view.View;
 import android.widget.Button;
 
+import com.google.android.gms.analytics.HitBuilders;
+
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
@@ -67,6 +69,13 @@ public class AlignedImageWidget extends BaseImageWidget {
         setUpLayout();
         setUpBinary();
         addAnswerView(answerLayout);
+
+        Collect.getInstance().getDefaultTracker()
+                .send(new HitBuilders.EventBuilder()
+                        .setCategory("AlignedImageWidget")
+                        .setAction("created")
+                        .setLabel(Collect.getCurrentFormIdentifierHash())
+                        .build());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -35,6 +35,8 @@ import android.widget.TableLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.gms.analytics.HitBuilders;
+
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -127,6 +129,13 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
             answerLayout.addView(imageDisplay);
         }
         addAnswerView(answerLayout);
+
+        Collect.getInstance().getDefaultTracker()
+                .send(new HitBuilders.EventBuilder()
+                        .setCategory("ImageWebViewWidget")
+                        .setAction("created")
+                        .setLabel(Collect.getCurrentFormIdentifierHash())
+                        .build());
     }
 
     private String constructImageElement() {


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Nothing.

#### Why is this the best possible solution? Were any other approaches considered?
AlignedImageWidget and ImageWebViewWidget are widgets we should deprecate or remove at all (https://github.com/opendatakit/collect/issues/1063 https://github.com/opendatakit/collect/issues/775) but first, we should get to know if they are really used.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't affect anything

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)