### PR TITLE
Use toString() method instead of Casting in order to avoid exceptions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -232,7 +232,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                 createAlertDialog(getString(R.string.no_connection));
             }
             currentPath.clear();
-            currentPath.add((String) rootButton.getText());
+            currentPath.add(rootButton.getText().toString());
         }
     }
 


### PR DESCRIPTION
Closes #2635 

#### What has been done to verify that this works as intended?
I wasn't able to reproduce the issue. It's a rare but long-standing problem so I just used a safer way to convert into strings,

#### Why is this the best possible solution? Were any other approaches considered?
toString() is a safer way for converting into strings.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It safe and doesn't affect anything.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)