### PR TITLE
Use contentLength requested by server

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
@@ -297,7 +297,8 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     public @NonNull ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList,
                                                       @NonNull File submissionFile,
                                                       @NonNull URI uri,
-                                                      @Nullable HttpCredentialsInterface credentials) throws IOException {
+                                                      @Nullable HttpCredentialsInterface credentials,
+                                                      @NonNull long contentLength) throws IOException {
         addCredentialsForHost(uri, credentials);
         clearCookieStore();
 
@@ -353,7 +354,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                 // we've added at least one attachment to the request...
                 if (fileIndex + 1 < fileList.size()) {
                     if ((fileIndex - lastFileIndex + 1 > 100) || (byteCount + fileList.get(fileIndex + 1).length()
-                            > 10000000L)) {
+                            > contentLength)) {
                         // the next file would exceed the 10MB threshold...
                         Timber.i("Extremely long post is being split into multiple posts");
                         try {

--- a/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
@@ -55,6 +55,7 @@ public interface OpenRosaHttpInterface {
      * @param fileList List of Files to be uploaded
      * @param submissionFile The main file to be uploaded (Form file)
      * @param uri where to send the submissionFile and fileList
+     * @param contentLength contentLength requested by the server
      * @return ResponseMessageParser object that contains the response XML
      * @throws IOException can be thrown if files do not exist
      */
@@ -62,6 +63,7 @@ public interface OpenRosaHttpInterface {
     ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList,
                                                @NonNull File submissionFile,
                                                @NonNull URI uri,
-                                               @Nullable HttpCredentialsInterface credentials) throws IOException;
+                                               @Nullable HttpCredentialsInterface credentials,
+                                               @NonNull long contentLength) throws IOException;
 
 }


### PR DESCRIPTION
Closes #2012

#### What has been done to verify that this works as intended?

Nothing. Mostly because I don't know of a server that returns a X-OpenRosa-Accept-Content-Length larger than 10MB. 

Ona seems to use [10,000,000 bytes](https://github.com/onaio/onadata/search?q=DEFAULT_CONTENT_LENGTH) (SI prefix, technically correct) and Aggregate uses [10,485,760 bytes](https://github.com/opendatakit/aggregate/search?q=OPEN_ROSA_ACCEPT_CONTENT_LENGTH_HEADER) (Binary prefix).

#### Why is this the best possible solution? Were any other approaches considered?
This change makes us more compliant with the spec and decouples the head and upload calls.

As the spec requires, if the head request returns a `X-OpenRosa-Accept-Content-Length` header, we use it in the upload. If it doesn't have that header, we default to 10MB which is a long standing default.

It feels like a pretty safe change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users with submissions larger than 10MB should experience fewer POSTs. This is probably better, but it might not be.

#### Do we need any specific form for testing your changes? If so, please attach one.

No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [X] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [X] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [X] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)