### PR TITLE
Fixed wrong default date in CopticWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CopticDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CopticDatePickerDialog.java
@@ -62,7 +62,7 @@ public class CopticDatePickerDialog extends CustomDatePickerDialog {
                 .toDateTime()
                 .withChronology(CopticChronology.getInstance())
                 .toLocalDateTime();
-        setUpDayPicker(copticDate.getDayOfMonth(), copticDate.monthOfYear().getMaximumValue());
+        setUpDayPicker(copticDate.getDayOfMonth(), copticDate.dayOfMonth().getMaximumValue());
         setUpMonthPicker(copticDate.getMonthOfYear(), monthsArray);
         setUpYearPicker(copticDate.getYear(), MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
     }


### PR DESCRIPTION
Closes #2747 

#### What has been done to verify that this works as intended?
I tested `Copic date widget` available in the `AllWidgets` form.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a bug fix. It doesn't affect anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
`AllWidgets` form is enough.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)