### PR TITLE
Fixed notifications on Android >=8

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsNotificationReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsNotificationReceiver.java
@@ -23,6 +23,7 @@ import timber.log.Timber;
 
 import static org.odk.collect.android.tasks.sms.SmsSender.SMS_INSTANCE_ID;
 import static org.odk.collect.android.tasks.sms.SmsSender.SMS_RESULT_CODE;
+import static org.odk.collect.android.utilities.NotificationUtils.CHANNEL_ID;
 
 public class SmsNotificationReceiver extends BroadcastReceiver {
     public static final String SMS_NOTIFICATION_ACTION = "org.odk.collect.android.COLLECT_SMS_NOTIFICATION_ACTION";
@@ -70,7 +71,7 @@ public class SmsNotificationReceiver extends BroadcastReceiver {
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
                 intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        return new NotificationCompat.Builder(context)
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setContentTitle(smsSubmission.getDisplayName())
                 .setContentText(getContentText())
                 .setWhen(smsSubmission.getLastUpdated().getTime())
@@ -91,7 +92,7 @@ public class SmsNotificationReceiver extends BroadcastReceiver {
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
                 intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        return new NotificationCompat.Builder(context)
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setContentTitle(context.getString(R.string.sms_submissions_notif_title))
                 .setContentText(context.getString(R.string.sms_submissions_notif_description))
                 .setWhen(smsSubmission.getLastUpdated().getTime())

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsNotificationReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsNotificationReceiver.java
@@ -27,7 +27,7 @@ import static org.odk.collect.android.utilities.NotificationUtils.CHANNEL_ID;
 
 public class SmsNotificationReceiver extends BroadcastReceiver {
     public static final String SMS_NOTIFICATION_ACTION = "org.odk.collect.android.COLLECT_SMS_NOTIFICATION_ACTION";
-    public static final String SMS_NOTIFICATION_GROUP = "org.odk.collect.android.COLLECT_SMS_NOTIFICATION_GROUP";
+    private static final String SMS_NOTIFICATION_GROUP = "org.odk.collect.android.COLLECT_SMS_NOTIFICATION_GROUP";
     private static final int SUMMARY_ID = 4324;
     private int resultCode;
 

--- a/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.upload;
 
 import android.annotation.SuppressLint;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -25,7 +24,6 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Environment;
 import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
 
 import com.google.android.gms.analytics.HitBuilders;
 
@@ -42,8 +40,8 @@ import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
-import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
+import org.odk.collect.android.utilities.NotificationUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
@@ -304,16 +302,12 @@ public class AutoSendWorker extends Worker {
         PendingIntent pendingNotify = PendingIntent.getActivity(Collect.getInstance(), FORMS_UPLOADED_NOTIFICATION,
                 notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(Collect.getInstance())
-                .setSmallIcon(IconUtils.getNotificationAppIcon())
-                .setContentTitle(Collect.getInstance().getString(R.string.odk_auto_note))
-                .setContentIntent(pendingNotify)
-                .setContentText(anyFailure ? Collect.getInstance().getString(R.string.failures)
-                        : Collect.getInstance().getString(R.string.success))
-                .setAutoCancel(true);
+        NotificationUtils.showNotification(
+                pendingNotify,
+                AUTO_SEND_RESULT_NOTIFICATION_ID,
+                R.string.odk_auto_note,
+                anyFailure ? Collect.getInstance().getString(R.string.failures)
+                        : Collect.getInstance().getString(R.string.success));
 
-        NotificationManager notificationManager = (NotificationManager) Collect.getInstance()
-                .getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.notify(AUTO_SEND_RESULT_NOTIFICATION_ID, builder.build());
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
@@ -28,7 +28,7 @@ import org.odk.collect.android.application.Collect;
 
 public class NotificationUtils {
 
-    private static final String CHANNEL_ID = "collect_notification_channel";
+    public static final String CHANNEL_ID = "collect_notification_channel";
     public static final int FORM_UPDATE_NOTIFICATION_ID = 0;
 
     private NotificationUtils() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
@@ -30,7 +30,6 @@ public class NotificationUtils {
 
     private static final String CHANNEL_ID = "collect_notification_channel";
     public static final int FORM_UPDATE_NOTIFICATION_ID = 0;
-    public static final int AUTO_SEND_NOTIFICATION_ID = 1328974928;
 
     private NotificationUtils() {
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/NotificationUtils.java
@@ -54,14 +54,13 @@ public class NotificationUtils {
                                         String contentText) {
         Context context = Collect.getInstance();
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context).setContentIntent(contentIntent);
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID).setContentIntent(contentIntent);
 
         builder
                 .setContentTitle(context.getString(title))
                 .setContentText(contentText)
                 .setSmallIcon(IconUtils.getNotificationAppIcon())
-                .setAutoCancel(true)
-                .setChannelId(CHANNEL_ID);
+                .setAutoCancel(true);
 
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         if (manager != null) {


### PR DESCRIPTION
Closes #2759 

#### What has been done to verify that this works as intended?
I have tested a notification displayed after sending forms automatically and a notification displayed after sending forms via SMS.

#### Why is this the best possible solution? Were any other approaches considered?
Notifications just have to use channels, more info: 
>When you target Android 8.0 (API level 26), you must implement one or more notification channels. If your targetSdkVersion is set to 25 or lower, when your app runs on Android 8.0 (API level 26) or higher, it behaves the same as it would on devices running Android 7.1 (API level 25) or lower.

https://developer.android.com/training/notify-user/channels

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change should fix notifications on Android 8 which currently are not displayed because the don't use channels. Those two mentioned notifications should be tested but
**This pr should be tested once #2757 is merged, it doesn't make sense to do that before because the notification displayed after sending forms via SMS won't work anyway.**

#### Do we need any specific form for testing your changes? If so, please attach one.
No, any form we can send via SMS eg. 
[SMS form.xml.txt](https://github.com/opendatakit/collect/files/2694494/SMS.form.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)