### PR TITLE
Remove file permission revoking for Android <=4.4

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -27,7 +27,6 @@ import android.os.Bundle;
 import android.provider.MediaStore.Images;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.content.FileProvider;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
@@ -70,7 +69,6 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.joda.time.LocalDateTime;
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.IconMenuListAdapter;
 import org.odk.collect.android.adapters.model.IconMenuItem;
@@ -730,13 +728,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 // file
                 ImageConverter.execute(Collect.TMPFILE_PATH, getWidgetWaitingForBinaryData(), this);
                 File fi = new File(Collect.TMPFILE_PATH);
-
-                //revoke permissions granted to this file due its possible usage in
-                //the camera app
-                Uri uri = FileProvider.getUriForFile(this,
-                        BuildConfig.APPLICATION_ID + ".provider",
-                        fi);
-                FileUtils.revokeFileReadWritePermission(this, uri);
 
                 String instanceFolder = formController.getInstanceFile()
                         .getParent();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -515,61 +515,54 @@ public class FileUtils {
     }
 
     /**
-     * With the FileProvider you have to manually grant and revoke read/write permissions to files you
-     * are sharing. With this approach the access only lasts as long as the target activity on Api versions
-     * above Kit Kat. Once you are below that you have to manually revoke the permissions.
+     * Grants read and write permissions to a content URI added to the specified intent.
      *
-     * @param intent that needs to have the permission flags
-     * @param uri    that the permissions are being applied to
-     * @return intent that has read and write permissions
+     * For Android > 4.4, the permissions expire when the receiving app's stack is finished. For
+     * Android <= 4.4, the permissions are granted to all applications that can respond to the
+     * intent.
+     *
+     * For true security, the permissions for Android <= 4.4 should be revoked manually but we don't
+     * revoke them because we don't have many users on lower API levels and prior to targeting API
+     * 24+, all apps always had access to the files anyway.
      */
     public static void grantFilePermissions(Intent intent, Uri uri, Context context) {
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
-        /*
-         Workaround for Android bug.
-         grantUriPermission also needed for KITKAT,
-         see https://code.google.com/p/android/issues/detail?id=76683
-         */
+        // The preferred flag-based strategy does not work with all intent types for Android <= 4.4
+        // bug report: https://issuetracker.google.com/issues/37005552
+        // workaround: https://stackoverflow.com/a/18332000/137744
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+            List<ResolveInfo> resInfoList = context.getPackageManager()
+                    .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
             for (ResolveInfo resolveInfo : resInfoList) {
                 String packageName = resolveInfo.activityInfo.packageName;
-                context.grantUriPermission(packageName, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                context.grantUriPermission(packageName, uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
             }
         }
     }
 
     /**
-     * With the FileProvider you have to manually grant and revoke read/write permissions to files you
-     * are sharing. With this approach the access only lasts as long as the target activity on Api versions
-     * above Kit Kat. Once you are below that you have to manually revoke the permissions.
+     * Grants read permissions to a content URI added to the specified Intent.
      *
-     * @param intent that needs to have the permission flags
-     * @param uri    that the permissions are being applied to
-     * @return intent that has read and write permissions
+     * See {@link #grantFileReadPermissions(Intent, Uri, Context)} for details.
      */
     public static void grantFileReadPermissions(Intent intent, Uri uri, Context context) {
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-        /*
-         Workaround for Android bug.
-         grantUriPermission also needed for KITKAT,
-         see https://code.google.com/p/android/issues/detail?id=76683
-         */
+        // The preferred flag-based strategy does not work with all intent types for Android <= 4.4
+        // bug report: https://issuetracker.google.com/issues/37005552
+        // workaround: https://stackoverflow.com/a/18332000/137744
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            List<ResolveInfo> resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+            List<ResolveInfo> resInfoList = context.getPackageManager()
+                    .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
             for (ResolveInfo resolveInfo : resInfoList) {
                 String packageName = resolveInfo.activityInfo.packageName;
                 context.grantUriPermission(packageName, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
             }
-        }
-    }
-
-    public static void revokeFileReadWritePermission(Context context, Uri uri) {
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-            context.revokeUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -157,8 +157,7 @@ public class AnnotateWidget extends BaseImageWidget {
 
     private void captureImage() {
         errorTextView.setVisibility(View.GONE);
-        Intent intent = new Intent(
-                android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+        Intent intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
         // We give the camera an absolute filename/path where to put the
         // picture because of bug:
         // http://code.google.com/p/android/issues/detail?id=1480
@@ -173,8 +172,8 @@ public class AnnotateWidget extends BaseImageWidget {
         // if this gets modified, the onActivityResult in
         // FormEntyActivity will also need to be updated.
         intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-         FileUtils.grantFilePermissions(intent, uri, getContext());
+        FileUtils.grantFilePermissions(intent, uri, getContext());
 
         imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, R.string.annotate_image);
-        }
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -101,7 +101,6 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
         File newFile;
         // get the file path and create a copy in the instance folder
         if (object instanceof Uri) {
-            FileUtils.revokeFileReadWritePermission(getContext(), (Uri) object);
             String sourcePath = getSourcePathFromUri((Uri) object);
             String destinationPath = getDestinationPathFromSourcePath(sourcePath);
             File source = fileUtil.getFileAtPath(sourcePath);


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Bumped the target API to 26 and verified that I can take photos and view them in the external viewer on Android 7.0.

#### Why is this the best possible solution? Were any other approaches considered?
We discussed alternatives in #2599 and decided to remove the method and improve the comments.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no user-visible change. Removing the revoke method does mean that in one case with an arbitrary file question, access to a file is granted for longer than before but that case was not exhaustive anyway.

I also improved some comments and formatting while I was there so we have a record of the decisions made. I don't think there's any risk so I would not tend to QA this but it's up to the reviewer to decide.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form that includes an arbitrary file question.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)