### PR TITLE
Don't close a cursor in FormsDao#getFormsFromCursor() since we may need to reuse it

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -194,56 +194,53 @@ public class FormsDao {
     }
 
     /**
-     * Returns all forms available through the cursor and closes the cursor.
+     * Returns all forms available through the cursor.
+     * Don't close the cursor here because we might need to reuse it!
      */
     public List<Form> getFormsFromCursor(Cursor cursor) {
         List<Form> forms = new ArrayList<>();
         if (cursor != null) {
-            try {
-                cursor.moveToPosition(-1);
-                while (cursor.moveToNext()) {
-                    int idColumnIndex = cursor.getColumnIndex(BaseColumns._ID);
-                    int displayNameColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME);
-                    int descriptionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DESCRIPTION);
-                    int jrFormIdColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID);
-                    int jrVersionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_VERSION);
-                    int formFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH);
-                    int submissionUriColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.SUBMISSION_URI);
-                    int base64RSAPublicKeyColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY);
-                    int displaySubtextColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT);
-                    int md5HashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MD5_HASH);
-                    int dateColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DATE);
-                    int jrCacheFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH);
-                    int formMediaPathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH);
-                    int languageColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LANGUAGE);
-                    int autoSendColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_SEND);
-                    int autoDeleteColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_DELETE);
-                    int lastDetectedFormVersionHashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH);
+            cursor.moveToPosition(-1);
+            while (cursor.moveToNext()) {
+                int idColumnIndex = cursor.getColumnIndex(BaseColumns._ID);
+                int displayNameColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_NAME);
+                int descriptionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DESCRIPTION);
+                int jrFormIdColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_FORM_ID);
+                int jrVersionColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JR_VERSION);
+                int formFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH);
+                int submissionUriColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.SUBMISSION_URI);
+                int base64RSAPublicKeyColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY);
+                int displaySubtextColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT);
+                int md5HashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MD5_HASH);
+                int dateColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DATE);
+                int jrCacheFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH);
+                int formMediaPathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH);
+                int languageColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LANGUAGE);
+                int autoSendColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_SEND);
+                int autoDeleteColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.AUTO_DELETE);
+                int lastDetectedFormVersionHashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH);
 
-                    Form form = new Form.Builder()
-                            .id(cursor.getInt(idColumnIndex))
-                            .displayName(cursor.getString(displayNameColumnIndex))
-                            .description(cursor.getString(descriptionColumnIndex))
-                            .jrFormId(cursor.getString(jrFormIdColumnIndex))
-                            .jrVersion(cursor.getString(jrVersionColumnIndex))
-                            .formFilePath(cursor.getString(formFilePathColumnIndex))
-                            .submissionUri(cursor.getString(submissionUriColumnIndex))
-                            .base64RSAPublicKey(cursor.getString(base64RSAPublicKeyColumnIndex))
-                            .displaySubtext(cursor.getString(displaySubtextColumnIndex))
-                            .md5Hash(cursor.getString(md5HashColumnIndex))
-                            .date(cursor.getLong(dateColumnIndex))
-                            .jrCacheFilePath(cursor.getString(jrCacheFilePathColumnIndex))
-                            .formMediaPath(cursor.getString(formMediaPathColumnIndex))
-                            .language(cursor.getString(languageColumnIndex))
-                            .autoSend(cursor.getString(autoSendColumnIndex))
-                            .autoDelete(cursor.getString(autoDeleteColumnIndex))
-                            .lastDetectedFormVersionHash(cursor.getString(lastDetectedFormVersionHashColumnIndex))
-                            .build();
+                Form form = new Form.Builder()
+                        .id(cursor.getInt(idColumnIndex))
+                        .displayName(cursor.getString(displayNameColumnIndex))
+                        .description(cursor.getString(descriptionColumnIndex))
+                        .jrFormId(cursor.getString(jrFormIdColumnIndex))
+                        .jrVersion(cursor.getString(jrVersionColumnIndex))
+                        .formFilePath(cursor.getString(formFilePathColumnIndex))
+                        .submissionUri(cursor.getString(submissionUriColumnIndex))
+                        .base64RSAPublicKey(cursor.getString(base64RSAPublicKeyColumnIndex))
+                        .displaySubtext(cursor.getString(displaySubtextColumnIndex))
+                        .md5Hash(cursor.getString(md5HashColumnIndex))
+                        .date(cursor.getLong(dateColumnIndex))
+                        .jrCacheFilePath(cursor.getString(jrCacheFilePathColumnIndex))
+                        .formMediaPath(cursor.getString(formMediaPathColumnIndex))
+                        .language(cursor.getString(languageColumnIndex))
+                        .autoSend(cursor.getString(autoSendColumnIndex))
+                        .autoDelete(cursor.getString(autoDeleteColumnIndex))
+                        .lastDetectedFormVersionHash(cursor.getString(lastDetectedFormVersionHashColumnIndex))
+                        .build();
 
-                    forms.add(form);
-                }
-            } finally {
-                cursor.close();
+                forms.add(form);
             }
         }
         return forms;


### PR DESCRIPTION
Closes #2686 

#### What has been done to verify that this works as intended?
Confirmed that the app doesn't crash anymore.

#### Why is this the best possible solution? Were any other approaches considered?
We can't close a cursor in that method because we might need to reuse it. Generally, a cursor should be closed in a place it's created. Her it's passed as a parameter so it wasn't a good idea to close it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't change anything, just fix the bug. I guess It's not risku because it worked without closing a cursor here before. Closing has been added here https://github.com/opendatakit/collect/pull/2619/commits/015d9798cf6fe1c989d4250587547e495c8b2d99 but as I understand not to fix anything.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)