### PR TITLE
Change star colors

### DIFF
--- a/collect_app/src/main/res/drawable/ic_star.xml
+++ b/collect_app/src/main/res/drawable/ic_star.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="?iconColor"
+        android:fillColor="@color/highContrastHighlight"
         android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
 </vector>

--- a/collect_app/src/main/res/drawable/ic_star_border.xml
+++ b/collect_app/src/main/res/drawable/ic_star_border.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="?iconColor"
-        android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
+        android:fillColor="@color/lightIconColorDisabled"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
 </vector>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -32,5 +32,6 @@ the License.
     <color name="lightIconColorDisabled">#aaaaaa</color>
     <color name="lightIconColorEnabled">@android:color/black</color>
 
+    <color name="highContrastHighlight">#ff8c00</color>
     <color name="displaySubtextColor">#4CAF50</color>
 </resources>


### PR DESCRIPTION
Closes #2711 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Tested on Moto M (android 7.0)
#### Why is this the best possible solution? Were any other approaches considered?
As discussed orange color for selected stars is used for both light and dark themes.
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None.
#### Do we need any specific form for testing your changes? If so, please attach one.
No specific testing is needed. Need to check if UI is appealing. 
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)