### PR TITLE
Removed revokeFileReadWritePermission() method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -27,7 +27,6 @@ import android.os.Bundle;
 import android.provider.MediaStore.Images;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.FileProvider;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
@@ -70,7 +69,6 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.joda.time.LocalDateTime;
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.IconMenuListAdapter;
 import org.odk.collect.android.adapters.model.IconMenuItem;
@@ -730,13 +728,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 // file
                 ImageConverter.execute(Collect.TMPFILE_PATH, getWidgetWaitingForBinaryData(), this);
                 File fi = new File(Collect.TMPFILE_PATH);
-
-                //revoke permissions granted to this file due its possible usage in
-                //the camera app
-                Uri uri = FileProvider.getUriForFile(this,
-                        BuildConfig.APPLICATION_ID + ".provider",
-                        fi);
-                FileUtils.revokeFileReadWritePermission(this, uri);
 
                 String instanceFolder = formController.getInstanceFile()
                         .getParent();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -515,9 +515,9 @@ public class FileUtils {
     }
 
     /**
-     * With the FileProvider you have to manually grant and revoke read/write permissions to files you
+     * With the FileProvider you have to manually grant read/write permissions to files you
      * are sharing. With this approach the access only lasts as long as the target activity on Api versions
-     * above Kit Kat. Once you are below that you have to manually revoke the permissions.
+     * above Kit Kat. Once you are below permissions are not revoked.
      *
      * @param intent that needs to have the permission flags
      * @param uri    that the permissions are being applied to
@@ -542,9 +542,9 @@ public class FileUtils {
     }
 
     /**
-     * With the FileProvider you have to manually grant and revoke read/write permissions to files you
+     * With the FileProvider you have to manually grant read/write permissions to files you
      * are sharing. With this approach the access only lasts as long as the target activity on Api versions
-     * above Kit Kat. Once you are below that you have to manually revoke the permissions.
+     * above Kit Kat. Once you are below permissions are not revoked.
      *
      * @param intent that needs to have the permission flags
      * @param uri    that the permissions are being applied to
@@ -564,12 +564,6 @@ public class FileUtils {
                 String packageName = resolveInfo.activityInfo.packageName;
                 context.grantUriPermission(packageName, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
             }
-        }
-    }
-
-    public static void revokeFileReadWritePermission(Context context, Uri uri) {
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            context.revokeUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -101,7 +101,6 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
         File newFile;
         // get the file path and create a copy in the instance folder
         if (object instanceof Uri) {
-            FileUtils.revokeFileReadWritePermission(getContext(), (Uri) object);
             String sourcePath = getSourcePathFromUri((Uri) object);
             String destinationPath = getDestinationPathFromSourcePath(sourcePath);
             File source = fileUtil.getFileAtPath(sourcePath);


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Nothing, it's just a small change.

#### Why is this the best possible solution? Were any other approaches considered?
We decided to remove this method in https://github.com/opendatakit/collect/pull/2600

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's safe and doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)