### PR TITLE
Support notification channels

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -52,6 +52,7 @@ import org.odk.collect.android.preferences.FormMetadataMigrator;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.LocaleHelper;
+import org.odk.collect.android.utilities.NotificationUtils;
 import org.odk.collect.android.utilities.PRNGFixes;
 
 import java.io.ByteArrayInputStream;
@@ -223,6 +224,8 @@ public class Collect extends Application implements HasActivityInjector {
                 .build();
 
         applicationComponent.inject(this);
+
+        NotificationUtils.createNotificationChannel(singleton);
 
         try {
             JobManager

--- a/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/receivers/NetworkReceiver.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android.receivers;
 
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -11,7 +10,6 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Environment;
 import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.NotificationActivity;
@@ -19,7 +17,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.tasks.ServerPollingJob;
-import org.odk.collect.android.utilities.IconUtils;
+import org.odk.collect.android.utilities.NotificationUtils;
 import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
@@ -39,6 +37,7 @@ import java.util.Set;
 
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SEND;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.FORMS_UPLOADED_NOTIFICATION;
+import static org.odk.collect.android.utilities.NotificationUtils.AUTO_SEND_NOTIFICATION_ID;
 
 public class NetworkReceiver extends BroadcastReceiver implements InstanceUploaderListener {
 
@@ -263,16 +262,11 @@ public class NetworkReceiver extends BroadcastReceiver implements InstanceUpload
         PendingIntent pendingNotify = PendingIntent.getActivity(Collect.getInstance(), FORMS_UPLOADED_NOTIFICATION,
                 notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(Collect.getInstance())
-                .setSmallIcon(IconUtils.getNotificationAppIcon())
-                .setContentTitle(Collect.getInstance().getString(R.string.odk_auto_note))
-                .setContentIntent(pendingNotify)
-                .setContentText(getContentText(resultMessagesByInstanceId))
-                .setAutoCancel(true);
-
-        NotificationManager notificationManager = (NotificationManager) Collect.getInstance()
-                .getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.notify(1328974928, builder.build());
+        NotificationUtils.showNotification(
+                pendingNotify,
+                AUTO_SEND_NOTIFICATION_ID,
+                R.string.odk_auto_note,
+                getContentText(resultMessagesByInstanceId));
     }
 
     private String getContentText(Map<String, String> resultsMessagesByInstanceId) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/ServerPollingJob.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/ServerPollingJob.java
@@ -16,7 +16,6 @@
 
 package org.odk.collect.android.tasks;
 
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ContentValues;
 import android.content.Context;
@@ -25,7 +24,6 @@ import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
 
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobManager;
@@ -40,7 +38,7 @@ import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.utilities.DownloadFormListUtils;
 import org.odk.collect.android.utilities.FormDownloader;
-import org.odk.collect.android.utilities.IconUtils;
+import org.odk.collect.android.utilities.NotificationUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,6 +54,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION;
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_AUTH_REQUIRED;
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_ERROR_MSG;
+import static org.odk.collect.android.utilities.NotificationUtils.FORM_UPDATE_NOTIFICATION_ID;
 
 public class ServerPollingJob extends Job {
 
@@ -153,16 +152,11 @@ public class ServerPollingJob extends Job {
         intent.putExtra(DISPLAY_ONLY_UPDATED_FORMS, true);
         PendingIntent contentIntent = PendingIntent.getActivity(getContext(), FORM_UPDATES_AVAILABLE_NOTIFICATION, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext())
-                .setSmallIcon(IconUtils.getNotificationAppIcon())
-                .setContentTitle(getContext().getString(R.string.form_updates_available))
-                .setAutoCancel(true)
-                .setContentIntent(contentIntent);
-
-        NotificationManager manager = (NotificationManager) getContext().getSystemService(Context.NOTIFICATION_SERVICE);
-        if (manager != null) {
-            manager.notify(0, builder.build());
-        }
+        NotificationUtils.showNotification(
+                contentIntent,
+                FORM_UPDATE_NOTIFICATION_ID,
+                R.string.form_updates_available,
+                null);
     }
 
     private void informAboutNewDownloadedForms(String title, HashMap<FormDetails, String> result) {
@@ -171,17 +165,10 @@ public class ServerPollingJob extends Job {
         intent.putExtra(NotificationActivity.NOTIFICATION_MESSAGE, FormDownloadList.getDownloadResultMessage(result));
         PendingIntent contentIntent = PendingIntent.getActivity(getContext(), FORMS_DOWNLOADED_NOTIFICATION, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext())
-                .setSmallIcon(IconUtils.getNotificationAppIcon())
-                .setContentTitle(getContext().getString(R.string.odk_auto_download_notification_title))
-                .setContentText(getContentText(result))
-                .setAutoCancel(true)
-                .setContentIntent(contentIntent);
-
-        NotificationManager manager = (NotificationManager) getContext().getSystemService(Context.NOTIFICATION_SERVICE);
-        if (manager != null) {
-            manager.notify(0, builder.build());
-        }
+        NotificationUtils.showNotification(contentIntent,
+                FORM_UPDATE_NOTIFICATION_ID,
+                R.string.odk_auto_download_notification_title,
+                getContentText(result));
     }
 
     private void updateLastDetectedFormVersionHash(String formId, String formVersionHash) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.os.Build;
+import android.support.v4.app.NotificationCompat;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+
+public class NotificationUtils {
+
+    private static final String CHANNEL_ID = "collect_notification_channel";
+    public static final int FORM_UPDATE_NOTIFICATION_ID = 0;
+    public static final int AUTO_SEND_NOTIFICATION_ID = 1328974928;
+
+    private NotificationUtils() {
+    }
+
+    public static void createNotificationChannel(Collect collect) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager notificationManager = collect.getSystemService(NotificationManager.class);
+
+            if (notificationManager != null) {
+                notificationManager.createNotificationChannel(new NotificationChannel(
+                                        CHANNEL_ID,
+                                        collect.getString(R.string.notification_channel_name),
+                                        NotificationManager.IMPORTANCE_DEFAULT)
+                );
+            }
+        }
+    }
+
+    public static void showNotification(PendingIntent contentIntent,
+                                        int notificationId,
+                                        int title,
+                                        String contentText) {
+        Context context = Collect.getInstance();
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context).setContentIntent(contentIntent);
+
+        builder
+                .setContentTitle(context.getString(title))
+                .setContentText(contentText)
+                .setSmallIcon(IconUtils.getNotificationAppIcon())
+                .setAutoCancel(true)
+                .setChannelId(CHANNEL_ID);
+
+        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (manager != null) {
+            manager.notify(notificationId, builder.build());
+        }
+    }
+}

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -660,4 +660,5 @@
     <string name="current_predicate_warning_title">Action needed</string>
     <string name="current_predicate_forum">Read details</string>
     <string name="current_predicate_continue">Continue</string>
+    <string name="notification_channel_name">General notifications</string>
 </resources>


### PR DESCRIPTION
Closes #2675

#### What has been done to verify that this works as intended?
I tested displaying a notification with uploaded forms (auto send) and a notification with a not that form updates are available.

#### Why is this the best possible solution? Were any other approaches considered?
Channels are required since API 26 https://developer.android.com/training/notify-user/channels

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We just need to test all three notifications we use in ODK Collect: two mentioned above and the last one which is a notification displayed after downloading new form versions automatically. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)