### PR TITLE
PermissionUtils refactor

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivityNewApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivityNewApi.java
@@ -26,7 +26,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.Camera2Fragment;
 import org.odk.collect.android.utilities.ToastUtils;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfCameraPermissionGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isCameraPermissionGranted;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class CaptureSelfieActivityNewApi extends CollectAbstractActivity {
@@ -35,7 +35,7 @@ public class CaptureSelfieActivityNewApi extends CollectAbstractActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!checkIfCameraPermissionGranted(this)) {
+        if (!isCameraPermissionGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivityNewApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivityNewApi.java
@@ -26,7 +26,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.Camera2VideoFragment;
 import org.odk.collect.android.utilities.ToastUtils;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfCameraAndRecordAudioPermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isCameraAndRecordAudioPermissionsGranted;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class CaptureSelfieVideoActivityNewApi extends Activity {
@@ -35,7 +35,7 @@ public class CaptureSelfieVideoActivityNewApi extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!checkIfCameraAndRecordAudioPermissionsGranted(this)) {
+        if (!isCameraAndRecordAudioPermissionsGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
@@ -22,15 +22,15 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 
+import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.injection.config.AppComponent;
-import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.ThemeUtils;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfStoragePermissionsGranted;
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
 import static org.odk.collect.android.utilities.PermissionUtils.isEntryPointActivity;
+import static org.odk.collect.android.utilities.PermissionUtils.isStoragePermissionGranted;
 
 public abstract class CollectAbstractActivity extends AppCompatActivity {
 
@@ -51,7 +51,7 @@ public abstract class CollectAbstractActivity extends AppCompatActivity {
          * This code won't run on activities that are entry points to the app because those activities
          * are able to handle permission checks and requests by themselves.
          */
-        if (!checkIfStoragePermissionsGranted(this) && !isEntryPointActivity(this)) {
+        if (!isStoragePermissionGranted(this) && !isEntryPointActivity(this)) {
             AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Theme_AppCompat_Light_Dialog);
 
             builder.setTitle(R.string.storage_runtime_permission_denied_title)

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -38,12 +38,12 @@ import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.VersionHidingCursorAdapter;
 
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying all the valid forms in the forms directory. Stores the path to
@@ -66,7 +66,7 @@ public class FormChooserList extends FormListActivity implements
 
         setTitle(getString(R.string.enter_data));
 
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -66,7 +66,7 @@ public class FormChooserList extends FormListActivity implements
 
         setTitle(getString(R.string.enter_data));
 
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -49,6 +49,7 @@ import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
@@ -67,7 +68,6 @@ import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_AUTH_REQUIRED;
 import static org.odk.collect.android.utilities.DownloadFormListUtils.DL_ERROR_MSG;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying, adding and deleting all the valid forms in the forms directory. One
@@ -161,7 +161,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         setTitle(getString(R.string.get_forms));
 
         // This activity is accessed directly externally
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -161,7 +161,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         setTitle(getString(R.string.get_forms));
 
         // This activity is accessed directly externally
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -108,6 +108,7 @@ import org.odk.collect.android.tasks.SaveFormIndexTask;
 import org.odk.collect.android.tasks.SavePointTask;
 import org.odk.collect.android.tasks.SaveResult;
 import org.odk.collect.android.tasks.SaveToDiskTask;
+import org.odk.collect.android.upload.AutoSendWorker;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DependencyProvider;
@@ -116,6 +117,7 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ImageConverter;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
 import org.odk.collect.android.utilities.TimerLogger;
 import org.odk.collect.android.utilities.ToastUtils;
@@ -124,7 +126,6 @@ import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangeWidget;
 import org.odk.collect.android.widgets.StringWidget;
-import org.odk.collect.android.upload.AutoSendWorker;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -155,8 +156,6 @@ import static org.odk.collect.android.preferences.AdminKeys.KEY_MOVING_BACKWARDS
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 import static org.odk.collect.android.utilities.PermissionUtils.checkIfStoragePermissionsGranted;
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.requestReadPhoneStatePermission;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * FormEntryActivity is responsible for displaying questions, animating
@@ -337,7 +336,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             mediaLoadingFragment = (MediaLoadingFragment) getFragmentManager().findFragmentByTag(TAG_MEDIA_LOADING_FRAGMENT);
         }
 
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent
@@ -2295,7 +2294,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         final FormController formController = task.getFormController();
         if (formController != null) {
             if (readPhoneStatePermissionRequestNeeded) {
-                requestReadPhoneStatePermission(this, new PermissionListener() {
+                new PermissionUtils(this).requestReadPhoneStatePermission(this, new PermissionListener() {
                     @Override
                     public void granted() {
                         readPhoneStatePermissionRequestNeeded = false;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -98,8 +98,8 @@ import org.odk.collect.android.logic.FormController.FailedConstraint;
 import org.odk.collect.android.logic.FormInfo;
 import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
@@ -154,8 +154,8 @@ import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_MOVING_BACKWARDS;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfStoragePermissionsGranted;
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
+import static org.odk.collect.android.utilities.PermissionUtils.isStoragePermissionGranted;
 
 /**
  * FormEntryActivity is responsible for displaying questions, animating
@@ -2115,7 +2115,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     protected void onResume() {
         super.onResume();
 
-        if (!checkIfStoragePermissionsGranted(this)) {
+        if (!isStoragePermissionGranted(this)) {
             onResumeWasCalledWithoutPermissions = true;
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -336,7 +336,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             mediaLoadingFragment = (MediaLoadingFragment) getFragmentManager().findFragmentByTag(TAG_MEDIA_LOADING_FRAGMENT);
         }
 
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent
@@ -2294,7 +2294,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         final FormController formController = task.getFormController();
         if (formController != null) {
             if (readPhoneStatePermissionRequestNeeded) {
-                new PermissionUtils(this).requestReadPhoneStatePermission(this, new PermissionListener() {
+                new PermissionUtils(this).requestReadPhoneStatePermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         readPhoneStatePermissionRequestNeeded = false;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -43,7 +43,7 @@ import java.util.TimerTask;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfLocationPermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isLocationPermissionGranted;
 
 public class GeoPointActivity extends CollectAbstractActivity implements LocationListener,
         LocationClient.LocationClientListener, GpsStatus.Listener {
@@ -74,7 +74,7 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!checkIfLocationPermissionsGranted(this)) {
+        if (!isLocationPermissionGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -50,7 +50,7 @@ import java.text.DecimalFormat;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfLocationPermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isLocationPermissionGranted;
 
 /**
  * Version of the GeoPointMapActivity that uses the new Maps v2 API and Fragments to enable
@@ -108,7 +108,7 @@ public class GeoPointMapActivity extends CollectAbstractActivity implements OnMa
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!checkIfLocationPermissionsGranted(this)) {
+        if (!isLocationPermissionGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointOsmMapActivity.java
@@ -50,7 +50,7 @@ import java.text.DecimalFormat;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfLocationPermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isLocationPermissionGranted;
 
 /**
  * Version of the GeoPointMapActivity that uses the new OSMDDroid
@@ -107,7 +107,7 @@ public class GeoPointOsmMapActivity extends CollectAbstractActivity implements L
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (!checkIfLocationPermissionsGranted(this)) {
+        if (!isLocationPermissionGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeActivity.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfLocationPermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isLocationPermissionGranted;
 
 /** Activity for entering or editing a polygon on a map. */
 public class GeoShapeActivity extends CollectAbstractActivity implements IRegisterReceiver {
@@ -72,7 +72,7 @@ public class GeoShapeActivity extends CollectAbstractActivity implements IRegist
             restoredPoints = savedInstanceState.getParcelableArrayList(POINTS_KEY);
         }
 
-        if (!checkIfLocationPermissionsGranted(this)) {
+        if (!isLocationPermissionGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceActivity.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfLocationPermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isLocationPermissionGranted;
 
 public class GeoTraceActivity extends CollectAbstractActivity implements IRegisterReceiver {
     public static final String PREF_VALUE_GOOGLE_MAPS = "google_maps";
@@ -113,7 +113,7 @@ public class GeoTraceActivity extends CollectAbstractActivity implements IRegist
             restoredTimeUnitsIndex = savedInstanceState.getInt(TIME_UNITS_KEY, 0);
         }
 
-        if (!checkIfLocationPermissionsGranted(this)) {
+        if (!isLocationPermissionGranted(this)) {
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -40,11 +40,11 @@ import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.PermissionUtils;
 
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying all the valid instances in the instance directory.
@@ -89,7 +89,7 @@ public class InstanceChooserList extends InstanceListActivity implements
             ((TextView) findViewById(android.R.id.empty)).setText(R.string.no_items_display_sent_forms);
         }
 
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -89,7 +89,7 @@ public class InstanceChooserList extends InstanceListActivity implements
             ((TextView) findViewById(android.R.id.empty)).setText(R.string.no_items_display_sent_forms);
         }
 
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -33,6 +33,7 @@ import org.odk.collect.android.utilities.ArrayUtils;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,8 +42,6 @@ import java.util.Iterator;
 import java.util.Set;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Activity to upload completed forms.
@@ -83,7 +82,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
         Timber.i("onCreate: %s", savedInstanceState == null ? "creating" : "re-initializing");
 
         // This activity is accessed directly externally
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -82,7 +82,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
         Timber.i("onCreate: %s", savedInstanceState == null ? "creating" : "re-initializing");
 
         // This activity is accessed directly externally
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -53,6 +53,7 @@ import org.odk.collect.android.tasks.sms.SmsService;
 import org.odk.collect.android.tasks.sms.contracts.SmsSubmissionManagerContract;
 import org.odk.collect.android.tasks.sms.models.SmsSubmission;
 import org.odk.collect.android.upload.AutoSendWorker;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.PlayServicesUtil;
 import org.odk.collect.android.utilities.ToastUtils;
 
@@ -72,9 +73,6 @@ import static org.odk.collect.android.preferences.GeneralKeys.KEY_PROTOCOL;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.tasks.sms.SmsSender.SMS_INSTANCE_ID;
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
-import static org.odk.collect.android.utilities.PermissionUtils.requestReadPhoneStatePermission;
-import static org.odk.collect.android.utilities.PermissionUtils.requestSendSMSPermission;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 /**
  * Responsible for displaying all the valid forms in the forms directory. Stores
@@ -140,7 +138,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
             showAllMode = savedInstanceState.getBoolean(SHOW_ALL_MODE);
         }
 
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 init();
@@ -317,7 +315,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
         Transport transport = Transport.fromPreference(GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE));
 
         if (transport.equals(Transport.Sms) || buttonId == R.id.sms_upload_button) {
-            requestSendSMSPermission(this, new PermissionListener() {
+            new PermissionUtils(this).requestSendSMSPermission(this, new PermissionListener() {
                 @Override
                 public void granted() {
                     smsService.submitForms(instanceIds);
@@ -347,7 +345,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
                 Intent i = new Intent(this, InstanceUploaderActivity.class);
                 i.putExtra(FormEntryActivity.KEY_INSTANCES, instanceIds);
                 // Not required but without this permission a Device ID attached to a request will be empty.
-                requestReadPhoneStatePermission(this, new PermissionListener() {
+                new PermissionUtils(this).requestReadPhoneStatePermission(this, new PermissionListener() {
                     @Override
                     public void granted() {
                         startActivityForResult(i, INSTANCE_UPLOADER);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -138,7 +138,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
             showAllMode = savedInstanceState.getBoolean(SHOW_ALL_MODE);
         }
 
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 init();
@@ -315,7 +315,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
         Transport transport = Transport.fromPreference(GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE));
 
         if (transport.equals(Transport.Sms) || buttonId == R.id.sms_upload_button) {
-            new PermissionUtils(this).requestSendSMSPermission(this, new PermissionListener() {
+            new PermissionUtils(this).requestSendSMSPermission(new PermissionListener() {
                 @Override
                 public void granted() {
                     smsService.submitForms(instanceIds);
@@ -345,7 +345,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
                 Intent i = new Intent(this, InstanceUploaderActivity.class);
                 i.putExtra(FormEntryActivity.KEY_INSTANCES, instanceIds);
                 // Not required but without this permission a Device ID attached to a request will be empty.
-                new PermissionUtils(this).requestReadPhoneStatePermission(this, new PermissionListener() {
+                new PermissionUtils(this).requestReadPhoneStatePermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         startActivityForResult(i, INSTANCE_UPLOADER);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -59,7 +59,7 @@ public class SplashScreenActivity extends Activity {
         // this splash screen should be a blank slate
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 
-        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -32,9 +32,10 @@ import android.widget.LinearLayout;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,7 +45,6 @@ import java.io.IOException;
 import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_SPLASH_PATH;
-import static org.odk.collect.android.utilities.PermissionUtils.requestStoragePermissions;
 
 public class SplashScreenActivity extends Activity {
 
@@ -59,7 +59,7 @@ public class SplashScreenActivity extends Activity {
         // this splash screen should be a blank slate
         requestWindowFeature(Window.FEATURE_NO_TITLE);
 
-        requestStoragePermissions(this, new PermissionListener() {
+        new PermissionUtils(this).requestStoragePermissions(this, new PermissionListener() {
             @Override
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -54,6 +54,7 @@ import org.odk.collect.android.preferences.PreferenceSaver;
 import org.odk.collect.android.utilities.CompressionUtils;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.LocaleHelper;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.QRCodeUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
@@ -77,7 +78,6 @@ import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_ADMIN_PW;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_PASSWORD;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 import static org.odk.collect.android.utilities.QRCodeUtils.QR_CODE_FILEPATH;
 
 public class ShowQRCodeFragment extends Fragment {
@@ -161,7 +161,7 @@ public class ShowQRCodeFragment extends Fragment {
 
     @OnClick(R.id.btnScan)
     void scanButtonClicked() {
-        requestCameraPermission(getActivity(), new PermissionListener() {
+        new PermissionUtils(getActivity()).requestCameraPermission(getActivity(), new PermissionListener() {
             @Override
             public void granted() {
                 IntentIntegrator.forFragment(ShowQRCodeFragment.this)

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -161,7 +161,7 @@ public class ShowQRCodeFragment extends Fragment {
 
     @OnClick(R.id.btnScan)
     void scanButtonClicked() {
-        new PermissionUtils(getActivity()).requestCameraPermission(getActivity(), new PermissionListener() {
+        new PermissionUtils(getActivity()).requestCameraPermission(new PermissionListener() {
             @Override
             public void granted() {
                 IntentIntegrator.forFragment(ShowQRCodeFragment.this)

--- a/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
@@ -40,7 +40,7 @@ import timber.log.Timber;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_METADATA_EMAIL;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_METADATA_PHONENUMBER;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_METADATA_USERNAME;
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfReadPhoneStatePermissionGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isReadPhoneStatePermissionGranted;
 
 /**
  * Returns device properties and metadata to JavaRosa
@@ -171,7 +171,7 @@ public class PropertyManager implements IPropertyManager {
 
     @Override
     public String getSingularProperty(String propertyName) {
-        if (!checkIfReadPhoneStatePermissionGranted(Collect.getInstance()) && isPropertyDangerous(propertyName)) {
+        if (!isReadPhoneStatePermissionGranted(Collect.getInstance()) && isPropertyDangerous(propertyName)) {
             eventBus.post(new ReadPhoneStatePermissionRxEvent());
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormMetadataFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormMetadataFragment.java
@@ -35,7 +35,7 @@ public class FormMetadataFragment extends BasePreferenceFragment {
         initNormalPrefs();
 
         if (savedInstanceState == null) {
-            new PermissionUtils(getActivity()).requestReadPhoneStatePermission(getActivity(), new PermissionListener() {
+            new PermissionUtils(getActivity()).requestReadPhoneStatePermission(new PermissionListener() {
                 @Override
                 public void granted() {
                     initDangerousPrefs();

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormMetadataFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormMetadataFragment.java
@@ -11,6 +11,7 @@ import android.view.View;
 import org.odk.collect.android.R;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.Validator;
 
@@ -23,7 +24,6 @@ import static org.odk.collect.android.logic.PropertyManager.PROPMGR_USERNAME;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_METADATA_EMAIL;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_METADATA_PHONENUMBER;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_METADATA_USERNAME;
-import static org.odk.collect.android.utilities.PermissionUtils.requestReadPhoneStatePermission;
 
 public class FormMetadataFragment extends BasePreferenceFragment {
     @Override
@@ -35,7 +35,7 @@ public class FormMetadataFragment extends BasePreferenceFragment {
         initNormalPrefs();
 
         if (savedInstanceState == null) {
-            requestReadPhoneStatePermission(getActivity(), new PermissionListener() {
+            new PermissionUtils(getActivity()).requestReadPhoneStatePermission(getActivity(), new PermissionListener() {
                 @Override
                 public void granted() {
                     initDangerousPrefs();

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import timber.log.Timber;
 
 import static org.odk.collect.android.database.helpers.FormsDatabaseHelper.FORMS_TABLE_NAME;
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfStoragePermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isStoragePermissionGranted;
 
 public class FormsProvider extends ContentProvider {
     private static HashMap<String, String> sFormsProjectionMap;
@@ -76,7 +76,7 @@ public class FormsProvider extends ContentProvider {
     @Override
     public boolean onCreate() {
 
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             Timber.i("Read and write permissions are required for this content provider to function.");
             return false;
         }
@@ -90,7 +90,7 @@ public class FormsProvider extends ContentProvider {
     public Cursor query(@NonNull Uri uri, String[] projection, String selection,
                         String[] selectionArgs, String sortOrder) {
 
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return null;
         }
 
@@ -155,7 +155,7 @@ public class FormsProvider extends ContentProvider {
             throw new IllegalArgumentException("Unknown URI " + uri);
         }
 
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return null;
         }
 
@@ -290,7 +290,7 @@ public class FormsProvider extends ContentProvider {
      */
     @Override
     public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return 0;
         }
         int count = 0;
@@ -385,7 +385,7 @@ public class FormsProvider extends ContentProvider {
     public int update(Uri uri, ContentValues values, String where,
                       String[] whereArgs) {
 
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return 0;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -41,7 +41,7 @@ import java.util.Locale;
 import timber.log.Timber;
 
 import static org.odk.collect.android.database.helpers.InstancesDatabaseHelper.INSTANCES_TABLE_NAME;
-import static org.odk.collect.android.utilities.PermissionUtils.checkIfStoragePermissionsGranted;
+import static org.odk.collect.android.utilities.PermissionUtils.isStoragePermissionGranted;
 
 public class InstanceProvider extends ContentProvider {
     private static HashMap<String, String> sInstancesProjectionMap;
@@ -70,7 +70,7 @@ public class InstanceProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             Timber.i("Read and write permissions are required for this content provider to function.");
             return false;
         }
@@ -84,7 +84,7 @@ public class InstanceProvider extends ContentProvider {
     public Cursor query(@NonNull Uri uri, String[] projection, String selection, String[] selectionArgs,
                         String sortOrder) {
 
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return null;
         }
 
@@ -138,7 +138,7 @@ public class InstanceProvider extends ContentProvider {
             throw new IllegalArgumentException("Unknown URI " + uri);
         }
 
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return null;
         }
 
@@ -241,7 +241,7 @@ public class InstanceProvider extends ContentProvider {
      */
     @Override
     public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return 0;
         }
         int count = 0;
@@ -331,7 +331,7 @@ public class InstanceProvider extends ContentProvider {
 
     @Override
     public int update(@NonNull Uri uri, ContentValues values, String where, String[] whereArgs) {
-        if (!checkIfStoragePermissionsGranted(getContext())) {
+        if (!isStoragePermissionGranted(getContext())) {
             return 0;
         }
         int count = 0;

--- a/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
@@ -39,13 +39,13 @@ import org.odk.collect.android.dto.Instance;
 import org.odk.collect.android.exception.MultipleFoldersFoundException;
 import org.odk.collect.android.http.HttpClientConnection;
 import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.utilities.IconUtils;
+import org.odk.collect.android.utilities.InstanceUploaderUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
-import org.odk.collect.android.utilities.InstanceUploaderUtils;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
-import org.odk.collect.android.preferences.GeneralKeys;
-import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
 
 import java.io.IOException;
@@ -114,7 +114,7 @@ public class AutoSendWorker extends Worker {
         boolean anyFailure = false;
 
         if (protocol.equals(getApplicationContext().getString(R.string.protocol_google_sheets))) {
-            if (PermissionUtils.checkIfGetAccountsPermissionGranted(getApplicationContext())) {
+            if (PermissionUtils.isGetAccountsPermissionGranted(getApplicationContext())) {
                 GoogleAccountsManager accountsManager = new GoogleAccountsManager(Collect.getInstance());
                 String googleUsername = accountsManager.getSelectedAccount();
                 if (googleUsername.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -47,7 +47,7 @@ public class PermissionUtils {
      */
     private final Activity activity;
 
-    PermissionUtils(@NonNull Activity activity) {
+    public PermissionUtils(@NonNull Activity activity) {
         this.activity = activity;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -281,38 +281,45 @@ public class PermissionUtils {
     }
 
     public static boolean checkIfStoragePermissionsGranted(Context context) {
-        int read = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE);
-        int write = ContextCompat.checkSelfPermission(context, android.Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-        return read == PackageManager.PERMISSION_GRANTED && write == PackageManager.PERMISSION_GRANTED;
+        return checkIfPermissionsGranted(context,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
     public static boolean checkIfCameraPermissionGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
+        return checkIfPermissionsGranted(context, Manifest.permission.CAMERA);
     }
 
     public static boolean checkIfLocationPermissionsGranted(Context context) {
-        int accessFineLocation = ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION);
-        int accessCoarseLocation = ContextCompat.checkSelfPermission(context, android.Manifest.permission.ACCESS_COARSE_LOCATION);
-
-        return accessFineLocation == PackageManager.PERMISSION_GRANTED
-                && accessCoarseLocation == PackageManager.PERMISSION_GRANTED;
+        return checkIfPermissionsGranted(context,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION);
     }
 
     public static boolean checkIfCameraAndRecordAudioPermissionsGranted(Context context) {
-        int cameraPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA);
-        int recordAudioPermission = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO);
-
-        return cameraPermission == PackageManager.PERMISSION_GRANTED
-                && recordAudioPermission == PackageManager.PERMISSION_GRANTED;
+        return checkIfPermissionsGranted(context,
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO);
     }
 
     public static boolean checkIfGetAccountsPermissionGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context, Manifest.permission.GET_ACCOUNTS) == PackageManager.PERMISSION_GRANTED;
+        return checkIfPermissionsGranted(context, Manifest.permission.GET_ACCOUNTS);
     }
 
     public static boolean checkIfReadPhoneStatePermissionGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
+        return checkIfPermissionsGranted(context, Manifest.permission.READ_PHONE_STATE);
+    }
+
+    /**
+     * Returns true only if all of the requested permissions are granted to Collect, otherwise false
+     */
+    private static boolean checkIfPermissionsGranted(Context context, String... permissions) {
+        for (String permission : permissions) {
+            if (ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -59,7 +59,7 @@ public class PermissionUtils {
      *                 permission checking.
      * @param action   is a listener that provides the calling component with the permission result.
      */
-    public static void requestStoragePermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestStoragePermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
 
         MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
             @Override
@@ -89,7 +89,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public static void requestCameraPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestCameraPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -115,8 +115,8 @@ public class PermissionUtils {
                 .withErrorListener(error -> Timber.i(error.name()))
                 .check();
     }
-  
-    public static void requestLocationPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+
+    public void requestLocationPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
         MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
             @Override
             public void onPermissionsChecked(MultiplePermissionsReport report) {
@@ -143,7 +143,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public static void requestRecordAudioPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestRecordAudioPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -170,7 +170,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public static void requestCameraAndRecordAudioPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestCameraAndRecordAudioPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
         MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
             @Override
             public void onPermissionsChecked(MultiplePermissionsReport report) {
@@ -197,7 +197,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public static void requestGetAccountsPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestGetAccountsPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -224,7 +224,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public static void requestSendSMSPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestSendSMSPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -251,7 +251,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public static void requestReadPhoneStatePermission(@NonNull Activity activity, @NonNull PermissionListener action, boolean displayPermissionDeniedDialog) {
+    public void requestReadPhoneStatePermission(@NonNull Activity activity, @NonNull PermissionListener action, boolean displayPermissionDeniedDialog) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -52,11 +52,88 @@ public class PermissionUtils {
         this.activity = activity;
     }
 
+    public static boolean checkIfStoragePermissionsGranted(Context context) {
+        return checkIfPermissionsGranted(context,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    }
+
+    public static boolean checkIfCameraPermissionGranted(Context context) {
+        return checkIfPermissionsGranted(context, Manifest.permission.CAMERA);
+    }
+
+    public static boolean checkIfLocationPermissionsGranted(Context context) {
+        return checkIfPermissionsGranted(context,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION);
+    }
+
+    public static boolean checkIfCameraAndRecordAudioPermissionsGranted(Context context) {
+        return checkIfPermissionsGranted(context,
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO);
+    }
+
+    public static boolean checkIfGetAccountsPermissionGranted(Context context) {
+        return checkIfPermissionsGranted(context, Manifest.permission.GET_ACCOUNTS);
+    }
+
+    public static boolean checkIfReadPhoneStatePermissionGranted(Context context) {
+        return checkIfPermissionsGranted(context, Manifest.permission.READ_PHONE_STATE);
+    }
+
+    /**
+     * Returns true only if all of the requested permissions are granted to Collect, otherwise false
+     */
+    private static boolean checkIfPermissionsGranted(Context context, String... permissions) {
+        for (String permission : permissions) {
+            if (ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks to see if an activity is one of the entry points to the app i.e
+     * an activity that has a view action that can launch the app.
+     *
+     * @param activity that has permission requesting code.
+     * @return true if the activity is an entry point to the app.
+     */
+    public static boolean isEntryPointActivity(CollectAbstractActivity activity) {
+
+        List<Class<?>> activities = new ArrayList<>();
+        activities.add(FormEntryActivity.class);
+        activities.add(InstanceChooserList.class);
+        activities.add(FormChooserList.class);
+        activities.add(InstanceUploaderList.class);
+        activities.add(SplashScreenActivity.class);
+        activities.add(FormDownloadList.class);
+        activities.add(InstanceUploaderActivity.class);
+
+        for (Class<?> act : activities) {
+            if (activity.getClass().equals(act)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static void finishAllActivities(Activity activity) {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            activity.finishAndRemoveTask();
+        } else {
+            activity.finishAffinity();
+        }
+    }
+
     /**
      * Checks to see if the user granted Collect the permissions necessary for reading
      * and writing to storage and if not utilizes the permissions API to request them.
      *
-     * @param action   is a listener that provides the calling component with the permission result.
+     * @param action is a listener that provides the calling component with the permission result.
      */
     public void requestStoragePermissions(@NonNull PermissionListener action) {
         requestPermissions(new PermissionListener() {
@@ -235,83 +312,6 @@ public class PermissionUtils {
                         token.continuePermissionRequest();
                     }
                 });
-    }
-
-    public static boolean checkIfStoragePermissionsGranted(Context context) {
-        return checkIfPermissionsGranted(context,
-                Manifest.permission.READ_EXTERNAL_STORAGE,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE);
-    }
-
-    public static boolean checkIfCameraPermissionGranted(Context context) {
-        return checkIfPermissionsGranted(context, Manifest.permission.CAMERA);
-    }
-
-    public static boolean checkIfLocationPermissionsGranted(Context context) {
-        return checkIfPermissionsGranted(context,
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION);
-    }
-
-    public static boolean checkIfCameraAndRecordAudioPermissionsGranted(Context context) {
-        return checkIfPermissionsGranted(context,
-                Manifest.permission.CAMERA,
-                Manifest.permission.RECORD_AUDIO);
-    }
-
-    public static boolean checkIfGetAccountsPermissionGranted(Context context) {
-        return checkIfPermissionsGranted(context, Manifest.permission.GET_ACCOUNTS);
-    }
-
-    public static boolean checkIfReadPhoneStatePermissionGranted(Context context) {
-        return checkIfPermissionsGranted(context, Manifest.permission.READ_PHONE_STATE);
-    }
-
-    /**
-     * Returns true only if all of the requested permissions are granted to Collect, otherwise false
-     */
-    private static boolean checkIfPermissionsGranted(Context context, String... permissions) {
-        for (String permission : permissions) {
-            if (ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Checks to see if an activity is one of the entry points to the app i.e
-     * an activity that has a view action that can launch the app.
-     *
-     * @param activity that has permission requesting code.
-     * @return true if the activity is an entry point to the app.
-     */
-    public static boolean isEntryPointActivity(CollectAbstractActivity activity) {
-
-        List<Class<?>> activities = new ArrayList<>();
-        activities.add(FormEntryActivity.class);
-        activities.add(InstanceChooserList.class);
-        activities.add(FormChooserList.class);
-        activities.add(InstanceUploaderList.class);
-        activities.add(SplashScreenActivity.class);
-        activities.add(FormDownloadList.class);
-        activities.add(InstanceUploaderActivity.class);
-
-        for (Class<?> act : activities) {
-            if (activity.getClass().equals(act)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public static void finishAllActivities(Activity activity) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            activity.finishAndRemoveTask();
-        } else {
-            activity.finishAffinity();
-        }
     }
 
     private void showAdditionalExplanation(int title, int message, int drawable, @NonNull PermissionListener action) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -41,8 +41,14 @@ import timber.log.Timber;
 
 public class PermissionUtils {
 
-    private PermissionUtils() {
+    /**
+     * Required for context and spawning of Dexter's activity that handles
+     * permission checking.
+     */
+    private final Activity activity;
 
+    PermissionUtils(@NonNull Activity activity) {
+        this.activity = activity;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -65,7 +65,7 @@ public class PermissionUtils {
                 if (report.areAllPermissionsGranted()) {
                     action.granted();
                 } else {
-                    showAdditionalExplanation(activity, R.string.storage_runtime_permission_denied_title,
+                    showAdditionalExplanation(R.string.storage_runtime_permission_denied_title,
                             R.string.storage_runtime_permission_denied_desc, R.drawable.sd, action);
                 }
             }
@@ -96,7 +96,7 @@ public class PermissionUtils {
 
             @Override
             public void onPermissionDenied(PermissionDeniedResponse response) {
-                showAdditionalExplanation(activity, R.string.camera_runtime_permission_denied_title,
+                showAdditionalExplanation(R.string.camera_runtime_permission_denied_title,
                         R.string.camera_runtime_permission_denied_desc, R.drawable.ic_photo_camera, action);
             }
 
@@ -121,7 +121,7 @@ public class PermissionUtils {
                 if (report.areAllPermissionsGranted()) {
                     action.granted();
                 } else {
-                    showAdditionalExplanation(activity, R.string.location_runtime_permissions_denied_title,
+                    showAdditionalExplanation(R.string.location_runtime_permissions_denied_title,
                             R.string.location_runtime_permissions_denied_desc, R.drawable.ic_place_black, action);
                 }
             }
@@ -150,7 +150,7 @@ public class PermissionUtils {
 
             @Override
             public void onPermissionDenied(PermissionDeniedResponse response) {
-                showAdditionalExplanation(activity, R.string.record_audio_runtime_permission_denied_title,
+                showAdditionalExplanation(R.string.record_audio_runtime_permission_denied_title,
                         R.string.record_audio_runtime_permission_denied_desc, R.drawable.ic_mic, action);
             }
 
@@ -175,7 +175,7 @@ public class PermissionUtils {
                 if (report.areAllPermissionsGranted()) {
                     action.granted();
                 } else {
-                    showAdditionalExplanation(activity, R.string.camera_runtime_permission_denied_title,
+                    showAdditionalExplanation(R.string.camera_runtime_permission_denied_title,
                             R.string.camera_runtime_permission_denied_desc, R.drawable.ic_photo_camera, action);
                 }
             }
@@ -204,7 +204,7 @@ public class PermissionUtils {
 
             @Override
             public void onPermissionDenied(PermissionDeniedResponse response) {
-                showAdditionalExplanation(activity, R.string.get_accounts_runtime_permission_denied_title,
+                showAdditionalExplanation(R.string.get_accounts_runtime_permission_denied_title,
                         R.string.get_accounts_runtime_permission_denied_desc, R.drawable.ic_get_accounts, action);
             }
 
@@ -231,7 +231,7 @@ public class PermissionUtils {
 
             @Override
             public void onPermissionDenied(PermissionDeniedResponse response) {
-                showAdditionalExplanation(activity, R.string.send_sms_runtime_permission_denied_title,
+                showAdditionalExplanation(R.string.send_sms_runtime_permission_denied_title,
                         R.string.send_sms_runtime_permission_denied_desc, R.drawable.ic_sms, action);
             }
 
@@ -259,7 +259,7 @@ public class PermissionUtils {
             @Override
             public void onPermissionDenied(PermissionDeniedResponse response) {
                 if (displayPermissionDeniedDialog) {
-                    showAdditionalExplanation(activity, R.string.read_phone_state_runtime_permission_denied_title,
+                    showAdditionalExplanation(R.string.read_phone_state_runtime_permission_denied_title,
                             R.string.read_phone_state_runtime_permission_denied_desc, R.drawable.ic_phone, action);
                 } else {
                     action.denied();
@@ -350,17 +350,15 @@ public class PermissionUtils {
         }
     }
 
-    private static void showAdditionalExplanation(@NonNull Activity activity, int title,
-                                                  int message, int drawable,
-                                                  @NonNull PermissionListener action) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Light_Dialog);
-
-        builder.setTitle(title)
+    private void showAdditionalExplanation(int title, int message, int drawable, @NonNull PermissionListener action) {
+        AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Light_Dialog)
+                .setTitle(title)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> action.denied())
                 .setCancelable(false)
-                .setIcon(drawable);
+                .setIcon(drawable)
+                .create();
 
-        DialogUtils.showDialog(builder.create(), activity);
+        DialogUtils.showDialog(alertDialog, activity);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -55,11 +55,9 @@ public class PermissionUtils {
      * Checks to see if the user granted Collect the permissions necessary for reading
      * and writing to storage and if not utilizes the permissions API to request them.
      *
-     * @param activity required for context and spawning of Dexter's activity that handles
-     *                 permission checking.
      * @param action   is a listener that provides the calling component with the permission result.
      */
-    public void requestStoragePermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestStoragePermissions(@NonNull PermissionListener action) {
 
         MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
             @Override
@@ -89,7 +87,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestCameraPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestCameraPermission(@NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -116,7 +114,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestLocationPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestLocationPermissions(@NonNull PermissionListener action) {
         MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
             @Override
             public void onPermissionsChecked(MultiplePermissionsReport report) {
@@ -143,7 +141,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestRecordAudioPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestRecordAudioPermission(@NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -170,7 +168,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestCameraAndRecordAudioPermissions(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestCameraAndRecordAudioPermissions(@NonNull PermissionListener action) {
         MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
             @Override
             public void onPermissionsChecked(MultiplePermissionsReport report) {
@@ -197,7 +195,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestGetAccountsPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestGetAccountsPermission(@NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -224,7 +222,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestSendSMSPermission(@NonNull Activity activity, @NonNull PermissionListener action) {
+    public void requestSendSMSPermission(@NonNull PermissionListener action) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {
@@ -251,7 +249,7 @@ public class PermissionUtils {
                 .check();
     }
 
-    public void requestReadPhoneStatePermission(@NonNull Activity activity, @NonNull PermissionListener action, boolean displayPermissionDeniedDialog) {
+    public void requestReadPhoneStatePermission(@NonNull PermissionListener action, boolean displayPermissionDeniedDialog) {
         com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
             @Override
             public void onPermissionGranted(PermissionGrantedResponse response) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -59,206 +59,119 @@ public class PermissionUtils {
      * @param action   is a listener that provides the calling component with the permission result.
      */
     public void requestStoragePermissions(@NonNull PermissionListener action) {
-
-        MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionsChecked(MultiplePermissionsReport report) {
-                if (report.areAllPermissionsGranted()) {
-                    action.granted();
-                } else {
-                    showAdditionalExplanation(R.string.storage_runtime_permission_denied_title,
-                            R.string.storage_runtime_permission_denied_desc, R.drawable.sd, action);
-                }
+            public void granted() {
+                action.granted();
             }
 
             @Override
-            public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {
-                token.continuePermissionRequest();
+            public void denied() {
+                showAdditionalExplanation(R.string.storage_runtime_permission_denied_title,
+                        R.string.storage_runtime_permission_denied_desc, R.drawable.sd, action);
             }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermissions(
-                        Manifest.permission.READ_EXTERNAL_STORAGE,
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE
-                ).withListener(multiplePermissionsListener)
-                .withErrorListener(error -> {
-                    Timber.i(error.name());
-                })
-                .check();
+        }, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
     public void requestCameraPermission(@NonNull PermissionListener action) {
-        com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionGranted(PermissionGrantedResponse response) {
+            public void granted() {
                 action.granted();
             }
 
             @Override
-            public void onPermissionDenied(PermissionDeniedResponse response) {
+            public void denied() {
                 showAdditionalExplanation(R.string.camera_runtime_permission_denied_title,
                         R.string.camera_runtime_permission_denied_desc, R.drawable.ic_photo_camera, action);
             }
-
-            @Override
-            public void onPermissionRationaleShouldBeShown(PermissionRequest permission, PermissionToken token) {
-                token.continuePermissionRequest();
-            }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermission(
-                        Manifest.permission.CAMERA
-                ).withListener(permissionListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.CAMERA);
     }
 
     public void requestLocationPermissions(@NonNull PermissionListener action) {
-        MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionsChecked(MultiplePermissionsReport report) {
-                if (report.areAllPermissionsGranted()) {
-                    action.granted();
-                } else {
-                    showAdditionalExplanation(R.string.location_runtime_permissions_denied_title,
-                            R.string.location_runtime_permissions_denied_desc, R.drawable.ic_place_black, action);
-                }
+            public void granted() {
+                action.granted();
             }
 
             @Override
-            public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {
-                token.continuePermissionRequest();
+            public void denied() {
+                showAdditionalExplanation(R.string.location_runtime_permissions_denied_title,
+                        R.string.location_runtime_permissions_denied_desc, R.drawable.ic_place_black, action);
             }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermissions(
-                        Manifest.permission.ACCESS_FINE_LOCATION,
-                        Manifest.permission.ACCESS_COARSE_LOCATION
-                ).withListener(multiplePermissionsListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION);
     }
 
     public void requestRecordAudioPermission(@NonNull PermissionListener action) {
-        com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionGranted(PermissionGrantedResponse response) {
+            public void granted() {
                 action.granted();
             }
 
             @Override
-            public void onPermissionDenied(PermissionDeniedResponse response) {
+            public void denied() {
                 showAdditionalExplanation(R.string.record_audio_runtime_permission_denied_title,
                         R.string.record_audio_runtime_permission_denied_desc, R.drawable.ic_mic, action);
             }
-
-            @Override
-            public void onPermissionRationaleShouldBeShown(PermissionRequest permission, PermissionToken token) {
-                token.continuePermissionRequest();
-            }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermission(
-                        Manifest.permission.RECORD_AUDIO
-                ).withListener(permissionListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.RECORD_AUDIO);
     }
 
     public void requestCameraAndRecordAudioPermissions(@NonNull PermissionListener action) {
-        MultiplePermissionsListener multiplePermissionsListener = new MultiplePermissionsListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionsChecked(MultiplePermissionsReport report) {
-                if (report.areAllPermissionsGranted()) {
-                    action.granted();
-                } else {
-                    showAdditionalExplanation(R.string.camera_runtime_permission_denied_title,
-                            R.string.camera_runtime_permission_denied_desc, R.drawable.ic_photo_camera, action);
-                }
+            public void granted() {
+                action.granted();
             }
 
             @Override
-            public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {
-                token.continuePermissionRequest();
+            public void denied() {
+                showAdditionalExplanation(R.string.camera_runtime_permission_denied_title,
+                        R.string.camera_runtime_permission_denied_desc, R.drawable.ic_photo_camera, action);
             }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermissions(
-                        Manifest.permission.CAMERA,
-                        Manifest.permission.RECORD_AUDIO
-                ).withListener(multiplePermissionsListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO);
     }
 
     public void requestGetAccountsPermission(@NonNull PermissionListener action) {
-        com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionGranted(PermissionGrantedResponse response) {
+            public void granted() {
                 action.granted();
             }
 
             @Override
-            public void onPermissionDenied(PermissionDeniedResponse response) {
+            public void denied() {
                 showAdditionalExplanation(R.string.get_accounts_runtime_permission_denied_title,
                         R.string.get_accounts_runtime_permission_denied_desc, R.drawable.ic_get_accounts, action);
             }
-
-            @Override
-            public void onPermissionRationaleShouldBeShown(PermissionRequest permission, PermissionToken token) {
-                token.continuePermissionRequest();
-            }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermission(
-                        Manifest.permission.GET_ACCOUNTS
-                ).withListener(permissionListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.GET_ACCOUNTS);
     }
 
     public void requestSendSMSPermission(@NonNull PermissionListener action) {
-        com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionGranted(PermissionGrantedResponse response) {
+            public void granted() {
                 action.granted();
             }
 
             @Override
-            public void onPermissionDenied(PermissionDeniedResponse response) {
+            public void denied() {
                 showAdditionalExplanation(R.string.send_sms_runtime_permission_denied_title,
                         R.string.send_sms_runtime_permission_denied_desc, R.drawable.ic_sms, action);
             }
-
-            @Override
-            public void onPermissionRationaleShouldBeShown(PermissionRequest permission, PermissionToken token) {
-                token.continuePermissionRequest();
-            }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermission(
-                        Manifest.permission.SEND_SMS
-                ).withListener(permissionListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.SEND_SMS);
     }
 
     public void requestReadPhoneStatePermission(@NonNull PermissionListener action, boolean displayPermissionDeniedDialog) {
-        com.karumi.dexter.listener.single.PermissionListener permissionListener = new com.karumi.dexter.listener.single.PermissionListener() {
+        requestPermissions(new PermissionListener() {
             @Override
-            public void onPermissionGranted(PermissionGrantedResponse response) {
+            public void granted() {
                 action.granted();
             }
 
             @Override
-            public void onPermissionDenied(PermissionDeniedResponse response) {
+            public void denied() {
                 if (displayPermissionDeniedDialog) {
                     showAdditionalExplanation(R.string.read_phone_state_runtime_permission_denied_title,
                             R.string.read_phone_state_runtime_permission_denied_desc, R.drawable.ic_phone, action);
@@ -266,22 +179,10 @@ public class PermissionUtils {
                     action.denied();
                 }
             }
-
-            @Override
-            public void onPermissionRationaleShouldBeShown(PermissionRequest permission, PermissionToken token) {
-                token.continuePermissionRequest();
-            }
-        };
-
-        Dexter.withActivity(activity)
-                .withPermission(
-                        Manifest.permission.READ_PHONE_STATE
-                ).withListener(permissionListener)
-                .withErrorListener(error -> Timber.i(error.name()))
-                .check();
+        }, Manifest.permission.READ_PHONE_STATE);
     }
 
-    private void requestPermission(@NonNull PermissionListener listener, String... permissions) {
+    private void requestPermissions(@NonNull PermissionListener listener, String... permissions) {
         DexterBuilder builder = null;
 
         if (permissions.length == 1) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -52,40 +52,40 @@ public class PermissionUtils {
         this.activity = activity;
     }
 
-    public static boolean checkIfStoragePermissionsGranted(Context context) {
-        return checkIfPermissionsGranted(context,
+    public static boolean isStoragePermissionGranted(Context context) {
+        return isPermissionGranted(context,
                 Manifest.permission.READ_EXTERNAL_STORAGE,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
-    public static boolean checkIfCameraPermissionGranted(Context context) {
-        return checkIfPermissionsGranted(context, Manifest.permission.CAMERA);
+    public static boolean isCameraPermissionGranted(Context context) {
+        return isPermissionGranted(context, Manifest.permission.CAMERA);
     }
 
-    public static boolean checkIfLocationPermissionsGranted(Context context) {
-        return checkIfPermissionsGranted(context,
+    public static boolean isLocationPermissionGranted(Context context) {
+        return isPermissionGranted(context,
                 Manifest.permission.ACCESS_FINE_LOCATION,
                 Manifest.permission.ACCESS_COARSE_LOCATION);
     }
 
-    public static boolean checkIfCameraAndRecordAudioPermissionsGranted(Context context) {
-        return checkIfPermissionsGranted(context,
+    public static boolean isCameraAndRecordAudioPermissionsGranted(Context context) {
+        return isPermissionGranted(context,
                 Manifest.permission.CAMERA,
                 Manifest.permission.RECORD_AUDIO);
     }
 
-    public static boolean checkIfGetAccountsPermissionGranted(Context context) {
-        return checkIfPermissionsGranted(context, Manifest.permission.GET_ACCOUNTS);
+    public static boolean isGetAccountsPermissionGranted(Context context) {
+        return isPermissionGranted(context, Manifest.permission.GET_ACCOUNTS);
     }
 
-    public static boolean checkIfReadPhoneStatePermissionGranted(Context context) {
-        return checkIfPermissionsGranted(context, Manifest.permission.READ_PHONE_STATE);
+    public static boolean isReadPhoneStatePermissionGranted(Context context) {
+        return isPermissionGranted(context, Manifest.permission.READ_PHONE_STATE);
     }
 
     /**
      * Returns true only if all of the requested permissions are granted to Collect, otherwise false
      */
-    private static boolean checkIfPermissionsGranted(Context context, String... permissions) {
+    private static boolean isPermissionGranted(Context context, String... permissions) {
         for (String permission : permissions) {
             if (ContextCompat.checkSelfPermission(context, permission) != PackageManager.PERMISSION_GRANTED) {
                 return false;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
@@ -36,12 +36,12 @@ import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.ServerPreferencesFragment;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
 
 import java.util.Collections;
 
 import static org.odk.collect.android.utilities.DialogUtils.showDialog;
-import static org.odk.collect.android.utilities.PermissionUtils.requestGetAccountsPermission;
 
 public class GoogleAccountsManager {
     public static final int REQUEST_ACCOUNT_PICKER = 1000;
@@ -124,7 +124,7 @@ public class GoogleAccountsManager {
 
     public void chooseAccountAndRequestPermissionIfNeeded() {
         if (activity != null) {
-            requestGetAccountsPermission(activity, new PermissionListener() {
+            new PermissionUtils(getActivity()).requestGetAccountsPermission(activity, new PermissionListener() {
                 @Override
                 public void granted() {
                     chooseAccount();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
@@ -124,7 +124,7 @@ public class GoogleAccountsManager {
 
     public void chooseAccountAndRequestPermissionIfNeeded() {
         if (activity != null) {
-            new PermissionUtils(getActivity()).requestGetAccountsPermission(activity, new PermissionListener() {
+            new PermissionUtils(activity).requestGetAccountsPermission(new PermissionListener() {
                 @Override
                 public void granted() {
                     chooseAccount();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -25,7 +25,6 @@ import com.google.android.gms.analytics.HitBuilders;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
 
@@ -131,7 +130,7 @@ public class AlignedImageWidget extends BaseImageWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AlignedImageWidget.java
@@ -32,7 +32,6 @@ import org.odk.collect.android.listeners.PermissionListener;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 
 /**
  * Widget that allows user to invoke the aligned-image camera to take pictures and add them to the
@@ -132,7 +131,7 @@ public class AlignedImageWidget extends BaseImageWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -28,7 +28,6 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.utilities.FileUtils;
@@ -120,7 +119,7 @@ public class AnnotateWidget extends BaseImageWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -39,7 +39,6 @@ import java.util.Locale;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 
 /**
  * Image widget that supports annotations on the image.
@@ -121,7 +120,7 @@ public class AnnotateWidget extends BaseImageWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -45,7 +45,6 @@ import java.util.Locale;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestRecordAudioPermission;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -227,7 +226,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_audio:
-                requestRecordAudioPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestRecordAudioPermission((FormEntryActivity) getContext(), new PermissionListener() {
                     @Override
                     public void granted() {
                         captureAudio();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -32,7 +32,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.MediaManager;
@@ -226,7 +225,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_audio:
-                getPermissionUtils().requestRecordAudioPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestRecordAudioPermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         captureAudio();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -106,7 +106,7 @@ public class BarcodeWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestCameraPermission(new PermissionListener() {
             @Override
             public void granted() {
                 waitForData();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -33,8 +33,6 @@ import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
 
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
-
 /**
  * Widget that allows user to scan barcodes and add them to the form.
  *
@@ -108,7 +106,7 @@ public class BarcodeWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
                 waitForData();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -31,7 +31,6 @@ import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.GeoPointActivity;
 import org.odk.collect.android.activities.GeoPointMapActivity;
 import org.odk.collect.android.activities.GeoPointOsmMapActivity;
@@ -277,7 +276,7 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        getPermissionUtils().requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestLocationPermissions(new PermissionListener() {
             @Override
             public void granted() {
                 startGeoPoint();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -44,7 +44,6 @@ import java.text.DecimalFormat;
 import java.util.Locale;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestLocationPermissions;
 
 /**
  * GeoPointWidget is the widget that allows the user to get GPS readings.
@@ -278,7 +277,7 @@ public class GeoPointWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
                 startGeoPoint();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -27,7 +27,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.GeoShapeActivity;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralKeys;
@@ -127,7 +126,7 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        getPermissionUtils().requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestLocationPermissions(new PermissionListener() {
             @Override
             public void granted() {
                 waitForData();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -35,7 +35,6 @@ import org.odk.collect.android.utilities.PlayServicesUtil;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestLocationPermissions;
 
 /**
  * GeoShapeWidget is the widget that allows the user to get Collect multiple GPS points.
@@ -128,7 +127,7 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
                 waitForData();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -28,7 +28,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.GeoTraceActivity;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralKeys;
@@ -131,7 +130,7 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        getPermissionUtils().requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestLocationPermissions(new PermissionListener() {
             @Override
             public void granted() {
                 waitForData();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -36,7 +36,6 @@ import org.odk.collect.android.utilities.PlayServicesUtil;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestLocationPermissions;
 
 /**
  * GeoTraceWidget allows the user to collect a trace of GPS points as the
@@ -132,7 +131,7 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void onButtonClick(int buttonId) {
-        requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+        getPermissionUtils().requestLocationPermissions((FormEntryActivity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
                 waitForData();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -54,7 +54,6 @@ import java.util.Date;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -272,7 +271,7 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWebViewWidget.java
@@ -41,7 +41,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.utilities.MediaManager;
@@ -271,7 +270,7 @@ public class ImageWebViewWidget extends QuestionWidget implements FileWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.util.Locale;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the form.
@@ -119,7 +118,7 @@ public class ImageWidget extends BaseImageWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -27,7 +27,6 @@ import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CaptureSelfieActivity;
 import org.odk.collect.android.activities.CaptureSelfieActivityNewApi;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.utilities.CameraUtils;
@@ -118,7 +117,7 @@ public class ImageWidget extends BaseImageWidget {
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                getPermissionUtils().requestCameraPermission(new PermissionListener() {
                     @Override
                     public void granted() {
                         captureImage();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -83,7 +83,7 @@ public abstract class QuestionWidget
     private final View guidanceTextLayout;
     private final View textLayout;
     private final TextView warningText;
-    private final PermissionUtils permissionUtils;
+    private PermissionUtils permissionUtils;
     private static final String GUIDANCE_EXPANDED_STATE = "expanded_state";
     private AtomicBoolean expanded;
     private Bundle state;
@@ -95,10 +95,10 @@ public abstract class QuestionWidget
 
         themeUtils = new ThemeUtils(context);
         playColor = themeUtils.getAccentColor();
-        permissionUtils = new PermissionUtils((FormEntryActivity) getContext());
 
         if (context instanceof FormEntryActivity) {
             state = ((FormEntryActivity) context).getState();
+            permissionUtils = new PermissionUtils((FormEntryActivity) getContext());
         }
 
         if (context instanceof DependencyProvider) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -51,6 +51,7 @@ import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.utilities.AnimateUtils;
 import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
 import org.odk.collect.android.utilities.TextUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
@@ -82,6 +83,7 @@ public abstract class QuestionWidget
     private final View guidanceTextLayout;
     private final View textLayout;
     private final TextView warningText;
+    private final PermissionUtils permissionUtils;
     private static final String GUIDANCE_EXPANDED_STATE = "expanded_state";
     private AtomicBoolean expanded;
     private Bundle state;
@@ -93,6 +95,7 @@ public abstract class QuestionWidget
 
         themeUtils = new ThemeUtils(context);
         playColor = themeUtils.getAccentColor();
+        permissionUtils = new PermissionUtils((FormEntryActivity) getContext());
 
         if (context instanceof FormEntryActivity) {
             state = ((FormEntryActivity) context).getState();
@@ -668,5 +671,9 @@ public abstract class QuestionWidget
 
     public int getPlayColor() {
         return playColor;
+    }
+
+    public PermissionUtils getPermissionUtils() {
+        return permissionUtils;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -40,7 +40,6 @@ import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CaptureSelfieVideoActivity;
 import org.odk.collect.android.activities.CaptureSelfieVideoActivityNewApi;
-import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralKeys;
@@ -319,7 +318,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         switch (id) {
             case R.id.capture_video:
                 if (selfie) {
-                    getPermissionUtils().requestCameraAndRecordAudioPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+                    getPermissionUtils().requestCameraAndRecordAudioPermissions(new PermissionListener() {
                         @Override
                         public void granted() {
                             captureVideo();
@@ -330,7 +329,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
                         }
                     });
                 } else {
-                    getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                    getPermissionUtils().requestCameraPermission(new PermissionListener() {
                         @Override
                         public void granted() {
                             captureVideo();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -61,8 +61,6 @@ import timber.log.Timber;
 
 import static android.os.Build.MODEL;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraAndRecordAudioPermissions;
-import static org.odk.collect.android.utilities.PermissionUtils.requestCameraPermission;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -321,7 +319,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         switch (id) {
             case R.id.capture_video:
                 if (selfie) {
-                    requestCameraAndRecordAudioPermissions((FormEntryActivity) getContext(), new PermissionListener() {
+                    getPermissionUtils().requestCameraAndRecordAudioPermissions((FormEntryActivity) getContext(), new PermissionListener() {
                         @Override
                         public void granted() {
                             captureVideo();
@@ -332,7 +330,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
                         }
                     });
                 } else {
-                    requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
+                    getPermissionUtils().requestCameraPermission((FormEntryActivity) getContext(), new PermissionListener() {
                         @Override
                         public void granted() {
                             captureVideo();


### PR DESCRIPTION
I have been trying to add some unit tests around the widgets to perform button click and verify the behavior for each widget. The only problem I am dealing with is to mock the runtime permissions of `PermissionUtils`. All the methods have `static` modifier.
So I had to choose one of the following method to proceed with writing tests:
 1. Mock `static` methods using @PrepareForTest and `PowerMockRunner`
 2. Create a [**shadow**](http://robolectric.org/extending/) for `PermissionUtils`
 3. Refactor `PermissionUtils` and mock the utility class for unit tests

**Method 1** cannot be chosen as we are using `RobolectricTestRunner` in `WIdgetTest` and using `PowerMockRunner` breaks the current set of tests.
**Method 2** cannot be chosen as robolectric doesn't support creating shadows for static methods
So the only option I was left with was to reformat the code to make the code testable. This PR performs some cleanup and refactors `PermissionUtils` to make the code more testable

#### What has been done to verify that this works as intended?
1. Storage permission request dialog appears when the app is freshly installed
2. Tried opening all of the widgets available in `All-Widgets` form and verified the appropriate permission check is requested.
3. Verified that behavior of `Allow` and `Denied` button in the dialog isn't changed

#### Why is this the best possible solution? Were any other approaches considered?
I had a conversation with @seadowg and he wrote a tutorial which illustrates how to refactor code to make it more testable in such scenarios (https://www.seadowg.com/dip-lesson/)
From there I learnt that we can refactor our code containing  static methods in different ways to test the code.
But I chose to refactor the `PermissionUtils` and make the methods not static instead of adding another wrapper class around the `PermissionUtils`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no changes for the user. I have modified the way permissions are checked, so there is a risk that the behavior might have changed

#### Do we need any specific form for testing your changes? If so, please attach one.
`All-Widgets` form can be used

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)