### PR TITLE
Add tests to verify launching intents in Widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -250,7 +250,7 @@ public class PermissionUtils {
         }, Manifest.permission.READ_PHONE_STATE);
     }
 
-    protected void requestSendSMSAndReadPhoneStatePermissions(Activity activity, @NonNull PermissionListener action) {
+    public void requestSendSMSAndReadPhoneStatePermissions(Activity activity, @NonNull PermissionListener action) {
         requestPermissions(activity, new PermissionListener() {
             @Override
             public void granted() {
@@ -265,7 +265,7 @@ public class PermissionUtils {
         }, Manifest.permission.SEND_SMS, Manifest.permission.READ_PHONE_STATE);
     }
 
-    private void requestPermissions(Activity activity, @NonNull PermissionListener listener, String... permissions) {
+    protected void requestPermissions(Activity activity, @NonNull PermissionListener listener, String... permissions) {
         DexterBuilder builder = null;
 
         if (permissions.length == 1) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -250,7 +250,7 @@ public class PermissionUtils {
         }, Manifest.permission.READ_PHONE_STATE);
     }
 
-    public void requestSendSMSAndReadPhoneStatePermissions(Activity activity, @NonNull PermissionListener action) {
+    protected void requestSendSMSAndReadPhoneStatePermissions(Activity activity, @NonNull PermissionListener action) {
         requestPermissions(activity, new PermissionListener() {
             @Override
             public void granted() {
@@ -320,7 +320,7 @@ public class PermissionUtils {
                 });
     }
 
-    private void showAdditionalExplanation(Activity activity, int title, int message, int drawable, @NonNull PermissionListener action) {
+    protected void showAdditionalExplanation(Activity activity, int title, int message, int drawable, @NonNull PermissionListener action) {
         AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.PermissionAlertDialogTheme)
                 .setTitle(title)
                 .setMessage(message)

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -36,6 +36,8 @@ import org.odk.collect.android.utilities.FileUtils;
 import java.io.File;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
@@ -165,13 +167,17 @@ public class AnnotateWidget extends BaseImageWidget {
         // images returned by the camera in 1.6 (and earlier) are ~1/4
         // the size. boo.
 
-        Uri uri = FileProvider.getUriForFile(getContext(),
-                BuildConfig.APPLICATION_ID + ".provider",
-                new File(Collect.TMPFILE_PATH));
-        // if this gets modified, the onActivityResult in
-        // FormEntyActivity will also need to be updated.
-        intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-        FileUtils.grantFilePermissions(intent, uri, getContext());
+        try {
+            Uri uri = FileProvider.getUriForFile(getContext(),
+                    BuildConfig.APPLICATION_ID + ".provider",
+                    new File(Collect.TMPFILE_PATH));
+            // if this gets modified, the onActivityResult in
+            // FormEntyActivity will also need to be updated.
+            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
+            FileUtils.grantFilePermissions(intent, uri, getContext());
+        } catch (IllegalArgumentException e) {
+            Timber.e(e);
+        }
 
         imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, R.string.annotate_image);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -107,7 +107,7 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
     private final Button launchIntentButton;
     private final Drawable textBackground;
 
-    private ActivityAvailability activityAvailability;
+    private ActivityAvailability activityAvailability = new ActivityAvailability(getContext());
 
     public ExStringWidget(Context context, FormEntryPrompt prompt) {
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -36,6 +36,8 @@ import org.odk.collect.android.utilities.FileUtils;
 import java.io.File;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
@@ -161,13 +163,17 @@ public class ImageWidget extends BaseImageWidget {
             // images returned by the camera in 1.6 (and earlier) are ~1/4
             // the size. boo.
 
-            Uri uri = FileProvider.getUriForFile(getContext(),
-                    BuildConfig.APPLICATION_ID + ".provider",
-                    new File(Collect.TMPFILE_PATH));
-            // if this gets modified, the onActivityResult in
-            // FormEntyActivity will also need to be updated.
-            intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
-            FileUtils.grantFilePermissions(intent, uri, getContext());
+            try {
+                Uri uri = FileProvider.getUriForFile(getContext(),
+                        BuildConfig.APPLICATION_ID + ".provider",
+                        new File(Collect.TMPFILE_PATH));
+                // if this gets modified, the onActivityResult in
+                // FormEntyActivity will also need to be updated.
+                intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);
+                FileUtils.grantFilePermissions(intent, uri, getContext());
+            } catch (IllegalArgumentException e) {
+                Timber.e(e);
+            }
         }
 
         imageCaptureHandler.captureImage(intent, RequestCodes.IMAGE_CAPTURE, R.string.capture_image);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -3,11 +3,10 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.view.View;
@@ -161,22 +160,14 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
             //send encode tag data structure to intent
             writeOsmRequiredTagsToExtras(launchIntent);
 
-            //verify the package resolves before starting activity
-            Context ctx = getContext();
-            PackageManager packageManager = ctx.getPackageManager();
-            List<ResolveInfo> activities = packageManager.queryIntentActivities(launchIntent, 0);
-            boolean isIntentSafe = !activities.isEmpty();
-
-            //launch activity if it is safe
-            if (isIntentSafe) {
-                // notify that the form is waiting for data
+            try {
                 waitForData();
-
-                // launch
-                ((Activity) ctx).startActivityForResult(launchIntent, RequestCodes.OSM_CAPTURE);
-            } else {
+                ((Activity) getContext()).startActivityForResult(launchIntent, RequestCodes.OSM_CAPTURE);
+            } catch (ActivityNotFoundException e) {
+                cancelWaitingForData();
                 errorTextView.setVisibility(View.VISIBLE);
             }
+
         } catch (Exception ex) {
             AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
             builder.setTitle(R.string.alert);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -86,7 +86,7 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
         osmFileName = prompt.getAnswerText();
 
         // Setup Launch OpenMapKit Button
-        launchOpenMapKitButton = getSimpleButton(ViewIds.generateViewId());
+        launchOpenMapKitButton = getSimpleButton(R.id.simple_button);
 
         // Button Styling
         if (osmFileName != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -675,4 +675,8 @@ public abstract class QuestionWidget
     public PermissionUtils getPermissionUtils() {
         return permissionUtils;
     }
+
+    public void setPermissionUtils(PermissionUtils permissionUtils) {
+        this.permissionUtils = permissionUtils;
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -424,10 +424,14 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         Intent intent = new Intent("android.intent.action.VIEW");
         File file = new File(getInstanceFolder() + File.separator + binaryName);
 
-        Uri uri =
-                FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", file);
+        Uri uri = null;
+        try {
+            uri = FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", file);
+            FileUtils.grantFileReadPermissions(intent, uri, getContext());
+        } catch (IllegalArgumentException e) {
+            Timber.e(e);
+        }
 
-        FileUtils.grantFileReadPermissions(intent, uri, getContext());
         intent.setDataAndType(uri, "video/*");
         try {
             getContext().startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -421,7 +421,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
     }
 
     private void playVideoFile() {
-        Intent intent = new Intent("android.intent.action.VIEW");
+        Intent intent = new Intent(Intent.ACTION_VIEW);
         File file = new File(getInstanceFolder() + File.separator + binaryName);
 
         Uri uri = null;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/interfaces/Widget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/interfaces/Widget.java
@@ -1,10 +1,6 @@
 package org.odk.collect.android.widgets.interfaces;
 
-import android.widget.Button;
-
 import org.javarosa.core.model.data.IAnswerData;
-
-import java.util.List;
 
 /**
  * @author James Knight
@@ -20,6 +16,4 @@ public interface Widget {
     void cancelWaitingForData();
 
     boolean isWaitingForData();
-
-    List<Button> getSimpleButtonList();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/interfaces/Widget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/interfaces/Widget.java
@@ -1,6 +1,10 @@
 package org.odk.collect.android.widgets.interfaces;
 
+import android.widget.Button;
+
 import org.javarosa.core.model.data.IAnswerData;
+
+import java.util.List;
 
 /**
  * @author James Knight
@@ -16,4 +20,6 @@ public interface Widget {
     void cancelWaitingForData();
 
     boolean isWaitingForData();
+
+    List<Button> getSimpleButtonList();
 }

--- a/collect_app/src/test/java/org/odk/collect/android/ShadowPlayServicesUtil.java
+++ b/collect_app/src/test/java/org/odk/collect/android/ShadowPlayServicesUtil.java
@@ -7,7 +7,7 @@ import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 
 @Implements(PlayServicesUtil.class)
-public class ShadowPlayServicesUtil {
+public abstract class ShadowPlayServicesUtil {
 
     @Implementation
     public static boolean isGooglePlayServicesAvailable(Context context) {

--- a/collect_app/src/test/java/org/odk/collect/android/ShadowPlayServicesUtil.java
+++ b/collect_app/src/test/java/org/odk/collect/android/ShadowPlayServicesUtil.java
@@ -1,0 +1,17 @@
+package org.odk.collect.android;
+
+import android.content.Context;
+
+import org.odk.collect.android.utilities.PlayServicesUtil;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+@Implements(PlayServicesUtil.class)
+public class ShadowPlayServicesUtil {
+
+    @Implementation
+    public static boolean isGooglePlayServicesAvailable(Context context) {
+        return true;
+    }
+}
+

--- a/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionUtils.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.mocks;
+package org.odk.collect.android.fakes;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
@@ -12,11 +12,11 @@ import org.odk.collect.android.utilities.PermissionUtils;
  *
  * @author Shobhit Agarwal
  */
-public class MockedPermissionUtils extends PermissionUtils {
+public class FakePermissionUtils extends PermissionUtils {
 
     private boolean isPermissionGranted;
 
-    public MockedPermissionUtils(@NonNull Activity activity) {
+    public FakePermissionUtils(@NonNull Activity activity) {
         super(activity);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionUtils.java
@@ -16,12 +16,8 @@ public class FakePermissionUtils extends PermissionUtils {
 
     private boolean isPermissionGranted;
 
-    public FakePermissionUtils(@NonNull Activity activity) {
-        super(activity);
-    }
-
     @Override
-    protected void requestPermissions(@NonNull PermissionListener listener, String... permissions) {
+    protected void requestPermissions(Activity activity, @NonNull PermissionListener listener, String... permissions) {
         if (isPermissionGranted) {
             listener.granted();
         } else {
@@ -30,7 +26,7 @@ public class FakePermissionUtils extends PermissionUtils {
     }
 
     @Override
-    protected void showAdditionalExplanation(int title, int message, int drawable, @NonNull PermissionListener action) {
+    protected void showAdditionalExplanation(Activity activity, int title, int message, int drawable, @NonNull PermissionListener action) {
         action.denied();
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/mocks/MockedPermissionUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/mocks/MockedPermissionUtils.java
@@ -1,0 +1,35 @@
+package org.odk.collect.android.mocks;
+
+import android.app.Activity;
+import android.support.annotation.NonNull;
+
+import org.odk.collect.android.listeners.PermissionListener;
+import org.odk.collect.android.utilities.PermissionUtils;
+
+/**
+ * Mocked implementation of {@link PermissionUtils}.
+ * The runtime permissions can be stubbed for unit testing
+ *
+ * @author Shobhit Agarwal
+ */
+public class MockedPermissionUtils extends PermissionUtils {
+
+    private boolean isPermissionGranted;
+
+    public MockedPermissionUtils(@NonNull Activity activity) {
+        super(activity);
+    }
+
+    @Override
+    public void requestPermissions(@NonNull PermissionListener listener, String... permissions) {
+        if (isPermissionGranted) {
+            listener.granted();
+        } else {
+            listener.denied();
+        }
+    }
+
+    public void setPermissionGranted(boolean permissionGranted) {
+        isPermissionGranted = permissionGranted;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/mocks/MockedPermissionUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/mocks/MockedPermissionUtils.java
@@ -21,12 +21,17 @@ public class MockedPermissionUtils extends PermissionUtils {
     }
 
     @Override
-    public void requestPermissions(@NonNull PermissionListener listener, String... permissions) {
+    protected void requestPermissions(@NonNull PermissionListener listener, String... permissions) {
         if (isPermissionGranted) {
             listener.granted();
         } else {
             listener.denied();
         }
+    }
+
+    @Override
+    protected void showAdditionalExplanation(int title, int message, int drawable, @NonNull PermissionListener action) {
+        action.denied();
     }
 
     public void setPermissionGranted(boolean permissionGranted) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -3,10 +3,8 @@ package org.odk.collect.android.widgets;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.content.Intent;
-import android.net.Uri;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -17,7 +15,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
@@ -56,33 +53,6 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
         when(file.getName()).thenReturn(answerData.getDisplayText());
 
         return file;
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-
-        switch (clickedButton.getId()) {
-            case R.id.capture_image:
-                if (permissionGranted) {
-                    intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-                }
-                break;
-
-            /* We aren't checking for storage permissions as without that permission
-             * FormEntryActivity cannot be started */
-            case R.id.choose_image:
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("image/*");
-                break;
-            case R.id.markup_image:
-                intent = new Intent(activity, DrawActivity.class);
-                intent.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE);
-                intent.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
-                intent.putExtra(DrawActivity.SCREEN_ORIENTATION, 0);
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -1,29 +1,39 @@
 package org.odk.collect.android.widgets;
 
+import android.content.ComponentName;
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.AlignedImageWidget.DIMENSIONS_EXTRA;
+import static org.odk.collect.android.widgets.AlignedImageWidget.FILE_PATH_EXTRA;
+import static org.odk.collect.android.widgets.AlignedImageWidget.ODK_CAMERA_INTENT_PACKAGE;
+import static org.odk.collect.android.widgets.AlignedImageWidget.ODK_CAMERA_TAKE_PICTURE_INTENT_COMPONENT;
+import static org.odk.collect.android.widgets.AlignedImageWidget.RETAKE_OPTION_EXTRA;
 
 /**
  * @author James Knight
  */
 public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
+
     @Mock
     File file;
 
     @NonNull
     @Override
     public AnnotateWidget createWidget() {
-        return new AnnotateWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new AnnotateWidget(activity, formEntryPrompt);
     }
 
     @NonNull
@@ -38,5 +48,31 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
         when(file.getName()).thenReturn(answerData.getDisplayText());
 
         return file;
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+
+        switch (clickedButton.getId()) {
+            case R.id.capture_image:
+                if (permissionGranted) {
+                    intent = new Intent();
+                    intent.setComponent(new ComponentName(ODK_CAMERA_INTENT_PACKAGE, ODK_CAMERA_TAKE_PICTURE_INTENT_COMPONENT));
+                    intent.putExtra(FILE_PATH_EXTRA, Collect.CACHE_PATH);
+                    intent.putExtra(DIMENSIONS_EXTRA, new int[6]);
+                    intent.putExtra(RETAKE_OPTION_EXTRA, false);
+                }
+                break;
+            case R.id.choose_image:
+
+                /* We aren't checking for storage permissions as without that permission
+                 * FormEntryActivity cannot be started */
+
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("image/*");
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -4,12 +4,14 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.Intent;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
@@ -20,6 +22,7 @@ import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.widgets.AlignedImageWidget.DIMENSIONS_EXTRA;
 import static org.odk.collect.android.widgets.AlignedImageWidget.FILE_PATH_EXTRA;
@@ -80,5 +83,27 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.capture_image);
+        assertActionEquals(MediaStore.ACTION_IMAGE_CAPTURE, intent);
+
+        intent = getIntentLaunchedByClick(R.id.choose_image);
+        assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
+
+        intent = getIntentLaunchedByClick(R.id.markup_image);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE, intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.capture_image));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -2,6 +2,8 @@ package org.odk.collect.android.widgets;
 
 import android.content.ComponentName;
 import android.content.Intent;
+import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.widget.Button;
 
@@ -10,6 +12,9 @@ import net.bytebuddy.utility.RandomString;
 import org.javarosa.core.model.data.StringData;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 
@@ -57,20 +62,21 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
         switch (clickedButton.getId()) {
             case R.id.capture_image:
                 if (permissionGranted) {
-                    intent = new Intent();
-                    intent.setComponent(new ComponentName(ODK_CAMERA_INTENT_PACKAGE, ODK_CAMERA_TAKE_PICTURE_INTENT_COMPONENT));
-                    intent.putExtra(FILE_PATH_EXTRA, Collect.CACHE_PATH);
-                    intent.putExtra(DIMENSIONS_EXTRA, new int[6]);
-                    intent.putExtra(RETAKE_OPTION_EXTRA, false);
+                    intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
                 }
                 break;
+
+            /* We aren't checking for storage permissions as without that permission
+             * FormEntryActivity cannot be started */
             case R.id.choose_image:
-
-                /* We aren't checking for storage permissions as without that permission
-                 * FormEntryActivity cannot be started */
-
                 intent = new Intent(Intent.ACTION_GET_CONTENT);
                 intent.setType("image/*");
+                break;
+            case R.id.markup_image:
+                intent = new Intent(activity, DrawActivity.class);
+                intent.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE);
+                intent.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
+                intent.putExtra(DrawActivity.SCREEN_ORIENTATION, 0);
                 break;
         }
         return intent;

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -1,7 +1,5 @@
 package org.odk.collect.android.widgets;
 
-import android.content.ComponentName;
-import android.content.Intent;
 import android.content.Intent;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
@@ -12,8 +10,6 @@ import org.javarosa.core.model.data.StringData;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 
@@ -21,11 +17,6 @@ import java.io.File;
 
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.widgets.AlignedImageWidget.DIMENSIONS_EXTRA;
-import static org.odk.collect.android.widgets.AlignedImageWidget.FILE_PATH_EXTRA;
-import static org.odk.collect.android.widgets.AlignedImageWidget.ODK_CAMERA_INTENT_PACKAGE;
-import static org.odk.collect.android.widgets.AlignedImageWidget.ODK_CAMERA_TAKE_PICTURE_INTENT_COMPONENT;
-import static org.odk.collect.android.widgets.AlignedImageWidget.RETAKE_OPTION_EXTRA;
 
 /**
  * @author James Knight

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -1,22 +1,27 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
+import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.MediaUtil;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
+import static android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION;
+import static android.provider.MediaStore.EXTRA_OUTPUT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,7 +49,7 @@ public class AudioWidgetTest extends FileWidgetTest<AudioWidget> {
     @Override
     public AudioWidget createWidget() {
         when(audioController.getPlayerLayout(any(ViewGroup.class))).thenReturn(mock(View.class));
-        return new AudioWidget(RuntimeEnvironment.application, formEntryPrompt, fileUtil, mediaUtil, audioController);
+        return new AudioWidget(activity, formEntryPrompt, fileUtil, mediaUtil, audioController);
     }
 
     @NonNull
@@ -80,5 +85,28 @@ public class AudioWidgetTest extends FileWidgetTest<AudioWidget> {
 
         when(firstFile.exists()).thenReturn(true);
         when(firstFile.getName()).thenReturn(destinationName);
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+
+        switch (clickedButton.getId()) {
+            case R.id.capture_audio:
+                if (permissionGranted) {
+                    intent = new Intent(RECORD_SOUND_ACTION);
+                    intent.putExtra(EXTRA_OUTPUT, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI.toString());
+                }
+                break;
+            case R.id.choose_sound:
+
+                /* We aren't checking for storage permissions as without that permission
+                 * FormEntryActivity cannot be started */
+
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("audio/*");
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -7,7 +7,6 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -21,8 +20,6 @@ import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
 
-import static android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION;
-import static android.provider.MediaStore.EXTRA_OUTPUT;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -87,29 +84,6 @@ public class AudioWidgetTest extends FileWidgetTest<AudioWidget> {
 
         when(firstFile.exists()).thenReturn(true);
         when(firstFile.getName()).thenReturn(destinationName);
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-
-        switch (clickedButton.getId()) {
-            case R.id.capture_audio:
-                if (permissionGranted) {
-                    intent = new Intent(RECORD_SOUND_ACTION);
-                    intent.putExtra(EXTRA_OUTPUT, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI.toString());
-                }
-                break;
-            case R.id.choose_sound:
-
-                /* We aren't checking for storage permissions as without that permission
-                 * FormEntryActivity cannot be started */
-
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("audio/*");
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -12,6 +12,7 @@ import android.widget.Button;
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.FileUtil;
@@ -22,6 +23,7 @@ import java.io.File;
 
 import static android.provider.MediaStore.Audio.Media.RECORD_SOUND_ACTION;
 import static android.provider.MediaStore.EXTRA_OUTPUT;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -108,5 +110,23 @@ public class AudioWidgetTest extends FileWidgetTest<AudioWidget> {
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.capture_audio);
+        assertActionEquals(MediaStore.Audio.Media.RECORD_SOUND_ACTION, intent);
+
+        intent = getIntentLaunchedByClick(R.id.choose_sound);
+        assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.capture_audio));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -10,9 +10,12 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.ScannerWithFlashlightActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
+
+import static org.junit.Assert.assertNull;
 
 /**
  * @author James Knight
@@ -66,5 +69,20 @@ public class BarcodeWidgetTest extends BinaryWidgetTest<BarcodeWidget, StringDat
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, ScannerWithFlashlightActivity.class, intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.simple_button));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -2,9 +2,6 @@ package org.odk.collect.android.widgets;
 
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.widget.Button;
-
-import com.google.zxing.integration.android.IntentIntegrator;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -51,24 +48,6 @@ public class BarcodeWidgetTest extends BinaryWidgetTest<BarcodeWidget, StringDat
     public void setUp() throws Exception {
         super.setUp();
         barcodeData = RandomString.make();
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-        switch (clickedButton.getId()) {
-            case R.id.simple_button:
-                if (permissionGranted) {
-                    intent = new IntentIntegrator(activity)
-                            .setCaptureActivity(ScannerWithFlashlightActivity.class)
-                            .setDesiredBarcodeFormats(IntentIntegrator.ALL_CODE_TYPES)
-                            .setOrientationLocked(false)
-                            .setPrompt(activity.getString(R.string.barcode_scanner_prompt))
-                            .createScanIntent();
-                }
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -1,13 +1,18 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
+
+import com.google.zxing.integration.android.IntentIntegrator;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.ScannerWithFlashlightActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 /**
  * @author James Knight
@@ -20,7 +25,7 @@ public class BarcodeWidgetTest extends BinaryWidgetTest<BarcodeWidget, StringDat
     @NonNull
     @Override
     public BarcodeWidget createWidget() {
-        return new BarcodeWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new BarcodeWidget(activity, formEntryPrompt);
     }
 
     @Override
@@ -43,5 +48,23 @@ public class BarcodeWidgetTest extends BinaryWidgetTest<BarcodeWidget, StringDat
     public void setUp() throws Exception {
         super.setUp();
         barcodeData = RandomString.make();
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+        switch (clickedButton.getId()) {
+            case R.id.simple_button:
+                if (permissionGranted) {
+                    intent = new IntentIntegrator(activity)
+                            .setCaptureActivity(ScannerWithFlashlightActivity.class)
+                            .setDesiredBarcodeFormats(IntentIntegrator.ALL_CODE_TYPES)
+                            .setOrientationLocked(false)
+                            .setPrompt(activity.getString(R.string.barcode_scanner_prompt))
+                            .createScanIntent();
+                }
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
@@ -1,8 +1,6 @@
 package org.odk.collect.android.widgets;
 
-import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -43,11 +41,5 @@ public class BearingWidgetTest extends BinaryWidgetTest<BearingWidget, StringDat
     public void setUp() throws Exception {
         super.setUp();
         barcodeData = RandomString.make();
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        // TODO: mock availability of sensors and return a valid intent
-        return null;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
@@ -1,13 +1,14 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 /**
  * @author James Knight
@@ -19,7 +20,7 @@ public class BearingWidgetTest extends BinaryWidgetTest<BearingWidget, StringDat
     @NonNull
     @Override
     public BearingWidget createWidget() {
-        return new BearingWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new BearingWidget(activity, formEntryPrompt);
     }
 
     @Override
@@ -42,5 +43,11 @@ public class BearingWidgetTest extends BinaryWidgetTest<BearingWidget, StringDat
     public void setUp() throws Exception {
         super.setUp();
         barcodeData = RandomString.make();
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        // TODO: mock availability of sensors and return a valid intent
+        return null;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -1,9 +1,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -14,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 import org.robolectric.RobolectricTestRunner;
 
@@ -61,19 +58,6 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
 
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-        switch (clickedButton.getId()) {
-            case R.id.simple_button:
-                intent = new Intent(activity, DrawActivity.class);
-                intent.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_DRAW);
-                intent.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -9,6 +9,7 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
@@ -73,5 +74,14 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_DRAW, intent);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -1,6 +1,9 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -8,9 +11,11 @@ import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.DrawActivity;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
@@ -30,7 +35,7 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
     @NonNull
     @Override
     public DrawWidget createWidget() {
-        return new DrawWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new DrawWidget(activity, formEntryPrompt);
     }
 
     @NonNull
@@ -55,5 +60,18 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
 
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+        switch (clickedButton.getId()) {
+            case R.id.simple_button:
+                intent = new Intent(activity, DrawActivity.class);
+                intent.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_DRAW);
+                intent.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
@@ -1,20 +1,29 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.GeoPointData;
 import org.junit.Before;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
+import org.odk.collect.android.ShadowPlayServicesUtil;
+import org.odk.collect.android.activities.GeoPointMapActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.GeoPointWidget.ACCURACY_THRESHOLD;
+import static org.odk.collect.android.widgets.GeoPointWidget.DRAGGABLE_ONLY;
+import static org.odk.collect.android.widgets.GeoPointWidget.READ_ONLY;
 
 /**
  * @author James Knight
  */
 
+@Config(shadows = {ShadowPlayServicesUtil.class})
 public class GeoPointWidgetTest extends BinaryWidgetTest<GeoPointWidget, GeoPointData> {
 
     @Mock
@@ -31,7 +40,7 @@ public class GeoPointWidgetTest extends BinaryWidgetTest<GeoPointWidget, GeoPoin
     @NonNull
     @Override
     public GeoPointWidget createWidget() {
-        return new GeoPointWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new GeoPointWidget(activity, formEntryPrompt);
     }
 
     @Override
@@ -82,5 +91,24 @@ public class GeoPointWidgetTest extends BinaryWidgetTest<GeoPointWidget, GeoPoin
         }
 
         return b.toString();
+    }
+
+    // todo: add more tests for different appearances
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+
+        switch (clickedButton.getId()) {
+            case R.id.get_point:
+            case R.id.get_location:
+                if (permissionGranted) {
+                    intent = new Intent(activity, GeoPointMapActivity.class);
+                    intent.putExtra(READ_ONLY, false);
+                    intent.putExtra(DRAGGABLE_ONLY, true);
+                    intent.putExtra(ACCURACY_THRESHOLD, 5.0);
+                }
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets;
 
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.GeoPointData;
@@ -12,15 +11,11 @@ import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
 import org.odk.collect.android.activities.GeoPointActivity;
-import org.odk.collect.android.activities.GeoPointMapActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.widgets.GeoPointWidget.ACCURACY_THRESHOLD;
-import static org.odk.collect.android.widgets.GeoPointWidget.DRAGGABLE_ONLY;
-import static org.odk.collect.android.widgets.GeoPointWidget.READ_ONLY;
 
 /**
  * @author James Knight
@@ -94,25 +89,6 @@ public class GeoPointWidgetTest extends BinaryWidgetTest<GeoPointWidget, GeoPoin
         }
 
         return b.toString();
-    }
-
-    // todo: add more tests for different appearances
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-
-        switch (clickedButton.getId()) {
-            case R.id.get_point:
-            case R.id.get_location:
-                if (permissionGranted) {
-                    intent = new Intent(activity, GeoPointMapActivity.class);
-                    intent.putExtra(READ_ONLY, false);
-                    intent.putExtra(DRAGGABLE_ONLY, true);
-                    intent.putExtra(ACCURACY_THRESHOLD, 5.0);
-                }
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
@@ -7,13 +7,16 @@ import android.widget.Button;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.GeoPointData;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
+import org.odk.collect.android.activities.GeoPointActivity;
 import org.odk.collect.android.activities.GeoPointMapActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.annotation.Config;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.widgets.GeoPointWidget.ACCURACY_THRESHOLD;
 import static org.odk.collect.android.widgets.GeoPointWidget.DRAGGABLE_ONLY;
@@ -110,5 +113,24 @@ public class GeoPointWidgetTest extends BinaryWidgetTest<GeoPointWidget, GeoPoin
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.get_point);
+        assertComponentEquals(activity, GeoPointActivity.class, intent);
+
+        intent = getIntentLaunchedByClick(R.id.get_location);
+        assertComponentEquals(activity, GeoPointActivity.class, intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.get_point));
+        assertNull(getIntentLaunchedByClick(R.id.get_location));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
@@ -1,22 +1,31 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.odk.collect.android.R;
+import org.odk.collect.android.ShadowPlayServicesUtil;
+import org.odk.collect.android.activities.GeoShapeActivity;
+import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.GeoShapeWidget.GOOGLE_MAP_KEY;
+import static org.odk.collect.android.widgets.GeoShapeWidget.SHAPE_LOCATION;
 
 /**
  * @author James Knight
  */
 
+@Config(shadows = {ShadowPlayServicesUtil.class})
 public class GeoShapeWidgetTest extends BinaryWidgetTest<GeoShapeWidget, StringData> {
 
     private ArrayList<double[]> initialDoubles;
@@ -30,7 +39,7 @@ public class GeoShapeWidgetTest extends BinaryWidgetTest<GeoShapeWidget, StringD
     @NonNull
     @Override
     public GeoShapeWidget createWidget() {
-        return new GeoShapeWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new GeoShapeWidget(activity, formEntryPrompt);
     }
 
     @Override
@@ -104,5 +113,21 @@ public class GeoShapeWidgetTest extends BinaryWidgetTest<GeoShapeWidget, StringD
         }
 
         return b.toString();
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+
+        switch (clickedButton.getId()) {
+            case R.id.simple_button:
+                if (permissionGranted) {
+                    intent = new Intent(activity, GeoShapeActivity.class);
+                    intent.putExtra(SHAPE_LOCATION, "");
+                    intent.putExtra(PreferenceKeys.KEY_MAP_SDK, GOOGLE_MAP_KEY);
+                }
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
@@ -7,6 +7,7 @@ import android.widget.Button;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
 import org.odk.collect.android.activities.GeoShapeActivity;
@@ -17,6 +18,7 @@ import org.robolectric.annotation.Config;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.widgets.GeoShapeWidget.GOOGLE_MAP_KEY;
 import static org.odk.collect.android.widgets.GeoShapeWidget.SHAPE_LOCATION;
@@ -129,5 +131,20 @@ public class GeoShapeWidgetTest extends BinaryWidgetTest<GeoShapeWidget, StringD
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, GeoShapeActivity.class, intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.simple_button));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
-import org.odk.collect.android.activities.GeoShapeActivity;
+import org.odk.collect.android.activities.GeoPolyActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.annotation.Config;
 
@@ -118,7 +118,7 @@ public class GeoShapeWidgetTest extends BinaryWidgetTest<GeoShapeWidget, StringD
         stubAllRuntimePermissionsGranted(true);
 
         Intent intent = getIntentLaunchedByClick(R.id.simple_button);
-        assertComponentEquals(activity, GeoShapeActivity.class, intent);
+        assertComponentEquals(activity, GeoPolyActivity.class, intent);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoShapeWidgetTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets;
 
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.StringData;
@@ -11,7 +10,6 @@ import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
 import org.odk.collect.android.activities.GeoShapeActivity;
-import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.annotation.Config;
 
@@ -20,8 +18,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.widgets.GeoShapeWidget.GOOGLE_MAP_KEY;
-import static org.odk.collect.android.widgets.GeoShapeWidget.SHAPE_LOCATION;
 
 /**
  * @author James Knight
@@ -115,22 +111,6 @@ public class GeoShapeWidgetTest extends BinaryWidgetTest<GeoShapeWidget, StringD
         }
 
         return b.toString();
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-
-        switch (clickedButton.getId()) {
-            case R.id.simple_button:
-                if (permissionGranted) {
-                    intent = new Intent(activity, GeoShapeActivity.class);
-                    intent.putExtra(SHAPE_LOCATION, "");
-                    intent.putExtra(PreferenceKeys.KEY_MAP_SDK, GOOGLE_MAP_KEY);
-                }
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
@@ -1,21 +1,30 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.odk.collect.android.R;
+import org.odk.collect.android.ShadowPlayServicesUtil;
+import org.odk.collect.android.activities.GeoTraceActivity;
+import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
-import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.GeoTraceWidget.GOOGLE_MAP_KEY;
+import static org.odk.collect.android.widgets.GeoTraceWidget.TRACE_LOCATION;
 
 /**
  * @author James Knight
  */
 
+@Config(shadows = {ShadowPlayServicesUtil.class})
 public class GeoTraceWidgetTest extends BinaryWidgetTest<GeoTraceWidget, StringData> {
 
     private List<double[]> initialDoubles;
@@ -29,7 +38,7 @@ public class GeoTraceWidgetTest extends BinaryWidgetTest<GeoTraceWidget, StringD
     @NonNull
     @Override
     public GeoTraceWidget createWidget() {
-        return new GeoTraceWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new GeoTraceWidget(activity, formEntryPrompt);
     }
 
     @Override
@@ -103,5 +112,20 @@ public class GeoTraceWidgetTest extends BinaryWidgetTest<GeoTraceWidget, StringD
         }
 
         return b.toString();
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+        switch (clickedButton.getId()) {
+            case R.id.simple_button:
+                if (permissionGranted) {
+                    intent = new Intent(activity, GeoTraceActivity.class);
+                    intent.putExtra(TRACE_LOCATION, "");
+                    intent.putExtra(PreferenceKeys.KEY_MAP_SDK, GOOGLE_MAP_KEY);
+                }
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
-import org.odk.collect.android.activities.GeoTraceActivity;
+import org.odk.collect.android.activities.GeoPolyActivity;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.annotation.Config;
 
@@ -117,7 +117,7 @@ public class GeoTraceWidgetTest extends BinaryWidgetTest<GeoTraceWidget, StringD
         stubAllRuntimePermissionsGranted(true);
 
         Intent intent = getIntentLaunchedByClick(R.id.simple_button);
-        assertComponentEquals(activity, GeoTraceActivity.class, intent);
+        assertComponentEquals(activity, GeoPolyActivity.class, intent);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
@@ -6,6 +6,7 @@ import android.widget.Button;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
 import org.odk.collect.android.activities.GeoTraceActivity;
@@ -16,6 +17,7 @@ import org.robolectric.annotation.Config;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.widgets.GeoTraceWidget.GOOGLE_MAP_KEY;
 import static org.odk.collect.android.widgets.GeoTraceWidget.TRACE_LOCATION;
@@ -127,5 +129,20 @@ public class GeoTraceWidgetTest extends BinaryWidgetTest<GeoTraceWidget, StringD
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, GeoTraceActivity.class, intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.simple_button));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoTraceWidgetTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets;
 
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
@@ -10,7 +9,6 @@ import org.junit.Test;
 import org.odk.collect.android.R;
 import org.odk.collect.android.ShadowPlayServicesUtil;
 import org.odk.collect.android.activities.GeoTraceActivity;
-import org.odk.collect.android.preferences.PreferenceKeys;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 import org.robolectric.annotation.Config;
 
@@ -19,8 +17,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.widgets.GeoTraceWidget.GOOGLE_MAP_KEY;
-import static org.odk.collect.android.widgets.GeoTraceWidget.TRACE_LOCATION;
 
 /**
  * @author James Knight
@@ -114,21 +110,6 @@ public class GeoTraceWidgetTest extends BinaryWidgetTest<GeoTraceWidget, StringD
         }
 
         return b.toString();
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-        switch (clickedButton.getId()) {
-            case R.id.simple_button:
-                if (permissionGranted) {
-                    intent = new Intent(activity, GeoTraceActivity.class);
-                    intent.putExtra(TRACE_LOCATION, "");
-                    intent.putExtra(PreferenceKeys.KEY_MAP_SDK, GOOGLE_MAP_KEY);
-                }
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -1,14 +1,16 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
@@ -27,7 +29,7 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
     @NonNull
     @Override
     public ImageWidget createWidget() {
-        return new ImageWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new ImageWidget(activity, formEntryPrompt);
     }
 
     @NonNull
@@ -53,5 +55,24 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
 
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
+    }
+
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+
+        switch (clickedButton.getId()) {
+            case R.id.capture_image:
+                if (permissionGranted) {
+                    intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
+                }
+                break;
+            case R.id.choose_image:
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("image/*");
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -6,7 +6,6 @@ import android.provider.MediaStore;
 import android.content.Intent;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -63,24 +62,6 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
 
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-
-        switch (clickedButton.getId()) {
-            case R.id.capture_image:
-                if (permissionGranted) {
-                    intent = new Intent(android.provider.MediaStore.ACTION_IMAGE_CAPTURE);
-                }
-                break;
-            case R.id.choose_image:
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("image/*");
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -1,6 +1,9 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Intent;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.widget.Button;
 
@@ -9,6 +12,8 @@ import net.bytebuddy.utility.RandomString;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.R;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 
@@ -56,7 +61,6 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
     }
-
 
     @Override
     protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -1,9 +1,6 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Intent;
-import android.net.Uri;
-import android.provider.MediaStore;
-import android.content.Intent;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 
@@ -13,8 +10,6 @@ import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.R;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.content.Intent;
+import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.widget.Button;
 
@@ -11,6 +12,7 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
@@ -19,6 +21,7 @@ import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -78,5 +81,24 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.capture_image);
+        assertActionEquals(MediaStore.ACTION_IMAGE_CAPTURE, intent);
+
+        intent = getIntentLaunchedByClick(R.id.choose_image);
+        assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
+        assertTypeEquals("image/*", intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.capture_image));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -13,7 +13,9 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.osm.OSMTag;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
 import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
@@ -92,5 +94,13 @@ public class OSMWidgetTest extends BinaryWidgetTest<OSMWidget, StringData> {
         launchIntent.putExtra("FORM_FILE_NAME", "test");
         launchIntent.putStringArrayListExtra("TAG_KEYS", new ArrayList<>());
         return launchIntent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertActionEquals(Intent.ACTION_SEND, intent);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -1,6 +1,8 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import com.google.common.collect.ImmutableList;
 
@@ -12,11 +14,12 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.osm.OSMTag;
 import org.junit.Before;
 import org.mockito.Mock;
+import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
+import java.util.ArrayList;
 
 import static org.mockito.Mockito.when;
 
@@ -38,7 +41,7 @@ public class OSMWidgetTest extends BinaryWidgetTest<OSMWidget, StringData> {
     @NonNull
     @Override
     public OSMWidget createWidget() {
-        return new OSMWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new OSMWidget(activity, formEntryPrompt);
     }
 
     @NonNull
@@ -77,5 +80,17 @@ public class OSMWidgetTest extends BinaryWidgetTest<OSMWidget, StringData> {
         when(questionDef.getOsmTags()).thenReturn(ImmutableList.<OSMTag>of());
 
         fileName = RandomString.make();
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent launchIntent = new Intent(Intent.ACTION_SEND);
+        launchIntent.setType(CollectServerClient.getPlainTextMimeType());
+        launchIntent.putExtra("FORM_ID", "0");
+        launchIntent.putExtra("INSTANCE_ID", "");
+        launchIntent.putExtra("INSTANCE_DIR", instancePath.getParent());
+        launchIntent.putExtra("FORM_FILE_NAME", "test");
+        launchIntent.putStringArrayListExtra("TAG_KEYS", new ArrayList<>());
+        return launchIntent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.widgets;
 
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import com.google.common.collect.ImmutableList;
 
@@ -16,12 +15,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
-import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.base.BinaryWidgetTest;
 
 import java.io.File;
-import java.util.ArrayList;
 
 import static org.mockito.Mockito.when;
 
@@ -82,18 +79,6 @@ public class OSMWidgetTest extends BinaryWidgetTest<OSMWidget, StringData> {
         when(questionDef.getOsmTags()).thenReturn(ImmutableList.<OSMTag>of());
 
         fileName = RandomString.make();
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent launchIntent = new Intent(Intent.ACTION_SEND);
-        launchIntent.setType(CollectServerClient.getPlainTextMimeType());
-        launchIntent.putExtra("FORM_ID", "0");
-        launchIntent.putExtra("INSTANCE_ID", "");
-        launchIntent.putExtra("INSTANCE_DIR", instancePath.getParent());
-        launchIntent.putExtra("FORM_FILE_NAME", "test");
-        launchIntent.putStringArrayListExtra("TAG_KEYS", new ArrayList<>());
-        return launchIntent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -1,9 +1,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -13,7 +11,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
@@ -57,20 +54,6 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
     protected void prepareForSetAnswer() {
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-
-        switch (clickedButton.getId()) {
-            case R.id.simple_button:
-                intent = new Intent(activity, DrawActivity.class);
-                intent.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_SIGNATURE);
-                intent.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -1,14 +1,19 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.DrawActivity;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
@@ -27,7 +32,7 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
     @NonNull
     @Override
     public SignatureWidget createWidget() {
-        return new SignatureWidget(RuntimeEnvironment.application, formEntryPrompt);
+        return new SignatureWidget(activity, formEntryPrompt);
     }
 
     @NonNull
@@ -51,5 +56,19 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
     protected void prepareForSetAnswer() {
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(fileName);
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+
+        switch (clickedButton.getId()) {
+            case R.id.simple_button:
+                intent = new Intent(activity, DrawActivity.class);
+                intent.putExtra(DrawActivity.OPTION, DrawActivity.OPTION_SIGNATURE);
+                intent.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(Collect.TMPFILE_PATH)));
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -9,6 +9,7 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
@@ -70,5 +71,14 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_SIGNATURE, intent);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -10,6 +10,7 @@ import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.FileUtil;
@@ -18,6 +19,7 @@ import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -118,5 +120,28 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
                 break;
         }
         return intent;
+    }
+
+    @Test
+    public void buttonsShouldLaunchCorrectIntents() {
+        stubAllRuntimePermissionsGranted(true);
+
+        Intent intent = getIntentLaunchedByClick(R.id.capture_video);
+        assertActionEquals(MediaStore.ACTION_VIDEO_CAPTURE, intent);
+
+        intent = getIntentLaunchedByClick(R.id.choose_video);
+        assertActionEquals(Intent.ACTION_GET_CONTENT, intent);
+        assertTypeEquals("video/*", intent);
+
+        intent = getIntentLaunchedByClick(R.id.play_video);
+        assertActionEquals(Intent.ACTION_VIEW, intent);
+        assertTypeEquals("video/*", intent);
+    }
+
+    @Test
+    public void buttonsShouldNotLaunchIntentsWhenPermissionsDenied() {
+        stubAllRuntimePermissionsGranted(false);
+
+        assertNull(getIntentLaunchedByClick(R.id.capture_video));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -4,7 +4,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
-import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
@@ -97,29 +96,6 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
                 .thenReturn(file);
 
         when(file.getName()).thenReturn(destinationName);
-    }
-
-    @Override
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        Intent intent = null;
-        switch (clickedButton.getId()) {
-            case R.id.capture_video:
-                if (permissionGranted) {
-                    intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
-                    intent.putExtra(MediaStore.EXTRA_OUTPUT, MediaStore.Video.Media.EXTERNAL_CONTENT_URI.toString());
-                    intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1);
-                }
-                break;
-            case R.id.choose_video:
-                intent = new Intent(Intent.ACTION_GET_CONTENT);
-                intent.setType("video/*");
-                break;
-            case R.id.play_video:
-                intent = new Intent("android.intent.action.VIEW");
-                intent.setDataAndType(null, "video/*");
-                break;
-        }
-        return intent;
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -1,18 +1,20 @@
 package org.odk.collect.android.widgets;
 
+import android.content.Intent;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
+import android.widget.Button;
 
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.mockito.Mock;
+import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.MediaUtil;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
-import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
 
@@ -40,7 +42,7 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
     @NonNull
     @Override
     public VideoWidget createWidget() {
-        return new VideoWidget(RuntimeEnvironment.application, formEntryPrompt, fileUtil, mediaUtil);
+        return new VideoWidget(activity, formEntryPrompt, fileUtil, mediaUtil);
     }
 
     @NonNull
@@ -82,7 +84,7 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
         when(formEntryPrompt.isReadOnly()).thenReturn(false);
 
         when(mediaUtil.getPathFromUri(
-                RuntimeEnvironment.application,
+                activity,
                 uri,
                 MediaStore.Video.Media.DATA)
 
@@ -93,5 +95,28 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
                 .thenReturn(file);
 
         when(file.getName()).thenReturn(destinationName);
+    }
+
+    @Override
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        Intent intent = null;
+        switch (clickedButton.getId()) {
+            case R.id.capture_video:
+                if (permissionGranted) {
+                    intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
+                    intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, MediaStore.Video.Media.EXTERNAL_CONTENT_URI.toString());
+                    intent.putExtra(android.provider.MediaStore.EXTRA_VIDEO_QUALITY, 1);
+                }
+                break;
+            case R.id.choose_video:
+                intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("video/*");
+                break;
+            case R.id.play_video:
+                intent = new Intent("android.intent.action.VIEW");
+                intent.setDataAndType(null, "video/*");
+                break;
+        }
+        return intent;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -103,9 +103,9 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
         switch (clickedButton.getId()) {
             case R.id.capture_video:
                 if (permissionGranted) {
-                    intent = new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE);
-                    intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, MediaStore.Video.Media.EXTERNAL_CONTENT_URI.toString());
-                    intent.putExtra(android.provider.MediaStore.EXTRA_VIDEO_QUALITY, 1);
+                    intent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
+                    intent.putExtra(MediaStore.EXTRA_OUTPUT, MediaStore.Video.Media.EXTERNAL_CONTENT_URI.toString());
+                    intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1);
                 }
                 break;
             case R.id.choose_video:

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/BinaryWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/BinaryWidgetTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
  * @author James Knight
  */
 public abstract class BinaryWidgetTest<W extends BinaryWidget, A extends IAnswerData>
-        extends QuestionWidgetTest<W, A> {
+        extends ButtonWidgetTest<W, A> {
 
     public abstract Object createBinaryData(A answerData);
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -4,19 +4,14 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
-import android.widget.Button;
 
 import org.javarosa.core.model.data.IAnswerData;
-import org.junit.Test;
 import org.odk.collect.android.fakes.FakePermissionUtils;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 import org.robolectric.shadow.api.Shadow;
-import org.robolectric.shadows.ShadowActivity;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.robolectric.Shadows.shadowOf;
 
 
@@ -35,106 +30,6 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
     protected void stubAllRuntimePermissionsGranted(boolean isGranted) {
         permissionUtils.setPermissionGranted(isGranted);
         ((QuestionWidget) getActualWidget()).setPermissionUtils(permissionUtils);
-    }
-
-    @Test
-    public void performButtonClickShouldLaunchIntentWhenPermissionGranted() {
-        stubAllRuntimePermissionsGranted(true);
-
-        runButtonClickTest(true);
-    }
-
-    @Test
-    public void performButtonClickShouldNotLaunchIntentWhenPermissionNotGranted() {
-        stubAllRuntimePermissionsGranted(false);
-
-        runButtonClickTest(false);
-    }
-
-    private void runButtonClickTest(boolean isPermissionGranted) {
-        for (Button button : getWidget().getSimpleButtonList()) {
-
-            // perform button click
-            button.performClick();
-
-            Intent expectedIntent = getExpectedIntent(button, isPermissionGranted);
-
-            // obtain launched intent
-            ShadowActivity shadowActivity = shadowOf(activity);
-            Intent startedIntent = shadowActivity.getNextStartedActivity();
-
-            // assert results
-            assertIntentEquals(expectedIntent, startedIntent);
-        }
-    }
-
-    /**
-     * Get the expected {@link Intent} from the widget which will be launched
-     *
-     * @param clickedButton     The button which was clicked
-     * @param permissionGranted Whether permission was granted while triggering the button
-     */
-    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
-    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
-        return null;
-    }
-
-    /**
-     * Things to be asserted:
-     * <p>
-     * 1. If a permission is required before triggering activity, then the intent should only be
-     * launched if the permissions are granted, otherwise not.
-     * <p>
-     * 2. Assert that the triggered intent has expected COMPONENT, ACTION, EXTRAS and TYPE
-     */
-    private void assertIntentEquals(Intent expectedIntent, Intent launchedIntent) {
-
-        if (expectedIntent == null && launchedIntent == null) {
-            return;
-        }
-
-        assertNotNull(expectedIntent);
-        assertNotNull(launchedIntent);
-
-        assertEquals(expectedIntent.getPackage(), launchedIntent.getPackage());
-        assertEquals(expectedIntent.getClass(), launchedIntent.getClass());
-        assertEquals(expectedIntent.getAction(), launchedIntent.getAction());
-        assertEquals(expectedIntent.getType(), launchedIntent.getType());
-        assertBundleEquals(expectedIntent.getExtras(), launchedIntent.getExtras());
-    }
-
-    /**
-     * Asserts that both bundles are similar
-     */
-    private void assertBundleEquals(Bundle expectedBundle, Bundle actualBundle) {
-        // check if both are null
-        if (expectedBundle == null && actualBundle == null) {
-            return;
-        }
-
-        // assert if both are not null and have same number of extras
-        assertNotNull(expectedBundle);
-        assertNotNull(actualBundle);
-        assertEquals(expectedBundle.size(), actualBundle.size());
-
-        // assert that (key, value) pair is in both bundles
-        for (String expectedKey : expectedBundle.keySet()) {
-            Object expectedValue = expectedBundle.get(expectedKey);
-            Object actualValue = actualBundle.get(expectedKey);
-
-            /*
-             * Iterate through each value if value is an int array
-             *
-             * Required because of {@link AlignedImageWidget#DIMENSIONS_EXTRA}
-             */
-            if (expectedValue instanceof int[]) {
-                for (int i = 0; i < ((int[]) expectedValue).length; i++) {
-                    assertEquals(((int[]) expectedValue)[i], ((int[]) actualValue)[i]);
-                }
-            } else {
-                assertEquals("Value mismatch for extra key: " + expectedKey + "\n", expectedValue, actualValue);
-            }
-        }
     }
 
     protected Intent getIntentLaunchedByClick(int buttonId) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -129,7 +129,7 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
                     assertEquals(((int[]) expectedValue)[i], ((int[]) actualValue)[i]);
                 }
             } else {
-                assertEquals(expectedValue, actualValue);
+                assertEquals("Value mismatch for extra key: " + expectedKey + "\n", expectedValue, actualValue);
             }
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -82,7 +82,7 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
      * 1. If a permission is required before triggering activity, then the intent should only be
      * launched if the permissions are granted, otherwise not.
      * <p>
-     * 2. Assert that the triggered intent has expected ACTION, EXTRAS and TYPE
+     * 2. Assert that the triggered intent has expected COMPONENT, ACTION, EXTRAS and TYPE
      */
     private void assertIntentEquals(Intent expectedIntent, Intent launchedIntent) {
 
@@ -92,6 +92,9 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
 
         assertNotNull(expectedIntent);
         assertNotNull(launchedIntent);
+
+        assertEquals(expectedIntent.getPackage(), launchedIntent.getPackage());
+        assertEquals(expectedIntent.getClass(), launchedIntent.getClass());
         assertEquals(expectedIntent.getAction(), launchedIntent.getAction());
         assertEquals(expectedIntent.getType(), launchedIntent.getType());
         assertBundleEquals(expectedIntent.getExtras(), launchedIntent.getExtras());
@@ -111,12 +114,23 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
         assertNotNull(actualBundle);
         assertEquals(expectedBundle.size(), actualBundle.size());
 
+        // assert that (key, value) pair is in both bundles
         for (String expectedKey : expectedBundle.keySet()) {
             Object expectedValue = expectedBundle.get(expectedKey);
             Object actualValue = actualBundle.get(expectedKey);
 
-            // assert that (key, value) pair is in both bundles
-            assertEquals(expectedValue, actualValue);
+            /*
+             * Iterate through each value if value is an int array
+             *
+             * Required because of {@link AlignedImageWidget#DIMENSIONS_EXTRA}
+             */
+            if (expectedValue instanceof int[]) {
+                for (int i = 0; i < ((int[]) expectedValue).length; i++) {
+                    assertEquals(((int[]) expectedValue)[i], ((int[]) actualValue)[i]);
+                }
+            } else {
+                assertEquals(expectedValue, actualValue);
+            }
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android.widgets.base;
 
-import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -9,7 +8,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.odk.collect.android.fakes.FakePermissionUtils;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
-import org.robolectric.shadow.api.Shadow;
 
 import static org.junit.Assert.assertEquals;
 import static org.robolectric.Shadows.shadowOf;
@@ -24,7 +22,7 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
     private final FakePermissionUtils permissionUtils;
 
     ButtonWidgetTest() {
-        permissionUtils = new FakePermissionUtils(Shadow.newInstanceOf(Activity.class));
+        permissionUtils = new FakePermissionUtils();
     }
 
     protected void stubAllRuntimePermissionsGranted(boolean isGranted) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -1,6 +1,8 @@
 package org.odk.collect.android.widgets.base;
 
 import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
@@ -30,7 +32,7 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
         permissionUtils = new FakePermissionUtils(Shadow.newInstanceOf(Activity.class));
     }
 
-    private void stubAllRuntimePermissionsGranted(boolean isGranted) {
+    protected void stubAllRuntimePermissionsGranted(boolean isGranted) {
         permissionUtils.setPermissionGranted(isGranted);
         ((QuestionWidget) getActualWidget()).setPermissionUtils(permissionUtils);
     }
@@ -69,7 +71,7 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
     /**
      * Get the expected {@link Intent} from the widget which will be launched
      *
-     *  @param clickedButton     The button which was clicked
+     * @param clickedButton     The button which was clicked
      * @param permissionGranted Whether permission was granted while triggering the button
      */
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
@@ -133,5 +135,30 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
                 assertEquals("Value mismatch for extra key: " + expectedKey + "\n", expectedValue, actualValue);
             }
         }
+    }
+
+    protected Intent getIntentLaunchedByClick(int buttonId) {
+        ((QuestionWidget) getWidget()).findViewById(buttonId).performClick();
+        return shadowOf(activity).getNextStartedActivity();
+    }
+
+    protected void assertComponentEquals(String pkg, String cls, Intent intent) {
+        assertEquals(new ComponentName(pkg, cls), intent.getComponent());
+    }
+
+    protected void assertComponentEquals(Context context, Class<?> cls, Intent intent) {
+        assertEquals(new ComponentName(context, cls), intent.getComponent());
+    }
+
+    protected void assertActionEquals(String expectedAction, Intent intent) {
+        assertEquals(expectedAction, intent.getAction());
+    }
+
+    protected void assertTypeEquals(String type, Intent intent) {
+        assertEquals(type, intent.getType());
+    }
+
+    protected void assertExtraEquals(String key, Object value, Intent intent) {
+        assertEquals(intent.getExtras().get(key), value);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -7,7 +7,7 @@ import android.widget.Button;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
-import org.odk.collect.android.mocks.MockedPermissionUtils;
+import org.odk.collect.android.fakes.FakePermissionUtils;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 import org.robolectric.shadow.api.Shadow;
@@ -24,10 +24,10 @@ import static org.robolectric.Shadows.shadowOf;
 public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswerData>
         extends QuestionWidgetTest<W, A> {
 
-    private final MockedPermissionUtils permissionUtils;
+    private final FakePermissionUtils permissionUtils;
 
     ButtonWidgetTest() {
-        permissionUtils = new MockedPermissionUtils(Shadow.newInstanceOf(Activity.class));
+        permissionUtils = new FakePermissionUtils(Shadow.newInstanceOf(Activity.class));
     }
 
     private void stubAllRuntimePermissionsGranted(boolean isGranted) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -1,10 +1,21 @@
 package org.odk.collect.android.widgets.base;
 
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
 import android.widget.Button;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.junit.Test;
+import org.odk.collect.android.mocks.MockedPermissionUtils;
+import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowActivity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.robolectric.Shadows.shadowOf;
 
 
 /**
@@ -13,16 +24,99 @@ import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswerData>
         extends QuestionWidgetTest<W, A> {
 
+    private final MockedPermissionUtils permissionUtils;
+
+    ButtonWidgetTest() {
+        permissionUtils = new MockedPermissionUtils(Shadow.newInstanceOf(Activity.class));
+    }
+
+    private void stubAllRuntimePermissionsGranted(boolean isGranted) {
+        permissionUtils.setPermissionGranted(isGranted);
+        ((QuestionWidget) getActualWidget()).setPermissionUtils(permissionUtils);
+    }
+
     @Test
-    public void performButtonClickShouldLaunchIntent() {
+    public void performButtonClickShouldLaunchIntentWhenPermissionGranted() {
+        stubAllRuntimePermissionsGranted(true);
+
+        runButtonClickTest(true);
+    }
+
+    @Test
+    public void performButtonClickShouldNotLaunchIntentWhenPermissionNotGranted() {
+        stubAllRuntimePermissionsGranted(false);
+
+        runButtonClickTest(false);
+    }
+
+    private void runButtonClickTest(boolean isPermissionGranted) {
         for (Button button : getWidget().getSimpleButtonList()) {
+
+            // perform button click
             button.performClick();
-            buttonClicked(button);
+
+            Intent expectedIntent = getExpectedIntent(button, isPermissionGranted);
+
+            // obtain launched intent
+            ShadowActivity shadowActivity = shadowOf(activity);
+            Intent startedIntent = shadowActivity.getNextStartedActivity();
+
+            // assert results
+            assertIntentEquals(expectedIntent, startedIntent);
         }
     }
 
-    public void buttonClicked(Button button) {
-
+    /**
+     * Get the expected {@link Intent} from the widget which will be launched
+     *
+     *  @param clickedButton     The button which was clicked
+     * @param permissionGranted Whether permission was granted while triggering the button
+     */
+    protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
+        return null;
     }
 
+    /**
+     * Things to be asserted:
+     * <p>
+     * 1. If a permission is required before triggering activity, then the intent should only be
+     * launched if the permissions are granted, otherwise not.
+     * <p>
+     * 2. Assert that the triggered intent has expected ACTION, EXTRAS and TYPE
+     */
+    private void assertIntentEquals(Intent expectedIntent, Intent launchedIntent) {
+
+        if (expectedIntent == null && launchedIntent == null) {
+            return;
+        }
+
+        assertNotNull(expectedIntent);
+        assertNotNull(launchedIntent);
+        assertEquals(expectedIntent.getAction(), launchedIntent.getAction());
+        assertEquals(expectedIntent.getType(), launchedIntent.getType());
+        assertBundleEquals(expectedIntent.getExtras(), launchedIntent.getExtras());
+    }
+
+    /**
+     * Asserts that both bundles are similar
+     */
+    private void assertBundleEquals(Bundle expectedBundle, Bundle actualBundle) {
+        // check if both are null
+        if (expectedBundle == null && actualBundle == null) {
+            return;
+        }
+
+        // assert if both are not null and have same number of extras
+        assertNotNull(expectedBundle);
+        assertNotNull(actualBundle);
+        assertEquals(expectedBundle.size(), actualBundle.size());
+
+        for (String expectedKey : expectedBundle.keySet()) {
+            Object expectedValue = expectedBundle.get(expectedKey);
+            Object actualValue = actualBundle.get(expectedKey);
+
+            // assert that (key, value) pair is in both bundles
+            assertEquals(expectedValue, actualValue);
+        }
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -72,6 +72,7 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
      *  @param clickedButton     The button which was clicked
      * @param permissionGranted Whether permission was granted while triggering the button
      */
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     protected Intent getExpectedIntent(Button clickedButton, boolean permissionGranted) {
         return null;
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -1,0 +1,28 @@
+package org.odk.collect.android.widgets.base;
+
+import android.widget.Button;
+
+import org.javarosa.core.model.data.IAnswerData;
+import org.junit.Test;
+import org.odk.collect.android.widgets.interfaces.ButtonWidget;
+
+
+/**
+ * @author Shobhit Agarwal
+ */
+public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswerData>
+        extends QuestionWidgetTest<W, A> {
+
+    @Test
+    public void performButtonClickShouldLaunchIntent() {
+        for (Button button : getWidget().getSimpleButtonList()) {
+            button.performClick();
+            buttonClicked(button);
+        }
+    }
+
+    public void buttonClicked(Button button) {
+
+    }
+
+}

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.widgets.base;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 
 import org.javarosa.core.model.FormIndex;
@@ -11,6 +12,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.ItemsetWidgetTest;
 import org.odk.collect.android.widgets.interfaces.Widget;
+import org.robolectric.Robolectric;
 
 import java.util.Random;
 
@@ -24,6 +26,7 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
         extends WidgetTest {
 
     protected Random random = new Random();
+    protected Activity activity = Robolectric.setupActivity(Activity.class);
     private W widget;
     private W actualWidget;
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
@@ -25,6 +25,7 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
 
     protected Random random = new Random();
     private W widget;
+    private W actualWidget;
 
     @Mock
     public FormIndex formIndex;
@@ -42,9 +43,28 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
         return getNextAnswer();
     }
 
+    /**
+     * @return Real {@link Widget} object if present otherwise creates one
+     * <p>
+     * This should be used for mutating the {@link org.odk.collect.android.widgets.QuestionWidget}
+     */
+    public W getActualWidget() {
+        if (actualWidget == null) {
+            actualWidget = createWidget();
+        }
+
+        return actualWidget;
+    }
+
+    /**
+     * @return {@link org.mockito.Spy} of the {@link #actualWidget}
+     * <p>
+     * This should be unless we want to mutate {@link org.odk.collect.android.widgets.QuestionWidget}
+     * This is because a spy is not the real object and changing it won't have any effect on the real object
+     */
     public W getWidget() {
         if (widget == null) {
-            widget = spy(createWidget());
+            widget = spy(getActualWidget());
         }
 
         return widget;


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Tried running the tests locally and verified that all are passing successfully

#### Why is this the best possible solution? Were any other approaches considered?
- I added an abstract class `ButtonWIdgetTest` and made `BinaryWidgetTest` extend it (since all binary widgets are by default button widgets). 
- Then using a mocked version of `PermissionUtils`, I added two tests in the `ButtonWidgetTest` to click the buttons when the permissions are granted and when permissions are not granted.
- Then I verified within each widget tests that the launched intent and the expected intent is equal

This is the only approach I considered but it would be good to understand if these tests can be structered in a better way

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I haven't changed any user side behavior. Possible risks include regression in the click behavior of buttons in widgets

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)