### PR TITLE
Wrong status message when sending submissions by SMS with no sim card

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -44,6 +44,7 @@ import javax.inject.Inject;
 import timber.log.Timber;
 
 import static android.app.Activity.RESULT_OK;
+import static android.telephony.SmsManager.RESULT_ERROR_GENERIC_FAILURE;
 import static android.telephony.SmsManager.RESULT_ERROR_NO_SERVICE;
 import static android.telephony.SmsManager.RESULT_ERROR_RADIO_OFF;
 import static org.odk.collect.android.tasks.sms.SmsNotificationReceiver.SMS_NOTIFICATION_ACTION;
@@ -373,6 +374,7 @@ public class SmsService {
 
         try {
             switch (resultCode) {
+                case RESULT_ERROR_GENERIC_FAILURE:
                 case RESULT_ERROR_NO_SERVICE:
                     return new SimpleDateFormat(context.getString(R.string.sms_no_reception), Locale.getDefault()).format(date);
                 case RESULT_ERROR_RADIO_OFF:


### PR DESCRIPTION
Closes #2693 

#### What has been done to verify that this works as intended?
Tested the mentioned steps 

#### Why is this the best possible solution? Were any other approaches considered?
Newer Android versions just returns a different resultCode - `RESULT_ERROR_GENERIC_FAILURE` when other uses `RESULT_ERROR_NO_SERVICE` in case of reception problems

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the mentioned issue and not change anything else. The same messge should be displayed for all android vesrions in case of reception problems.

#### Do we need any specific form for testing your changes? If so, please attach one.
[SMS_form.xml.txt](https://github.com/opendatakit/collect/files/2530298/SMS_form.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)