### PR TITLE
Always allowClick across different activities

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/AboutActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AboutActivity.java
@@ -85,7 +85,7 @@ public class AboutActivity extends CollectAbstractActivity implements
 
     @Override
     public void onClick(int position) {
-        if (Collect.allowClick(this.getClass().getSimpleName())) {
+        if (Collect.allowClick(getClass().getName())) {
             switch (position) {
                 case 0:
                     websiteTabHelper.openUri(this, websiteUri);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/AboutActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AboutActivity.java
@@ -85,7 +85,7 @@ public class AboutActivity extends CollectAbstractActivity implements
 
     @Override
     public void onClick(int position) {
-        if (Collect.allowClick()) {
+        if (Collect.allowClick(this.getClass().getSimpleName())) {
             switch (position) {
                 case 0:
                     websiteTabHelper.openUri(this, websiteUri);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
@@ -74,7 +74,7 @@ public class CaptureSelfieVideoActivity extends Activity {
         this.camPreview.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     if (!recording) {
                         // initialize video camera
                         if (prepareVideoRecorder()) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
@@ -74,7 +74,7 @@ public class CaptureSelfieVideoActivity extends Activity {
         this.camPreview.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     if (!recording) {
                         // initialize video camera
                         if (prepareVideoRecorder()) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -120,7 +120,7 @@ public class FormChooserList extends FormListActivity implements
      */
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        if (Collect.allowClick(this.getClass().getSimpleName())) {
+        if (Collect.allowClick(getClass().getName())) {
             // get uri to form
             long idFormsTable = listView.getAdapter().getItemId(position);
             Uri formUri = ContentUris.withAppendedId(FormsColumns.CONTENT_URI, idFormsTable);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -120,7 +120,7 @@ public class FormChooserList extends FormListActivity implements
      */
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        if (Collect.allowClick()) {
+        if (Collect.allowClick(this.getClass().getSimpleName())) {
             // get uri to form
             long idFormsTable = listView.getAdapter().getItemId(position);
             Uri formUri = ContentUris.withAppendedId(FormsColumns.CONTENT_URI, idFormsTable);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -123,7 +123,7 @@ public class InstanceChooserList extends InstanceListActivity implements
      */
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        if (Collect.allowClick()) {
+        if (Collect.allowClick(this.getClass().getSimpleName())) {
             Cursor c = (Cursor) listView.getAdapter().getItem(position);
             startManagingCursor(c);
             Uri instanceUri =

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -123,7 +123,7 @@ public class InstanceChooserList extends InstanceListActivity implements
      */
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        if (Collect.allowClick(this.getClass().getSimpleName())) {
+        if (Collect.allowClick(getClass().getName())) {
             Cursor c = (Cursor) listView.getAdapter().getItem(position);
             startManagingCursor(c);
             Uri instanceUri =

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -119,7 +119,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         enterDataButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     Intent i = new Intent(getApplicationContext(),
                             FormChooserList.class);
                     startActivity(i);
@@ -133,7 +133,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         reviewDataButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     Intent i = new Intent(getApplicationContext(), InstanceChooserList.class);
                     i.putExtra(ApplicationConstants.BundleKeys.FORM_MODE,
                             ApplicationConstants.FormModes.EDIT_SAVED);
@@ -148,7 +148,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         sendDataButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     Intent i = new Intent(getApplicationContext(),
                             InstanceUploaderList.class);
                     startActivity(i);
@@ -161,7 +161,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         viewSentFormsButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     Intent i = new Intent(getApplicationContext(), InstanceChooserList.class);
                     i.putExtra(ApplicationConstants.BundleKeys.FORM_MODE,
                             ApplicationConstants.FormModes.VIEW_SENT);
@@ -176,7 +176,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         getFormsButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     SharedPreferences sharedPreferences = PreferenceManager
                             .getDefaultSharedPreferences(MainMenuActivity.this);
                     String protocol = sharedPreferences.getString(
@@ -205,7 +205,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         manageFilesButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     Intent i = new Intent(getApplicationContext(),
                             FileManagerTabs.class);
                     startActivity(i);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -119,7 +119,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         enterDataButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(),
                             FormChooserList.class);
                     startActivity(i);
@@ -133,7 +133,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         reviewDataButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(), InstanceChooserList.class);
                     i.putExtra(ApplicationConstants.BundleKeys.FORM_MODE,
                             ApplicationConstants.FormModes.EDIT_SAVED);
@@ -148,7 +148,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         sendDataButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(),
                             InstanceUploaderList.class);
                     startActivity(i);
@@ -161,7 +161,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         viewSentFormsButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(), InstanceChooserList.class);
                     i.putExtra(ApplicationConstants.BundleKeys.FORM_MODE,
                             ApplicationConstants.FormModes.VIEW_SENT);
@@ -176,7 +176,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         getFormsButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     SharedPreferences sharedPreferences = PreferenceManager
                             .getDefaultSharedPreferences(MainMenuActivity.this);
                     String protocol = sharedPreferences.getString(
@@ -205,7 +205,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         manageFilesButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(),
                             FileManagerTabs.class);
                     startActivity(i);

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -94,6 +94,7 @@ public class Collect extends Application implements HasActivityInjector {
     public static String defaultSysLanguage;
     private static Collect singleton;
     private static long lastClickTime;
+    private static String lastClickName;
 
     @Nullable
     private FormController formController;
@@ -319,13 +320,16 @@ public class Collect extends Application implements HasActivityInjector {
         AdminSharedPreferences.getInstance().reloadPreferences();
     }
 
-    // Preventing multiple clicks, using threshold of 1000 ms
-    public static boolean allowClick() {
+    // Debounce multiple clicks within the same activity
+    public static boolean allowClick(String activityName) {
         long elapsedRealtime = SystemClock.elapsedRealtime();
-        boolean allowClick = (lastClickTime == 0 || lastClickTime == elapsedRealtime) // just for tests
-                || elapsedRealtime - lastClickTime > 1000;
+        boolean isSameActivity = activityName.equals(lastClickName);
+        boolean isBeyondThreshold = elapsedRealtime - lastClickTime > 1000;
+        boolean isBeyondTestThreshold = lastClickTime == 0 || lastClickTime == elapsedRealtime; // just for tests
+        boolean allowClick = !isSameActivity || isBeyondThreshold || isBeyondTestThreshold;
         if (allowClick) {
             lastClickTime = elapsedRealtime;
+            lastClickName = activityName;
         }
         return allowClick;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -91,6 +91,8 @@ public class Collect extends Application implements HasActivityInjector {
     public static final String OFFLINE_LAYERS = ODK_ROOT + File.separator + "layers";
     public static final String SETTINGS = ODK_ROOT + File.separator + "settings";
 
+    public static final int CLICK_DEBOUNCE_MS = 1000;
+
     public static String defaultSysLanguage;
     private static Collect singleton;
     private static long lastClickTime;
@@ -324,7 +326,7 @@ public class Collect extends Application implements HasActivityInjector {
     public static boolean allowClick(String activityName) {
         long elapsedRealtime = SystemClock.elapsedRealtime();
         boolean isSameActivity = activityName.equals(lastClickName);
-        boolean isBeyondThreshold = elapsedRealtime - lastClickTime > 1000;
+        boolean isBeyondThreshold = elapsedRealtime - lastClickTime > CLICK_DEBOUNCE_MS;
         boolean isBeyondTestThreshold = lastClickTime == 0 || lastClickTime == elapsedRealtime; // just for tests
         boolean allowClick = !isSameActivity || isBeyondThreshold || isBeyondTestThreshold;
         if (allowClick) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -322,16 +322,16 @@ public class Collect extends Application implements HasActivityInjector {
         AdminSharedPreferences.getInstance().reloadPreferences();
     }
 
-    // Debounce multiple clicks within the same activity
-    public static boolean allowClick(String activityName) {
+    // Debounce multiple clicks within the same screen
+    public static boolean allowClick(String className) {
         long elapsedRealtime = SystemClock.elapsedRealtime();
-        boolean isSameActivity = activityName.equals(lastClickName);
+        boolean isSameClass = className.equals(lastClickName);
         boolean isBeyondThreshold = elapsedRealtime - lastClickTime > CLICK_DEBOUNCE_MS;
         boolean isBeyondTestThreshold = lastClickTime == 0 || lastClickTime == elapsedRealtime; // just for tests
-        boolean allowClick = !isSameActivity || isBeyondThreshold || isBeyondTestThreshold;
+        boolean allowClick = !isSameClass || isBeyondThreshold || isBeyondTestThreshold;
         if (allowClick) {
             lastClickTime = elapsedRealtime;
-            lastClickName = activityName;
+            lastClickName = className;
         }
         return allowClick;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -297,7 +297,7 @@ public class Camera2VideoFragment extends Fragment
     @Override
     public void onClick(View view) {
         if (view.getId() == R.id.texture) {
-            if (Collect.allowClick()) { // avoid multiple quick taps that may cause various problems
+            if (Collect.allowClick(this.getClass().getSimpleName())) { // avoid multiple quick taps that may cause various problems
                 if (isRecordingVideo) {
                     textureView.setClickable(false);
                     stopRecordingVideo();

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -297,7 +297,7 @@ public class Camera2VideoFragment extends Fragment
     @Override
     public void onClick(View view) {
         if (view.getId() == R.id.texture) {
-            if (Collect.allowClick(this.getClass().getSimpleName())) { // avoid multiple quick taps that may cause various problems
+            if (Collect.allowClick(getClass().getName())) { // avoid multiple quick taps that may cause various problems
                 if (isRecordingVideo) {
                     textureView.setClickable(false);
                     stopRecordingVideo();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -241,7 +241,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
         @Override
         public void clickImage(String context) {
-            if (Collect.allowClick()) {
+            if (Collect.allowClick(this.getClass().getSimpleName())) {
                 launchDrawActivity();
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -241,7 +241,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
         @Override
         public void clickImage(String context) {
-            if (Collect.allowClick(this.getClass().getSimpleName())) {
+            if (Collect.allowClick(getClass().getName())) {
                 launchDrawActivity();
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -528,7 +528,7 @@ public abstract class QuestionWidget
             button.setLayoutParams(params);
 
             button.setOnClickListener(v -> {
-                if (Collect.allowClick(this.getClass().getSimpleName())) {
+                if (Collect.allowClick(getClass().getName())) {
                     ((ButtonWidget) this).onButtonClick(withId);
                 }
             });

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -528,7 +528,7 @@ public abstract class QuestionWidget
             button.setLayoutParams(params);
 
             button.setOnClickListener(v -> {
-                if (Collect.allowClick()) {
+                if (Collect.allowClick(this.getClass().getSimpleName())) {
                     ((ButtonWidget) this).onButtonClick(withId);
                 }
             });


### PR DESCRIPTION
Closes https://github.com/opendatakit/collect/issues/2642

#### What has been done to verify that this works as intended?

1. Click any of the buttons on the main menu (e.g. Fill Blank Form)
2. Immediately click a button on the new activity (e.g. a particular form)

Result: Prior to this PR, clicks within 1000 ms of each other would be ignored. Now clicks across different activities are allowed (but clicking the same button twice in a row is still ignored).

#### Why is this the best possible solution? Were any other approaches considered?

Other approaches:
* Sub-class Android's `Button` and add individual debounce behavior -- but usage is hard to enforce and it also doesn't apply to different buttons on the same activity
* Shorten the debounce time so it's less annoying -- but that could lead to bugs where clicking a button twice before the activity appears leads to pushing duplicate activities onto the stack

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Hasty clicks on sub-activities are no longer ignored. Users may be surprised at how fast they can navigate around :racehorse: 

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)