### PR TITLE
Nepali date widget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
             url "https://maven.google.com"
         }
         maven { url 'https://jitpack.io' }
+        maven { url 'https://staging.dev.medicmobile.org/_couch/maven-repo' }
     }
 }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -210,6 +210,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents'
     }
 
+    implementation 'bikramsambat:bikram-sambat:1.0.0'
     implementation "com.evernote:android-job:1.2.5"
     implementation "com.rarepebble:colorpicker:2.3.1"
     implementation "commons-io:commons-io:2.6"

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -38,6 +38,7 @@ public class DateTimeUtilsTest {
     private DatePickerDetails ethiopianDatePickerDetails;
     private DatePickerDetails copticDatePickerDetails;
     private DatePickerDetails islamicDatePickerDetails;
+    private DatePickerDetails nepaliDatePickerDetails;
 
     private Context context;
 
@@ -47,6 +48,7 @@ public class DateTimeUtilsTest {
         ethiopianDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.ETHIOPIAN, DatePickerDetails.DatePickerMode.SPINNERS);
         copticDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
+        nepaliDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.SPINNERS);
 
         context = Collect.getInstance();
     }
@@ -71,5 +73,9 @@ public class DateTimeUtilsTest {
         Locale.setDefault(Locale.ENGLISH);
         assertEquals("11 Rabī‘ ath-thānī 1412 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), islamicDatePickerDetails, false, context));
         assertEquals("11 Rabī‘ ath-thānī 1412, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), islamicDatePickerDetails, true, context));
+
+        Locale.setDefault(Locale.ENGLISH);
+        assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), nepaliDatePickerDetails, false, context));
+        assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), nepaliDatePickerDetails, true, context));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CopticDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CopticDatePickerDialog.java
@@ -47,7 +47,8 @@ public class CopticDatePickerDialog extends CustomDatePickerDialog {
 
     @Override
     protected void updateDays() {
-        setUpDayPicker(getCurrentCopticDate());
+        LocalDateTime localDateTime = getCurrentCopticDate();
+        setUpDayPicker(localDateTime.getDayOfMonth(), localDateTime.dayOfMonth().getMaximumValue());
     }
 
     @Override
@@ -61,9 +62,9 @@ public class CopticDatePickerDialog extends CustomDatePickerDialog {
                 .toDateTime()
                 .withChronology(CopticChronology.getInstance())
                 .toLocalDateTime();
-        setUpDayPicker(copticDate);
-        setUpMonthPicker(copticDate, monthsArray);
-        setUpYearPicker(copticDate, MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
+        setUpDayPicker(copticDate.getDayOfMonth(), copticDate.monthOfYear().getMaximumValue());
+        setUpMonthPicker(copticDate.getMonthOfYear(), monthsArray);
+        setUpYearPicker(copticDate.getYear(), MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
     }
 
     private void setUpValues() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomDatePickerDialog.java
@@ -187,26 +187,26 @@ public abstract class CustomDatePickerDialog extends DialogFragment {
         gregorianDateText.setText(label);
     }
 
-    protected void setUpDayPicker(LocalDateTime date) {
+    protected void setUpDayPicker(int dayOfMonth, int daysInMonth) {
         dayPicker.setMinValue(1);
-        dayPicker.setMaxValue(date.dayOfMonth().getMaximumValue());
+        dayPicker.setMaxValue(daysInMonth);
         if (datePickerDetails.isSpinnerMode()) {
-            dayPicker.setValue(date.getDayOfMonth());
+            dayPicker.setValue(dayOfMonth);
         }
     }
 
-    protected void setUpMonthPicker(LocalDateTime date, String[] monthsArray) {
+    protected void setUpMonthPicker(int monthOfYear, String[] monthsArray) {
         monthPicker.setMaxValue(monthsArray.length - 1);
         monthPicker.setDisplayedValues(monthsArray);
         if (!datePickerDetails.isYearMode()) {
-            monthPicker.setValue(date.getMonthOfYear() - 1);
+            monthPicker.setValue(monthOfYear - 1);
         }
     }
 
-    protected void setUpYearPicker(LocalDateTime date, int minSupportedYear, int maxSupportedYear) {
+    protected void setUpYearPicker(int year, int minSupportedYear, int maxSupportedYear) {
         yearPicker.setMinValue(minSupportedYear);
         yearPicker.setMaxValue(maxSupportedYear);
-        yearPicker.setValue(date.getYear());
+        yearPicker.setValue(year);
     }
 
     public int getDay() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/EthiopianDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/EthiopianDatePickerDialog.java
@@ -51,7 +51,8 @@ public class EthiopianDatePickerDialog extends CustomDatePickerDialog {
 
     @Override
     protected void updateDays() {
-        setUpDayPicker(getCurrentEthiopianDate());
+        LocalDateTime localDateTime = getCurrentEthiopianDate();
+        setUpDayPicker(localDateTime.getDayOfMonth(), localDateTime.dayOfMonth().getMaximumValue());
     }
 
     @Override
@@ -65,9 +66,9 @@ public class EthiopianDatePickerDialog extends CustomDatePickerDialog {
                 .toDateTime()
                 .withChronology(EthiopicChronology.getInstance())
                 .toLocalDateTime();
-        setUpDayPicker(ethiopianDate);
-        setUpMonthPicker(ethiopianDate, monthsArray);
-        setUpYearPicker(ethiopianDate, MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
+        setUpDayPicker(ethiopianDate.getDayOfMonth(), ethiopianDate.dayOfMonth().getMaximumValue());
+        setUpMonthPicker(ethiopianDate.getMonthOfYear(), monthsArray);
+        setUpYearPicker(ethiopianDate.getYear(), MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
     }
 
     private void setUpValues() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/IslamicDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/IslamicDatePickerDialog.java
@@ -48,7 +48,8 @@ public class IslamicDatePickerDialog extends CustomDatePickerDialog {
 
     @Override
     protected void updateDays() {
-        setUpDayPicker(getCurrentIslamicDate());
+        LocalDateTime localDateTime = getCurrentIslamicDate();
+        setUpDayPicker(localDateTime.getDayOfMonth(), localDateTime.dayOfMonth().getMaximumValue());
     }
 
     @Override
@@ -62,9 +63,9 @@ public class IslamicDatePickerDialog extends CustomDatePickerDialog {
                 .toDateTime()
                 .withChronology(IslamicChronology.getInstance())
                 .toLocalDateTime();
-        setUpDayPicker(islamicDate);
-        setUpMonthPicker(islamicDate, monthsArray);
-        setUpYearPicker(islamicDate, MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
+        setUpDayPicker(islamicDate.getDayOfMonth(), islamicDate.dayOfMonth().getMaximumValue());
+        setUpMonthPicker(islamicDate.getMonthOfYear(), monthsArray);
+        setUpYearPicker(islamicDate.getYear(), MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
     }
 
     private void setUpValues() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/NepaliDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/NepaliDatePickerDialog.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.fragments.dialogs;
+
+import org.javarosa.core.model.FormIndex;
+import org.joda.time.LocalDateTime;
+import org.odk.collect.android.logic.DatePickerDetails;
+
+import java.util.Arrays;
+
+import bikramsambat.BikramSambatDate;
+import bikramsambat.BsCalendar;
+import bikramsambat.BsException;
+import bikramsambat.BsGregorianDate;
+import timber.log.Timber;
+
+public class NepaliDatePickerDialog extends CustomDatePickerDialog {
+    private static final int MIN_SUPPORTED_YEAR = 2008; //1951 in Gregorian calendar
+    private static final int MAX_SUPPORTED_YEAR = 2090; //2033 in Gregorian calendar
+
+    private final String[] monthsArray = BsCalendar.MONTH_NAMES.toArray(new String[BsCalendar.MONTH_NAMES.size()]);
+
+    public static NepaliDatePickerDialog newInstance(FormIndex formIndex, LocalDateTime date, DatePickerDetails datePickerDetails) {
+        NepaliDatePickerDialog dialog = new NepaliDatePickerDialog();
+        dialog.setArguments(getArgs(formIndex, date, datePickerDetails));
+
+        return dialog;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        setUpValues();
+    }
+
+    @Override
+    protected void updateDays() {
+        BikramSambatDate bikramSambatDate = new BikramSambatDate(getYear(), Arrays.asList(monthsArray).indexOf(getMonth()), getDay());
+        int daysInMonth = 0;
+        try {
+            daysInMonth = BsCalendar.getInstance().daysInMonth(bikramSambatDate.year, bikramSambatDate.month);
+        } catch (BsException e) {
+            Timber.e(e);
+        }
+        setUpDayPicker(bikramSambatDate.day, daysInMonth);
+    }
+
+    @Override
+    protected LocalDateTime getOriginalDate() {
+        BsGregorianDate bsGregorianDate = null;
+        try {
+            bsGregorianDate = BsCalendar.getInstance().toGreg(new BikramSambatDate(getYear(), Arrays.asList(monthsArray).indexOf(getMonth()) + 1, getDay()));
+        } catch (BsException e) {
+            Timber.e(e);
+        }
+
+        return new LocalDateTime()
+                .withYear(bsGregorianDate.year)
+                .withMonthOfYear(bsGregorianDate.month)
+                .withDayOfMonth(bsGregorianDate.day)
+                .withHourOfDay(0)
+                .withMinuteOfHour(0)
+                .withSecondOfMinute(0)
+                .withMillisOfSecond(0);
+    }
+
+    private void setUpDatePicker() {
+        LocalDateTime localDateTime = getDate();
+        try {
+            BikramSambatDate bikramSambatDate = BsCalendar.getInstance().toBik(localDateTime.getYear(), localDateTime.getMonthOfYear(), localDateTime.getDayOfMonth());
+            setUpDayPicker(bikramSambatDate.day, BsCalendar.getInstance().daysInMonth(bikramSambatDate.year, bikramSambatDate.month));
+            setUpMonthPicker(bikramSambatDate.month, monthsArray);
+            setUpYearPicker(bikramSambatDate.year, MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
+        } catch (BsException e) {
+            Timber.e(e);
+        }
+    }
+
+    private void setUpValues() {
+        setUpDatePicker();
+        updateGregorianDateLabel();
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/logic/DatePickerDetails.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/DatePickerDetails.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 
 public class DatePickerDetails implements Serializable {
     public enum DatePickerType {
-        GREGORIAN, ETHIOPIAN, COPTIC, ISLAMIC
+        GREGORIAN, ETHIOPIAN, COPTIC, ISLAMIC, NEPALI
     }
 
     public enum DatePickerMode {
@@ -45,6 +45,14 @@ public class DatePickerDetails implements Serializable {
 
     public boolean isCopticType() {
         return datePickerType.equals(DatePickerType.COPTIC);
+    }
+
+    public boolean isIslamicType() {
+        return datePickerType.equals(DatePickerType.ISLAMIC);
+    }
+
+    public boolean isNepaliType() {
+        return datePickerType.equals(DatePickerType.NEPALI);
     }
 
     public boolean isCalendarMode() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
@@ -14,8 +14,15 @@ import org.odk.collect.android.logic.DatePickerDetails;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+
+import bikramsambat.BikramSambatDate;
+import bikramsambat.BsCalendar;
+import bikramsambat.BsException;
+import bikramsambat.BsGregorianDate;
+import timber.log.Timber;
 
 public class DateTimeUtils {
 
@@ -54,20 +61,45 @@ public class DateTimeUtils {
         } else if (datePickerDetails.isCopticType()) {
             customDate = new DateTime(date).withChronology(CopticChronology.getInstance());
             monthArray = context.getResources().getStringArray(R.array.coptic_months);
-        } else {
+        } else if (datePickerDetails.isIslamicType()) {
             customDate = new DateTime(date).withChronology(IslamicChronology.getInstance());
             monthArray = context.getResources().getStringArray(R.array.islamic_months);
-        }
-
-        String day = datePickerDetails.isSpinnerMode() ? customDate.getDayOfMonth() + " " : "";
-        String month = datePickerDetails.isSpinnerMode() || datePickerDetails.isMonthYearMode() ? monthArray[customDate.getMonthOfYear() - 1] + " " : "";
-
-        String customDateText;
-        if (containsTime) {
-            SimpleDateFormat df = new SimpleDateFormat("HH:mm", Locale.getDefault());
-            customDateText = day + month + customDate.getYear() + ", " + df.format(customDate.toDate());
         } else {
-            customDateText = day + month + customDate.getYear();
+            customDate = new DateTime(date);
+            monthArray = BsCalendar.MONTH_NAMES.toArray(new String[BsCalendar.MONTH_NAMES.size()]);
+        }
+        String customDateText = "";
+
+        SimpleDateFormat df = new SimpleDateFormat("HH:mm", Locale.getDefault());
+        if (datePickerDetails.isNepaliType()) {
+            BikramSambatDate bikramSambatDate;
+            try {
+                Calendar calendar = Calendar.getInstance();
+                calendar.setTime(date);
+                bikramSambatDate = BsCalendar.getInstance().toBik(new BsGregorianDate(
+                                        calendar.get(Calendar.YEAR),
+                                        calendar.get(Calendar.MONTH) + 1,
+                                        calendar.get(Calendar.DAY_OF_MONTH)));
+                String day = datePickerDetails.isSpinnerMode() ? bikramSambatDate.day + " " : "";
+                String month = datePickerDetails.isSpinnerMode() || datePickerDetails.isMonthYearMode() ? monthArray[bikramSambatDate.month - 1] + " " : "";
+
+                if (containsTime) {
+                    customDateText = day + month + bikramSambatDate.year + ", " + df.format(customDate.toDate());
+                } else {
+                    customDateText = day + month + bikramSambatDate.year;
+                }
+            } catch (BsException e) {
+                Timber.e(e);
+            }
+        } else {
+            String day = datePickerDetails.isSpinnerMode() ? customDate.getDayOfMonth() + " " : "";
+            String month = datePickerDetails.isSpinnerMode() || datePickerDetails.isMonthYearMode() ? monthArray[customDate.getMonthOfYear() - 1] + " " : "";
+
+            if (containsTime) {
+                customDateText = day + month + customDate.getYear() + ", " + df.format(customDate.toDate());
+            } else {
+                customDateText = day + month + customDate.getYear();
+            }
         }
         return String.format(context.getString(R.string.custom_date), customDateText, gregorianDateText);
     }
@@ -111,6 +143,9 @@ public class DateTimeUtils {
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
             } else if (appearance.contains("islamic")) {
                 datePickerType = DatePickerDetails.DatePickerType.ISLAMIC;
+                datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
+            } else if (appearance.contains("nepali")) {
+                datePickerType = DatePickerDetails.DatePickerType.NEPALI;
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
             } else if (appearance.contains("no-calendar")) {
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -51,6 +51,8 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget {
             dateWidget = new CopticDateWidget(context, prompt);
         } else if (appearance != null && appearance.contains("islamic")) {
             dateWidget = new IslamicDateWidget(context, prompt);
+        } else if (appearance != null && appearance.contains("nepali")) {
+            dateWidget = new NepaliDateWidget(context, prompt);
         } else {
             dateWidget = new DateWidget(context, prompt);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/NepaliDateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/NepaliDateWidget.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.widgets;
+
+import android.content.Context;
+
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.fragments.dialogs.NepaliDatePickerDialog;
+
+import static org.odk.collect.android.fragments.dialogs.CustomDatePickerDialog.DATE_PICKER_DIALOG;
+
+public class NepaliDateWidget extends AbstractDateWidget {
+
+    public NepaliDateWidget(Context context, FormEntryPrompt prompt) {
+        super(context, prompt);
+    }
+
+    protected void showDatePickerDialog() {
+        NepaliDatePickerDialog nepaliDatePickerDialog = NepaliDatePickerDialog.newInstance(getFormEntryPrompt().getIndex(), date, datePickerDetails);
+        nepaliDatePickerDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), DATE_PICKER_DIALOG);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -84,6 +84,8 @@ public class WidgetFactory {
                             questionWidget = new CopticDateWidget(context, fep);
                         } else if (appearance.contains("islamic")) {
                             questionWidget = new IslamicDateWidget(context, fep);
+                        } else if (appearance.contains("nepali")) {
+                            questionWidget = new NepaliDateWidget(context, fep);
                         } else {
                             questionWidget = new DateWidget(context, fep);
                         }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -47,6 +47,9 @@ public class DateTimeUtilsTest {
     private DatePickerDetails islamic;
     private DatePickerDetails islamicMonthYear;
     private DatePickerDetails islamicYear;
+    private DatePickerDetails nepali;
+    private DatePickerDetails nepaliMonthYear;
+    private DatePickerDetails nepaliYear;
 
     @Before
     public void setUp() {
@@ -63,6 +66,9 @@ public class DateTimeUtilsTest {
         islamic = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         islamicYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.YEAR);
+        nepali = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.SPINNERS);
+        nepaliMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.MONTH_YEAR);
+        nepaliYear = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.YEAR);
     }
 
     @Test
@@ -128,5 +134,16 @@ public class DateTimeUtilsTest {
         assertEquals(islamicYear, DateTimeUtils.getDatePickerDetails(appearance));
         appearance = "year islamic";
         assertEquals(islamicYear, DateTimeUtils.getDatePickerDetails(appearance));
+
+        appearance = "nepali";
+        assertEquals(nepali, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "Nepali month-year";
+        assertEquals(nepaliMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "month-year nepali";
+        assertEquals(nepaliMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "Nepali year";
+        assertEquals(nepaliYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "year nepali";
+        assertEquals(nepaliYear, DateTimeUtils.getDatePickerDetails(appearance));
     }
 }


### PR DESCRIPTION
Closes #1509

#### What has been done to verify that this works as intended?
I used an online converter like: http://www.nepcal.com/date_conv.php and confirmed that results are the same. I also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I used https://github.com/medic/bikram-sambat because implementing changes in the original joda-time repository was not possible.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pull request adds a new date widget which should be tested. Additionally, I implemented some changes in other date widgets (Ethiopian, Coptic, Islamic) so regression risk is related to those date widgets.

#### Do we need any specific form for testing your changes? If so, please attach one.
[nepali.xml.txt](https://github.com/opendatakit/collect/files/2458520/nepali.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)