### PR TITLE
Fixed calling Cursor.getCount() on a null object

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DownloadFormListUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DownloadFormListUtils.java
@@ -420,7 +420,12 @@ public class DownloadFormListUtils {
     }
 
     private static boolean isNewerFormVersionAvailable(String md5Hash) {
-        return md5Hash != null && new FormsDao().getFormsCursorForMd5Hash(md5Hash).getCount() == 0;
+        if (md5Hash == null) {
+            return false;
+        }
+        try (Cursor cursor = new FormsDao().getFormsCursorForMd5Hash(md5Hash)) {
+            return cursor != null && cursor.getCount() == 0;
+        }
     }
 
     private static boolean areNewerMediaFilesAvailable(String formId, String formVersion, List<MediaFile> newMediaFiles) {


### PR DESCRIPTION
Closes #2789 

#### What has been done to verify that this works as intended?
Nothing, it's just a null check which I added.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check we should add + try-with-resources statement to close the cursor automatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change doesn't affect anything. I think it doesn't require testing, just a review.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)