### PR TITLE
Fixed NullPointerException in GoogleSheetsUploaderActivity.java:288

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -285,7 +285,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
             }
 
             Cursor results = new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs);
-            if (results.getCount() > 0) {
+            if (results != null && results.getCount() > 0) {
                 message = InstanceUploaderUtils.getUploadResultMessage(results, result);
             } else {
                 if (instanceGoogleSheetsUploaderTask.isAuthFailed()) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -284,15 +284,16 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
                 }
             }
 
-            Cursor results = new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs);
-            if (results != null && results.getCount() > 0) {
-                message = InstanceUploaderUtils.getUploadResultMessage(results, result);
-            } else {
-                if (instanceGoogleSheetsUploaderTask.isAuthFailed()) {
-                    message = getString(R.string.google_auth_io_exception_msg);
-                    instanceGoogleSheetsUploaderTask.setAuthFailedToFalse();
+            try (Cursor results = new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs)) {
+                if (results != null && results.getCount() > 0) {
+                    message = InstanceUploaderUtils.getUploadResultMessage(results, result);
                 } else {
-                    message = getString(R.string.no_forms_uploaded);
+                    if (instanceGoogleSheetsUploaderTask.isAuthFailed()) {
+                        message = getString(R.string.google_auth_io_exception_msg);
+                        instanceGoogleSheetsUploaderTask.setAuthFailedToFalse();
+                    } else {
+                        message = getString(R.string.no_forms_uploaded);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #2779 

#### What has been done to verify that this works as intended?
Nothing, it's just a null check.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check we should add + try-with-resources statement to close the cursor automatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't change anything and doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)