### PR TITLE
Fix crash if storage permission is modified and display a screen to request for the permission

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -276,6 +276,7 @@ the specific language governing permissions and limitations under the License.
         <activity android:name=".activities.WebViewActivity" />
         <activity android:name=".activities.CaptureSelfieVideoActivity" />
         <activity android:name=".activities.CaptureSelfieVideoActivityNewApi" />
+        <activity android:name=".activities.StoragePermissionActivity" />
 
         <receiver
             android:name=".tasks.sms.SmsSentBroadcastReceiver"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
@@ -19,18 +19,14 @@ package org.odk.collect.android.activities;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.injection.config.AppComponent;
-import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.ThemeUtils;
 
 import static org.odk.collect.android.utilities.PermissionUtils.checkIfStoragePermissionsGranted;
-import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.isEntryPointActivity;
 
 public abstract class CollectAbstractActivity extends AppCompatActivity {
 
@@ -44,24 +40,20 @@ public abstract class CollectAbstractActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         /**
-         * If a user has revoked the storage permission then this check ensures the app doesn't quit unexpectedly and
-         * informs the user of the implications of their decision before exiting. The app can't function with these permissions
-         * so if a user wishes to grant them they just restart.
+         * If a user has revoked the storage permission then this check ensures the app doesn't quit
+         * unexpectedly and starts {@link  StoragePermissionActivity} which informs the user that
+         * the app can't function without storage permission and gives an option to re-allow it or
+         * ignore the warning which quits the app.
          *
-         * This code won't run on activities that are entry points to the app because those activities
-         * are able to handle permission checks and requests by themselves.
+         * Since all of the activities extend {@link CollectAbstractActivity}, so this also removes
+         * the overhead of checking for this permission separately in each of the activities.
+         *
+         * We also finish this activity and later re-create it from within {@link StoragePermissionActivity}
+         * if the user decides to re-allow the permission
          */
-        if (!checkIfStoragePermissionsGranted(this) && !isEntryPointActivity(this)) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Theme_AppCompat_Light_Dialog);
-
-            builder.setTitle(R.string.storage_runtime_permission_denied_title)
-                    .setMessage(R.string.storage_runtime_permission_denied_desc)
-                    .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> {
-                        finishAllActivities(this);
-                    })
-                    .setIcon(R.drawable.sd)
-                    .setCancelable(false)
-                    .show();
+        if (!checkIfStoragePermissionsGranted(this)) {
+            StoragePermissionActivity.startActivity(this, getIntent(), getClass());
+            finish();
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
@@ -38,12 +38,17 @@ public abstract class CollectAbstractActivity extends AppCompatActivity {
         themeUtils = new ThemeUtils(this);
         setTheme(this instanceof FormEntryActivity ? themeUtils.getFormEntryActivityTheme() : themeUtils.getAppTheme());
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
 
         /**
-         * If a user has revoked the storage permission then this check ensures the app doesn't quit
-         * unexpectedly and starts {@link  StoragePermissionActivity} which informs the user that
-         * the app can't function without storage permission and gives an option to re-allow it or
-         * ignore the warning which quits the app.
+         * If the user has revoked the storage permission then this check ensures the app doesn't
+         * quit unexpectedly and starts {@link  StoragePermissionActivity} which informs the user
+         * that the app can't function without storage permission and gives an option to re-allow it
+         * or ignore the warning which quits the app.
          *
          * Since all of the activities extend {@link CollectAbstractActivity}, so this also removes
          * the overhead of checking for this permission separately in each of the activities.
@@ -54,7 +59,20 @@ public abstract class CollectAbstractActivity extends AppCompatActivity {
         if (!checkIfStoragePermissionsGranted(this)) {
             StoragePermissionActivity.startActivity(this, getIntent(), getClass());
             finish();
+        } else {
+            /*
+             * Storage permission is already given to the app.
+             * So, we can proceed with using storage related functions
+             */
+            init();
         }
+    }
+
+    /**
+     * This method should be overridden wherever storage permission check is required before
+     * initializing the activity
+     */
+    protected void init() {
     }
 
     public AppComponent getComponent() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
@@ -72,6 +72,7 @@ public abstract class CollectAbstractActivity extends AppCompatActivity {
      * This method should be overridden wherever storage permission check is required before
      * initializing the activity
      */
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     protected void init() {
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -62,8 +62,15 @@ public class FormChooserList extends FormListActivity implements
         setContentView(R.layout.chooser_list_layout);
 
         setTitle(getString(R.string.enter_data));
-        setupAdapter();
 
+        sortingOptions = new String[]{
+                getString(R.string.sort_by_name_asc), getString(R.string.sort_by_name_desc),
+                getString(R.string.sort_by_date_asc), getString(R.string.sort_by_date_desc),
+        };
+    }
+
+    @Override
+    protected void init() {
         // DiskSyncTask checks the disk for any forms not already in the content provider
         // that is, put here by dragging and dropping onto the SDCard
         diskSyncTask = (DiskSyncTask) getLastCustomNonConfigurationInstance();
@@ -73,10 +80,6 @@ public class FormChooserList extends FormListActivity implements
             diskSyncTask.setDiskSyncListener(this);
             diskSyncTask.execute((Void[]) null);
         }
-        sortingOptions = new String[]{
-                getString(R.string.sort_by_name_asc), getString(R.string.sort_by_name_desc),
-                getString(R.string.sort_by_date_asc), getString(R.string.sort_by_date_desc),
-        };
 
         setupAdapter();
         getSupportLoaderManager().initLoader(LOADER_ID, null, this);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -32,7 +32,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.listeners.DiskSyncListener;
-import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
@@ -42,9 +41,6 @@ import org.odk.collect.android.utilities.FormUtils;
 import org.odk.collect.android.utilities.VersionHidingCursorAdapter;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying all the valid forms in the forms directory. Stores the path to
@@ -66,29 +62,6 @@ public class FormChooserList extends FormListActivity implements
         setContentView(R.layout.chooser_list_layout);
 
         setTitle(getString(R.string.enter_data));
-
-        requestStoragePermissions(this, new PermissionListener() {
-            @Override
-            public void granted() {
-                // must be at the beginning of any activity that can be called from an external intent
-                try {
-                    Collect.createODKDirs();
-                    init();
-                } catch (RuntimeException e) {
-                    createErrorDialog(e.getMessage(), EXIT);
-                    return;
-                }
-            }
-
-            @Override
-            public void denied() {
-                // The activity has to finish because ODK Collect cannot function without these permissions.
-                finishAllActivities(FormChooserList.this);
-            }
-        });
-    }
-
-    private void init() {
         setupAdapter();
 
         // DiskSyncTask checks the disk for any forms not already in the content provider

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -14,9 +14,7 @@
 
 package org.odk.collect.android.activities;
 
-import android.app.AlertDialog;
 import android.content.ContentUris;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -53,7 +51,6 @@ public class FormChooserList extends FormListActivity implements
         DiskSyncListener, AdapterView.OnItemClickListener, LoaderManager.LoaderCallbacks<Cursor> {
     private static final String FORM_CHOOSER_LIST_SORTING_ORDER = "formChooserListSortingOrder";
 
-    private static final boolean EXIT = true;
     private DiskSyncTask diskSyncTask;
 
     @Override
@@ -166,32 +163,6 @@ public class FormChooserList extends FormListActivity implements
     @Override
     protected void updateAdapter() {
         getSupportLoaderManager().restartLoader(LOADER_ID, null, this);
-    }
-
-    /**
-     * Creates a dialog with the given message. Will exit the activity when the user preses "ok" if
-     * shouldExit is set to true.
-     */
-    private void createErrorDialog(String errorMsg, final boolean shouldExit) {
-
-        AlertDialog alertDialog = new AlertDialog.Builder(this).create();
-        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
-        alertDialog.setMessage(errorMsg);
-        DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int i) {
-                switch (i) {
-                    case DialogInterface.BUTTON_POSITIVE:
-                        if (shouldExit) {
-                            finish();
-                        }
-                        break;
-                }
-            }
-        };
-        alertDialog.setCancelable(false);
-        alertDialog.setButton(getString(R.string.ok), errorListener);
-        alertDialog.show();
     }
 
     @NonNull

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -281,6 +281,16 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
         filteredFormList.addAll(formList);
 
+        listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+        listView.setItemsCanFocus(false);
+
+        sortingOptions = new String[]{
+                getString(R.string.sort_by_name_asc), getString(R.string.sort_by_name_desc)
+        };
+    }
+
+    @Override
+    protected void init() {
         if (getLastCustomNonConfigurationInstance() instanceof DownloadFormListTask) {
             downloadFormListTask = (DownloadFormListTask) getLastCustomNonConfigurationInstance();
             if (downloadFormListTask.getStatus() == AsyncTask.Status.FINISHED) {
@@ -305,13 +315,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             // first time, so get the formlist
             downloadFormList();
         }
-
-        listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
-        listView.setItemsCanFocus(false);
-
-        sortingOptions = new String[]{
-                getString(R.string.sort_by_name_asc), getString(R.string.sort_by_name_desc)
-        };
     }
 
     private void clearChoices() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -42,13 +42,11 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.http.HttpCredentialsInterface;
 import org.odk.collect.android.listeners.DownloadFormsTaskListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
-import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
-import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
@@ -67,7 +65,6 @@ import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_AUTH_REQUIRED;
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_ERROR_MSG;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying, adding and deleting all the valid forms in the forms directory. One
@@ -160,30 +157,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         getComponent().inject(this);
         setTitle(getString(R.string.get_forms));
 
-        // This activity is accessed directly externally
-        requestStoragePermissions(this, new PermissionListener() {
-            @Override
-            public void granted() {
-                // must be at the beginning of any activity that can be called from an external intent
-                try {
-                    Collect.createODKDirs();
-                } catch (RuntimeException e) {
-                    DialogUtils.showDialog(DialogUtils.createErrorDialog(FormDownloadList.this, e.getMessage(), EXIT), FormDownloadList.this);
-                    return;
-                }
-
-                init(savedInstanceState);
-            }
-
-            @Override
-            public void denied() {
-                // The activity has to finish because ODK Collect cannot function without these permissions.
-                finish();
-            }
-        });
-    }
-
-    private void init(Bundle savedInstanceState) {
         formsFound = new ArrayList<>();
         formResult = new HashMap<>();
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -115,6 +115,7 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ImageConverter;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
 import org.odk.collect.android.utilities.TimerLogger;
 import org.odk.collect.android.utilities.ToastUtils;
@@ -296,12 +297,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         compositeDisposable
                 .add(eventBus
-                .register(ReadPhoneStatePermissionRxEvent.class)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(event -> {
-                    readPhoneStatePermissionRequestNeeded = true;
-                }));
+                        .register(ReadPhoneStatePermissionRxEvent.class)
+                        .subscribeOn(Schedulers.io())
+                        .observeOn(AndroidSchedulers.mainThread())
+                        .subscribe(event -> {
+                            readPhoneStatePermissionRequestNeeded = true;
+                        }));
 
         errorMessage = null;
 
@@ -329,14 +330,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             getFragmentManager().beginTransaction().add(mediaLoadingFragment, TAG_MEDIA_LOADING_FRAGMENT).commit();
         } else {
             mediaLoadingFragment = (MediaLoadingFragment) getFragmentManager().findFragmentByTag(TAG_MEDIA_LOADING_FRAGMENT);
-        }
 
-        setupFields(savedInstanceState);
-        loadForm();
-    }
-
-    private void setupFields(Bundle savedInstanceState) {
-        if (savedInstanceState != null) {
             state = savedInstanceState;
             if (savedInstanceState.containsKey(KEY_FORMPATH)) {
                 formPath = savedInstanceState.getString(KEY_FORMPATH);
@@ -367,7 +361,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 readPhoneStatePermissionRequestNeeded = savedInstanceState.getBoolean(KEY_READ_PHONE_STATE_PERMISSION_REQUEST_NEEDED);
             }
         }
+    }
 
+    @Override
+    protected void init() {
+        loadForm();
     }
 
     private void loadForm() {
@@ -2081,6 +2079,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     protected void onResume() {
         super.onResume();
+
+        if (!PermissionUtils.checkIfStoragePermissionsGranted(this)) {
+            return;
+        }
 
         String navigation = (String) GeneralSharedPreferences.getInstance().get(PreferenceKeys.KEY_NAVIGATION);
         showNavigationButtons = navigation.contains(PreferenceKeys.NAVIGATION_BUTTONS);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -53,7 +53,6 @@ public class InstanceChooserList extends InstanceListActivity implements
     private static final String INSTANCE_LIST_ACTIVITY_SORTING_ORDER = "instanceListActivitySortingOrder";
     private static final String VIEW_SENT_FORM_SORTING_ORDER = "ViewSentFormSortingOrder";
 
-    private static final boolean EXIT = true;
     private static final boolean DO_NOT_EXIT = false;
 
     private InstanceSyncTask instanceSyncTask;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -35,16 +35,12 @@ import org.odk.collect.android.adapters.ViewSentListAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.listeners.DiskSyncListener;
-import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying all the valid instances in the instance directory.
@@ -89,28 +85,6 @@ public class InstanceChooserList extends InstanceListActivity implements
             ((TextView) findViewById(android.R.id.empty)).setText(R.string.no_items_display_sent_forms);
         }
 
-        requestStoragePermissions(this, new PermissionListener() {
-            @Override
-            public void granted() {
-                // must be at the beginning of any activity that can be called from an external intent
-                try {
-                    Collect.createODKDirs();
-                } catch (RuntimeException e) {
-                    createErrorDialog(e.getMessage(), EXIT);
-                    return;
-                }
-                init();
-            }
-
-            @Override
-            public void denied() {
-                // The activity has to finish because ODK Collect cannot function without these permissions.
-                finishAllActivities(InstanceChooserList.this);
-            }
-        });
-    }
-
-    private void init() {
         setupAdapter();
         instanceSyncTask = new InstanceSyncTask();
         instanceSyncTask.setDiskSyncListener(this);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -84,7 +84,10 @@ public class InstanceChooserList extends InstanceListActivity implements
             };
             ((TextView) findViewById(android.R.id.empty)).setText(R.string.no_items_display_sent_forms);
         }
+    }
 
+    @Override
+    protected void init() {
         setupAdapter();
         instanceSyncTask = new InstanceSyncTask();
         instanceSyncTask.setDiskSyncListener(this);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -25,13 +25,11 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.fragments.dialogs.SimpleDialog;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
-import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceServerUploaderTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ArrayUtils;
 import org.odk.collect.android.utilities.AuthDialogUtility;
-import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
 
 import java.util.ArrayList;
@@ -41,8 +39,6 @@ import java.util.Iterator;
 import java.util.Set;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Activity to upload completed forms.
@@ -80,34 +76,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Timber.i("onCreate: %s", savedInstanceState == null ? "creating" : "re-initializing");
 
-        // This activity is accessed directly externally
-        requestStoragePermissions(this, new PermissionListener() {
-            @Override
-            public void granted() {
-                // must be at the beginning of any activity that can be called from an external intent
-                try {
-                    Collect.createODKDirs();
-                } catch (RuntimeException e) {
-                    DialogUtils.showDialog(DialogUtils.createErrorDialog(InstanceUploaderActivity.this,
-                            e.getMessage(), EXIT), InstanceUploaderActivity.this);
-                    return;
-                }
-
-                init(savedInstanceState);
-            }
-
-            @Override
-            public void denied() {
-                // The activity has to finish because ODK Collect cannot function without these permissions.
-                finish();
-            }
-        });
-
-    }
-
-    private void init(Bundle savedInstanceState) {
         alertMsg = getString(R.string.please_wait);
 
         setTitle(getString(R.string.send_data));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -54,8 +54,6 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
     private static final String ALERT_MSG = "alertmsg";
     private static final String TO_SEND = "tosend";
 
-    private static final boolean EXIT = true;
-
     private ProgressDialog progressDialog;
 
     private String alertMsg;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -126,7 +126,10 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
         }
 
         instancesToSend = ArrayUtils.toObject(selectedInstanceIDs);
+    }
 
+    @Override
+    protected void init() {
         if (instancesToSend.length == 0) {
             Timber.e("onCreate: No instances to upload!");
             // drop through -- everything will process through OK

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -137,8 +137,6 @@ public class InstanceUploaderList extends InstanceListActivity implements
         if (savedInstanceState != null) {
             showAllMode = savedInstanceState.getBoolean(SHOW_ALL_MODE);
         }
-
-        init();
     }
 
     /**
@@ -198,7 +196,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
         }
     }
 
-    private void init() {
+    protected void init() {
         setupUploadButtons();
         instancesDao = new InstancesDao();
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -71,10 +71,8 @@ import timber.log.Timber;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_PROTOCOL;
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.tasks.sms.SmsSender.SMS_INSTANCE_ID;
-import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
 import static org.odk.collect.android.utilities.PermissionUtils.requestReadPhoneStatePermission;
 import static org.odk.collect.android.utilities.PermissionUtils.requestSendSMSPermission;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying all the valid forms in the forms directory. Stores
@@ -140,18 +138,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
             showAllMode = savedInstanceState.getBoolean(SHOW_ALL_MODE);
         }
 
-        requestStoragePermissions(this, new PermissionListener() {
-            @Override
-            public void granted() {
-                init();
-            }
-
-            @Override
-            public void denied() {
-                // The activity has to finish because ODK Collect cannot function without these permissions.
-                finishAllActivities(InstanceUploaderList.this);
-            }
-        });
+        init();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -45,7 +45,6 @@ import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SPLASH_PATH
 public class SplashScreenActivity extends Activity {
 
     private static final int SPLASH_TIMEOUT = 2000; // milliseconds
-    private static final boolean EXIT = true;
 
     private int imageMaxWidth;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -30,11 +30,8 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
-import org.odk.collect.android.utilities.DialogUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,7 +41,6 @@ import java.io.IOException;
 import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.PreferenceKeys.KEY_SPLASH_PATH;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 public class SplashScreenActivity extends Activity {
 
@@ -59,30 +55,6 @@ public class SplashScreenActivity extends Activity {
         // this splash screen should be a blank slate
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 
-        requestStoragePermissions(this, new PermissionListener() {
-            @Override
-            public void granted() {
-                // must be at the beginning of any activity that can be called from an external intent
-                try {
-                    Collect.createODKDirs();
-                } catch (RuntimeException e) {
-                    DialogUtils.showDialog(DialogUtils.createErrorDialog(SplashScreenActivity.this,
-                            e.getMessage(), EXIT), SplashScreenActivity.this);
-                    return;
-                }
-
-                init();
-            }
-
-            @Override
-            public void denied() {
-                // The activity has to finish because ODK Collect cannot function without these permissions.
-                finish();
-            }
-        });
-    }
-
-    private void init() {
         DisplayMetrics displayMetrics = getApplicationContext().getResources().getDisplayMetrics();
         imageMaxWidth = displayMetrics.widthPixels;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -32,6 +32,7 @@ import android.widget.LinearLayout;
 import org.odk.collect.android.R;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferenceKeys;
+import org.odk.collect.android.utilities.PermissionUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -59,6 +60,14 @@ public class SplashScreenActivity extends Activity {
 
         setContentView(R.layout.splash_screen);
 
+        if (PermissionUtils.checkIfStoragePermissionsGranted(this)) {
+            init();
+        } else {
+            endSplashScreen();
+        }
+    }
+
+    private void init() {
         // get the shared preferences object
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         SharedPreferences.Editor editor = sharedPreferences.edit();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/StoragePermissionActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/StoragePermissionActivity.java
@@ -103,7 +103,12 @@ public class StoragePermissionActivity extends AppCompatActivity implements Perm
 
     @Override
     public void denied() {
-        PermissionUtils.finishAllActivities(this);
+        finishAffinity();
+    }
+
+    @Override
+    public void onBackPressed() {
+        denied();
     }
 
     @OnClick({R.id.btnPermission, R.id.btnCancel})
@@ -113,7 +118,7 @@ public class StoragePermissionActivity extends AppCompatActivity implements Perm
                 PermissionUtils.requestStoragePermissions(this, this);
                 break;
             case R.id.btnCancel:
-                PermissionUtils.finishAllActivities(this);
+                denied();
                 break;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/StoragePermissionActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/StoragePermissionActivity.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.activities;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.Window;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.listeners.PermissionListener;
+import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
+import org.odk.collect.android.utilities.ThemeUtils;
+
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+public class StoragePermissionActivity extends AppCompatActivity implements PermissionListener {
+
+    public static final String EXTRA_ACTION = "extra_action";
+    public static final String EXTRA_CLASS = "extra_class";
+    public static final String EXTRA_URI = "extra_uri";
+
+    public static void startActivity(Activity activity, Intent callingIntent, Class<?> clazz) {
+        Intent intent = new Intent(activity, StoragePermissionActivity.class);
+        intent.putExtra(EXTRA_ACTION, callingIntent.getAction());
+        intent.putExtra(EXTRA_CLASS, clazz);
+        intent.putExtra(EXTRA_URI, callingIntent.getData());
+
+        activity.startActivity(intent);
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        setTheme(new ThemeUtils(this).getAppTheme());
+        super.onCreate(savedInstanceState);
+
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+
+        setContentView(R.layout.storage_permission_layout);
+        ButterKnife.bind(this);
+    }
+
+    @Override
+    public void granted() {
+
+        // Create ODK Directories
+        try {
+            Collect.createODKDirs();
+        } catch (RuntimeException e) {
+            DialogUtils.showDialog(DialogUtils.createErrorDialog(this, e.getMessage(), true), this);
+            return;
+        }
+
+        Class<?> clazz = (Class<?>) getIntent().getSerializableExtra(EXTRA_CLASS);
+        String action = getIntent().getStringExtra(EXTRA_ACTION);
+        Uri uri = getIntent().getParcelableExtra(EXTRA_URI);
+
+        Intent intent = new Intent(this, clazz);
+
+        if (action != null && uri != null) {
+            intent.setAction(action);
+            intent.setData(uri);
+        }
+
+        startActivity(intent);
+        finish();
+    }
+
+    @Override
+    public void denied() {
+        PermissionUtils.finishAllActivities(this);
+    }
+
+    @OnClick({R.id.btnPermission, R.id.btnCancel})
+    public void onViewClicked(View view) {
+        switch (view.getId()) {
+            case R.id.btnPermission:
+                PermissionUtils.requestStoragePermissions(this, this);
+                break;
+            case R.id.btnCancel:
+                PermissionUtils.finishAllActivities(this);
+                break;
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/StoragePermissionActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/StoragePermissionActivity.java
@@ -40,12 +40,18 @@ public class StoragePermissionActivity extends AppCompatActivity implements Perm
     public static final String EXTRA_ACTION = "extra_action";
     public static final String EXTRA_CLASS = "extra_class";
     public static final String EXTRA_URI = "extra_uri";
+    public static final String EXTRA_BUNDLE = "extras_bundle";
 
     public static void startActivity(Activity activity, Intent callingIntent, Class<?> clazz) {
         Intent intent = new Intent(activity, StoragePermissionActivity.class);
         intent.putExtra(EXTRA_ACTION, callingIntent.getAction());
         intent.putExtra(EXTRA_CLASS, clazz);
         intent.putExtra(EXTRA_URI, callingIntent.getData());
+
+        // sometimes an activity is started along with some extras, so we need to persist those too
+        if (callingIntent.getExtras() != null) {
+            intent.putExtra(EXTRA_BUNDLE, callingIntent.getExtras());
+        }
 
         activity.startActivity(intent);
     }
@@ -73,14 +79,22 @@ public class StoragePermissionActivity extends AppCompatActivity implements Perm
         }
 
         Class<?> clazz = (Class<?>) getIntent().getSerializableExtra(EXTRA_CLASS);
-        String action = getIntent().getStringExtra(EXTRA_ACTION);
-        Uri uri = getIntent().getParcelableExtra(EXTRA_URI);
 
         Intent intent = new Intent(this, clazz);
 
-        if (action != null && uri != null) {
+        String action = getIntent().getStringExtra(EXTRA_ACTION);
+        if (action != null) {
             intent.setAction(action);
+        }
+
+        Uri uri = getIntent().getParcelableExtra(EXTRA_URI);
+        if (uri != null) {
             intent.setData(uri);
+        }
+
+        Bundle bundle = getIntent().getBundleExtra(EXTRA_BUNDLE);
+        if (bundle != null) {
+            intent.putExtras(bundle);
         }
 
         startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -18,17 +18,8 @@ import com.karumi.dexter.listener.PermissionRequest;
 import com.karumi.dexter.listener.multi.MultiplePermissionsListener;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.CollectAbstractActivity;
-import org.odk.collect.android.activities.FormChooserList;
-import org.odk.collect.android.activities.FormDownloadList;
-import org.odk.collect.android.activities.FormEntryActivity;
-import org.odk.collect.android.activities.InstanceChooserList;
-import org.odk.collect.android.activities.InstanceUploaderActivity;
-import org.odk.collect.android.activities.InstanceUploaderList;
-import org.odk.collect.android.activities.SplashScreenActivity;
 import org.odk.collect.android.listeners.PermissionListener;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import timber.log.Timber;
@@ -309,33 +300,6 @@ public class PermissionUtils {
 
     public static boolean checkIfReadPhoneStatePermissionGranted(Context context) {
         return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
-    }
-
-    /**
-     * Checks to see if an activity is one of the entry points to the app i.e
-     * an activity that has a view action that can launch the app.
-     *
-     * @param activity that has permission requesting code.
-     * @return true if the activity is an entry point to the app.
-     */
-    public static boolean isEntryPointActivity(CollectAbstractActivity activity) {
-
-        List<Class<?>> activities = new ArrayList<>();
-        activities.add(FormEntryActivity.class);
-        activities.add(InstanceChooserList.class);
-        activities.add(FormChooserList.class);
-        activities.add(InstanceUploaderList.class);
-        activities.add(SplashScreenActivity.class);
-        activities.add(FormDownloadList.class);
-        activities.add(InstanceUploaderActivity.class);
-
-        for (Class<?> act : activities) {
-            if (activity.getClass().equals(act)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     public static void finishAllActivities(Activity activity) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -4,7 +4,6 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
@@ -300,14 +299,6 @@ public class PermissionUtils {
 
     public static boolean checkIfReadPhoneStatePermissionGranted(Context context) {
         return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
-    }
-
-    public static void finishAllActivities(Activity activity) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            activity.finishAndRemoveTask();
-        } else {
-            activity.finishAffinity();
-        }
     }
 
     private static void showAdditionalExplanation(@NonNull Activity activity, int title,

--- a/collect_app/src/main/res/layout/storage_permission_layout.xml
+++ b/collect_app/src/main/res/layout/storage_permission_layout.xml
@@ -50,7 +50,9 @@ the License.
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
-        android:background="@color/zxing_transparent"
+        android:layout_margin="@dimen/margin_small"
+        android:background="@android:color/transparent"
+        android:foreground="?android:attr/selectableItemBackground"
         android:text="@string/not_now"
         android:textAllCaps="true"
         android:textColor="@color/gray600" />

--- a/collect_app/src/main/res/layout/storage_permission_layout.xml
+++ b/collect_app/src/main/res/layout/storage_permission_layout.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2018 Shobhit Agarwal
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.StoragePermissionActivity">
+
+    <ImageView
+        android:layout_width="60dp"
+        android:layout_height="60dp"
+        android:layout_above="@+id/textView"
+        android:layout_centerInParent="true"
+        android:src="@drawable/notes" />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:layout_margin="@dimen/margin_large"
+        android:text="@string/storage_permission_description"
+        android:textAlignment="center"
+        android:textSize="@dimen/text_size_small" />
+
+    <Button
+        android:id="@+id/btnPermission"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/textView"
+        android:layout_centerInParent="true"
+        android:text="@string/grant_permission"
+        android:textAllCaps="true" />
+
+    <Button
+        android:id="@+id/btnCancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/zxing_transparent"
+        android:text="@string/not_now"
+        android:textAllCaps="true"
+        android:textColor="@color/gray600" />
+
+</RelativeLayout>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -654,4 +654,7 @@
     <string name="missing_google_account_dialog_desc">To submit forms via Google Sheets you have to set up your Google account in the Server settings.</string>
     <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
     <string name="notification_channel_name">General notifications</string>
+    <string name="storage_permission_description">ODK Collect needs access to photos, media and files on your device to download and save forms</string>
+    <string name="grant_permission">Grant permission</string>
+    <string name="not_now">Not now</string>
 </resources>


### PR DESCRIPTION
Closes #2694 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
1. Open app for the first time, the user sees the screen(attached below) which asks for storage permission. Then allow the storage permission
2. Open any activity and minimize the app
3. Unselect storage permission from system settings
4. Reopen the app 
5. The user sees the same screen asked on the first app launch which asks for the permission.
6. Granting the permission reopens the last opened activity, denying closes the app. 

#### Why is this the best possible solution? Were any other approaches considered?
1. Provides some context to the user before asking access to storage permission.
2. Since this check is implemented in the base activity, so the behavior remains constant across all activities
 3. I have also checked that only the code which relies on storage permissions is in `init()`

I only considered this approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Users will now see an extra screen instead of getting directly prompted with the permission access dialog when the app launches for the first time or whenever the storage permission is revoked from system settings. 
Until now, only entry point activities were able to request for permissions, but now all activities can since the base activity has the implementation to request for permission

Possible risks include crashes due to mishandled storage permission, incorrect loading of data in all of the screens (since this change affects all screens)

#### Do we need any specific form for testing your changes? If so, please attach one.
No, any form can be used to verify the behavior of FormEntryActivity

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Not required
https://docs.opendatakit.org/collect-install/?highlight=permission

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

![Light theme](https://user-images.githubusercontent.com/8918023/47666837-92594200-dbca-11e8-8e17-0df42bd81705.png)

![Dark theme](https://user-images.githubusercontent.com/8918023/47671029-adc94a80-dbd4-11e8-874f-f3afd5b75654.png)
