### PR TITLE
added automatic permissions for running tests and modified BitmapSca…

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
@@ -28,8 +28,7 @@ public class InstanceServerUploaderTest extends MockedServerTest {
     private InstancesDao dao;
 
     @Rule
-    public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule .grant(android.Manifest.permission.READ_PHONE_STATE);
-
+    public GrantPermissionRule runtimepermissionrule = GrantPermissionRule .grant(android.Manifest.permission.READ_PHONE_STATE);
 
     @Before
     public void setUp() throws Exception {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/InstanceServerUploaderTest.java
@@ -1,11 +1,13 @@
 package org.odk.collect.android.tasks;
 
 import android.net.Uri;
+import android.support.test.rule.GrantPermissionRule;
 
 import java.io.File;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.dto.Instance;
@@ -24,6 +26,10 @@ import static org.odk.collect.android.test.TestUtils.resetInstancesContentProvid
 
 public class InstanceServerUploaderTest extends MockedServerTest {
     private InstancesDao dao;
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule .grant(android.Manifest.permission.READ_PHONE_STATE);
+
 
     @Before
     public void setUp() throws Exception {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/BitmapScaledToDisplayTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/BitmapScaledToDisplayTest.java
@@ -14,17 +14,13 @@ import static org.junit.Assert.assertEquals;
 @RunWith(AndroidJUnit4.class)
 public class BitmapScaledToDisplayTest {
 
-    /**
-     * These cases all have a window smaller than the image so the image should be scaled down.
-     * Note that the scaling isn't exact -- the factor is the closest power of 2 to the exact one.
-     */
     @Test
     @SuppressWarnings("ParenPad")
     public void scaleDownBitmapWhenNeeded() {
         runScaleTest(1000,   1000,    500,    500,    500,    500,    false);
         runScaleTest( 600,    800,    600,    200,    150,    200,    false);
         runScaleTest( 500,    400,    250,    200,    250,    200,    false);
-        runScaleTest(2000,    800,    300,    400,    500,    200,    false);
+        runScaleTest(2000,    800,    300,    400,    300,    120,    false);
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -185,20 +185,14 @@ public class FileUtils {
      * @return scaled bitmap
      */
     public static Bitmap getBitmapScaledToDisplay(File file, int screenHeight, int screenWidth, boolean upscaleEnabled) {
-        // Determine image size of file
+        // Load the image
         BitmapFactory.Options options = new BitmapFactory.Options();
-        options.inJustDecodeBounds = true;
-        getBitmap(file.getAbsolutePath(), options);
-        // Load full size bitmap image
-        options = new BitmapFactory.Options();
         options.inInputShareable = true;
         options.inPurgeable = true;
-        Bitmap bitmap;
-        bitmap = getBitmap(file.getAbsolutePath(), options);
+        Bitmap bitmap = getBitmap(file.getAbsolutePath(), options);
         double heightScale = ((double) (options.outHeight)) / screenHeight;
         double widthScale = ((double) options.outWidth) / screenWidth;
-        double scale;
-        scale = Math.max(widthScale, heightScale);
+        double scale = Math.max(widthScale, heightScale);
 
         if (!upscaleEnabled && scale < 1) {
             scale = 1;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -22,7 +22,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
-import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
 import org.javarosa.xform.parse.XFormParser;
@@ -190,20 +189,19 @@ public class FileUtils {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         getBitmap(file.getAbsolutePath(), options);
-        Bitmap bitmap;
-        double scale;
-
         // Load full size bitmap image
         options = new BitmapFactory.Options();
         options.inInputShareable = true;
         options.inPurgeable = true;
+        Bitmap bitmap;
         bitmap = getBitmap(file.getAbsolutePath(), options);
         double heightScale = ((double) (options.outHeight)) / screenHeight;
         double widthScale = ((double) options.outWidth) / screenWidth;
+        double scale;
         scale = Math.max(widthScale, heightScale);
 
-        if (!upscaleEnabled && scale<1) {
-            scale=1;
+        if (!upscaleEnabled && scale < 1) {
+            scale = 1;
         }
 
         double newHeight = Math.ceil(options.outHeight / scale);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -22,7 +22,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
-import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
 import org.javarosa.xform.parse.XFormParser;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -22,6 +22,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
 import org.javarosa.xform.parse.XFormParser;
@@ -189,40 +190,25 @@ public class FileUtils {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         getBitmap(file.getAbsolutePath(), options);
-
         Bitmap bitmap;
         double scale;
-        if (upscaleEnabled) {
-            // Load full size bitmap image
-            options = new BitmapFactory.Options();
-            options.inInputShareable = true;
-            options.inPurgeable = true;
-            bitmap = getBitmap(file.getAbsolutePath(), options);
 
-            double heightScale = ((double) (options.outHeight)) / screenHeight;
-            double widthScale = ((double) options.outWidth) / screenWidth;
-            scale = Math.max(widthScale, heightScale);
+        // Load full size bitmap image
+        options = new BitmapFactory.Options();
+        options.inInputShareable = true;
+        options.inPurgeable = true;
+        bitmap = getBitmap(file.getAbsolutePath(), options);
+        double heightScale = ((double) (options.outHeight)) / screenHeight;
+        double widthScale = ((double) options.outWidth) / screenWidth;
+        scale = Math.max(widthScale, heightScale);
 
-            double newHeight = Math.ceil(options.outHeight / scale);
-            double newWidth = Math.ceil(options.outWidth / scale);
-
-            bitmap = Bitmap.createScaledBitmap(bitmap, (int) newWidth, (int) newHeight, false);
-        } else {
-            int heightScale = options.outHeight / screenHeight;
-            int widthScale = options.outWidth / screenWidth;
-
-            // Powers of 2 work faster, sometimes, according to the doc.
-            // We're just doing closest size that still fills the screen.
-            scale = Math.max(widthScale, heightScale);
-
-            // get bitmap with scale ( < 1 is the same as 1)
-            options = new BitmapFactory.Options();
-            options.inInputShareable = true;
-            options.inPurgeable = true;
-            options.inSampleSize = (int) scale;
-            bitmap = getBitmap(file.getAbsolutePath(), options);
+        if (!upscaleEnabled && scale<1) {
+            scale=1;
         }
 
+        double newHeight = Math.ceil(options.outHeight / scale);
+        double newWidth = Math.ceil(options.outWidth / scale);
+        bitmap = Bitmap.createScaledBitmap(bitmap, (int) newWidth, (int) newHeight, false);
         if (bitmap != null) {
             Timber.i("Screen is %dx%d.  Image has been scaled down by %f to %dx%d",
                     screenHeight, screenWidth, scale, bitmap.getHeight(), bitmap.getWidth());


### PR DESCRIPTION
Closes #2550 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
All the tests on API 22 & 25 pass. Also one of the tests have been change to work correctly.

#### Why is this the best possible solution? Were any other approaches considered?
Initially an approach in which the scaling was dependent on the API version was considered but this was because of the method used to scale had changed from API>22. It only scaled by powers of two before but the in the new API it scales exactly. So now I am using a different method `Bitmap.createScaledBitmap` to do the scaling which does exact scaling. This was being used previously but only for a part of the code.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Images will be scaled more accurately to window size

#### Do we need any specific form for testing your changes? If so, please attach one.
I have modified one of the test cases to correct it.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)