### PR TITLE
Fixed FormDownloadList: android.database.Cursor.getCount()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -646,7 +646,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         Cursor formCursor = null;
         try {
             formCursor = new FormsDao().getFormsCursorForFormId(formId);
-            return formCursor.getCount() == 0 // form does not already exist locally
+            return formCursor != null && formCursor.getCount() == 0 // form does not already exist locally
                     || formNamesAndURLs.get(formId).isNewerFormVersionAvailable() // or a newer version of this form is available
                     || formNamesAndURLs.get(formId).areNewerMediaFilesAvailable(); // or newer versions of media files are available
         } finally {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -643,16 +643,10 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             return true;
         }
 
-        Cursor formCursor = null;
-        try {
-            formCursor = new FormsDao().getFormsCursorForFormId(formId);
+        try (Cursor formCursor = new FormsDao().getFormsCursorForFormId(formId)) {
             return formCursor != null && formCursor.getCount() == 0 // form does not already exist locally
                     || formNamesAndURLs.get(formId).isNewerFormVersionAvailable() // or a newer version of this form is available
                     || formNamesAndURLs.get(formId).areNewerMediaFilesAvailable(); // or newer versions of media files are available
-        } finally {
-            if (formCursor != null) {
-                formCursor.close();
-            }
         }
     }
 


### PR DESCRIPTION
Closes #2781 

#### What has been done to verify that this works as intended?
Nothing, it's just a null check.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check we should add + try-with-resources statement to close the cursor automatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't change anything and doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)