### PR TITLE
Fix: Google Account Popup Opening Twice

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -85,7 +85,8 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
     private List<String> urlList;
     private Preference selectedGoogleAccountPreference;
     private GoogleAccountsManager accountsManager;
-
+    private boolean allowClickSelectedGoogleAccountPreference = true;            
+                
     @Inject
     CollectServerClient collectServerClient;
 
@@ -249,11 +250,14 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
 
         selectedGoogleAccountPreference.setSummary(accountsManager.getSelectedAccount());
         selectedGoogleAccountPreference.setOnPreferenceClickListener(preference -> {
+                if(allowClickSelectedGoogleAccountPreference){
+                allowClickSelectedGoogleAccountPreference = false;
             if (PlayServicesUtil.isGooglePlayServicesAvailable(getActivity())) {
                 accountsManager.chooseAccountAndRequestPermissionIfNeeded();
             } else {
                 PlayServicesUtil.showGooglePlayServicesAvailabilityErrorDialog(getActivity());
             }
+                }
             return true;
         });
     }
@@ -450,6 +454,7 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                     String accountName = data.getStringExtra(AccountManager.KEY_ACCOUNT_NAME);
                     accountsManager.setSelectedAccountName(accountName);
                 }
+                allowClickSelectedGoogleAccountPreference = true;
                 break;
         }
     }


### PR DESCRIPTION
Closes #2689

### What has been done to verify that this works as intended?

On click of the view i set enable to false. So this prevents further clicking of the view at once. Once the goole accounts dialog prompts up depending on whether the user clicks cancel or onselected account i re-enable the view by setting it to true

### Why is this the best possible solution? Were any other approaches considered?

This is more efficient i think so cause it immediately renders the view inactive... upon a click. Yes another approach could be use by setting a value true and listening on the click it event then toggle that value to false but that could be time consuming and additional block of code which would work but not so relevant.

### Do we need any specific form for testing your changes? If so, please attach one.

No just follow the steps on the issue and you no longer have the effect

### Does this change require updates to documentation? If so, please file an issue here and include the link below.
No. not in my knowledge though 😃
Before submitting this PR, please make sure you have:
- [x] -run ./gradlew checkAll and confirmed all checks still pass OR confirm CircleCI build passes and run ./gradlew connectedDebugAndroidTest locally.
- [x] -verified that any code or assets from external sources are properly credited in comments and/or in the about file.
- [x] - verified that any new UI elements use theme colors. UI Components Style guidelines
