### PR TITLE
Check for null after calling listFiles() in InstanceProvider#deleteAllFilesInDirectory()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -224,10 +224,12 @@ public class InstanceProvider extends ContentProvider {
 
                 // delete all the files in the directory
                 File[] files = directory.listFiles();
-                for (File f : files) {
-                    // should make this recursive if we get worried about
-                    // the media directory containing directories
-                    f.delete();
+                if (files != null) {
+                    for (File f : files) {
+                        // should make this recursive if we get worried about
+                        // the media directory containing directories
+                        f.delete();
+                    }
                 }
             }
             directory.delete();


### PR DESCRIPTION
Closes #2720 

#### What has been done to verify that this works as intended?
Nothing since it's kist a null check.

#### Why is this the best possible solution? Were any other approaches considered?
It's a rare case but I've noticed before that sometimes `listFiles()` might return null so we should check it to avoid `NPE`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a null check so it's not risky and this change doesn't affect anything. We don't need to test it manually.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)