### PR TITLE
Fixed temporary failed status when sending multiple submissions via SMS

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -169,11 +169,8 @@ public class InstanceUploaderAdapter extends CursorAdapter {
             case RESULT_QUEUED:
             case RESULT_OK_OTHERS_PENDING:
             case RESULT_SENDING:
-                viewHolder.statusIcon.setImageResource(R.drawable.message_text_outline);
-                break;
-
             case RESULT_MESSAGE_READY:
-                viewHolder.statusIcon.setImageResource(R.drawable.pencil);
+                viewHolder.statusIcon.setImageResource(R.drawable.message_text_outline);
                 break;
 
             default:

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -380,6 +380,8 @@ public class SmsService {
                 case RESULT_OK_OTHERS_PENDING:
                     return context.getResources().getQuantityString(R.plurals.sms_sending, (int) progress.getTotalCount(), progress.getCompletedCount(), progress.getTotalCount());
                 case RESULT_QUEUED:
+                case RESULT_SENDING:
+                case RESULT_MESSAGE_READY:
                     return context.getString(R.string.sms_submission_queued);
                 case RESULT_OK:
                     return new SimpleDateFormat(context.getString(R.string.sms_sent_on_date_at_time),


### PR DESCRIPTION
Closes #2688 

#### What has been done to verify that this works as intended?
I tested sending forms via SMS and confirmed that an appropriate message is displayed.

#### Why is this the best possible solution? Were any other approaches considered?
The main problem was that in https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2688?expand=1#diff-3c6ecef4b9b32806d2c6f7274283f4d7L375 we didn't have specified two codes:
`RESULT_SENDING` and `RESULT_MESSAGE_READY` so it was treated as default value and failed status was returned https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2688?expand=1#diff-3c6ecef4b9b32806d2c6f7274283f4d7R401

Of course, we could add different strings for `RESULT_QUEUED`, `RESULT_SENDING` and `RESULT_MESSAGE_READY` but it works pretty fast and is barely visible so it doesn't make sense to use three different messages.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change causes that for all three mentioned above codes: `RESULT_QUEUED`, `RESULT_SENDING` and `RESULT_MESSAGE_READY` we return the same message `sms_submission_queued`.

Additionally, I removed displaying the pencil icon since it was also barely visible because just after using the pencil icon another one (`message_text_outline`) is used.
https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2688?expand=1#diff-64d69d5afb524d0ae3eedab3e370ca39L176

so during sending forms, we can use the `message_text_outline` icon immediately and not the `pencil` one and then the `message_text_outline` what makes the first one as I said barely visible and moreover 
the `pencil` icon doesn't really match to the `RESULT_MESSAGE_READY` code.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)