### PR TITLE
Specify google dependency repo before jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,13 @@ plugins {
 
 allprojects {
     repositories {
+        // Needs to go first to get specialty libraries https://stackoverflow.com/a/48438866/137744
+        google()
+
         jcenter()
-        maven { url = 'https://oss.sonatype.org/content/groups/public' }
-        maven {
-            url "https://maven.google.com"
-        }
+        maven { url 'https://oss.sonatype.org/content/groups/public' }
         maven { url 'https://jitpack.io' }
         maven { url 'https://staging.dev.medicmobile.org/_couch/maven-repo' }
-        google()
     }
 }
 


### PR DESCRIPTION
The build is broken because some dependencies can't be found. This is because the jcenter repository is specified before the google repository. I tried to fix this in 014437d but I put it in `buildscript` which is for Gradle dependencies rather than `allprojects` which is for resolving Collect's dependencies. 🤦🏻‍♀️

#### What has been done to verify that this works as intended?
Looked for that happy green check.

#### Why is this the best possible solution? Were any other approaches considered?
I got some success upgrading some libraries because it looks like some versions are available through `jcenter()` but not others. This seemed too high-risk right before a release, though, so I prefer that this truly has no risk.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't affect users at all. 🎉 It just allows the CircleCI build to succeed.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)