### PR TITLE
Fixed Bugs in SelectOne/SelectMultiple layouts

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -145,6 +146,8 @@ public abstract class SelectWidget extends QuestionWidget {
             imageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index),
                     FormEntryCaption.TEXT_FORM_IMAGE);
         }
+
+        textView.setGravity(Gravity.CENTER_VERTICAL);
 
         String videoURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "video");
         String bigImageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "big-image");

--- a/collect_app/src/main/res/layout/quick_select_layout.xml
+++ b/collect_app/src/main/res/layout/quick_select_layout.xml
@@ -1,27 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="horizontal">
 
     <org.odk.collect.android.views.MediaLayout
         android:id="@+id/mediaLayout"
         android:orientation="horizontal"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true" />
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"/>
 
     <ImageView
         android:id="@+id/auto_advance_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
+        android:layout_gravity="center_vertical"
         android:contentDescription="@string/select_answer"
         app:srcCompat="@drawable/expander_ic_right"/>
 
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
Closes #2752 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue and a form with media files: 
https://drive.google.com/file/d/1SRtrp3TobXyc49EzSDZLPdtBOPWEG6pL/view?usp=sharing

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pr just fixes two mentioned bugs and that's all. The risk here is related to all places where we use `MediaLayouts`:
- Select one/multiple widgets (options)
- Each widget label

sample (both rectangles are MediaLayouts):
![screenshot_2018-12-12-12-47-15](https://user-images.githubusercontent.com/3276264/49869667-5cd28600-fe11-11e8-96c3-dc65d40bb56c.png)

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)