### PR TITLE
Handle case when the progress dialog needs to be dismissed after onSaveInstanceState

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -26,6 +26,8 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
@@ -2166,6 +2168,26 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         if (saveToDiskTask != null) {
             saveToDiskTask.setFormSavedListener(this);
+        }
+    }
+
+    @Override
+    protected void onResumeFragments() {
+        super.onResumeFragments();
+
+        /*
+          Make sure the progress dialog is dismissed.
+          In most cases that dialog is dismissed in MediaLoadingTask#onPostExecute() but if the app
+          is in the background when MediaLoadingTask#onPostExecute() is called then the dialog
+          can not be dismissed. In such a case we need to make sure it's dismissed in order
+          to avoid blocking the UI.
+         */
+        if (!mediaLoadingFragment.isMediaLoadingTaskRunning()) {
+            Fragment progressDialogFragment =
+                    getSupportFragmentManager().findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+            if (progressDialogFragment != null) {
+                ((DialogFragment) progressDialogFragment).dismiss();
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/MediaLoadingFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/MediaLoadingFragment.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.fragments;
 import android.app.Activity;
 import android.app.Fragment;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
@@ -40,5 +41,9 @@ public class MediaLoadingFragment extends Fragment {
         if (mediaLoadingTask != null) {
             mediaLoadingTask.onDetach();
         }
+    }
+
+    public boolean isMediaLoadingTaskRunning() {
+        return mediaLoadingTask != null && mediaLoadingTask.getStatus() == AsyncTask.Status.RUNNING;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -89,7 +89,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
     @Override
     protected void onPostExecute(File result) {
         Fragment prev = formEntryActivity.get().getSupportFragmentManager().findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
-        if (prev != null) {
+        if (prev != null && !formEntryActivity.get().isInstanceStateSaved()) {
             ((DialogFragment) prev).dismiss();
         }
 


### PR DESCRIPTION
Closes #2728 

#### What has been done to verify that this works as intended?
I tested the steps mentioned in the issue and confirmed it works as expected now.

#### Why is this the best possible solution? Were any other approaches considered?
Here is a good explanation of how it works in Android https://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html

Generally, it's not a good approach to perform transactions inside asynchronous callback methods like we do here but we need that so my solution looks like the best one.
Another possible solution would be just call `dismissAllowingStateLoss()` insetad of `dismiss()` here: https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2728?expand=1#diff-47502535bf28efc3bee8aedcd7d0792dR93

but it's a faulty workaround.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pr should just fix the bug but the code I edited might affect all cases when a file is attached (chosen) in `FormEntryActivity`.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `ImageWidget`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)