### PR TITLE
GeoTrace/GeoShapeActivity: Preserve instance state on screen rotation

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -146,7 +146,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
             return;
         }
         if (center != null) {
-            map.animateCamera(CameraUpdateFactory.newLatLngZoom(toLatLng(center), (float) zoom));
+            map.moveCamera(CameraUpdateFactory.newLatLngZoom(toLatLng(center), (float) zoom));
         }
     }
 
@@ -168,7 +168,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
             } else if (count > 1) {
                 final LatLngBounds bounds = expandBounds(builder.build(), 1 / scaleFactor);
                 new Handler().postDelayed(() -> {
-                    map.animateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
+                    map.moveCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0));
                 }, 100);
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
@@ -41,6 +41,9 @@ import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.events.MapEventsReceiver;
+import org.osmdroid.events.MapListener;
+import org.osmdroid.events.ScrollEvent;
+import org.osmdroid.events.ZoomEvent;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
@@ -71,6 +74,7 @@ public class OsmMapFragment extends Fragment implements MapFragment,
     protected Map<Integer, MapFeature> features = new HashMap<>();
     protected AlertDialog gpsErrorDialog;
     protected boolean gpsLocationEnabled;
+    protected IGeoPoint lastMapCenter;
 
     @Override public void addTo(@NonNull FragmentActivity activity, int containerId, @Nullable ReadyListener listener) {
         readyListener = listener;
@@ -95,6 +99,7 @@ public class OsmMapFragment extends Fragment implements MapFragment,
         map.getController().setZoom(INITIAL_ZOOM);
         map.setTilesScaledToDpi(true);
         map.getOverlays().add(new MapEventsOverlay(this));
+        addMapLayoutChangeListener(map);
         myLocationOverlay = new MyLocationNewOverlay(map);
         locationClient = LocationClients.clientForContext(getActivity());
         locationClient.setListener(this);
@@ -289,6 +294,31 @@ public class OsmMapFragment extends Fragment implements MapFragment,
 
     @VisibleForTesting public AlertDialog getGpsErrorDialog() {
         return gpsErrorDialog;
+    }
+
+    /**
+     * Adds a listener that keeps track of the map center, and another
+     * listener that restores the map center when the MapView's layout changes.
+     * We have to do this because the MapView is buggy and fails to preserve its
+     * view on a layout change, causing the map viewport to jump around when the
+     * screen is resized or rotated in a way that doesn't restart the activity.
+     */
+    protected void addMapLayoutChangeListener(MapView map) {
+        lastMapCenter = map.getMapCenter();
+        map.setMapListener(new MapListener() {
+            @Override public boolean onScroll(ScrollEvent event) {
+                lastMapCenter = map.getMapCenter();
+                return false;
+            }
+
+            @Override public boolean onZoom(ZoomEvent event) {
+                lastMapCenter = map.getMapCenter();
+                return false;
+            }
+        });
+        map.addOnLayoutChangeListener(
+            (view, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) ->
+            map.getController().setCenter(lastMapCenter));
     }
 
     protected static @Nullable MapPoint fromLocation(@NonNull MyLocationNewOverlay overlay) {


### PR DESCRIPTION
Closes #2492.

Addresses #2310 for GeoShapeActivity and GeoTraceActivity but not for GeoPointActivity.

#### What has been done to verify that this works as intended?
I manually tested GeoShape in both Google and OSM modes:
  * Added a polygon, then rotated the screen to verify it was preserved (#2310)
  * Cleared the polygon, then rotated the screen to verify it didn't reappear (#2492)
  * After rotating the screen, verified that long-presses added more points as expected
  * After rotating the screen, verified that the "Back" button triggered the confirmation prompt when it was supposed to

I manually tested GeoTrace in both Google and OSM modes:
  * Added a trace, then rotated the screen to verify it was preserved (#2310)
  * While a trace was actively being recorded in manual mode, rotated the screen and continued recording
  * While a trace was actively being recorded in automatic mode, rotated the screen and verified that recording continued with the same time interval between points
  * While a trace was actively being recorded in manual mode, paused recording, rotated the screen, and unpaused recording
  * While a trace was actively being recorded in automatic mode, paused recording, rotated the screen, and unpaused recording

#### Why is this the best possible solution? Were any other approaches considered?
`onSaveInstanceState` is the recommended way to handle orientation changes.  A nice side benefit of this change is that this also preserves state when the activity is killed for any other reason (e.g. incoming phone call, switch to other apps, etc.)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only observable change to behaviour should be that the activity appears to continue working normally when the screen is rotated, instead of discarding entered data and losing track of the map view.

Note the following limitations:
* Rotating the screen in GeoTraceActivity while automatic recording is running will restart the recording timer.  So, for example, if your interval is 10 seconds, and 8 seconds have elapsed since the last points, rotating the screen will restart the timer and the next point will be recorded 10 seconds later instead of only 2 seconds later.
* The offline basemap tile selection is not preserved; it is still lost when the screen is rotated.

#### Do we need any specific form for testing your changes?
Any form with geo widgets will do.  Here is one:
[geo-widgets.zip](https://github.com/opendatakit/collect/files/2472813/geo-widgets.zip)

#### Does this change require updates to documentation?
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)