### PR TITLE
Visible groups in jump screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -458,16 +458,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         elementsToDisplay.add(groupElement);
 
                         // Skip to the next item outside the group.
-                        formController.stepOverGroup();
-
-                        // As long as we're not at the end yet, go back one.
-                        // This puts us in the right spot to continue the while loop,
-                        // which increments the index automatically.
-                        if (!formController.getFormIndex().isEndOfFormIndex()) {
-                            formController.stepToPreviousEvent();
-                        }
-
-                        break;
+                        event = formController.stepOverGroup();
+                        continue;
                     }
                     case FormEntryController.EVENT_PROMPT_NEW_REPEAT: {
                         // this would display the 'add new repeat' dialog
@@ -517,8 +509,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                 }
-                event =
-                        formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
+
+                event = formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
             }
 
             recyclerView.setAdapter(new HierarchyListAdapter(elementsToDisplay, this::onElementClick));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -451,6 +451,13 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                             // Skip to the next item outside the group.
                             formController.stepOverGroup();
+
+                            // As long as we're not at the end yet, go back one.
+                            // This puts us in the right spot to continue the while loop,
+                            // which increments the index automatically.
+                            if (!formController.getFormIndex().isEndOfFormIndex()) {
+                                formController.stepToPreviousEvent();
+                            }
                         }
 
                         break;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
+import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -82,7 +83,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
      * A ref to the current context group.
      * Useful to make sure we only render items inside of the group.
      */
-    private String contextGroupRef;
+    private TreeReference contextGroupRef;
 
     /**
      * If this index is non-null, we will render an intermediary "picker" view
@@ -275,7 +276,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         // If we're not at the first level, we're inside a repeated group so we want to only
         // display everything enclosed within that group.
-        contextGroupRef = "";
+        contextGroupRef = null;
 
         // Save the index to the screen itself, before potentially moving into it.
         screenIndex = startIndex;
@@ -324,20 +325,16 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         return formController.isDisplayableGroup(index);
     }
 
-    private String getGroupRef(FormController formController) {
-        return formController.getFormIndex().getReference().toString();
+    private TreeReference getGroupRef(FormController formController) {
+        return getGroupRef(formController.getFormIndex());
     }
 
-    private String getParentGroupRef(FormController formController) {
-        return formController.getFormIndex().getReference().getParentRef().toString();
+    private TreeReference getGroupRef(FormIndex index) {
+        return index.getReference();
     }
 
-    private String getUnindexedGroupRef(FormController formController) {
-        return getUnindexedGroupRef(formController.getFormIndex());
-    }
-
-    private String getUnindexedGroupRef(FormIndex index) {
-        return index.getReference().toString(false);
+    private TreeReference getParentGroupRef(FormController formController) {
+        return formController.getFormIndex().getReference().getParentRef();
     }
 
     private boolean shouldShowRepeatGroupPicker() {
@@ -385,23 +382,16 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             //
             // Because of the guard conditions below, we will skip
             // everything until we exit this group.
-            //
-            // Note that currentRef includes the multiplicity of the
-            // repeat (e.g., [0], [1], ...), so every repeat will be
-            // detected as different and reach this case statement.
-            // Only the [0] emits the repeat header.
-            // Every one displays the descend-into action element.
-            String visibleGroupRef = null;
+            TreeReference visibleGroupRef = null;
 
             while (event != FormEntryController.EVENT_END_OF_FORM) {
                 // get the ref to this element
-                String currentRef = getGroupRef(formController);
-                String currentUnindexedRef = getUnindexedGroupRef(formController);
+                TreeReference currentRef = getGroupRef(formController);
 
                 // retrieve the current group
-                String curGroup = (visibleGroupRef == null) ? contextGroupRef : visibleGroupRef;
+                TreeReference curGroup = (visibleGroupRef == null) ? contextGroupRef : visibleGroupRef;
 
-                if (!currentRef.startsWith(curGroup)) {
+                if (!curGroup.isParentOf(currentRef, false)) {
                     // We have left the current group
                     if (visibleGroupRef == null) {
                         // We are done.
@@ -479,8 +469,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                         if (shouldShowRepeatGroupPicker()) {
                             // Don't render other groups' instances.
-                            String repeatGroupPickerRef = getUnindexedGroupRef(repeatGroupPickerIndex);
-                            if (!currentUnindexedRef.startsWith(repeatGroupPickerRef)) {
+                            String repeatGroupPickerRef = getGroupRef(repeatGroupPickerIndex).toString(false);
+                            if (!currentRef.toString(false).startsWith(repeatGroupPickerRef)) {
                                 break;
                             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -424,7 +424,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         }
 
                         FormEntryPrompt fp = formController.getQuestionPrompt();
-                        String label = getLabel(fp);
+                        String label = fp.getShortText();
                         if (!fp.isReadOnly() || (label != null && label.length() > 0)) {
                             // show the question if it is an editable field.
                             // or if it is read-only and the label is not blank.
@@ -452,7 +452,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                         FormEntryCaption caption = formController.getCaptionPrompt();
                         HierarchyElement groupElement = new HierarchyElement(
-                                getLabel(caption), getString(R.string.group_label),
+                                caption.getShortText(), getString(R.string.group_label),
                                 ContextCompat.getDrawable(this, R.drawable.ic_folder_open),
                                 HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
                         elementsToDisplay.add(groupElement);
@@ -489,12 +489,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                             int itemNumber = fc.getMultiplicity() + 1;
 
                             // e.g. `friends > 1`
-                            String repeatLabel = getLabel(fc) + " > " + itemNumber;
+                            String repeatLabel = fc.getShortText() + " > " + itemNumber;
 
                             // If the child of the group has a more descriptive label, use that instead.
                             if (fc.getFormElement().getChildren().size() == 1 && fc.getFormElement().getChild(0) instanceof GroupDef) {
                                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
-                                String itemLabel = getLabel(formController.getCaptionPrompt());
+                                String itemLabel = formController.getCaptionPrompt().getShortText();
                                 if (itemLabel != null) {
                                     // e.g. `1. Alice`
                                     repeatLabel = itemNumber + ".\u200E " + itemLabel;
@@ -508,7 +508,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         } else if (fc.getMultiplicity() == 0) {
                             // Display the repeat header for the group.
                             HierarchyElement group = new HierarchyElement(
-                                    getLabel(fc), getString(R.string.repeatable_group_label),
+                                    fc.getShortText(), getString(R.string.repeatable_group_label),
                                     ContextCompat.getDrawable(this, R.drawable.ic_repeat),
                                     HierarchyElement.Type.REPEATABLE_GROUP, fc.getIndex());
                             elementsToDisplay.add(group);
@@ -638,10 +638,5 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         alertDialog.setCancelable(false);
         alertDialog.setButton(getString(R.string.ok), errorListener);
         alertDialog.show();
-    }
-
-    private String getLabel(FormEntryCaption formEntryCaption) {
-        return formEntryCaption.getShortText() != null && !formEntryCaption.getShortText().isEmpty()
-                ? formEntryCaption.getShortText() : formEntryCaption.getLongText();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -446,7 +446,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         FormIndex index = formController.getFormIndex();
                         if (formController.isDisplayableGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
-                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
+                            HierarchyElement groupElement = new HierarchyElement(
+                                    getLabel(caption), getString(R.string.group_label),
+                                    ContextCompat.getDrawable(this, R.drawable.ic_folder_open),
+                                    HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);
 
                             // Skip to the next item outside the group.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -446,7 +446,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         FormIndex index = formController.getFormIndex();
                         if (formController.isDisplayableGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
-                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
+                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);
 
                             // Skip to the next item outside the group.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -446,6 +446,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                             break;
                         }
 
+                        visibleGroupRef = currentRef;
+
                         FormEntryCaption caption = formController.getCaptionPrompt();
                         HierarchyElement groupElement = new HierarchyElement(
                                 getLabel(caption), getString(R.string.group_label),

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -470,7 +470,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         if (shouldShowRepeatGroupPicker()) {
                             // Don't render other groups' instances.
                             String repeatGroupPickerRef = getGroupRef(repeatGroupPickerIndex).toString(false);
-                            if (!currentRef.toString(false).startsWith(repeatGroupPickerRef)) {
+                            if (!currentRef.toString(false).equals(repeatGroupPickerRef)) {
                                 break;
                             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -381,42 +381,39 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             // Refresh the current event in case we did step forward.
             event = formController.getEvent();
 
-            // Big change from prior implementation:
+            // Ref to the parent group that's currently being displayed.
             //
-            // The ref strings now include the instance number designations
-            // i.e., [0], [1], etc. of the repeat groups (and also [1] for
-            // non-repeat elements).
+            // Because of the guard conditions below, we will skip
+            // everything until we exit this group.
             //
-            // The contextGroupRef is now also valid for the top-level form.
-            //
-            // The repeatGroupRef is null if we are not skipping a repeat
-            // section.
-            //
-            String repeatGroupRef = null;
+            // Note that currentRef includes the multiplicity of the
+            // repeat (e.g., [0], [1], ...), so every repeat will be
+            // detected as different and reach this case statement.
+            // Only the [0] emits the repeat header.
+            // Every one displays the descend-into action element.
+            String visibleGroupRef = null;
 
-            event_search:
             while (event != FormEntryController.EVENT_END_OF_FORM) {
-
                 // get the ref to this element
                 String currentRef = getGroupRef(formController);
                 String currentUnindexedRef = getUnindexedGroupRef(formController);
 
                 // retrieve the current group
-                String curGroup = (repeatGroupRef == null) ? contextGroupRef : repeatGroupRef;
+                String curGroup = (visibleGroupRef == null) ? contextGroupRef : visibleGroupRef;
 
                 if (!currentRef.startsWith(curGroup)) {
                     // We have left the current group
-                    if (repeatGroupRef == null) {
+                    if (visibleGroupRef == null) {
                         // We are done.
                         break;
                     } else {
-                        // exit the inner repeat group
-                        repeatGroupRef = null;
+                        // exit the inner group
+                        visibleGroupRef = null;
                     }
                 }
 
-                if (repeatGroupRef != null) {
-                    // We're in a repeat group within the one we want to list
+                if (visibleGroupRef != null) {
+                    // We're in a group within the one we want to list
                     // skip this question/group/repeat and move to the next index.
                     event =
                             formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
@@ -474,17 +471,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_REPEAT: {
+                        visibleGroupRef = currentRef;
+
                         FormEntryCaption fc = formController.getCaptionPrompt();
-                        // push this repeat onto the stack.
-                        repeatGroupRef = currentRef;
-                        // Because of the guard conditions above, we will skip
-                        // everything until we exit this repeat.
-                        //
-                        // Note that currentRef includes the multiplicity of the
-                        // repeat (e.g., [0], [1], ...), so every repeat will be
-                        // detected as different and reach this case statement.
-                        // Only the [0] emits the repeat header.
-                        // Every one displays the descend-into action element.
 
                         if (shouldShowRepeatGroupPicker()) {
                             // Don't render other groups' instances.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -450,7 +450,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                             elementsToDisplay.add(groupElement);
 
                             // Skip to the next item outside the group.
-                            formController.forceStepOverGroup();
+                            formController.stepOverGroup();
                         }
 
                         break;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -446,7 +446,17 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_GROUP: {
-                        // ignore group events
+                        // Only display groups with a specific appearance attribute.
+                        FormIndex index = formController.getFormIndex();
+                        if ("nested".equals(formController.getAppearanceAttr(index))) {
+                            FormEntryCaption caption = formController.getCaptionPrompt();
+                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
+                            elementsToDisplay.add(groupElement);
+
+                            // Skip to the next item outside the group.
+                            formController.forceStepOverGroup();
+                        }
+
                         break;
                     }
                     case FormEntryController.EVENT_PROMPT_NEW_REPEAT: {
@@ -533,6 +543,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 repeatGroupPickerIndex = index;
                 refreshView();
                 break;
+            case VISIBLE_GROUP:
             case REPEAT_INSTANCE:
                 // Hide the picker.
                 repeatGroupPickerIndex = null;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -436,6 +436,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                             break;
                         }
 
+                        // Don't render other groups' instances.
+                        if (!contextGroupRef.isParentOf(currentRef, false)) {
+                            break;
+                        }
+
                         visibleGroupRef = currentRef;
 
                         FormEntryCaption caption = formController.getCaptionPrompt();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -442,25 +442,28 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_GROUP: {
-                        // Only display groups with a specific appearance attribute.
                         FormIndex index = formController.getFormIndex();
-                        if (formController.isDisplayableGroup(index)) {
-                            FormEntryCaption caption = formController.getCaptionPrompt();
-                            HierarchyElement groupElement = new HierarchyElement(
-                                    getLabel(caption), getString(R.string.group_label),
-                                    ContextCompat.getDrawable(this, R.drawable.ic_folder_open),
-                                    HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
-                            elementsToDisplay.add(groupElement);
 
-                            // Skip to the next item outside the group.
-                            formController.stepOverGroup();
+                        // Only display groups with a specific appearance attribute.
+                        if (!formController.isDisplayableGroup(index)) {
+                            break;
+                        }
 
-                            // As long as we're not at the end yet, go back one.
-                            // This puts us in the right spot to continue the while loop,
-                            // which increments the index automatically.
-                            if (!formController.getFormIndex().isEndOfFormIndex()) {
-                                formController.stepToPreviousEvent();
-                            }
+                        FormEntryCaption caption = formController.getCaptionPrompt();
+                        HierarchyElement groupElement = new HierarchyElement(
+                                getLabel(caption), getString(R.string.group_label),
+                                ContextCompat.getDrawable(this, R.drawable.ic_folder_open),
+                                HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
+                        elementsToDisplay.add(groupElement);
+
+                        // Skip to the next item outside the group.
+                        formController.stepOverGroup();
+
+                        // As long as we're not at the end yet, go back one.
+                        // This puts us in the right spot to continue the while loop,
+                        // which increments the index automatically.
+                        if (!formController.getFormIndex().isEndOfFormIndex()) {
+                            formController.stepToPreviousEvent();
                         }
 
                         break;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -67,6 +67,12 @@ import timber.log.Timber;
  */
 public class FormHierarchyActivity extends CollectAbstractActivity {
     /**
+     * XML 'appearance' attribute that denotes a group as being displayed
+     * in the hierarchy (rather than invisible).
+     */
+    public static String VISIBLE_GROUP_APPEARANCE = "visible";
+
+    /**
      * The questions and repeats at the current level.
      * Recreated every time {@link #refreshView()} is called.
      */
@@ -327,12 +333,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         int event = formController.getEvent(index);
         return event == FormEntryController.EVENT_REPEAT
-                || (event == FormEntryController.EVENT_GROUP && isDisplayableGroup(index));
+                || (event == FormEntryController.EVENT_GROUP && isVisibleGroup(index));
     }
 
-    private boolean isDisplayableGroup(FormIndex groupIndex) {
+    private boolean isVisibleGroup(FormIndex groupIndex) {
         FormController formController = Collect.getInstance().getFormController();
-        return "nested".equals(formController.getAppearanceAttr(groupIndex));
+        return VISIBLE_GROUP_APPEARANCE.equals(formController.getAppearanceAttr(groupIndex));
     }
 
     private String getGroupRef(FormController formController) {
@@ -455,7 +461,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                     case FormEntryController.EVENT_GROUP: {
                         // Only display groups with a specific appearance attribute.
                         FormIndex index = formController.getFormIndex();
-                        if (isDisplayableGroup(index)) {
+                        if (isVisibleGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
                             HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -67,12 +67,6 @@ import timber.log.Timber;
  */
 public class FormHierarchyActivity extends CollectAbstractActivity {
     /**
-     * XML 'appearance' attribute that denotes a group as being displayed
-     * in the hierarchy (rather than invisible).
-     */
-    public static String VISIBLE_GROUP_APPEARANCE = "visible";
-
-    /**
      * The questions and repeats at the current level.
      * Recreated every time {@link #refreshView()} is called.
      */
@@ -278,7 +272,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private void jumpToHierarchyStartIndex() {
         FormController formController = Collect.getInstance().getFormController();
         FormIndex startIndex = formController.getFormIndex();
-        int event = formController.getEvent();
 
         // If we're not at the first level, we're inside a repeated group so we want to only
         // display everything enclosed within that group.
@@ -287,14 +280,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         // Save the index to the screen itself, before potentially moving into it.
         screenIndex = startIndex;
 
-        // If we're currently at a repeat node, record the name of the node and step to the next
+        // If we're currently at a displayable group, record the name of the node and step to the next
         // node to display.
-        if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_GROUP) {
+        if (formController.isDisplayableGroup(startIndex)) {
             contextGroupRef = getGroupRef(formController);
             formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
         } else {
             FormIndex potentialStartIndex = formController.stepIndexOut(startIndex);
-            // Step back until we hit a repeat or the beginning.
+            // Step back until we hit a displayable group or the beginning.
             while (!isScreenEvent(formController, potentialStartIndex)) {
                 potentialStartIndex = formController.stepIndexOut(potentialStartIndex);
             }
@@ -306,15 +299,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 // is, display the root level from the beginning.
                 formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
             } else {
-                // otherwise we're at a repeated group
+                // otherwise we're at a displayable group
                 formController.jumpToIndex(potentialStartIndex);
             }
 
-            event = formController.getEvent();
-
-            // now test again for repeat. This should be true at this point or we're at the
-            // beginning
-            if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_GROUP) {
+            // Now test again. This should be true at this point or we're at the beginning.
+            if (formController.isDisplayableGroup(formController.getFormIndex())) {
                 contextGroupRef = getGroupRef(formController);
                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
             }
@@ -322,7 +312,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Returns true if the event is an enclosing repeat, displayable group, or the start of the form.
+     * Returns true if the event is a displayable group or the start of the form.
      * See {@link FormController#stepToOuterScreenEvent} for more context.
      */
     private boolean isScreenEvent(FormController formController, FormIndex index) {
@@ -331,14 +321,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             return true;
         }
 
-        int event = formController.getEvent(index);
-        return event == FormEntryController.EVENT_REPEAT
-                || (event == FormEntryController.EVENT_GROUP && isVisibleGroup(index));
-    }
-
-    private boolean isVisibleGroup(FormIndex groupIndex) {
-        FormController formController = Collect.getInstance().getFormController();
-        return VISIBLE_GROUP_APPEARANCE.equals(formController.getAppearanceAttr(groupIndex));
+        return formController.isDisplayableGroup(index);
     }
 
     private String getGroupRef(FormController formController) {
@@ -461,7 +444,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                     case FormEntryController.EVENT_GROUP: {
                         // Only display groups with a specific appearance attribute.
                         FormIndex index = formController.getFormIndex();
-                        if (isVisibleGroup(index)) {
+                        if (formController.isDisplayableGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
                             HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -428,7 +428,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 }
 
                 switch (event) {
-                    case FormEntryController.EVENT_QUESTION:
+                    case FormEntryController.EVENT_QUESTION: {
                         if (shouldShowRepeatGroupPicker()) {
                             break;
                         }
@@ -444,14 +444,17 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                                             HierarchyElement.Type.QUESTION, fp.getIndex()));
                         }
                         break;
-                    case FormEntryController.EVENT_GROUP:
+                    }
+                    case FormEntryController.EVENT_GROUP: {
                         // ignore group events
                         break;
-                    case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
+                    }
+                    case FormEntryController.EVENT_PROMPT_NEW_REPEAT: {
                         // this would display the 'add new repeat' dialog
                         // ignore it.
                         break;
-                    case FormEntryController.EVENT_REPEAT:
+                    }
+                    case FormEntryController.EVENT_REPEAT: {
                         FormEntryCaption fc = formController.getCaptionPrompt();
                         // push this repeat onto the stack.
                         repeatGroupRef = currentRef;
@@ -500,6 +503,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         }
 
                         break;
+                    }
                 }
                 event =
                         formController.stepToNextEvent(FormController.STEP_INTO_GROUP);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -687,13 +687,13 @@ public class FormController {
      */
     public boolean isDisplayableGroup(FormIndex index) {
         return getEvent(index) == FormEntryController.EVENT_REPEAT ||
-                (getEvent(index) == FormEntryController.EVENT_GROUP && groupIsLabeled(index));
+                (getEvent(index) == FormEntryController.EVENT_GROUP && isGroupLabeled(index));
     }
 
     /**
      * Returns true if the group has a displayable label.
      */
-    private boolean groupIsLabeled(FormIndex groupIndex) {
+    private boolean isGroupLabeled(FormIndex groupIndex) {
         IFormElement group = formEntryController.getModel().getForm().getChild(groupIndex);
         String label = group.getLabelInnerText();
         return !TextUtils.isEmpty(label);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.logic;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import android.text.TextUtils;
 import com.google.android.gms.analytics.HitBuilders;
 
 import org.javarosa.core.model.CoreModelModule;
@@ -85,12 +86,6 @@ public class FormController {
      */
     private static final String AUDIT = "audit";
     public static final String AUDIT_FILE_NAME = "audit.csv";
-
-    /**
-     * XML 'appearance' attribute that denotes a group as being displayed
-     * in the hierarchy (rather than invisible).
-     */
-    public static final String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
 
     /*
      * Store the timerLogger object with the form controller state
@@ -692,8 +687,16 @@ public class FormController {
      */
     public boolean isDisplayableGroup(FormIndex index) {
         return getEvent(index) == FormEntryController.EVENT_REPEAT ||
-                (getEvent(index) == FormEntryController.EVENT_GROUP
-                && VISIBLE_GROUP_APPEARANCE.equals(getAppearanceAttr(index)));
+                (getEvent(index) == FormEntryController.EVENT_GROUP && groupIsLabeled(index));
+    }
+
+    /**
+     * Returns true if the group has a displayable label.
+     */
+    private boolean groupIsLabeled(FormIndex groupIndex) {
+        IFormElement group = formEntryController.getModel().getForm().getChild(groupIndex);
+        String label = group.getLabelInnerText();
+        return !TextUtils.isEmpty(label);
     }
 
     public static class FailedConstraint {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -687,13 +687,13 @@ public class FormController {
      */
     public boolean isDisplayableGroup(FormIndex index) {
         return getEvent(index) == FormEntryController.EVENT_REPEAT ||
-                (getEvent(index) == FormEntryController.EVENT_GROUP && isGroupLabeled(index));
+                (getEvent(index) == FormEntryController.EVENT_GROUP && isPresentationGroup(index));
     }
 
     /**
      * Returns true if the group has a displayable label.
      */
-    private boolean isGroupLabeled(FormIndex groupIndex) {
+    private boolean isPresentationGroup(FormIndex groupIndex) {
         String label = getCaptionPrompt(groupIndex).getShortText();
         return !TextUtils.isEmpty(label);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -694,8 +694,7 @@ public class FormController {
      * Returns true if the group has a displayable label.
      */
     private boolean isGroupLabeled(FormIndex groupIndex) {
-        IFormElement group = formEntryController.getModel().getForm().getChild(groupIndex);
-        String label = group.getLabelInnerText();
+        String label = getCaptionPrompt(groupIndex).getShortText();
         return !TextUtils.isEmpty(label);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -17,7 +17,6 @@ package org.odk.collect.android.logic;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import android.text.TextUtils;
 import com.google.android.gms.analytics.HitBuilders;
 
 import org.javarosa.core.model.CoreModelModule;
@@ -691,11 +690,12 @@ public class FormController {
     }
 
     /**
-     * Returns true if the group has a displayable label.
+     * Returns true if the group has a displayable label,
+     * i.e. it's a "presentation group".
      */
     private boolean isPresentationGroup(FormIndex groupIndex) {
         String label = getCaptionPrompt(groupIndex).getShortText();
-        return !TextUtils.isEmpty(label);
+        return label != null;
     }
 
     public static class FailedConstraint {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -373,14 +373,7 @@ public class FormController {
     }
 
     private boolean repeatIsFieldList(FormIndex index) {
-        // if this isn't a group, return right away
-        IFormElement element = formEntryController.getModel().getForm().getChild(index);
-        if (!(element instanceof GroupDef)) {
-            return false;
-        }
-
-        GroupDef gd = (GroupDef) element; // exceptions?
-        return ODKView.FIELD_LIST.equalsIgnoreCase(gd.getAppearanceAttr());
+        return groupIsFieldList(index);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -86,6 +86,12 @@ public class FormController {
     private static final String AUDIT = "audit";
     public static final String AUDIT_FILE_NAME = "audit.csv";
 
+    /**
+     * XML 'appearance' attribute that denotes a group as being displayed
+     * in the hierarchy (rather than invisible).
+     */
+    public static String VISIBLE_GROUP_APPEARANCE = "visible";
+
     /*
      * Store the timerLogger object with the form controller state
      */
@@ -648,29 +654,41 @@ public class FormController {
     }
 
     /**
-     * Move the current form index to the index of the first enclosing repeat
+     * Move the current form index to the index of the first displayable group
+     * (that is, a repeatable group or a visible group),
      * or to the start of the form.
      */
     public int stepToOuterScreenEvent() {
-        FormIndex index = stepIndexOut(getFormIndex());
-        int currentEvent = getEvent();
+        FormIndex index = getFormIndex();
 
-        // Step out of any group indexes that are present.
+        // Step out once to begin with if we're coming from a question.
+        if (getEvent() == FormEntryController.EVENT_QUESTION) {
+            index = stepIndexOut(index);
+        }
+
+        // Save where we started from.
+        FormIndex startIndex = index;
+
+        // Step out once more no matter what.
+        index = stepIndexOut(index);
+
+        // Step out of any group indexes that are present, unless they're visible.
         while (index != null
-                && getEvent(index) == FormEntryController.EVENT_GROUP) {
+                && getEvent(index) == FormEntryController.EVENT_GROUP
+                && !isDisplayableGroup(index)) {
             index = stepIndexOut(index);
         }
 
         if (index == null) {
             jumpToIndex(FormIndex.createBeginningOfFormIndex());
         } else {
-            if (currentEvent == FormEntryController.EVENT_REPEAT) {
-                // We were at a repeat, so stepping back brought us to then previous level
+            if (isDisplayableGroup(startIndex)) {
+                // We were at a displayable group, so stepping back brought us to the previous level
                 jumpToIndex(index);
             } else {
                 // We were at a question, so stepping back brought us to either:
-                // The beginning. or The start of a repeat. So we need to step
-                // out again to go passed the repeat.
+                // The beginning, or the start of a displayable group. So we need to step
+                // out again to go past the group.
                 index = stepIndexOut(index);
                 if (index == null) {
                     jumpToIndex(FormIndex.createBeginningOfFormIndex());
@@ -680,6 +698,15 @@ public class FormController {
             }
         }
         return getEvent();
+    }
+
+    /**
+     * Returns true if the index is either a repeatable group or a visible group.
+     */
+    public boolean isDisplayableGroup(FormIndex index) {
+        return getEvent(index) == FormEntryController.EVENT_REPEAT ||
+                (getEvent(index) == FormEntryController.EVENT_GROUP
+                && VISIBLE_GROUP_APPEARANCE.equals(getAppearanceAttr(index)));
     }
 
     public static class FailedConstraint {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -522,23 +522,10 @@ public class FormController {
     }
 
     /**
-     * Same as {@link #stepToNextEvent stepToNextEvent(false)}, but ignores question types.
-     * It always steps over the group.
-     */
-    public int forceStepOverGroup() {
-        if (getEvent() == FormEntryController.EVENT_GROUP
-                || getEvent() == FormEntryController.EVENT_REPEAT) {
-            return stepOverGroup();
-        } else {
-            return formEntryController.stepToNextEvent();
-        }
-    }
-
-    /**
      * If using a view like HierarchyView that doesn't support multi-question per screen, step over
      * the group represented by the FormIndex.
      */
-    private int stepOverGroup() {
+    public int stepOverGroup() {
         GroupDef gd =
                 (GroupDef) formEntryController.getModel().getForm()
                         .getChild(getFormIndex());

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -516,6 +516,19 @@ public class FormController {
     }
 
     /**
+     * Same as {@link #stepToNextEvent stepToNextEvent(false)}, but ignores question types.
+     * It always steps over the group.
+     */
+    public int forceStepOverGroup() {
+        if ((getEvent() == FormEntryController.EVENT_GROUP
+                || getEvent() == FormEntryController.EVENT_REPEAT)) {
+            return stepOverGroup();
+        } else {
+            return formEntryController.stepToNextEvent();
+        }
+    }
+
+    /**
      * If using a view like HierarchyView that doesn't support multi-question per screen, step over
      * the group represented by the FormIndex.
      */

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.logic;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.google.android.gms.analytics.HitBuilders;
@@ -368,12 +369,24 @@ public class FormController {
             return false;
         }
 
-        GroupDef gd = (GroupDef) element; // exceptions?
-        return ODKView.FIELD_LIST.equalsIgnoreCase(gd.getAppearanceAttr());
+        return ODKView.FIELD_LIST.equalsIgnoreCase(element.getAppearanceAttr());
     }
 
     private boolean repeatIsFieldList(FormIndex index) {
         return groupIsFieldList(index);
+    }
+
+    /**
+     * Returns the `appearance` attribute of the current index, if any.
+     */
+    public String getAppearanceAttr(@NonNull FormIndex index) {
+        // FormDef can't have an appearance, it would throw an exception.
+        if (index.isBeginningOfFormIndex()) {
+            return null;
+        }
+
+        IFormElement element = formEntryController.getModel().getForm().getChild(index);
+        return element.getAppearanceAttr();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -90,7 +90,7 @@ public class FormController {
      * XML 'appearance' attribute that denotes a group as being displayed
      * in the hierarchy (rather than invisible).
      */
-    public static String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
+    public static final String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
 
     /*
      * Store the timerLogger object with the form controller state
@@ -526,8 +526,8 @@ public class FormController {
      * It always steps over the group.
      */
     public int forceStepOverGroup() {
-        if ((getEvent() == FormEntryController.EVENT_GROUP
-                || getEvent() == FormEntryController.EVENT_REPEAT)) {
+        if (getEvent() == FormEntryController.EVENT_GROUP
+                || getEvent() == FormEntryController.EVENT_REPEAT) {
             return stepOverGroup();
         } else {
             return formEntryController.stepToNextEvent();

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -90,7 +90,7 @@ public class FormController {
      * XML 'appearance' attribute that denotes a group as being displayed
      * in the hierarchy (rather than invisible).
      */
-    public static String VISIBLE_GROUP_APPEARANCE = "visible";
+    public static String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
 
     /*
      * Store the timerLogger object with the form controller state

--- a/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
@@ -102,6 +102,7 @@ public class HierarchyElement {
      */
     public enum Type {
         QUESTION,
+        VISIBLE_GROUP,
         REPEATABLE_GROUP,
         REPEAT_INSTANCE
     }

--- a/collect_app/src/main/res/drawable/ic_folder_open.xml
+++ b/collect_app/src/main/res/drawable/ic_folder_open.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?iconColor"
+        android:pathData="M20,6h-8l-2,-2L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,8h16v10z"/>
+</vector>

--- a/collect_app/src/main/res/layout/hierarchy_element.xml
+++ b/collect_app/src/main/res/layout/hierarchy_element.xml
@@ -19,8 +19,8 @@ limitations under the License.
         android:id="@+id/icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="5dp"
-        android:layout_marginRight="5dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
         android:layout_centerVertical="true"/>
 
     <TextView

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="quit_application">Exit %s</string>
     <string name="quit_entry">Save Form and Exit</string>
     <string name="refresh">Refresh</string>
+    <string name="group_label">Group</string>
     <string name="repeatable_group_label">Repeatable Group</string>
     <string name="replace_barcode">Replace Barcode</string>
     <string name="required_answer_error">Sorry, this response is required!</string>


### PR DESCRIPTION
Makes labeled groups "visible" so they show up on the jump screen. You can then click on the group to see its children.

Currently, groups are invisible to the user, but with this new appearance, they become a selectable item in the jump screen. All children of the group are then hidden from the main screen, and will be shown on the inner screen instead, effectively giving these **visible** groups the exact same navigation behavior as existing **repeatable** groups.

To make a group visible, simply make sure it has a `ref` and a `label` like so:

```xml
<group ref="...">
    <label>Some label</label>
    ...
</group>
```

In more technical terms, groups must be both **presentable** and **logical** (see [docs](https://opendatakit.github.io/xforms-spec/#groups) for definitions) in order to be visible.

Example with old, existing UI:

<div>
<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/2047062/51065358-672f9d80-15d2-11e9-830d-53503c080625.png">
<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/2047062/51065359-672f9d80-15d2-11e9-96ac-e47d7dbef52a.png">
</div>

<br/>

Example with new, grouped UI:

<div>
<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/2047062/51065772-9e9f4980-15d4-11e9-9641-7bfe336083b9.png">
<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/2047062/51065773-9e9f4980-15d4-11e9-93eb-b1b9bd2cfbc8.png">
<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/2047062/51065774-9e9f4980-15d4-11e9-873f-dd8ceed9ba7a.png">
<img width="160" alt="screenshot" src="https://user-images.githubusercontent.com/2047062/51065775-9e9f4980-15d4-11e9-8710-54f0e2e1b9b2.png">
</div>

#### What has been done to verify that this works as intended?

Extensive manual testing with:
- visible_groups ([XML](https://drive.google.com/open?id=1JabZFs4NdFrLSjkqdDtXc2EnJWuK_IoD) / [XLS](https://drive.google.com/open?id=1DwXUPtcNly8mPRPAIreIhq7ME_D3X0W7gllCmSAX2g8)) (grouped widgets; the "Date and time widgets" group is marked as visible, and has a nested "Inner group" that's also visible)
- tcc-demo ([XML](https://github.com/opendatakit/collect/files/2781332/tcc-demo.xml.txt))

Navigating in and out of nested groups, using the back button, jumping back and forth between the FormEditor and FormHierarchy views.

#### Why is this the best possible solution? Were any other approaches considered?

Allowing groups to be visible gives more power to form designers who may want to prevent certain groups from cluttering the jump screen. It also makes it easier to focus on the questions within those groups if desired.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Labeled groups will require one more tap to navigate into, and the children of the group will be hidden from the previous page.

Regression risks include any code that previously assumed that regular groups could never be "screen events". There were several methods that checked for **repeatable** groups, which now also need to check for **visible** groups as well. All of the logic I could find has been updated accordingly.

#### Do we need any specific form for testing your changes? If so, please attach one.

Linked above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Yes, documenting the new logic [here](http://xlsform.org/en/#appearance). Issue [here](https://github.com/opendatakit/docs/issues/931).

#### Known issues being addressed
- [x] Groups with dynamic labels (e.g. a `ref`) aren't detected as "visible"
- [x] In some forms, the last item inside the group is shown outside the group
- [x] In forms without group `ref`s, other groups outside the group seem to be shown inside the group
- [ ] Update the docs issue above for the new default behavior

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)