### PR TITLE
Check if activity availibilyty before using it in ArbitrayFileWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -35,11 +35,13 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtil;
+import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 
 import java.io.File;
@@ -194,6 +196,13 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
         intent.setAction(Intent.ACTION_VIEW);
         intent.setDataAndType(contentUri, getMimeType(getSourcePathFromUri(fileUri)));
         FileUtils.grantFileReadPermissions(intent, contentUri, getContext());
-        getContext().startActivity(intent);
+
+        if (new ActivityAvailability(getContext()).isActivityAvailable(intent)) {
+            getContext().startActivity(intent);
+        } else {
+            String message = getContext().getString(R.string.activity_not_found, getContext().getString(R.string.open_file));
+            ToastUtils.showLongToast(message);
+            Timber.w(message);
+        }
     }
 }

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -656,4 +656,5 @@
     <string name="sms_invalid_phone_number_description">Set a destination phone number for SMS submissions or change your transport type.</string>
     <string name="notification_channel_name">General notifications</string>
     <string name="corrupt_imported_preferences_error">Current settings are corrupt. From the admin settings, reset settings or import working ones.</string>
+    <string name="open_file">Open file</string>
 </resources>


### PR DESCRIPTION
Closes #2791 

#### What has been done to verify that this works as intended?
Nothing, it's just a simple check I added to avoid that rare, difficult to reproduce crash.

#### Why is this the best possible solution? Were any other approaches considered?
I used the class we implemented to check if an activity is available - ActivityAvailability.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's safe it just checks if we can start an activity first. I don't think it requires testing. Reviewing the code should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)