### PR TITLE
Menu buttons for FormHierarchy

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1834,7 +1834,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * Creates a confirm/cancel dialog for deleting repeats.
      */
     private void createDeleteRepeatConfirmDialog() {
-        DialogUtils.createDeleteRepeatConfirmDialog(this, () -> {
+        DialogUtils.showDeleteRepeatConfirmDialog(this, () -> {
             showNextView();
         }, () -> {
             refreshCurrentView();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1834,39 +1834,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * Creates a confirm/cancel dialog for deleting repeats.
      */
     private void createDeleteRepeatConfirmDialog() {
-        FormController formController = getFormController();
-
-        alertDialog = new AlertDialog.Builder(this).create();
-        String name = formController.getLastRepeatedGroupName();
-        int repeatcount = formController.getLastRepeatedGroupRepeatCount();
-        if (repeatcount != -1) {
-            name += " (" + (repeatcount + 1) + ")";
-        }
-        alertDialog.setTitle(getString(R.string.delete_repeat_ask));
-        alertDialog
-                .setMessage(getString(R.string.delete_repeat_confirm, name));
-        DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int i) {
-                FormController formController = getFormController();
-                switch (i) {
-                    case BUTTON_POSITIVE: // yes
-                        formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, null, true);
-                        formController.deleteRepeat();
-                        showNextView();
-                        break;
-
-                    case BUTTON_NEGATIVE: // no
-                        refreshCurrentView();
-                        break;
-                }
-            }
-        };
-        alertDialog.setCancelable(false);
-        alertDialog.setButton(BUTTON_POSITIVE, getString(R.string.discard_group), quitListener);
-        alertDialog.setButton(BUTTON_NEGATIVE, getString(R.string.delete_repeat_no),
-                quitListener);
-        alertDialog.show();
+        DialogUtils.createDeleteRepeatConfirmDialog(this, () -> {
+            showNextView();
+        }, () -> {
+            refreshCurrentView();
+        });
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -349,12 +349,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Return the index of the "prompt" to add a new child to the given repeat group.
+     * Return the index of the "prompt" to add a new child to the given repeat group,
+     * without changing the current index.
      */
     private FormIndex getRepeatPromptIndex(FormIndex repeatIndex) {
         FormController formController = Collect.getInstance().getFormController();
         FormIndex originalIndex = formController.getFormIndex();
 
+        // Temporarily jump to the specified repeat group.
         formController.jumpToIndex(repeatIndex);
         String repeatRef = getGroupRef(repeatIndex).toString(false);
         String testRef = "";

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -216,7 +216,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         }
 
         FormController formController = Collect.getInstance().getFormController();
-        boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();
+        FormIndex currIndex = formController.getFormIndex();
+        boolean isAtBeginning = currIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
         boolean isInRepeat = !isAtBeginning && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -249,7 +249,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_delete_child:
-                DialogUtils.createDeleteRepeatConfirmDialog(this, () -> {
+                DialogUtils.showDeleteRepeatConfirmDialog(this, () -> {
                     goUpLevel();
                 }, null);
                 return true;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -216,8 +216,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         }
 
         FormController formController = Collect.getInstance().getFormController();
-        FormIndex currIndex = formController.getFormIndex();
-        boolean isAtBeginning = currIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
+        boolean isAtBeginning = screenIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
         boolean isInRepeat = !isAtBeginning && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
 
@@ -227,7 +226,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         boolean shouldShowAdd = shouldShowPicker;
         showAddButton(shouldShowAdd);
 
-        boolean shouldShowGoUp = !isAtBeginning || shouldShowPicker;
+        boolean shouldShowGoUp = !isAtBeginning;
         showGoUpButton(shouldShowGoUp);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -212,8 +212,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         // Not ready yet. Menu will be updated automatically once it's been prepared.
         if (optionsMenu == null) return;
 
+        FormController formController = Collect.getInstance().getFormController();
+        boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();
+
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
         optionsMenu.findItem(R.id.menu_add_child).setVisible(shouldShowPicker).setEnabled(shouldShowPicker);
+
+        boolean shouldShowGoUp = shouldShowPicker || !isAtBeginning;
+        optionsMenu.findItem(R.id.menu_go_up).setVisible(shouldShowGoUp).setEnabled(shouldShowGoUp);
     }
 
     @Override
@@ -222,6 +228,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             case R.id.menu_add_child:
                 FormIndex repeatPromptIndex = getRepeatPromptIndex(repeatGroupPickerIndex);
                 exitToIndex(repeatPromptIndex);
+                return true;
+
+            case R.id.menu_go_up:
+                goUpLevel();
                 return true;
 
             default:

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -407,12 +407,13 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         // There may be nested repeat groups within this group; skip over those.
         while (!repeatRef.equals(testRef)) {
-            if (formController.getEvent() == FormEntryController.EVENT_END_OF_FORM) {
+            int event = formController.stepToNextEventType(FormEntryController.EVENT_PROMPT_NEW_REPEAT);
+
+            if (event == FormEntryController.EVENT_END_OF_FORM) {
                 Timber.w("Failed to find repeat prompt, got end of form instead.");
                 break;
             }
 
-            formController.stepToNextEventType(FormEntryController.EVENT_PROMPT_NEW_REPEAT);
             testRef = getGroupRef(formController.getFormIndex()).toString(false);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -218,7 +218,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
-        boolean isInRepeat = !isAtBeginning && screenIndex != null && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
+        boolean isInRepeat = !isAtBeginning && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
 
         boolean shouldShowDelete = isInRepeat && !shouldShowPicker;
         showDeleteButton(shouldShowDelete);
@@ -409,14 +409,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             screenIndex = potentialStartIndex;
 
-            if (potentialStartIndex == null) {
-                // check to see if the question is at the first level of the hierarchy. If it
-                // is, display the root level from the beginning.
-                formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
-            } else {
-                // otherwise we're at a displayable group
-                formController.jumpToIndex(potentialStartIndex);
+            // Check to see if the question is at the first level of the hierarchy.
+            // If it is, display the root level from the beginning.
+            // Otherwise we're at a displayable group.
+            if (screenIndex == null) {
+                screenIndex = FormIndex.createBeginningOfFormIndex();
             }
+
+            formController.jumpToIndex(screenIndex);
 
             // Now test again. This should be true at this point or we're at the beginning.
             if (formController.isDisplayableGroup(formController.getFormIndex())) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -366,7 +366,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 break;
             }
 
-            formController.stepToNextEvent(FormEntryController.EVENT_PROMPT_NEW_REPEAT);
+            formController.stepToNextEventType(FormEntryController.EVENT_PROMPT_NEW_REPEAT);
             testRef = getGroupRef(formController.getFormIndex()).toString(false);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -215,14 +215,16 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();
-
-        boolean isInRepeat = !isAtBeginning && screenIndex != null && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
-        toggleDeleteButton(isInRepeat);
-
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
-        toggleAddButton(shouldShowPicker);
+        boolean isInRepeat = !isAtBeginning && screenIndex != null && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
 
-        boolean shouldShowGoUp = shouldShowPicker || !isAtBeginning;
+        boolean shouldShowDelete = isInRepeat && !shouldShowPicker;
+        toggleDeleteButton(shouldShowDelete);
+
+        boolean shouldShowAdd = shouldShowPicker;
+        toggleAddButton(shouldShowAdd);
+
+        boolean shouldShowGoUp = !isAtBeginning || shouldShowPicker;
         toggleGoUpButton(shouldShowGoUp);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -211,7 +211,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
     private void updateOptionsMenu() {
         // Not ready yet. Menu will be updated automatically once it's been prepared.
-        if (optionsMenu == null) return;
+        if (optionsMenu == null) {
+            return;
+        }
 
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -217,13 +217,28 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();
 
         boolean isInRepeat = !isAtBeginning && screenIndex != null && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
-        optionsMenu.findItem(R.id.menu_delete_child).setVisible(isInRepeat).setEnabled(isInRepeat);
+        toggleDeleteButton(isInRepeat);
 
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
-        optionsMenu.findItem(R.id.menu_add_child).setVisible(shouldShowPicker).setEnabled(shouldShowPicker);
+        toggleAddButton(shouldShowPicker);
 
         boolean shouldShowGoUp = shouldShowPicker || !isAtBeginning;
-        optionsMenu.findItem(R.id.menu_go_up).setVisible(shouldShowGoUp).setEnabled(shouldShowGoUp);
+        toggleGoUpButton(shouldShowGoUp);
+    }
+
+    /** Override to disable this button. */
+    protected void toggleDeleteButton(boolean isEnabled) {
+        optionsMenu.findItem(R.id.menu_delete_child).setVisible(isEnabled).setEnabled(isEnabled);
+    }
+
+    /** Override to disable this button. */
+    protected void toggleAddButton(boolean isEnabled) {
+        optionsMenu.findItem(R.id.menu_add_child).setVisible(isEnabled).setEnabled(isEnabled);
+    }
+
+    /** Override to disable this button. */
+    protected void toggleGoUpButton(boolean isEnabled) {
+        optionsMenu.findItem(R.id.menu_go_up).setVisible(isEnabled).setEnabled(isEnabled);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -40,6 +40,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.logic.HierarchyElement;
+import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.views.ODKView;
 
@@ -215,6 +216,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = formController.isCurrentQuestionFirstInForm() && !shouldShowRepeatGroupPicker();
 
+        boolean isInRepeat = !isAtBeginning && screenIndex != null && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
+        optionsMenu.findItem(R.id.menu_delete_child).setVisible(isInRepeat).setEnabled(isInRepeat);
+
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
         optionsMenu.findItem(R.id.menu_add_child).setVisible(shouldShowPicker).setEnabled(shouldShowPicker);
 
@@ -225,6 +229,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case R.id.menu_delete_child:
+                DialogUtils.createDeleteRepeatConfirmDialog(this, () -> {
+                    goUpLevel();
+                }, null);
+                return true;
+
             case R.id.menu_add_child:
                 FormIndex repeatPromptIndex = getRepeatPromptIndex(repeatGroupPickerIndex);
                 exitToIndex(repeatPromptIndex);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -23,6 +23,8 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -110,6 +112,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
      */
     private FormIndex screenIndex;
 
+    /**
+     * The toolbar menu.
+     */
+    private Menu optionsMenu;
+
     protected Button jumpPreviousButton;
     protected Button jumpBeginningButton;
     protected Button jumpEndButton;
@@ -183,6 +190,34 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private void restoreInstanceState(Bundle state) {
         if (state != null) {
             repeatGroupPickerIndex = (FormIndex) state.getSerializable(REPEAT_GROUP_PICKER_INDEX_KEY);
+        }
+    }
+
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.form_hierarchy_menu, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+
+        optionsMenu = menu;
+        updateOptionsMenu();
+
+        return true;
+    }
+
+    private void updateOptionsMenu() {
+        // Not ready yet. Menu will be updated automatically once it's been prepared.
+        if (optionsMenu == null) return;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            default:
+                return super.onOptionsItemSelected(item);
         }
     }
 
@@ -364,6 +399,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             elementsToDisplay = new ArrayList<>();
 
             jumpToHierarchyStartIndex();
+            updateOptionsMenu();
 
             int event = formController.getEvent();
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -305,11 +305,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             repeatGroupPickerIndex = null;
         } else {
             // Enter the picker if coming from a repeat group.
-            if (formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT) {
+            int event = formController.getEvent(screenIndex);
+            if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                 repeatGroupPickerIndex = screenIndex;
             }
 
-            Collect.getInstance().getFormController().stepToOuterScreenEvent();
+            formController.stepToOuterScreenEvent();
         }
 
         refreshView(true);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -30,6 +30,7 @@ import android.widget.TextView;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
+import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
@@ -219,15 +220,27 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         boolean isAtBeginning = screenIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
         boolean isInRepeat = !isAtBeginning && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
+        boolean isGroupSizeLocked = shouldShowPicker
+                ? isGroupSizeLocked(repeatGroupPickerIndex) : isGroupSizeLocked(screenIndex);
 
-        boolean shouldShowDelete = isInRepeat && !shouldShowPicker;
+        boolean shouldShowDelete = isInRepeat && !shouldShowPicker && !isGroupSizeLocked;
         showDeleteButton(shouldShowDelete);
 
-        boolean shouldShowAdd = shouldShowPicker;
+        boolean shouldShowAdd = shouldShowPicker && !isGroupSizeLocked;
         showAddButton(shouldShowAdd);
 
         boolean shouldShowGoUp = !isAtBeginning;
         showGoUpButton(shouldShowGoUp);
+    }
+
+    /**
+     * Returns true if the current index is a group that's designated as `noAddRemove`
+     * (e.g. if `jr:count` is explicitly set).
+     */
+    private boolean isGroupSizeLocked(FormIndex index) {
+        FormController formController = Collect.getInstance().getFormController();
+        IFormElement element = formController.getCaptionPrompt(index).getFormElement();
+        return element instanceof GroupDef && ((GroupDef) element).noAddRemove;
     }
 
     /** Override to disable this button. */

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -221,28 +221,28 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         boolean isInRepeat = !isAtBeginning && screenIndex != null && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
 
         boolean shouldShowDelete = isInRepeat && !shouldShowPicker;
-        toggleDeleteButton(shouldShowDelete);
+        showDeleteButton(shouldShowDelete);
 
         boolean shouldShowAdd = shouldShowPicker;
-        toggleAddButton(shouldShowAdd);
+        showAddButton(shouldShowAdd);
 
         boolean shouldShowGoUp = !isAtBeginning || shouldShowPicker;
-        toggleGoUpButton(shouldShowGoUp);
+        showGoUpButton(shouldShowGoUp);
     }
 
     /** Override to disable this button. */
-    protected void toggleDeleteButton(boolean isEnabled) {
-        optionsMenu.findItem(R.id.menu_delete_child).setVisible(isEnabled).setEnabled(isEnabled);
+    protected void showDeleteButton(boolean shouldShow) {
+        optionsMenu.findItem(R.id.menu_delete_child).setVisible(shouldShow);
     }
 
     /** Override to disable this button. */
-    protected void toggleAddButton(boolean isEnabled) {
-        optionsMenu.findItem(R.id.menu_add_child).setVisible(isEnabled).setEnabled(isEnabled);
+    protected void showAddButton(boolean shouldShow) {
+        optionsMenu.findItem(R.id.menu_add_child).setVisible(shouldShow);
     }
 
     /** Override to disable this button. */
-    protected void toggleGoUpButton(boolean isEnabled) {
-        optionsMenu.findItem(R.id.menu_go_up).setVisible(isEnabled).setEnabled(isEnabled);
+    protected void showGoUpButton(boolean shouldShow) {
+        optionsMenu.findItem(R.id.menu_go_up).setVisible(shouldShow);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ViewOnlyFormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ViewOnlyFormHierarchyActivity.java
@@ -47,12 +47,12 @@ public class ViewOnlyFormHierarchyActivity extends FormHierarchyActivity {
     }
 
     @Override
-    protected void toggleDeleteButton(boolean isEnabled) {
+    protected void showDeleteButton(boolean shouldShow) {
         // Disabled.
     }
 
     @Override
-    protected void toggleAddButton(boolean isEnabled) {
+    protected void showAddButton(boolean shouldShow) {
         // Disabled.
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ViewOnlyFormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ViewOnlyFormHierarchyActivity.java
@@ -46,6 +46,16 @@ public class ViewOnlyFormHierarchyActivity extends FormHierarchyActivity {
         jumpEndButton.setVisibility(View.GONE);
     }
 
+    @Override
+    protected void toggleDeleteButton(boolean isEnabled) {
+        // Disabled.
+    }
+
+    @Override
+    protected void toggleAddButton(boolean isEnabled) {
+        // Disabled.
+    }
+
     /**
      * Prevents the user from clicking on individual questions to jump into the form-filling view.
      */

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -644,9 +644,12 @@ public class FormController {
     public int stepToNextEvent(int eventType) {
         int event = getEvent();
         do {
-            if (event == FormEntryController.EVENT_END_OF_FORM) break;
+            if (event == FormEntryController.EVENT_END_OF_FORM) {
+                break;
+            }
             event = stepToNextEvent(FormController.STEP_OVER_GROUP);
         } while (event != eventType);
+
         return event;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -638,6 +638,19 @@ public class FormController {
     }
 
     /**
+     * Move the current form index to the next event of the given type
+     * (or the end if none is found).
+     */
+    public int stepToNextEvent(int eventType) {
+        int event = getEvent();
+        do {
+            if (event == FormEntryController.EVENT_END_OF_FORM) break;
+            event = stepToNextEvent(FormController.STEP_OVER_GROUP);
+        } while (event != eventType);
+        return event;
+    }
+
+    /**
      * Move the current form index to the index of the first displayable group
      * (that is, a repeatable group or a visible group),
      * or to the start of the form.

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -641,7 +641,7 @@ public class FormController {
      * Move the current form index to the next event of the given type
      * (or the end if none is found).
      */
-    public int stepToNextEvent(int eventType) {
+    public int stepToNextEventType(int eventType) {
         int event = getEvent();
         do {
             if (event == FormEntryController.EVENT_END_OF_FORM) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -85,9 +85,9 @@ public final class DialogUtils {
     }
 
     /**
-     * Creates a confirm/cancel dialog for deleting repeats.
+     * Shows a confirm/cancel dialog for deleting the current repeat group.
      */
-    public static void createDeleteRepeatConfirmDialog(Context context, Runnable onDeleted, Runnable onCanceled) {
+    public static void showDeleteRepeatConfirmDialog(Context context, Runnable onDeleted, Runnable onCanceled) {
         FormController formController = Collect.getInstance().getFormController();
         String name = formController.getLastRepeatedGroupName();
         int repeatcount = formController.getLastRepeatedGroupRepeatCount();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -103,12 +103,16 @@ public final class DialogUtils {
                     formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, null, true);
                     formController.deleteRepeat();
 
-                    if (onDeleted != null) onDeleted.run();
+                    if (onDeleted != null) {
+                        onDeleted.run();
+                    }
 
                     break;
 
                 case BUTTON_NEGATIVE: // no
-                    if (onCanceled != null) onCanceled.run();
+                    if (onCanceled != null) {
+                        onCanceled.run();
+                    }
 
                     break;
             }
@@ -152,16 +156,13 @@ public final class DialogUtils {
         AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertDialog.setMessage(errorMsg);
-        DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int i) {
-                switch (i) {
-                    case DialogInterface.BUTTON_POSITIVE:
-                        if (shouldExit) {
-                            activity.finish();
-                        }
-                        break;
-                }
+        DialogInterface.OnClickListener errorListener = (dialog, i) -> {
+            switch (i) {
+                case BUTTON_POSITIVE:
+                    if (shouldExit) {
+                        activity.finish();
+                    }
+                    break;
             }
         };
         alertDialog.setCancelable(false);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -28,7 +28,13 @@ import android.widget.ListView;
 
 import org.odk.collect.android.R;
 
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.AuditEvent;
+import org.odk.collect.android.logic.FormController;
 import timber.log.Timber;
+
+import static android.content.DialogInterface.BUTTON_NEGATIVE;
+import static android.content.DialogInterface.BUTTON_POSITIVE;
 
 /**
  * Reusable code between dialogs for keeping consistency
@@ -76,6 +82,41 @@ public final class DialogUtils {
         } catch (Exception e) {
             Timber.e(e);
         }
+    }
+
+    /**
+     * Creates a confirm/cancel dialog for deleting repeats.
+     */
+    public static void createDeleteRepeatConfirmDialog(Context context, Runnable onDeleted, Runnable onCanceled) {
+        FormController formController = Collect.getInstance().getFormController();
+        String name = formController.getLastRepeatedGroupName();
+        int repeatcount = formController.getLastRepeatedGroupRepeatCount();
+        if (repeatcount != -1) {
+            name += " (" + (repeatcount + 1) + ")";
+        }
+        android.support.v7.app.AlertDialog alertDialog = new android.support.v7.app.AlertDialog.Builder(context).create();
+        alertDialog.setTitle(context.getString(R.string.delete_repeat_ask));
+        alertDialog.setMessage(context.getString(R.string.delete_repeat_confirm, name));
+        DialogInterface.OnClickListener quitListener = (dialog, i) -> {
+            switch (i) {
+                case BUTTON_POSITIVE: // yes
+                    formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, null, true);
+                    formController.deleteRepeat();
+
+                    if (onDeleted != null) onDeleted.run();
+
+                    break;
+
+                case BUTTON_NEGATIVE: // no
+                    if (onCanceled != null) onCanceled.run();
+
+                    break;
+            }
+        };
+        alertDialog.setCancelable(false);
+        alertDialog.setButton(BUTTON_POSITIVE, context.getString(R.string.discard_group), quitListener);
+        alertDialog.setButton(BUTTON_NEGATIVE, context.getString(R.string.delete_repeat_no), quitListener);
+        alertDialog.show();
     }
 
     /**

--- a/collect_app/src/main/res/drawable/arrow_up.xml
+++ b/collect_app/src/main/res/drawable/arrow_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="120.0"
+    android:viewportHeight="120.0">
+    <path
+        android:fillColor="?iconColor"
+        android:pathData="M95 52.771a1.902 1.902 0 0 0-0.52-1.263L61.226 16.9a1.685 1.685 0 0 0-2.452 0L25.512 51.508a1.927 1.927 0 0 0-0.393 2.022c0.27 0.695 0.912 1.15 1.623 1.148h16.9v48.494c0 1.021 0.783 1.849 1.75 1.85h29.216c0.967-0.001 1.75-0.829 1.75-1.85L76.35 54.678h16.908a1.707 1.707 0 0 0 1.257-0.562 1.91 1.91 0 0 0 0.493-1.345H95z" />
+</vector>

--- a/collect_app/src/main/res/drawable/ic_add_circle.xml
+++ b/collect_app/src/main/res/drawable/ic_add_circle.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?iconColor"
         android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z" />
 </vector>

--- a/collect_app/src/main/res/drawable/ic_add_circle.xml
+++ b/collect_app/src/main/res/drawable/ic_add_circle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z" />
+</vector>

--- a/collect_app/src/main/res/drawable/ic_arrow_upward.xml
+++ b/collect_app/src/main/res/drawable/ic_arrow_upward.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="36dp"
-    android:height="36dp"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
-    <path
-        android:fillColor="?iconColor"
-        android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z" />
-</vector>

--- a/collect_app/src/main/res/drawable/ic_arrow_upward.xml
+++ b/collect_app/src/main/res/drawable/ic_arrow_upward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z" />
+</vector>

--- a/collect_app/src/main/res/drawable/ic_arrow_upward.xml
+++ b/collect_app/src/main/res/drawable/ic_arrow_upward.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="?iconColor"
         android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z" />
 </vector>

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2017 Shobhit Licensed under the Apache
+  License, Version 2.0 (the "License"); you may not use this file except in
+  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+  the specific language governing permissions and limitations under the License.
+-->
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+</menu>

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -13,6 +13,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/menu_delete_child"
+        android:icon="@drawable/ic_delete"
+        android:title="@string/delete_repeat"
+        android:visible="false"
+        app:showAsAction="always"/>
+
+    <item
         android:id="@+id/menu_add_child"
         android:icon="@drawable/ic_add_circle"
         android:title="@string/add_another_menu"

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -12,4 +12,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <item
+        android:id="@+id/menu_add_child"
+        android:icon="@drawable/ic_add_circle"
+        android:title="@string/add_another_menu"
+        android:visible="false"
+        app:showAsAction="always"/>
+
 </menu>

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -13,6 +13,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+            android:id="@+id/menu_go_up"
+            android:icon="@drawable/ic_arrow_upward"
+            android:title="@string/jump_to_previous"
+            android:visible="false"
+            app:showAsAction="always"/>
+
+    <item
         android:id="@+id/menu_delete_child"
         android:icon="@drawable/ic_delete"
         android:title="@string/delete_repeat"
@@ -23,13 +30,6 @@
         android:id="@+id/menu_add_child"
         android:icon="@drawable/ic_add_circle"
         android:title="@string/add_another_menu"
-        android:visible="false"
-        app:showAsAction="always"/>
-
-    <item
-        android:id="@+id/menu_go_up"
-        android:icon="@drawable/ic_arrow_upward"
-        android:title="@string/jump_to_previous"
         android:visible="false"
         app:showAsAction="always"/>
 

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -19,4 +19,11 @@
         android:visible="false"
         app:showAsAction="always"/>
 
+    <item
+        android:id="@+id/menu_go_up"
+        android:icon="@drawable/ic_arrow_upward"
+        android:title="@string/jump_to_previous"
+        android:visible="false"
+        app:showAsAction="always"/>
+
 </menu>

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -1,36 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  Copyright (C) 2017 Shobhit Licensed under the Apache
-  License, Version 2.0 (the "License"); you may not use this file except in
-  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-  Unless required by applicable law or agreed to in writing, software distributed
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
-  the specific language governing permissions and limitations under the License.
--->
 <menu
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-            android:id="@+id/menu_go_up"
-            android:icon="@drawable/arrow_up"
-            android:title="@string/jump_to_previous"
-            android:visible="false"
-            app:showAsAction="always"/>
+        android:id="@+id/menu_go_up"
+        android:icon="@drawable/arrow_up"
+        android:title="@string/jump_to_previous"
+        android:visible="false"
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_delete_child"
         android:icon="@drawable/ic_delete"
         android:title="@string/delete_repeat"
         android:visible="false"
-        app:showAsAction="always"/>
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_add_child"
         android:icon="@drawable/ic_add_circle"
         android:title="@string/add_another_menu"
         android:visible="false"
-        app:showAsAction="always"/>
+        app:showAsAction="always" />
 
 </menu>

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -14,7 +14,7 @@
 
     <item
             android:id="@+id/menu_go_up"
-            android:icon="@drawable/ic_arrow_upward"
+            android:icon="@drawable/arrow_up"
             android:title="@string/jump_to_previous"
             android:visible="false"
             app:showAsAction="always"/>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="view_video">View Video</string>
     <string name="choose_audio">Choose Audio</string>
     <string name="add_another">Add Group</string>
+    <string name="add_another_menu">Add another</string>
     <string name="add_another_repeat">Add another \"%s\" group?</string>
     <string name="add_repeat">Add a new \"%s\" group?</string>
     <string name="add_repeat_no">Do Not Add</string>


### PR DESCRIPTION
Implements menu buttons discussed in https://github.com/opendatakit/roadmap/issues/19

- **Add** repeat child (visible on the "repeat picker" screen)
- **Delete** repeat child (visible when viewing a repeat child)
- **Go up** (visible on any screen other than the beginning)

<img width="297" alt="screenshot with add, up" src="https://user-images.githubusercontent.com/2047062/49096574-cf037200-f238-11e8-9322-ad0a8aa097a0.png">

<img width="297" alt="screenshot with delete, up" src="https://user-images.githubusercontent.com/2047062/49096575-cf9c0880-f238-11e8-9271-ce360d383e1a.png">

Add/delete functionality already existed (swipe forward to add; long-press on question text to delete) -- this change just makes it more accessible.

#### What has been done to verify that this works as intended?

Extensive manual testing with nested-repeats-complex ([XML](https://drive.google.com/open?id=1zOvDEZz6vwQr5IBT91k7MuDMZ-hJDats) / [XLS](https://drive.google.com/open?id=1xVv682pbBMQ_MTZdNnj6aP11jhPp6fT8WQ42oEr7WaA)) (top-level "friends" and "enemies" groups; nested "friends/pets" group).

Navigating in and out of nested repeat groups, adding children, deleting children, editing names, using the back button, jumping back and forth between the FormEditor and FormHierarchy views.

#### Why is this the best possible solution? Were any other approaches considered?

Adding these buttons to the menu in FormHierarchy seems to make the most sense because that's where you get an overview of the form. FormHierarchy allows you to view children of repeat groups, and now on the same screen you can add new children. You can also delete the child currently being viewed.

Other approaches could involve showing menus elsewhere in the app, such as FormEntry, but that seems less intuitive.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The ability to add/delete repeat instances is now easier and more obvious. The new menu buttons should make repeat group navigation more efficient. Users may not expect to see the new buttons, but no old behavior has been changed.

The behavior changes should be isolated to FormHierarchyActivity, but this activity interacts with the global state via FormController, so regressions can be avoided by ensuring that the state is not mutated in some new unexpected way.

#### Do we need any specific form for testing your changes? If so, please attach one.

Linked above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Not that I can find. [This page](https://docs.opendatakit.org/collect-filling-forms/#jumping-to-questions) has screenshots of FormHierarchy but no repeat groups; the new buttons would not be visible in any of the screenshots.

#### Known issues being addressed
- [x] "Go up" button displays on the first screen in some forms
- [x] Deleting the last indexed (bottom) item in a repeat group causes a jump all the way to the first page in some forms
- [ ] Repeats with `jr:count` shouldn't have buttons to add/delete
- [ ] Deleting the last remaining item in a repeat group causes a navigation into the preceding repeat group, if there are 2 in a row, rather than navigating "up" in the hierarchy

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)
