### PR TITLE
Support multiple columns in select widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -18,6 +18,7 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 import android.support.v7.widget.DividerItemDecoration;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
@@ -38,6 +39,8 @@ import org.odk.collect.android.views.MediaLayout;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import timber.log.Timber;
 
 public abstract class SelectWidget extends QuestionWidget {
 
@@ -165,6 +168,7 @@ public abstract class SelectWidget extends QuestionWidget {
     protected RecyclerView setUpRecyclerView() {
         RecyclerView recyclerView = (RecyclerView) LayoutInflater.from(getContext()).inflate(R.layout.recycler_view, null); // keep in an xml file to enable the vertical scrollbar
         recyclerView.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
+        recyclerView.setLayoutManager(new GridLayoutManager(getContext(), getNumberOfColumns()));
 
         return recyclerView;
     }
@@ -178,5 +182,26 @@ public abstract class SelectWidget extends QuestionWidget {
         } else {
             recyclerView.setNestedScrollingEnabled(false);
         }
+    }
+
+    private int getNumberOfColumns() {
+        String columnsAppearance = "columns";
+
+        int numberOfColumns = 1;
+        String appearance = WidgetFactory.getAppearance(getFormEntryPrompt());
+        if (appearance.contains(columnsAppearance)) {
+            try {
+                appearance =
+                        appearance.substring(appearance.indexOf(columnsAppearance), appearance.length());
+                int idx = appearance.indexOf('-');
+                if (idx != -1) {
+                    numberOfColumns = Integer.parseInt(appearance.substring(idx + 1));
+                }
+            } catch (Exception e) {
+                Timber.e("Exception parsing columns");
+            }
+        }
+
+        return numberOfColumns;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.external.ExternalDataUtil;
 import java.util.List;
 import java.util.Locale;
 
+import io.reactivex.annotations.NonNull;
 import timber.log.Timber;
 
 /**
@@ -47,6 +48,25 @@ public class WidgetFactory {
 
     }
 
+    // Get appearance hint and clean it up so it is lower case, without the search function and never null.
+    @NonNull
+    static String getAppearance(FormEntryPrompt fep) {
+        String appearance = fep.getAppearanceHint();
+        if (appearance == null) {
+            appearance = "";
+        } else {
+            // For now, all appearance tags are in English.
+            appearance = appearance.toLowerCase(Locale.ENGLISH);
+
+            // Strip out the search() appearance/function which is handled in ExternalDataUtil so that
+            // it is not considered when matching other appearances. For example, a file named list.csv
+            // used as a parameter to search() should not be interpreted as a list appearance.
+            appearance = ExternalDataUtil.SEARCH_FUNCTION_REGEX.matcher(appearance).replaceAll("");
+        }
+
+        return appearance;
+    }
+
     /**
      * Returns the appropriate QuestionWidget for the given FormEntryPrompt.
      *
@@ -57,18 +77,7 @@ public class WidgetFactory {
     public static QuestionWidget createWidgetFromPrompt(FormEntryPrompt fep, Context context,
                                                         boolean readOnlyOverride) {
 
-        // Get appearance hint and clean it up so it is lower case and never null.
-        String appearance = fep.getAppearanceHint();
-        if (appearance == null) {
-            appearance = "";
-        }
-        // For now, all appearance tags are in English.
-        appearance = appearance.toLowerCase(Locale.ENGLISH);
-
-        // Strip out the search() appearance/function which is handled in ExternalDataUtil so that
-        // it is not considered when matching other appearances. For example, a file named list.csv
-        // used as a parameter to search() should not be interpreted as a list appearance.
-        appearance = ExternalDataUtil.SEARCH_FUNCTION_REGEX.matcher(appearance).replaceAll("");
+        String appearance = getAppearance(fep);
 
         final QuestionWidget questionWidget;
         switch (fep.getControlType()) {

--- a/collect_app/src/main/res/layout/recycler_view.xml
+++ b/collect_app/src/main/res/layout/recycler_view.xml
@@ -15,10 +15,8 @@ limitations under the License.
 -->
 <android.support.v7.widget.RecyclerView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:scrollbars="vertical"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:layoutManager="android.support.v7.widget.LinearLayoutManager">
+    android:layout_height="wrap_content">
 
 </android.support.v7.widget.RecyclerView>


### PR DESCRIPTION
Closes #426 

I realized that now as we use RecyclerView it's easy to solve this issue and give our users a new option.
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/3276264/46642349-029a1800-cb77-11e8-9876-a38c17d28672.gif)


#### What has been done to verify that this works as intended?
I used the attached form for testing and confirmed that it works as expected.

#### Why is this the best possible solution? Were any other approaches considered?
I'm not sure if the appearance `columns-n` I used is the best approach but it's easy to change. I was thinking about `compact-n` but it's already used to create `GridWidgets` so it would cause conflicts.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I can't see any risk here it should be safe and shouldn't change anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
[columns.zip](https://github.com/opendatakit/collect/files/2458532/columns.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)