### PR TITLE
Improve naming of filtered form list including only newest

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -222,8 +222,8 @@ public class FormChooserList extends FormListActivity implements
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
         showProgressBar();
 
-        boolean uniqueByFormId = GeneralSharedPreferences.getInstance().getBoolean(PreferenceKeys.KEY_HIDE_OLD_FORM_VERSIONS, false);
-        return new FormsDao().getFormsCursorLoader(getFilterText(), getSortingOrder(), uniqueByFormId);
+        boolean newestByFormId = GeneralSharedPreferences.getInstance().getBoolean(PreferenceKeys.KEY_HIDE_OLD_FORM_VERSIONS, false);
+        return new FormsDao().getFormsCursorLoader(getFilterText(), getSortingOrder(), newestByFormId);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -99,7 +99,7 @@ public class FormsDao {
      * uniqueByFormID is true, only the most recently-downloaded version of each form is included.
      */
     private CursorLoader getFormsCursorLoader(String selection, String[] selectionArgs, String sortOrder, boolean uniqueByFormId) {
-        Uri formUri = uniqueByFormId ? FormsProviderAPI.FormsColumns.UNIQUE_FORMS_BY_FORMID_URI
+        Uri formUri = uniqueByFormId ? FormsProviderAPI.FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI
                 : FormsProviderAPI.FormsColumns.CONTENT_URI;
 
         return new CursorLoader(Collect.getInstance(), formUri, null, selection, selectionArgs, sortOrder);

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -68,24 +68,24 @@ public class FormsDao {
         return getFormsCursor(null, selection, selectionArgs, order);
     }
 
-    private CursorLoader getFormsCursorLoader(String sortOrder, boolean uniqueByFormId) {
-        return getFormsCursorLoader(null, null, sortOrder, uniqueByFormId);
+    private CursorLoader getFormsCursorLoader(String sortOrder, boolean newestByFormId) {
+        return getFormsCursorLoader(null, null, sortOrder, newestByFormId);
     }
 
     /**
      * Returns a loader filtered by the specified charSequence in the specified sortOrder. If
-     * uniqueByFormId is true, only the most recently-downloaded version of each form is included.
+     * newestByFormId is true, only the most recently-downloaded version of each form is included.
      */
-    public CursorLoader getFormsCursorLoader(CharSequence charSequence, String sortOrder, boolean uniqueByFormId) {
+    public CursorLoader getFormsCursorLoader(CharSequence charSequence, String sortOrder, boolean newestByFormId) {
         CursorLoader cursorLoader;
 
         if (charSequence.length() == 0) {
-            cursorLoader = getFormsCursorLoader(sortOrder, uniqueByFormId);
+            cursorLoader = getFormsCursorLoader(sortOrder, newestByFormId);
         } else {
             String selection = FormsProviderAPI.FormsColumns.DISPLAY_NAME + " LIKE ?";
             String[] selectionArgs = new String[]{"%" + charSequence + "%"};
 
-            cursorLoader = getFormsCursorLoader(selection, selectionArgs, sortOrder, uniqueByFormId);
+            cursorLoader = getFormsCursorLoader(selection, selectionArgs, sortOrder, newestByFormId);
         }
         return cursorLoader;
     }
@@ -96,10 +96,10 @@ public class FormsDao {
 
     /**
      * Builds and returns a new CursorLoader, passing on the configuration parameters. If
-     * uniqueByFormID is true, only the most recently-downloaded version of each form is included.
+     * newestByFormID is true, only the most recently-downloaded version of each form is included.
      */
-    private CursorLoader getFormsCursorLoader(String selection, String[] selectionArgs, String sortOrder, boolean uniqueByFormId) {
-        Uri formUri = uniqueByFormId ? FormsProviderAPI.FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI
+    private CursorLoader getFormsCursorLoader(String selection, String[] selectionArgs, String sortOrder, boolean newestByFormId) {
+        Uri formUri = newestByFormId ? FormsProviderAPI.FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI
                 : FormsProviderAPI.FormsColumns.CONTENT_URI;
 
         return new CursorLoader(Collect.getInstance(), formUri, null, selection, selectionArgs, sortOrder);

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -52,7 +52,7 @@ public class FormsProvider extends ContentProvider {
     private static final int FORMS = 1;
     private static final int FORM_ID = 2;
     // Forms unique by ID, keeping only the latest one downloaded
-    private static final int UNIQUE_FORMS_BY_FORM_ID = 3;
+    private static final int NEWEST_FORMS_BY_FORM_ID = 3;
 
     private static final UriMatcher URI_MATCHER;
 
@@ -113,7 +113,7 @@ public class FormsProvider extends ContentProvider {
                     break;
 
                 // Only include the latest form that was downloaded with each form_id
-                case UNIQUE_FORMS_BY_FORM_ID:
+                case NEWEST_FORMS_BY_FORM_ID:
                     Map<String, String> filteredProjectionMap = new HashMap<>(sFormsProjectionMap);
                     filteredProjectionMap.put(FormsColumns.DATE, "MAX(" + FormsColumns.DATE + ")");
 
@@ -137,7 +137,7 @@ public class FormsProvider extends ContentProvider {
     public String getType(@NonNull Uri uri) {
         switch (URI_MATCHER.match(uri)) {
             case FORMS:
-            case UNIQUE_FORMS_BY_FORM_ID:
+            case NEWEST_FORMS_BY_FORM_ID:
                 return FormsColumns.CONTENT_TYPE;
 
             case FORM_ID:
@@ -554,10 +554,10 @@ public class FormsProvider extends ContentProvider {
 
     static {
         URI_MATCHER = new UriMatcher(UriMatcher.NO_MATCH);
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, "forms", FORMS);
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, "forms/#", FORM_ID);
+        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_URI.getPath(), FORMS);
+        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_URI.getPath() + "/#", FORM_ID);
         // Only available for query and type
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, "uniqueFormsByFormId", UNIQUE_FORMS_BY_FORM_ID);
+        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI.getPath(), NEWEST_FORMS_BY_FORM_ID);
 
         sFormsProjectionMap = new HashMap<>();
         sFormsProjectionMap.put(FormsColumns._ID, FormsColumns._ID);

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -552,12 +552,14 @@ public class FormsProvider extends ContentProvider {
         return newWhereArgs;
     }
 
+    // Leading slashes are removed from paths to support minSdkVersion < 18:
+    // https://developer.android.com/reference/android/content/UriMatcher
     static {
         URI_MATCHER = new UriMatcher(UriMatcher.NO_MATCH);
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_URI.getPath(), FORMS);
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_URI.getPath() + "/#", FORM_ID);
+        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_URI.getPath().replaceAll("^/+", ""), FORMS);
+        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_URI.getPath().replaceAll("^/+", "") + "/#", FORM_ID);
         // Only available for query and type
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI.getPath(), NEWEST_FORMS_BY_FORM_ID);
+        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI.getPath().replaceAll("^/+", ""), NEWEST_FORMS_BY_FORM_ID);
 
         sFormsProjectionMap = new HashMap<>();
         sFormsProjectionMap.put(FormsColumns._ID, FormsColumns._ID);

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -20,25 +20,37 @@ import android.net.Uri;
 import android.provider.BaseColumns;
 
 /**
- * Convenience definitions for NotePadProvider
+ * Contract between the forms provider and applications. Contains definitions for the supported URIs
+ * and data columns.
+ *
+ * This defines the data model for blank forms. Blank forms are unique by
+ * {@link FormsColumns#JR_FORM_ID} unless multiple {@link FormsColumns#JR_VERSION}s are defined.
  */
 public final class FormsProviderAPI {
-    public static final String AUTHORITY = "org.odk.collect.android.provider.odk.forms";
+    static final String AUTHORITY = "org.odk.collect.android.provider.odk.forms";
 
-    // This class cannot be instantiated
     private FormsProviderAPI() {
     }
 
     /**
-     * Notes table
+     * Columns for the Forms table.
      */
     public static final class FormsColumns implements BaseColumns {
-        // This class cannot be instantiated
         private FormsColumns() {
         }
 
+        /**
+         * The content:// style URL for accessing Forms.
+         */
         public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/forms");
-        public static final Uri UNIQUE_FORMS_BY_FORMID_URI = Uri.parse("content://" + AUTHORITY + "/uniqueFormsByFormId");
+
+        /**
+         * The content:// style URL for accessing the newest versions of Forms. For each
+         * {@link FormsColumns#JR_FORM_ID}, only the version with the most recent
+         * {@link FormsColumns#DATE} is included.
+         */
+        public static final Uri CONTENT_NEWEST_FORMS_BY_FORMID_URI = Uri.parse("content://" + AUTHORITY + "/newest_forms_by_form_id");
+
         public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.odk.form";
         public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.odk.form";
 


### PR DESCRIPTION
Closes #2705 

#### What has been done to verify that this works as intended?
Tried Fill Blank Form with and without the hide older versions setting. This uses all three content URIs. Opened the form list from collectTester and downloaded a blank form.

#### Why is this the best possible solution? Were any other approaches considered?
I thought about just changing the URI name but then I realized this was a good opportunity to improve some more naming and comments for greater consistency. In particular, introducing a constant for the new content URI and using the content URI constants in the URI matcher reduces the risk of errors.

I took a look at https://android.googlesource.com/platform/frameworks/base/+/android-4.2.2_r1/core/java/android/provider/CalendarContract.java for naming and comment inspiration. I saw that the convention for content provider paths is to use `snake_case` rather than `camelCase` so I changed that too.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
If someone started immediately using the `uniqueFormsByFormId` content URI in their external app, this change would disrupt them. This is vanishingly unlikely since it's been released for a day and is undocumented.

Users not using external apps should see no change. There is some risk around listing and selecting forms but I think the manual verification I described above is sufficient to confirm the behavior is as-expected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Yes, we should document the content provider URI. I have added a note at https://github.com/opendatakit/docs/issues/876#issuecomment-434552013.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)