### PR TITLE
Added the constraint to pick only local images as the splash screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/SplashClickListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/SplashClickListener.java
@@ -18,6 +18,7 @@ class SplashClickListener implements Preference.OnPreferenceClickListener {
 
     private void launchImageChooser() {
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
+        i.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
         i.setType("image/*");
         preferencesFragment.startActivityForResult(i, UserInterfacePreferences.IMAGE_CHOOSER);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/SplashClickListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/SplashClickListener.java
@@ -17,8 +17,7 @@ class SplashClickListener implements Preference.OnPreferenceClickListener {
     }
 
     private void launchImageChooser() {
-        Intent i = new Intent(Intent.ACTION_GET_CONTENT);
-        i.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+        Intent i = new Intent(Intent.ACTION_PICK);
         i.setType("image/*");
         preferencesFragment.startActivityForResult(i, UserInterfacePreferences.IMAGE_CHOOSER);
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,9 +1,6 @@
-#Fri Jun 01 19:51:59 EST 2018
+#Thu Dec 20 19:09:52 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-android.enableD8.desugaring=true
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
-# Android Studio Gradle wrapper 3.1.2 doesn't support configure on demand
-org.gradle.configureondemand=false
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Closes #2390 

#### What has been done to verify that this works as intended?
Added an option where user can only select the local images as splash screen.
#### Why is this the best possible solution? Were any other approaches considered?
This is the best possible solution because I am using intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true); instead of ACTION_PICK as it is poorly supported. In this, if a user wants to add drive picture, he/she initially will have to download the picture locally.
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Now the user cannot select splash screen which is not saved locally.
#### Do we need any specific form for testing your changes? If so, please attach one.
No
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No
#### Before submitting this PR, please make sure you have:
- [Done ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [Done ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ Done] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)