### PR TITLE
Fixed MediaUtils.getImageUriFromMediaProvider: Attempt to invoke interface method 'int android.database.Cursor.getCount()' on a null object reference

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -79,7 +79,7 @@ public class MediaUtils {
                     .getContentResolver()
                     .query(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
                             projection, selection, selectArgs, null);
-            if (c.getCount() > 0) {
+            if (c != null && c.getCount() > 0) {
                 c.moveToFirst();
                 String id = c.getString(c
                         .getColumnIndex(Images.ImageColumns._ID));

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -72,13 +72,11 @@ public class MediaUtils {
         String selection = Images.ImageColumns.DATA + "=?";
         String[] selectArgs = {imageFile};
         String[] projection = {Images.ImageColumns._ID};
-        Cursor c = null;
-        try {
-            c = Collect
-                    .getInstance()
-                    .getContentResolver()
-                    .query(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                            projection, selection, selectArgs, null);
+        try (Cursor c = Collect
+                .getInstance()
+                .getContentResolver()
+                .query(Images.Media.EXTERNAL_CONTENT_URI,
+                        projection, selection, selectArgs, null)) {
             if (c != null && c.getCount() > 0) {
                 c.moveToFirst();
                 String id = c.getString(c
@@ -86,14 +84,10 @@ public class MediaUtils {
 
                 return Uri
                         .withAppendedPath(
-                                android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                                Images.Media.EXTERNAL_CONTENT_URI,
                                 id);
             }
             return null;
-        } finally {
-            if (c != null) {
-                c.close();
-            }
         }
     }
 


### PR DESCRIPTION
Closes #2785

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check we should add + try-with-resources statement to close the cursor automatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't change anything and doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)