### PR TITLE
Replace newline with space instead of clearing form name

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1148,12 +1148,13 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 InputFilter returnFilter = new InputFilter() {
                     public CharSequence filter(CharSequence source, int start,
                                                int end, Spanned dest, int dstart, int dend) {
-                        for (int i = start; i < end; i++) {
-                            if (Character.getType(source.charAt(i)) == Character.CONTROL) {
-                                return "";
-                            }
-                        }
-                        return null;
+                        String newText = source.toString().substring(start, end);
+                        String invalidCharRegex = "[\\p{Cntrl}]";
+
+                        // Replace invalid characters, only modifying the string if necessary.
+                        return newText.matches(invalidCharRegex)
+                                ? newText.replaceAll(invalidCharRegex, " ")
+                                : null;
                     }
                 };
                 saveAs.setFilters(new InputFilter[]{returnFilter});


### PR DESCRIPTION
Closes https://github.com/opendatakit/collect/issues/184

Modifies [this commit](https://github.com/opendatakit/collect/commit/a6ef166) from 2011.

#### What has been done to verify that this works as intended?

Case A:

1. Download [instance_name_example.xml](https://github.com/opendatakit/collect/files/2481274/instance_name_example.xml.txt) to Collect
2. Fill the form, including a newline somewhere in the fields (e.g. your last name; form name is dynamic using the entered fields)
3. Try to save and finalize

Result: before this change, form is unsaveable if data contains a newline. After this change, newlines are replaced with spaces.

Case B:

1. Open any form
2. Go to the last page
3. Try to paste multi-line text into the form name

Result: before this change, clipboard cannot be used if data contains a newline (paste "fails" and no text is appended). After this change, newlines are replaced with spaces.

#### Technical notes

* The `\p{Cntrl}` regex matches "control characters" e.g. \r, \n, \t, etc.

#### Why is this the best possible solution? Were any other approaches considered?

This change simply replaces invalid characters instead of deleting the whole string.

Other approaches could include disallowing dynamic form names, or a feature to inform the user that a field used in dynamically calculating the form name is invalid, requiring them to go change it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

* Newlines will be turned into spaces, which may be unexpected
* It's possible that the newline will somehow persist or be added dynamically somewhere else, which could cause issues consuming the form somewhere else, whereas previously dynamic form names with newlines would have been disallowed from submission.

#### Needs verification :warning:

For dynamic form names, it seems that this change allows the form to be saved, but may not actually affect the final dynamic name of the form. It looks like the dynamically generated name is being displayed with spaces but still saved with newlines, at least on the app.

I submitted a form with newlines in the name to Aggregate, and the submission appeared just fine. Still, someone more familiar than I should probably verify this doesn't cause any issues.

#### Do we need any specific form for testing your changes? If so, please attach one.

Attached above in verification steps.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

None that I know of.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)