### PR TITLE
Use try/catch to avoid crashing if we try to unregister not registered broadcastReceiver

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -276,6 +276,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
 
     @Override
     protected void onResume() {
+        super.onResume();
         if (instanceSyncTask != null) {
             instanceSyncTask.setDiskSyncListener(this);
             if (instanceSyncTask.getStatus() == AsyncTask.Status.FINISHED) {
@@ -283,7 +284,6 @@ public class InstanceUploaderList extends InstanceListActivity implements
             }
 
         }
-        super.onResume();
 
         IntentFilter filter = new IntentFilter(SmsNotificationReceiver.SMS_NOTIFICATION_ACTION);
         // The default priority is 0. Positive values will be before
@@ -299,13 +299,12 @@ public class InstanceUploaderList extends InstanceListActivity implements
         if (instanceSyncTask != null) {
             instanceSyncTask.setDiskSyncListener(null);
         }
-        super.onPause();
-
         try {
             unregisterReceiver(smsForegroundReceiver);
         } catch (IllegalArgumentException e) {
             Timber.w(e);
         }
+        super.onPause();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -301,7 +301,11 @@ public class InstanceUploaderList extends InstanceListActivity implements
         }
         super.onPause();
 
-        unregisterReceiver(smsForegroundReceiver);
+        try {
+            unregisterReceiver(smsForegroundReceiver);
+        } catch (IllegalArgumentException e) {
+            Timber.w(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes #2777

#### What has been done to verify that this works as intended?
Nothing since it's just a try/catch block which I added.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a try/catch to avoid a random issue - trying to unregister not registered BroadcastReceiver. We register the BroadcastReceiver properly in onResume() method so it's not our fault. It's rather a rare random Android bug.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't change anything and it doesn't require any testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)