### PR TITLE
Remove current() warning

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -216,7 +216,7 @@ dependencies {
     implementation "commons-io:commons-io:2.6"
     implementation "net.sf.kxml:kxml2:2.3.0"
     implementation "net.sf.opencsv:opencsv:2.3"
-    implementation("org.opendatakit:opendatakit-javarosa:2.11.2") {
+    implementation("org.opendatakit:opendatakit-javarosa:2.12.0-SNAPSHOT") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -301,7 +301,7 @@ public class WidgetFactory {
 
                     if (predicates != null) {
                         for (XPathExpression predicate : predicates) {
-                            String actionName = predicate.toString().contains("current") ?
+                            String actionName = predicate.toString().contains("func-expr:current") ?
                                     "CurrentPredicate" : "NonCurrentPredicate";
 
                             Collect.getInstance().getDefaultTracker()

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -14,10 +14,7 @@
 
 package org.odk.collect.android.widgets;
 
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
 
 import com.google.android.gms.analytics.HitBuilders;
 
@@ -26,8 +23,6 @@ import org.javarosa.core.model.ItemsetBinding;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.expr.XPathExpression;
-import org.odk.collect.android.R;
-import org.odk.collect.android.activities.WebViewActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalDataUtil;
 
@@ -226,11 +221,7 @@ public class WidgetFactory {
                 } else {
                     questionWidget = new SelectOneWidget(context, fep, appearance.contains("quick"));
                 }
-
-                if (logChoiceFilterAnalytics(fep.getQuestion())) {
-                    showCurrentPredicateAlert(context);
-                }
-
+                logChoiceFilterAnalytics(fep.getQuestion());
                 break;
             case Constants.CONTROL_SELECT_MULTI:
                 // search() appearance/function (not part of XForms spec) added by SurveyCTO gets
@@ -266,11 +257,7 @@ public class WidgetFactory {
                 } else {
                     questionWidget = new SelectMultiWidget(context, fep);
                 }
-
-                if (logChoiceFilterAnalytics(fep.getQuestion())) {
-                    showCurrentPredicateAlert(context);
-                }
-
+                logChoiceFilterAnalytics(fep.getQuestion());
                 break;
             case Constants.CONTROL_RANK:
                 questionWidget = new RankingWidget(context, fep);
@@ -301,12 +288,10 @@ public class WidgetFactory {
 
     /**
      * Log analytics event each time a question with a choice filter is accessed, identifying
-     * choice filters with relative expressions. This will inform communication around the fix
-     * for a long-standing bug in JavaRosa: https://github.com/opendatakit/javarosa/issues/293
-     *
-     * @return True if a predicate with current() was found, false otherwise
+     * choice filters with relative expressions. This was initially introduced to inform messaging
+     * around a long-standing bug in JavaRosa: https://github.com/opendatakit/javarosa/issues/293
      */
-    private static boolean logChoiceFilterAnalytics(QuestionDef question) {
+    private static void logChoiceFilterAnalytics(QuestionDef question) {
         ItemsetBinding itemsetBinding = question.getDynamicChoices();
 
         if (itemsetBinding != null && itemsetBinding.nodesetRef != null) {
@@ -325,47 +310,10 @@ public class WidgetFactory {
                                     .setAction(actionName)
                                     .setLabel(Collect.getCurrentFormIdentifierHash())
                                     .build());
-
-                            if (predicate.toString().contains("current")) {
-                                return true;
-                            }
                         }
                     }
                 }
             }
         }
-        return false;
-    }
-
-    /**
-     * Show an alert explaining the upcoming change in current() predicates.
-     */
-    private static void showCurrentPredicateAlert(Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.current_predicate_warning_title);
-        builder.setMessage(R.string.current_predicate_warning);
-
-        DialogInterface.OnClickListener forumClickListener = (dialog, id) -> {
-            Intent intent = new Intent(context, WebViewActivity.class);
-            intent.putExtra("url", "https://forum.opendatakit.org/t/15122");
-            context.startActivity(intent);
-
-            Collect.getInstance().getDefaultTracker()
-                    .send(new HitBuilders.EventBuilder()
-                    .setCategory("Itemset")
-                    .setAction("CurrentChangeViewed")
-                    .setLabel(Collect.getCurrentFormIdentifierHash())
-                    .build());
-        };
-
-        builder.setPositiveButton(R.string.current_predicate_forum, forumClickListener);
-
-        DialogInterface.OnClickListener okClickListener = (dialog, id) -> {
-            dialog.dismiss();
-        };
-
-        builder.setNegativeButton(R.string.current_predicate_continue, okClickListener);
-        AlertDialog dialog = builder.create();
-        dialog.show();
     }
 }

--- a/collect_app/src/main/res/values-af/strings.xml
+++ b/collect_app/src/main/res/values-af/strings.xml
@@ -258,5 +258,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-am/strings.xml
+++ b/collect_app/src/main/res/values-am/strings.xml
@@ -298,6 +298,4 @@
   <string name="yes">አዎ</string>
   <string name="no">አይ</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">ይቀጥሉ</string>
 </resources>

--- a/collect_app/src/main/res/values-ar/strings.xml
+++ b/collect_app/src/main/res/values-ar/strings.xml
@@ -520,6 +520,4 @@
   <string name="automatic_download">تحميل آلي</string>
   <string name="hide_old_form_versions_setting_title">إخفاء الإصدارات القديمة من الاستمارة</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">المتابعة</string>
 </resources>

--- a/collect_app/src/main/res/values-bn/strings.xml
+++ b/collect_app/src/main/res/values-bn/strings.xml
@@ -203,5 +203,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-ca/strings.xml
+++ b/collect_app/src/main/res/values-ca/strings.xml
@@ -380,6 +380,4 @@
   <string name="main_menu_settings">Menú principal de configuració</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Continua</string>
 </resources>

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -645,9 +645,4 @@
   <string name="missing_google_account_dialog_title">Účet Google není nastaven</string>
   <string name="missing_google_account_dialog_desc">Chcete-li odeslat formuláře prostřednictvím tabulek Google, musíte nastavit účet Google v nastavení serveru.</string>
   <string name="sms_invalid_phone_number_description">Nastavte cílové telefonní číslo pro odesílání SMS nebo změňte typ transportu.</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Tato otázka nebude kompatibilní s budoucími verzemi ODK Collect, protože ve filtru pro výběr používá current(). \n\n Zkontrolujte, zda osoba, která tento formulář zpracovala, si přečte níže uvedené podrobnosti a podnikne kroky.</string>
-  <string name="current_predicate_warning_title">Je vyžadována akce</string>
-  <string name="current_predicate_forum">Přečtěte si podrobnosti</string>
-  <string name="current_predicate_continue">Pokračovat</string>
 </resources>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -643,9 +643,4 @@
   <string name="missing_google_account_dialog_title">Google-Konto nicht eingestellt</string>
   <string name="missing_google_account_dialog_desc">Um Formulare über Google Tabellen einzureichen, müssen Sie ihr Google-Konto bei den Server-Einstellungen einrichten.</string>
   <string name="sms_invalid_phone_number_description">Ziel-Telefonnummer für SMS-Versand einstellen oder Übertragungsart ändern.</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Diese Frage wird mit zukünftigen Versionen von ODK Collect nicht mehr kompatibel sein, weil sie current() in einem Auswahlfilter verwendet. \n\nBitte stellen Sie sicher, dass die Person, die dieses Formular erstellt hat, die Details unten liest und aktiv wird.</string>
-  <string name="current_predicate_warning_title">Aktion nötig</string>
-  <string name="current_predicate_forum">Details lesen</string>
-  <string name="current_predicate_continue">Weiter</string>
 </resources>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -645,9 +645,4 @@
   <string name="missing_google_account_dialog_title">No se ha definido una cuenta de Google</string>
   <string name="missing_google_account_dialog_desc">Para enviar formularios vía Google Sheets debe definir una cuenta de Google en ajustes de servidor.</string>
   <string name="sms_invalid_phone_number_description">Especifique un número telefónico para el envío de SMS o cambie el tipo de transporte</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Esta pregunta no será compatible con versiones futuras de la aplicaciónt debido a que usa current() en un choice filter. \n\nPor favor asegure que quien realizó el formulario lea los detalles abajo y tome la acción correspondiente.</string>
-  <string name="current_predicate_warning_title">Acción requerida</string>
-  <string name="current_predicate_forum">Leer detalles</string>
-  <string name="current_predicate_continue">Continuar</string>
 </resources>

--- a/collect_app/src/main/res/values-et/strings.xml
+++ b/collect_app/src/main/res/values-et/strings.xml
@@ -381,6 +381,4 @@
   <string name="exit">Välju</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Jätka</string>
 </resources>

--- a/collect_app/src/main/res/values-fa/strings.xml
+++ b/collect_app/src/main/res/values-fa/strings.xml
@@ -36,5 +36,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -643,9 +643,4 @@
   <string name="missing_google_account_dialog_title">Google-tiliä ei ole asetettu</string>
   <string name="missing_google_account_dialog_desc">Lähettääksesi lomakkeita Google Sheets -palvelun kautta sinun on asetettava Google-tili palvelinasetuksissa.</string>
   <string name="sms_invalid_phone_number_description">Aseta vastaanottopuhelinnumero SMS-lähetyksille tai vaihda siirtotapaa.</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Tämä kysymys ei tule olemaan yhteensopiva ODK Collect -sovelluksen tulevien versioiden kanssa, koska se käyttää current() -funktiota valintasuodatuksessa. \n\nVarmista, että tämän kyselyn tehnyt henkilö lukee yksityiskohdat alla ja tekee tarvittavat muutokset.</string>
-  <string name="current_predicate_warning_title">Toimenpiteitä tarvitaan</string>
-  <string name="current_predicate_forum">Lue yksityiskohdat</string>
-  <string name="current_predicate_continue">Jatka</string>
 </resources>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -622,9 +622,4 @@
   <string name="image_not_saved">L\'image n\'a pas pu être enregistrée à cause
 d\'un problème sur l\'instance du fichier.</string>
   <string name="missing_google_account_dialog_title">Compte Google non sélectionné</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Cette question ne sera pas compatible avec les versions futures de ODK Collect parce qu\'elle emploi current() dans un filtre de choix.\n\nVeuillez vous assurer que la personne qui a créé ce formulaire lise les details ci-dessous et agisse. </string>
-  <string name="current_predicate_warning_title">Action requise</string>
-  <string name="current_predicate_forum">Lire les details</string>
-  <string name="current_predicate_continue">Continuer</string>
 </resources>

--- a/collect_app/src/main/res/values-ha/strings.xml
+++ b/collect_app/src/main/res/values-ha/strings.xml
@@ -13,5 +13,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-hi/strings.xml
+++ b/collect_app/src/main/res/values-hi/strings.xml
@@ -479,6 +479,4 @@
   <string name="no">नहीं</string>
   <string name="start_video_capture_instruction">रिकॉर्डिंग प्रारंभ करने के लिए स्क्रीन को टैप करें</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">जारी रखें</string>
 </resources>

--- a/collect_app/src/main/res/values-hu/strings.xml
+++ b/collect_app/src/main/res/values-hu/strings.xml
@@ -14,5 +14,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -519,6 +519,4 @@
   <string name="no">Tidak</string>
   <string name="svg_file_does_not_exist">Berkas SVG tidak ada!</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Lanjut</string>
 </resources>

--- a/collect_app/src/main/res/values-it/strings.xml
+++ b/collect_app/src/main/res/values-it/strings.xml
@@ -490,6 +490,4 @@
   <string name="transport_type_sms">SMS</string>
   <string name="seconds">Secondi</string>
   <string name="rank_items">Ordina gli elementi</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Continua</string>
 </resources>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -642,9 +642,4 @@
   <string name="missing_google_account_dialog_title">Google アカウントが設定されていません</string>
   <string name="missing_google_account_dialog_desc">Google スプレッドでフォームを送信するには、サーバー設定で Google アカウントを設定する必要があります。</string>
   <string name="sms_invalid_phone_number_description">SMS 送信の宛先電話番号を設定するか、送信の種類を変更してください。</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">選択フィルタで current() を使用しているため、この質問は ODK Collect の将来のバージョンと互換性がありません。 \n\nこのフォームを作成した人は、以下の詳細を読んで対応してください。</string>
-  <string name="current_predicate_warning_title">対応が必要です</string>
-  <string name="current_predicate_forum">詳細を読む</string>
-  <string name="current_predicate_continue">続行</string>
 </resources>

--- a/collect_app/src/main/res/values-ka/strings.xml
+++ b/collect_app/src/main/res/values-ka/strings.xml
@@ -227,5 +227,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-km/strings.xml
+++ b/collect_app/src/main/res/values-km/strings.xml
@@ -589,6 +589,4 @@
   <string name="location_metadata">ផ្កាយរណបមាន៖ %1$d/24\n\nពេលវេលាកន្លងទៅ៖ %2$s</string>
   <string name="instance_upload_cancelled">បានបោះបង់ការផ្ទុកឡើងភ្លាមៗ</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">បន្តរ</string>
 </resources>

--- a/collect_app/src/main/res/values-ln/strings.xml
+++ b/collect_app/src/main/res/values-ln/strings.xml
@@ -44,5 +44,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-lo-rLA/strings.xml
+++ b/collect_app/src/main/res/values-lo-rLA/strings.xml
@@ -256,5 +256,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-lt/strings.xml
+++ b/collect_app/src/main/res/values-lt/strings.xml
@@ -199,5 +199,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-mg/strings.xml
+++ b/collect_app/src/main/res/values-mg/strings.xml
@@ -15,5 +15,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-ml/strings.xml
+++ b/collect_app/src/main/res/values-ml/strings.xml
@@ -57,5 +57,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-mr/strings.xml
+++ b/collect_app/src/main/res/values-mr/strings.xml
@@ -463,6 +463,4 @@
   <string name="not_supported_offline_layer_format">निवडलेली ऑफलाइन स्तर फाइल PBF स्वरूपन वापरते जी समर्थित नाही!</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">चालू ठेवा</string>
 </resources>

--- a/collect_app/src/main/res/values-my/strings.xml
+++ b/collect_app/src/main/res/values-my/strings.xml
@@ -209,5 +209,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-nb/strings.xml
+++ b/collect_app/src/main/res/values-nb/strings.xml
@@ -13,5 +13,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-ne-rNP/strings.xml
+++ b/collect_app/src/main/res/values-ne-rNP/strings.xml
@@ -398,5 +398,4 @@
   <string name="no">होइन</string>
   <string name="stop_video_capture_instruction">रेकर्डिङ सुरु भयो। रोक्न फेरि छुनुहोस् ।</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-nl/strings.xml
+++ b/collect_app/src/main/res/values-nl/strings.xml
@@ -275,5 +275,4 @@
   <string name="autosend_selector_title">Automatisch versturen</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-no/strings.xml
+++ b/collect_app/src/main/res/values-no/strings.xml
@@ -268,5 +268,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-pl/strings.xml
+++ b/collect_app/src/main/res/values-pl/strings.xml
@@ -441,6 +441,4 @@
   <string name="not_a_directory">%sistnieje, ale nie jest w folderze</string>
   <string name="hide_old_form_versions_setting_title">Ukryj stare wersje formularzy</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Kontynuuj</string>
 </resources>

--- a/collect_app/src/main/res/values-ps/strings.xml
+++ b/collect_app/src/main/res/values-ps/strings.xml
@@ -148,5 +148,4 @@
   <string name="hide_old_form_versions_setting_summary">یواځې نوې نسخه به په خالي فارم کې راښکاره شي</string>
   <!--Sms submission-->
   <string name="seconds">ثانیه</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-pt/strings.xml
+++ b/collect_app/src/main/res/values-pt/strings.xml
@@ -530,6 +530,4 @@ Escolher Imagem</string>
   <string name="hide_old_form_versions_setting_title">Esconder versões antigas de formulários</string>
   <string name="hide_old_form_versions_setting_summary">Somente a versão mais recente aparecerá em Formulário em Branco</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Continuar</string>
 </resources>

--- a/collect_app/src/main/res/values-ro/strings.xml
+++ b/collect_app/src/main/res/values-ro/strings.xml
@@ -310,5 +310,4 @@
   <string name="yes">Da</string>
   <string name="no">Nu</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-ru/strings.xml
+++ b/collect_app/src/main/res/values-ru/strings.xml
@@ -622,6 +622,4 @@
   <string name="missing_google_account_dialog_title">Учётная запись Google не установлена</string>
   <string name="missing_google_account_dialog_desc">Для отправки ответов через Google таблицы необходимо указать учётную запись через которую это будет происходить</string>
   <string name="sms_invalid_phone_number_description">Введите номер телефона для выгрузки или измените способ доставки.</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Продолжить</string>
 </resources>

--- a/collect_app/src/main/res/values-si/strings.xml
+++ b/collect_app/src/main/res/values-si/strings.xml
@@ -16,5 +16,4 @@
   <string name="every_six_hours">සෑම පැය 6 කට වරක්</string>
   <string name="every_24_hours">සෑම පැය24 කට වරක්</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-sl/strings.xml
+++ b/collect_app/src/main/res/values-sl/strings.xml
@@ -386,5 +386,4 @@
   <string name="transport_type_internet">WiFi / mobilno omrežje (priporočeno)</string>
   <string name="transport_type_sms">SMS sporočilo</string>
   <string name="seconds">Sekunde</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-so/strings.xml
+++ b/collect_app/src/main/res/values-so/strings.xml
@@ -45,5 +45,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-sq/strings.xml
+++ b/collect_app/src/main/res/values-sq/strings.xml
@@ -497,6 +497,4 @@
   <string name="transport_type_sms">SMS</string>
   <string name="seconds">Sekonda</string>
   <string name="rank_items">Rendit pohimet</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Vazhdo</string>
 </resources>

--- a/collect_app/src/main/res/values-sv-rSE/strings.xml
+++ b/collect_app/src/main/res/values-sv-rSE/strings.xml
@@ -543,6 +543,4 @@
   <string name="no">Nej</string>
   <string name="svg_file_does_not_exist">SVG-fil finns inte!</string>
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Fortsätt</string>
 </resources>

--- a/collect_app/src/main/res/values-sw-rKE/strings.xml
+++ b/collect_app/src/main/res/values-sw-rKE/strings.xml
@@ -236,6 +236,4 @@
   <string name="select_time">Chagua wakati</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">Endelea</string>
 </resources>

--- a/collect_app/src/main/res/values-sw/strings.xml
+++ b/collect_app/src/main/res/values-sw/strings.xml
@@ -643,9 +643,4 @@
   <string name="missing_google_account_dialog_title">Akaunti ya Google haijawekwa sawa</string>
   <string name="missing_google_account_dialog_desc">Kuwasilisha  fomu kupitia karatasi ya Google , unatakiwa kurekebisha  akaunti yako ya Google kwenye mpangilio wa seva. </string>
   <string name="sms_invalid_phone_number_description">Weka namba ya simu itakayotumiwa ujumbe au badilisha aina yako ya usafirishaji</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Swali hili halitakuwa tangamanifu na matoleo mapya ya ODK Collect kwa sababu linatumia current() katika chujio la kuchagua. \n\nTafadhali hakikisha aliyetengeneza fomu hii anasoma maelezo yafuatayo na kuyafanyia kazi.</string>
-  <string name="current_predicate_warning_title">Kitendo kinahitajika</string>
-  <string name="current_predicate_forum">Soma maelezo</string>
-  <string name="current_predicate_continue">Endelea</string>
 </resources>

--- a/collect_app/src/main/res/values-ta/strings.xml
+++ b/collect_app/src/main/res/values-ta/strings.xml
@@ -13,5 +13,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-th-rTH/strings.xml
+++ b/collect_app/src/main/res/values-th-rTH/strings.xml
@@ -369,6 +369,4 @@
   <string name="no_time_selected">ยังไม่ได้เลือกเวลา</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_continue">ดำเนินการต่อ</string>
 </resources>

--- a/collect_app/src/main/res/values-ti/strings.xml
+++ b/collect_app/src/main/res/values-ti/strings.xml
@@ -26,5 +26,4 @@
   <string name="ethiopian_month_13">ጳጐሜን</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-tl/strings.xml
+++ b/collect_app/src/main/res/values-tl/strings.xml
@@ -197,5 +197,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-tr/strings.xml
+++ b/collect_app/src/main/res/values-tr/strings.xml
@@ -159,5 +159,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-uk/strings.xml
+++ b/collect_app/src/main/res/values-uk/strings.xml
@@ -645,9 +645,4 @@
   <string name="missing_google_account_dialog_title">Нема облікового запису Google</string>
   <string name="missing_google_account_dialog_desc">Щоб надіслати анкету через Google Таблиці Ви повинні налаштувати обліковий запис Google в налаштуваннях сервера.</string>
   <string name="sms_invalid_phone_number_description">Вкажіть номер телефону для надсиланнячерез повідомлення або замініть тип відправки.</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">Це питання не буде сумісне з наступними версіями ODK Collect оскільки використовує current() в фільтрі альтернатив. \n\nБудь ласка, переконайтесь, що розробник цієї анкети прочитає докладну інформацію нижче та вжиє заходів.</string>
-  <string name="current_predicate_warning_title">Необхідна дія</string>
-  <string name="current_predicate_forum">Прочитайте докладну інформацію</string>
-  <string name="current_predicate_continue">Продовжити</string>
 </resources>

--- a/collect_app/src/main/res/values-ur-rPK/strings.xml
+++ b/collect_app/src/main/res/values-ur-rPK/strings.xml
@@ -204,5 +204,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-ur/strings.xml
+++ b/collect_app/src/main/res/values-ur/strings.xml
@@ -612,9 +612,4 @@
   <string name="missing_google_account_dialog_title">گوگل اکاؤنٹ مقرر نہیں ہے</string>
   <string name="missing_google_account_dialog_desc">گوگل شیٹس  کے ذریعے فارم جمع کرنے کے لئے آپ کو سرور کی ترتیبات میں اپناگوگل اکاؤنٹ قائم کرنا ہوگا.</string>
   <string name="sms_invalid_phone_number_description">ایس ایم ایس جمع کرانے کے لۓ ایک منزل فون نمبر مقرر کریں یا اپنے ٹرانسپورٹ کی قسم کو تبدیل کریں.</string>
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
-  <string name="current_predicate_warning">یہ سوال او ڈی کے کے مستقبل کے ورژن کے ساتھ مطابقت نہیں رکھتا ہے کیونکہ یہ ایک انتخاب فلٹر میں موجودہ () کا استعمال کرتا ہے. \ این \ این براہ کرم اس بات کو یقینی بنائیں کہ جو شخص اس فارم کو تشکیل دیتا ہے وہ ذیل میں تفصیلات پڑھتا ہے اور کارروائی کرتا ہے.</string>
-  <string name="current_predicate_warning_title">ایکشن کی ضرورت ہے</string>
-  <string name="current_predicate_forum">تفصیلات پڑھیں</string>
-  <string name="current_predicate_continue">جاری رہے</string>
 </resources>

--- a/collect_app/src/main/res/values-uz/strings.xml
+++ b/collect_app/src/main/res/values-uz/strings.xml
@@ -13,5 +13,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-vi/strings.xml
+++ b/collect_app/src/main/res/values-vi/strings.xml
@@ -203,5 +203,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-zh/strings.xml
+++ b/collect_app/src/main/res/values-zh/strings.xml
@@ -238,5 +238,4 @@
   <string name="autosend_selector_title">自动发送</string>
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values-zu/strings.xml
+++ b/collect_app/src/main/res/values-zu/strings.xml
@@ -218,5 +218,4 @@
   <!--%1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8"-->
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <!--Sms submission-->
-  <!--Text for temporary notification of upcoming change. Please do not translate "current()".-->
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -654,10 +654,4 @@
     <string name="missing_google_account_dialog_title">Google account not set</string>
     <string name="missing_google_account_dialog_desc">To submit forms via Google Sheets you have to set up your Google account in the Server settings.</string>
     <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
-
-    <!-- Text for temporary notification of upcoming change. Please do not translate "current()". -->
-    <string name="current_predicate_warning">This question will not be compatible with future versions of ODK Collect because it uses current() in a choice filter. \n\nPlease make sure the person who made this form reads the details below and takes action.</string>
-    <string name="current_predicate_warning_title">Action needed</string>
-    <string name="current_predicate_forum">Read details</string>
-    <string name="current_predicate_continue">Continue</string>
 </resources>


### PR DESCRIPTION
#2524 added a warning dialog for usage of `current()` in choice filters. We told users that the warning would be removed and the behavior fixed in 1.18.0. This PR updates JavaRosa to get the behavior fix and removes the dialog. It also removes the possibility of false positives for analytics by checking explicitly for `func-expr:current` rather than just `current`. This was supposed to be in #2524 and was described in the PR but it looks like I didn't make the commit. **Please verify this actually does what it says it does!**

#### What has been done to verify that this works as intended?
Ran with [predicate-warning.xml.txt](https://github.com/opendatakit/collect/files/2500157/predicate-warning.xml.txt) ([XLSForm](https://docs.google.com/spreadsheets/d/1j3u5el6XP4_MaRfi_IWjpvL_uIVdsXdmVPgZQJ3395k/edit#gid=0)) and verified that the questions with old (buggy) relative references that look like `current()/fruit` no longer show choices and that questions with new (fixed) relative references that look like `current()../fruit` do show choices. 

I also added a question at the end that generates a false positive on `master` because it refers to a question named `current_fruit` and verified that analytics are NOT logged for it after ee28573.

#### Why is this the best possible solution? Were any other approaches considered?
This is the approach and timeline that we discussed on the forum. I considered removing the analytics altogether but I think they will be helpful to track the popularity of such constructions as we start documenting the approach and adding form builder support for relative expressions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As users were warned of in 1.17.0, this changes the way `current()` is interpreted in a choice filter. That means that forms that worked in <1.18.0 will not work in >=1.18.0. There is regression risk around choice filters and other changes made in JavaRosa.

#### Do we need any specific form for testing your changes? If so, please attach one.
[predicate-warning.xml.txt](https://github.com/opendatakit/collect/files/2500157/predicate-warning.xml.txt) ([XLSForm](https://docs.google.com/spreadsheets/d/1j3u5el6XP4_MaRfi_IWjpvL_uIVdsXdmVPgZQJ3395k/edit#gid=0))

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Once this is in, we can start documenting the usage of relative expressions in choice filters.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)