### PR TITLE
Lint check permissions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.activities;
 
+import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -155,6 +156,7 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
 
     // LocationClientListener:
 
+    @SuppressLint("MissingPermission") // Checking Permissions handled in constructor
     @Override
     public void onClientStart() {
         locationClient.requestLocationUpdates(this);
@@ -277,6 +279,7 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
     }
 
     @Override
+    @SuppressLint("MissingPermission")
     public void onGpsStatusChanged(int event) {
         if (event == GpsStatus.GPS_EVENT_SATELLITE_STATUS) {
             LocationManager locationManager = (LocationManager) getSystemService(LOCATION_SERVICE);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.activities;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.graphics.Color;
@@ -181,6 +182,7 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
         return new DecimalFormat("#.##").format(f);
     }
 
+    @SuppressLint("MissingPermission") // Permission handled in Constructor
     private void setupMap(GoogleMap googleMap) {
         map = googleMap;
         if (map == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -16,6 +16,7 @@
 
 package org.odk.collect.android.fragments;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
@@ -536,6 +537,8 @@ public class Camera2Fragment extends Fragment
     /**
      * Opens the camera specified by {@link Camera2Fragment#cameraId}.
      */
+
+    @SuppressLint("MissingPermission") // Permission is handled in ImageWidget,
     private void openCamera(int width, int height) {
         setUpCameraOutputs(width, height);
         configureTransform(width, height);

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/AndroidLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/AndroidLocationClient.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.location.client;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
@@ -83,6 +84,7 @@ class AndroidLocationClient
     }
 
     @Override
+    @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public void requestLocationUpdates(@NonNull LocationListener locationListener) {
         if (!isConnected) {
             // This is to maintain expected behavior across LocationClient implementations.
@@ -112,6 +114,7 @@ class AndroidLocationClient
     }
 
     @Override
+    @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public Location getLastLocation() {
         String provider = getProvider();
         if (provider != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleLocationClient.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.location.client;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
@@ -111,7 +112,7 @@ class GoogleLocationClient
             onConnectionSuspended(0);
         }
     }
-
+    @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public void requestLocationUpdates(@NonNull LocationListener locationListener) {
         if (!isMonitoringLocation()) {
             fusedLocationProviderApi.requestLocationUpdates(googleApiClient, createLocationRequest(), this);
@@ -135,6 +136,7 @@ class GoogleLocationClient
     }
 
     @Override
+    @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public Location getLastLocation() {
         // We need to block if the Client isn't already connected:
         if (!googleApiClient.isConnected()) {

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleLocationClient.java
@@ -112,6 +112,7 @@ class GoogleLocationClient
             onConnectionSuspended(0);
         }
     }
+
     @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public void requestLocationUpdates(@NonNull LocationListener locationListener) {
         if (!isMonitoringLocation()) {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
@@ -89,7 +89,6 @@ public class PropertyManager implements IPropertyManager {
         Timber.i("calling constructor");
 
         Collect.getInstance().getComponent().inject(this);
-
         try {
             // Device-defined properties
             TelephonyManager telMgr = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
@@ -109,7 +108,7 @@ public class PropertyManager implements IPropertyManager {
         initUserDefined(prefs, KEY_METADATA_EMAIL,       PROPMGR_EMAIL,         SCHEME_MAILTO);
     }
 
-    private IdAndPrefix findDeviceId(Context context, TelephonyManager telephonyManager) {
+    private IdAndPrefix findDeviceId(Context context, TelephonyManager telephonyManager) throws SecurityException {
         final String androidIdName = Settings.Secure.ANDROID_ID;
         String deviceId = telephonyManager.getDeviceId();
         String scheme = null;

--- a/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
@@ -108,6 +108,7 @@ public class PropertyManager implements IPropertyManager {
         initUserDefined(prefs, KEY_METADATA_EMAIL,       PROPMGR_EMAIL,         SCHEME_MAILTO);
     }
 
+    // telephonyManager.getDeviceId() requires permission READ_PHONE_STATE (ISSUE #2506). Permission should be handled or exception caught.
     private IdAndPrefix findDeviceId(Context context, TelephonyManager telephonyManager) throws SecurityException {
         final String androidIdName = Settings.Secure.ANDROID_ID;
         String deviceId = telephonyManager.getDeviceId();

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -73,6 +73,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     // "map" field will be null and many operations will need to be stubbed out.
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "This flag is exposed for Robolectric tests to set")
     @VisibleForTesting public static boolean testMode;
+
     @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     @Override public void addTo(@NonNull FragmentActivity activity, int containerId, @Nullable ReadyListener listener) {
         activity.getSupportFragmentManager()

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.map;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.graphics.Color;
@@ -72,7 +73,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     // "map" field will be null and many operations will need to be stubbed out.
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "This flag is exposed for Robolectric tests to set")
     @VisibleForTesting public static boolean testMode;
-
+    @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     @Override public void addTo(@NonNull FragmentActivity activity, int containerId, @Nullable ReadyListener listener) {
         activity.getSupportFragmentManager()
             .beginTransaction().add(containerId, this).commitNow();

--- a/config/lint.xml
+++ b/config/lint.xml
@@ -44,5 +44,5 @@
 
     <issue id="ContentDescription" severity="ignore"/>
     <issue id="HardwareIds" severity="ignore"/>
-    <issue id="MissingPermission" severity="ignore"/>
+    <issue id="MissingPermission" severity="error"/>
 </lint>


### PR DESCRIPTION
Closes #2528

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

1.  On master, Analyze > Inspect Code > Create Profile Containing only Missing Permissions
2. On lint-check-permissions, run same tests to show errors removed
3. Break one of the permission fixes on this branch and make sure ./gradlew lint fails
4. On lint-check-permissions, run ./gradlew lint -> build successful

#### Why is this the best possible solution? Were any other approaches considered?
Rather than ignoring MissingPermission lint checks completely in the project, we suppress them locally. Because the current MissingPermissions errors are handled, the MissingPermission check was ignored throughout the project. Incorrectly handled MissingPermissions will result in SecurityException's. Therefore, it is safer to locally suppress the current MissingPermission errors that are known to be safe, so that future MissingPermission checks will be flagged.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This has no direct effect on users. Rather, it provides more checks for developers.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [:heavy_check_mark:] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [:heavy_check_mark:] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [N/A] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)