### PR TITLE
Set OSM map allowable min zoom to 2, max zoom to 22.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
@@ -94,7 +94,8 @@ public class OsmMapFragment extends Fragment implements MapFragment,
         map = view.findViewById(R.id.osm_map_view);
         map.setMultiTouchControls(true);
         map.setBuiltInZoomControls(true);
-        map.setMinZoomLevel(1);
+        map.setMinZoomLevel(2);
+        map.setMaxZoomLevel(22);
         map.getController().setCenter(INITIAL_CENTER);
         map.getController().setZoom(INITIAL_ZOOM);
         map.setTilesScaledToDpi(true);


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I manually tested the zoom controls in the GeoTrace activity in OSM map mode.

#### Why is this the best possible solution? Were any other approaches considered?
This adjustment addresses two small problems:
  - The minimum zoom level used to be 1, which zooms out far enough that you can see two vertically repeated copies of the map on most phones.  Setting the minimum to 2 means that when you are zoomed out as far as possible, you mostly don't see this repetition.
  - The maximum zoom level used to depend on the resolution of the map tiles, which usually would come out to level 19.  Increasing this to allow zooming in to level 22 is one of the things we wanted to do in Phase 2 of our geo roadmap (https://docs.google.com/document/d/1r3wJrOVDeFQkk4kWMoW29LtLI1vbBChqJ65w1Jyg4YU/edit).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only visible change should be the operation of the zoom buttons.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form that has geo widgets with maps can be used to test this change.  Here's one:
[geo-widgets.zip](https://github.com/opendatakit/collect/files/2497688/geo-widgets.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)