### PR TITLE
Fixed bug in filtering items that caused crashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -69,8 +69,10 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             @Override
             protected FilterResults performFiltering(CharSequence charSequence) {
                 String searchStr = charSequence.toString().toLowerCase(Locale.US);
+                FilterResults filterResults = new FilterResults();
                 if (searchStr.isEmpty()) {
-                    filteredItems = items;
+                    filterResults.values = items;
+                    filterResults.count = items.size();
                 } else {
                     List<SelectChoice> filteredList = new ArrayList<>();
                     FormEntryPrompt formEntryPrompt = widget.getFormEntryPrompt();
@@ -79,12 +81,10 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
                             filteredList.add(item);
                         }
                     }
-
-                    filteredItems = filteredList;
+                    filterResults.values = filteredList;
+                    filterResults.count = filteredList.size();
                 }
 
-                FilterResults filterResults = new FilterResults();
-                filterResults.values = filteredItems;
                 return filterResults;
             }
 


### PR DESCRIPTION
Closes #2625 #2623 

#### What has been done to verify that this works as intended?
I was able to reproduce the mentioned issues, especially #2625, when it comes to #2623 - only twice as I remember so it's difficult.
The problem occurs on slower devices so I only was able to reproduce the issue using Android 4.

Sample steps:
1. Open the attached form
2. Enter `33` quickly and try to remove the entered value quickly as well.

#### Why is this the best possible solution? Were any other approaches considered?
This solution is not perfect. It avoids the crash but the race condition problem still occurs and I'm able to reproduce it using the mentioned steps. So if I do the same (the mentioned steps) after removing the entered value (`33`) the list still contains only items with at least one `3`. As I said it's a race condition problem (first results for an empty value are [published](https://github.com/opendatakit/collect/pull/2627/files#diff-16abb480481e8a0a0d07cf1a8bee3aa2R92) and then for `3` but it should be the other way round of course)  that occurs on slower devices and I don't think we can fix it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's safe and shouldn't affect anything. We should just test searchable widgets (select one and multiple).

#### Do we need any specific form for testing your changes? If so, please attach one.
I used this form:
[sol40.xml.txt](https://github.com/opendatakit/collect/files/2464115/sol40.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)