### PR TITLE
Use bikram-sambat appearance instead of nepali

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -38,7 +38,7 @@ public class DateTimeUtilsTest {
     private DatePickerDetails ethiopianDatePickerDetails;
     private DatePickerDetails copticDatePickerDetails;
     private DatePickerDetails islamicDatePickerDetails;
-    private DatePickerDetails nepaliDatePickerDetails;
+    private DatePickerDetails bikramSambatDatePickerDetails;
 
     private Context context;
 
@@ -48,7 +48,7 @@ public class DateTimeUtilsTest {
         ethiopianDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.ETHIOPIAN, DatePickerDetails.DatePickerMode.SPINNERS);
         copticDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
-        nepaliDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.SPINNERS);
+        bikramSambatDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.SPINNERS);
 
         context = Collect.getInstance();
     }
@@ -75,7 +75,7 @@ public class DateTimeUtilsTest {
         assertEquals("11 Rabī‘ ath-thānī 1412, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), islamicDatePickerDetails, true, context));
 
         Locale.setDefault(Locale.ENGLISH);
-        assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), nepaliDatePickerDetails, false, context));
-        assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), nepaliDatePickerDetails, true, context));
+        assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), bikramSambatDatePickerDetails, false, context));
+        assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), bikramSambatDatePickerDetails, true, context));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/BikramSambatDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/BikramSambatDatePickerDialog.java
@@ -28,14 +28,14 @@ import bikramsambat.BsException;
 import bikramsambat.BsGregorianDate;
 import timber.log.Timber;
 
-public class NepaliDatePickerDialog extends CustomDatePickerDialog {
+public class BikramSambatDatePickerDialog extends CustomDatePickerDialog {
     private static final int MIN_SUPPORTED_YEAR = 2008; //1951 in Gregorian calendar
     private static final int MAX_SUPPORTED_YEAR = 2090; //2033 in Gregorian calendar
 
     private final String[] monthsArray = BsCalendar.MONTH_NAMES.toArray(new String[BsCalendar.MONTH_NAMES.size()]);
 
-    public static NepaliDatePickerDialog newInstance(FormIndex formIndex, LocalDateTime date, DatePickerDetails datePickerDetails) {
-        NepaliDatePickerDialog dialog = new NepaliDatePickerDialog();
+    public static BikramSambatDatePickerDialog newInstance(FormIndex formIndex, LocalDateTime date, DatePickerDetails datePickerDetails) {
+        BikramSambatDatePickerDialog dialog = new BikramSambatDatePickerDialog();
         dialog.setArguments(getArgs(formIndex, date, datePickerDetails));
 
         return dialog;

--- a/collect_app/src/main/java/org/odk/collect/android/logic/DatePickerDetails.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/DatePickerDetails.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 
 public class DatePickerDetails implements Serializable {
     public enum DatePickerType {
-        GREGORIAN, ETHIOPIAN, COPTIC, ISLAMIC, NEPALI
+        GREGORIAN, ETHIOPIAN, COPTIC, ISLAMIC, BIKRAM_SAMBAT
     }
 
     public enum DatePickerMode {
@@ -51,8 +51,8 @@ public class DatePickerDetails implements Serializable {
         return datePickerType.equals(DatePickerType.ISLAMIC);
     }
 
-    public boolean isNepaliType() {
-        return datePickerType.equals(DatePickerType.NEPALI);
+    public boolean isBikramSambatType() {
+        return datePickerType.equals(DatePickerType.BIKRAM_SAMBAT);
     }
 
     public boolean isCalendarMode() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
@@ -71,7 +71,7 @@ public class DateTimeUtils {
         String customDateText = "";
 
         SimpleDateFormat df = new SimpleDateFormat("HH:mm", Locale.getDefault());
-        if (datePickerDetails.isNepaliType()) {
+        if (datePickerDetails.isBikramSambatType()) {
             BikramSambatDate bikramSambatDate;
             try {
                 Calendar calendar = Calendar.getInstance();
@@ -144,8 +144,8 @@ public class DateTimeUtils {
             } else if (appearance.contains("islamic")) {
                 datePickerType = DatePickerDetails.DatePickerType.ISLAMIC;
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
-            } else if (appearance.contains("nepali")) {
-                datePickerType = DatePickerDetails.DatePickerType.NEPALI;
+            } else if (appearance.contains("bikram-sambat")) {
+                datePickerType = DatePickerDetails.DatePickerType.BIKRAM_SAMBAT;
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
             } else if (appearance.contains("no-calendar")) {
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BikramSambatDateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BikramSambatDateWidget.java
@@ -20,18 +20,18 @@ import android.content.Context;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.activities.FormEntryActivity;
-import org.odk.collect.android.fragments.dialogs.NepaliDatePickerDialog;
+import org.odk.collect.android.fragments.dialogs.BikramSambatDatePickerDialog;
 
 import static org.odk.collect.android.fragments.dialogs.CustomDatePickerDialog.DATE_PICKER_DIALOG;
 
-public class NepaliDateWidget extends AbstractDateWidget {
+public class BikramSambatDateWidget extends AbstractDateWidget {
 
-    public NepaliDateWidget(Context context, FormEntryPrompt prompt) {
+    public BikramSambatDateWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
     }
 
     protected void showDatePickerDialog() {
-        NepaliDatePickerDialog nepaliDatePickerDialog = NepaliDatePickerDialog.newInstance(getFormEntryPrompt().getIndex(), date, datePickerDetails);
-        nepaliDatePickerDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), DATE_PICKER_DIALOG);
+        BikramSambatDatePickerDialog bikramSambatDatePickerDialog = BikramSambatDatePickerDialog.newInstance(getFormEntryPrompt().getIndex(), date, datePickerDetails);
+        bikramSambatDatePickerDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), DATE_PICKER_DIALOG);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -51,8 +51,8 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget {
             dateWidget = new CopticDateWidget(context, prompt);
         } else if (appearance != null && appearance.contains("islamic")) {
             dateWidget = new IslamicDateWidget(context, prompt);
-        } else if (appearance != null && appearance.contains("nepali")) {
-            dateWidget = new NepaliDateWidget(context, prompt);
+        } else if (appearance != null && appearance.contains("bikram-sambat")) {
+            dateWidget = new BikramSambatDateWidget(context, prompt);
         } else {
             dateWidget = new DateWidget(context, prompt);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -84,8 +84,8 @@ public class WidgetFactory {
                             questionWidget = new CopticDateWidget(context, fep);
                         } else if (appearance.contains("islamic")) {
                             questionWidget = new IslamicDateWidget(context, fep);
-                        } else if (appearance.contains("nepali")) {
-                            questionWidget = new NepaliDateWidget(context, fep);
+                        } else if (appearance.contains("bikram-sambat")) {
+                            questionWidget = new BikramSambatDateWidget(context, fep);
                         } else {
                             questionWidget = new DateWidget(context, fep);
                         }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -47,9 +47,9 @@ public class DateTimeUtilsTest {
     private DatePickerDetails islamic;
     private DatePickerDetails islamicMonthYear;
     private DatePickerDetails islamicYear;
-    private DatePickerDetails nepali;
-    private DatePickerDetails nepaliMonthYear;
-    private DatePickerDetails nepaliYear;
+    private DatePickerDetails bikramSambat;
+    private DatePickerDetails bikramSambatMonthYear;
+    private DatePickerDetails bikramSambatYear;
 
     @Before
     public void setUp() {
@@ -66,9 +66,9 @@ public class DateTimeUtilsTest {
         islamic = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         islamicYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.YEAR);
-        nepali = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.SPINNERS);
-        nepaliMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.MONTH_YEAR);
-        nepaliYear = new DatePickerDetails(DatePickerDetails.DatePickerType.NEPALI, DatePickerDetails.DatePickerMode.YEAR);
+        bikramSambat = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.SPINNERS);
+        bikramSambatMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.MONTH_YEAR);
+        bikramSambatYear = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.YEAR);
     }
 
     @Test
@@ -135,15 +135,15 @@ public class DateTimeUtilsTest {
         appearance = "year islamic";
         assertEquals(islamicYear, DateTimeUtils.getDatePickerDetails(appearance));
 
-        appearance = "nepali";
-        assertEquals(nepali, DateTimeUtils.getDatePickerDetails(appearance));
-        appearance = "Nepali month-year";
-        assertEquals(nepaliMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
-        appearance = "month-year nepali";
-        assertEquals(nepaliMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
-        appearance = "Nepali year";
-        assertEquals(nepaliYear, DateTimeUtils.getDatePickerDetails(appearance));
-        appearance = "year nepali";
-        assertEquals(nepaliYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "bikram-sambat";
+        assertEquals(bikramSambat, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "Bikram-sambat month-year";
+        assertEquals(bikramSambatMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "month-year bikram-sambat";
+        assertEquals(bikramSambatMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "Bikram-sambat year";
+        assertEquals(bikramSambatYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "year bikram-sambat";
+        assertEquals(bikramSambatYear, DateTimeUtils.getDatePickerDetails(appearance));
     }
 }


### PR DESCRIPTION
Closes #2677

#### What has been done to verify that this works as intended?
I reviewed all changes to avoid mistakes.

#### Why is this the best possible solution? Were any other approaches considered?
We agreed on slack that since this calendar implemented in #2620 is used in other countries as well it would be better to use `bikram-sambat` appearance.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think we can merge this pr just without testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the pr #2620 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)