### PR TITLE
Make changes so JavaRosa can find external secondary instance files

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -218,7 +218,7 @@ dependencies {
     implementation "commons-io:commons-io:2.6"
     implementation "net.sf.kxml:kxml2:2.3.0"
     implementation "net.sf.opencsv:opencsv:2.3"
-    implementation("org.opendatakit:opendatakit-javarosa:2.12.1") {
+    implementation("org.opendatakit:opendatakit-javarosa:2.13.0-SNAPSHOT") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FileReferenceFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FileReferenceFactory.java
@@ -26,4 +26,10 @@ public class FileReferenceFactory extends PrefixedRootFactory {
         return new FileReference(localRoot, terminal);
     }
 
+    @Override
+    public String toString() {
+        return "FileReferenceFactory{" +
+                "localRoot='" + localRoot + '\'' +
+                "} " + super.toString();
+    }
 }


### PR DESCRIPTION
This will allow JavaRosa to find external secondary instance files.

Closes #2770

#### What has been done to verify that this works as intended?
Hand-tested using the forms from @cooperka in https://github.com/opendatakit/javarosa/issues/390.

#### Why is this the best possible solution? Were any other approaches considered?
I started with an inferior solution, but @grzesiek2010 pointed out the existing framework for resolving media files.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should not.

#### Do we need any specific form for testing your changes? If so, please attach one.
Please see https://github.com/opendatakit/javarosa/issues/390.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.