### PR TITLE
Fixed TransactionTooLargeException in FormDownloadList activity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -96,7 +96,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
-    private static final String SELECTED_FORMS = "selectedForms";
     private static final String IS_DOWNLOAD_ONLY_MODE = "isDownloadOnlyMode";
     private static final String FORM_IDS_TO_DOWNLOAD = "formIdsToDownload";
     private static final String URL = "url";
@@ -122,7 +121,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private Button toggleButton;
 
     private final ArrayList<HashMap<String, String>> filteredFormList = new ArrayList<>();
-    private LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
     private static final boolean EXIT = true;
     private static final boolean DO_NOT_EXIT = false;
@@ -225,10 +223,10 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             public void onClick(View v) {
                 downloadButton.setEnabled(toggleChecked(listView));
                 toggleButtonLabel(toggleButton, listView);
-                selectedForms.clear();
+                viewModel.clearSelectedForms();
                 if (listView.getCheckedItemCount() == listView.getCount()) {
                     for (HashMap<String, String> map : viewModel.getFormList()) {
-                        selectedForms.add(map.get(FORMDETAIL_KEY));
+                        viewModel.addSelectedForm(map.get(FORMDETAIL_KEY));
                     }
                 }
             }
@@ -250,10 +248,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             // Android should keep track of this, but broken on rotate...
             if (savedInstanceState.containsKey(BUNDLE_SELECTED_COUNT)) {
                 downloadButton.setEnabled(savedInstanceState.getInt(BUNDLE_SELECTED_COUNT) > 0);
-            }
-
-            if (savedInstanceState.containsKey(SELECTED_FORMS)) {
-                selectedForms = (LinkedHashSet<String>) savedInstanceState.getSerializable(SELECTED_FORMS);
             }
 
             if (savedInstanceState.containsKey(IS_DOWNLOAD_ONLY_MODE) && savedInstanceState.getBoolean(IS_DOWNLOAD_ONLY_MODE)) {
@@ -317,9 +311,9 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
 
         if (listView.isItemChecked(position)) {
-            selectedForms.add(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
+            viewModel.addSelectedForm(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
         } else {
-            selectedForms.remove(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
+            viewModel.removeSelectedForm(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
         }
     }
 
@@ -378,7 +372,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(BUNDLE_SELECTED_COUNT, listView.getCheckedItemCount());
-        outState.putSerializable(SELECTED_FORMS, selectedForms);
 
         // Download mode variables
 
@@ -492,7 +485,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         for (int i = 0; i < listView.getCount(); i++) {
             HashMap<String, String> item =
                     (HashMap<String, String>) listView.getAdapter().getItem(i);
-            if (selectedForms.contains(item.get(FORMDETAIL_KEY))) {
+            if (viewModel.getSelectedForms().contains(item.get(FORMDETAIL_KEY))) {
                 listView.setItemChecked(i, true);
             }
         }
@@ -620,7 +613,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             HashMap<String, String> item = filteredFormList.get(idx);
             if (isLocalFormSuperseded(item.get(FORM_ID_KEY))) {
                 ls.setItemChecked(idx, true);
-                selectedForms.add(item.get(FORMDETAIL_KEY));
+                viewModel.addSelectedForm(item.get(FORMDETAIL_KEY));
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -60,7 +60,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -96,7 +96,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
-    private static final String DIALOG_MSG = "dialogmsg";
     private static final String DIALOG_SHOWING = "dialogshowing";
     private static final String FORMLIST = "formlist";
     private static final String SELECTED_FORMS = "selectedForms";
@@ -115,7 +114,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     public static final String FORM_ID_KEY = "formid";
     private static final String FORM_VERSION_KEY = "formversion";
 
-    private String alertMsg;
     private boolean alertShowing;
 
     private AlertDialog alertDialog;
@@ -216,7 +214,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             }
         }
 
-        alertMsg = getString(R.string.please_wait);
+        viewModel.setAlertMsg(getString(R.string.please_wait));
 
         downloadButton = findViewById(R.id.add_button);
         downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
@@ -261,9 +259,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 downloadButton.setEnabled(savedInstanceState.getInt(BUNDLE_SELECTED_COUNT) > 0);
             }
 
-            if (savedInstanceState.containsKey(DIALOG_MSG)) {
-                alertMsg = savedInstanceState.getString(DIALOG_MSG);
-            }
             if (savedInstanceState.containsKey(DIALOG_SHOWING)) {
                 alertShowing = savedInstanceState.getBoolean(DIALOG_SHOWING);
             }
@@ -404,7 +399,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(BUNDLE_SELECTED_COUNT, listView.getCheckedItemCount());
-        outState.putString(DIALOG_MSG, alertMsg);
         outState.putBoolean(DIALOG_SHOWING, alertShowing);
         outState.putBoolean(SHOULD_EXIT, shouldExit);
         outState.putSerializable(FORMLIST, formList);
@@ -457,7 +451,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                             }
                         };
                 progressDialog.setTitle(getString(R.string.downloading_data));
-                progressDialog.setMessage(alertMsg);
+                progressDialog.setMessage(viewModel.getAlertMsg());
                 progressDialog.setIcon(android.R.drawable.ic_dialog_info);
                 progressDialog.setIndeterminate(true);
                 progressDialog.setCancelable(false);
@@ -612,7 +606,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask.setDownloaderListener(this);
         }
         if (alertShowing) {
-            createAlertDialog(viewModel.getAlertTitle(), alertMsg, shouldExit);
+            createAlertDialog(viewModel.getAlertTitle(), viewModel.getAlertMsg(), shouldExit);
         }
         super.onResume();
     }
@@ -793,7 +787,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         alertDialog.setCancelable(false);
         alertDialog.setButton(getString(R.string.ok), quitListener);
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
-        alertMsg = message;
+        viewModel.setAlertMsg(message);
         viewModel.setAlertTitle(title);
         alertShowing = true;
         this.shouldExit = shouldExit;
@@ -802,8 +796,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     @Override
     public void progressUpdate(String currentFile, int progress, int total) {
-        alertMsg = getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total));
-        progressDialog.setMessage(alertMsg);
+        viewModel.setAlertMsg(getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total)));
+        progressDialog.setMessage(viewModel.getAlertMsg());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -99,7 +99,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private static final String FORM_IDS_TO_DOWNLOAD = "formIdsToDownload";
     private static final String URL = "url";
     private static final String USERNAME = "username";
-    private static final String PASSWORD = "password";
     private static final String FORMS_FOUND = "formsFound";
 
     public static final String FORMNAME = "formname";
@@ -128,7 +127,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private String[] formIdsToDownload;
     private String url;
     private String username;
-    private String password;
     private ArrayList<String> formsFound;
 
     private FormDownloadListViewModel viewModel;
@@ -193,7 +191,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     if (bundle.containsKey(ApplicationConstants.BundleKeys.USERNAME)
                             && bundle.containsKey(ApplicationConstants.BundleKeys.PASSWORD)) {
                         username = bundle.getString(ApplicationConstants.BundleKeys.USERNAME);
-                        password = bundle.getString(ApplicationConstants.BundleKeys.PASSWORD);
+                        viewModel.setPassword(bundle.getString(ApplicationConstants.BundleKeys.PASSWORD));
                     }
                 }
             }
@@ -248,7 +246,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 formIdsToDownload = savedInstanceState.getStringArray(FORM_IDS_TO_DOWNLOAD);
                 url = savedInstanceState.getString(URL);
                 username = savedInstanceState.getString(USERNAME);
-                password = savedInstanceState.getString(PASSWORD);
                 formsFound = savedInstanceState.getStringArrayList(FORMS_FOUND);
                 formsFound = formsFound == null ? new ArrayList<>() : formsFound;
             }
@@ -343,7 +340,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
             if (viewModel.isDownloadOnlyMode()) {
                 // Pass over the nulls -> They have no effect if even one of them is a null
-                downloadFormListTask.setAlternateCredentials(url, username, password);
+                downloadFormListTask.setAlternateCredentials(url, username, viewModel.getPassword());
             }
 
             downloadFormListTask.execute();
@@ -369,7 +366,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             outState.putStringArray(FORM_IDS_TO_DOWNLOAD, formIdsToDownload);
             outState.putString(URL, url);
             outState.putString(USERNAME, username);
-            outState.putString(PASSWORD, password);
             outState.putStringArrayList(FORMS_FOUND, formsFound);
         }
     }
@@ -417,9 +413,9 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 viewModel.setAlertShowing(false);
 
                 AuthDialogUtility authDialogUtility = new AuthDialogUtility();
-                if (url != null && username != null && password != null) {
+                if (url != null && username != null && viewModel.getPassword() != null) {
                     authDialogUtility.setCustomUsername(username);
-                    authDialogUtility.setCustomPassword(password);
+                    authDialogUtility.setCustomPassword(viewModel.getPassword());
                 }
 
                 return authDialogUtility.createDialog(this, this, url);
@@ -520,8 +516,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask.setDownloaderListener(this);
 
             if (url != null) {
-                if (username != null && password != null) {
-                    webCredentialsUtils.saveCredentials(url, username, password);
+                if (username != null && viewModel.getPassword() != null) {
+                    webCredentialsUtils.saveCredentials(url, username, viewModel.getPassword());
                 } else {
                     webCredentialsUtils.clearCredentials(url);
                 }
@@ -828,7 +824,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
             if (httpCredentials != null) {
                 username = httpCredentials.getUsername();
-                password = httpCredentials.getPassword();
+                viewModel.setPassword(httpCredentials.getPassword());
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -297,7 +297,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             ToastUtils.showShortToast(R.string.no_connection);
 
             if (viewModel.isDownloadOnlyMode()) {
-                setReturnResult(false, getString(R.string.no_connection), viewModel.getFormResult());
+                setReturnResult(false, getString(R.string.no_connection), viewModel.getFormResults());
                 finish();
             }
         } else {
@@ -551,7 +551,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             String dialogTitle = getString(R.string.load_remote_form_error);
 
             if (viewModel.isDownloadOnlyMode()) {
-                setReturnResult(false, getString(R.string.load_remote_form_error), viewModel.getFormResult());
+                setReturnResult(false, getString(R.string.load_remote_form_error), viewModel.getFormResults());
             }
 
             createAlertDialog(dialogTitle, dialogMessage, DO_NOT_EXIT);
@@ -578,7 +578,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
                     // Insert the new form in alphabetical order.
                     if (viewModel.getFormList().isEmpty()) {
-                        viewModel.addFormList(item);
+                        viewModel.addForm(item);
                     } else {
                         int j;
                         for (j = 0; j < viewModel.getFormList().size(); j++) {
@@ -588,7 +588,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                                 break;
                             }
                         }
-                        viewModel.addFormList(j, item);
+                        viewModel.addForm(j, item);
                     }
                 }
             }
@@ -611,7 +611,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 for (FormDetails formDetails: viewModel.getFormNamesAndURLs().values()) {
                     String formId = formDetails.getFormID();
 
-                    if (viewModel.getFormResult().containsKey(formId)) {
+                    if (viewModel.getFormResults().containsKey(formId)) {
                         filesToDownload.add(formDetails);
                     }
                 }
@@ -621,7 +621,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     startFormsDownload(filesToDownload);
                 } else {
                     // None of the forms was found
-                    setReturnResult(false, "Forms not found on server", viewModel.getFormResult());
+                    setReturnResult(false, "Forms not found on server", viewModel.getFormResults());
                     finish();
                 }
 
@@ -681,7 +681,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                             // DownloadFormTask has a callback when cancelled and has code to handle
                             // cancellation when in download mode only
                             if (viewModel.isDownloadOnlyMode()) {
-                                setReturnResult(false, "User cancelled the operation", viewModel.getFormResult());
+                                setReturnResult(false, "User cancelled the operation", viewModel.getFormResults());
                                 finish();
                             }
                         }
@@ -753,13 +753,13 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             for (FormDetails formDetails: result.keySet()) {
                 String successKey = result.get(formDetails);
                 if (Collect.getInstance().getString(R.string.success).equals(successKey)) {
-                    if (viewModel.getFormResult().containsKey(formDetails.getFormID())) {
+                    if (viewModel.getFormResults().containsKey(formDetails.getFormID())) {
                         viewModel.putFormResult(formDetails.getFormID(), true);
                     }
                 }
             }
 
-            setReturnResult(true, null, viewModel.getFormResult());
+            setReturnResult(true, null, viewModel.getFormResults());
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -37,7 +37,7 @@ import android.widget.Button;
 import android.widget.ListView;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.view_models.FormDownloadListViewModel;
+import org.odk.collect.android.activities.viewmodels.FormDownloadListViewModel;
 import org.odk.collect.android.adapters.FormDownloadListAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -101,7 +101,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
     private static final String FORMS_FOUND = "formsFound";
-    private static final String FORM_RESULT = "formResult";
 
     public static final String FORMNAME = "formname";
     private static final String FORMDETAIL_KEY = "formdetailkey";
@@ -131,7 +130,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private String username;
     private String password;
     private ArrayList<String> formsFound;
-    private HashMap<String, Boolean> formResult;
 
     private FormDownloadListViewModel viewModel;
 
@@ -173,7 +171,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     private void init(Bundle savedInstanceState) {
         formsFound = new ArrayList<>();
-        formResult = new HashMap<>();
 
         Bundle bundle = getIntent().getExtras();
         if (bundle != null) {
@@ -253,10 +250,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 username = savedInstanceState.getString(USERNAME);
                 password = savedInstanceState.getString(PASSWORD);
                 formsFound = savedInstanceState.getStringArrayList(FORMS_FOUND);
-                formResult = (HashMap<String, Boolean>) savedInstanceState.getSerializable(FORM_RESULT);
-
                 formsFound = formsFound == null ? new ArrayList<>() : formsFound;
-                formResult = formResult == null ? new HashMap<>() : formResult;
             }
         }
 
@@ -324,7 +318,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             ToastUtils.showShortToast(R.string.no_connection);
 
             if (viewModel.isDownloadOnlyMode()) {
-                setReturnResult(false, getString(R.string.no_connection), formResult);
+                setReturnResult(false, getString(R.string.no_connection), viewModel.getFormResult());
                 finish();
             }
         } else {
@@ -377,7 +371,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             outState.putString(USERNAME, username);
             outState.putString(PASSWORD, password);
             outState.putStringArrayList(FORMS_FOUND, formsFound);
-            outState.putSerializable(FORM_RESULT, formResult);
         }
     }
 
@@ -402,7 +395,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                                     // DownloadFormTask has a callback when cancelled and has code to handle
                                     // cancellation when in download mode only
                                     if (viewModel.isDownloadOnlyMode()) {
-                                        setReturnResult(false, "User cancelled the operation", formResult);
+                                        setReturnResult(false, "User cancelled the operation", viewModel.getFormResult());
                                         finish();
                                     }
                                 }
@@ -644,7 +637,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             String dialogTitle = getString(R.string.load_remote_form_error);
 
             if (viewModel.isDownloadOnlyMode()) {
-                setReturnResult(false, getString(R.string.load_remote_form_error), formResult);
+                setReturnResult(false, getString(R.string.load_remote_form_error), viewModel.getFormResult());
             }
 
             createAlertDialog(dialogTitle, dialogMessage, DO_NOT_EXIT);
@@ -696,7 +689,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 //1. First check if all form IDS could be found on the server - Register forms that could not be found
 
                 for (String formId: formIdsToDownload) {
-                    formResult.put(formId, false);
+                    viewModel.putFormResult(formId, false);
                 }
 
                 ArrayList<FormDetails> filesToDownload  = new ArrayList<>();
@@ -704,7 +697,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 for (FormDetails formDetails: viewModel.getFormNamesAndURLs().values()) {
                     String formId = formDetails.getFormID();
 
-                    if (formResult.containsKey(formId)) {
+                    if (viewModel.getFormResult().containsKey(formId)) {
                         formsFound.add(formId);
                         filesToDownload.add(formDetails);
                     }
@@ -715,7 +708,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     startFormsDownload(filesToDownload);
                 } else {
                     // None of the forms was found
-                    setReturnResult(false, "Forms not found on server", formResult);
+                    setReturnResult(false, "Forms not found on server", viewModel.getFormResult());
                     finish();
                 }
 
@@ -783,13 +776,13 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             for (FormDetails formDetails: result.keySet()) {
                 String successKey = result.get(formDetails);
                 if (Collect.getInstance().getString(R.string.success).equals(successKey)) {
-                    if (formResult.containsKey(formDetails.getFormID())) {
-                        formResult.put(formDetails.getFormID(), true);
+                    if (viewModel.getFormResult().containsKey(formDetails.getFormID())) {
+                        viewModel.putFormResult(formDetails.getFormID(), true);
                     }
                 }
             }
 
-            setReturnResult(true, null, formResult);
+            setReturnResult(true, null, viewModel.getFormResult());
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -96,7 +96,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
-    private static final String FORMS_FOUND = "formsFound";
 
     public static final String FORMNAME = "formname";
     private static final String FORMDETAIL_KEY = "formdetailkey";
@@ -120,8 +119,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private static final boolean DO_NOT_EXIT = false;
 
     private boolean displayOnlyUpdatedForms;
-
-    private ArrayList<String> formsFound;
 
     private FormDownloadListViewModel viewModel;
 
@@ -162,8 +159,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     }
 
     private void init(Bundle savedInstanceState) {
-        formsFound = new ArrayList<>();
-
         Bundle bundle = getIntent().getExtras();
         if (bundle != null) {
             if (bundle.containsKey(DISPLAY_ONLY_UPDATED_FORMS)) {
@@ -234,11 +229,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             // Android should keep track of this, but broken on rotate...
             if (savedInstanceState.containsKey(BUNDLE_SELECTED_COUNT)) {
                 downloadButton.setEnabled(savedInstanceState.getInt(BUNDLE_SELECTED_COUNT) > 0);
-            }
-
-            if (viewModel.isDownloadOnlyMode()) {
-                formsFound = savedInstanceState.getStringArrayList(FORMS_FOUND);
-                formsFound = formsFound == null ? new ArrayList<>() : formsFound;
             }
         }
 
@@ -349,13 +339,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(BUNDLE_SELECTED_COUNT, listView.getCheckedItemCount());
-
-        // Download mode variables
-
-        if (viewModel.isDownloadOnlyMode()) {
-            // String can be stored and retrieved
-            outState.putStringArrayList(FORMS_FOUND, formsFound);
-        }
     }
 
     @Override
@@ -682,7 +665,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     String formId = formDetails.getFormID();
 
                     if (viewModel.getFormResult().containsKey(formId)) {
-                        formsFound.add(formId);
+                        viewModel.addFormsFound(formId);
                         filesToDownload.add(formDetails);
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -97,7 +97,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
     private static final String FORM_IDS_TO_DOWNLOAD = "formIdsToDownload";
-    private static final String URL = "url";
     private static final String FORMS_FOUND = "formsFound";
 
     public static final String FORMNAME = "formname";
@@ -124,7 +123,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private boolean displayOnlyUpdatedForms;
 
     private String[] formIdsToDownload;
-    private String url;
     private ArrayList<String> formsFound;
 
     private FormDownloadListViewModel viewModel;
@@ -184,7 +182,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 }
 
                 if (bundle.containsKey(ApplicationConstants.BundleKeys.URL)) {
-                    url = bundle.getString(ApplicationConstants.BundleKeys.URL);
+                    viewModel.setUrl(bundle.getString(ApplicationConstants.BundleKeys.URL));
 
                     if (bundle.containsKey(ApplicationConstants.BundleKeys.USERNAME)
                             && bundle.containsKey(ApplicationConstants.BundleKeys.PASSWORD)) {
@@ -242,7 +240,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
             if (viewModel.isDownloadOnlyMode()) {
                 formIdsToDownload = savedInstanceState.getStringArray(FORM_IDS_TO_DOWNLOAD);
-                url = savedInstanceState.getString(URL);
                 formsFound = savedInstanceState.getStringArrayList(FORMS_FOUND);
                 formsFound = formsFound == null ? new ArrayList<>() : formsFound;
             }
@@ -337,7 +334,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
             if (viewModel.isDownloadOnlyMode()) {
                 // Pass over the nulls -> They have no effect if even one of them is a null
-                downloadFormListTask.setAlternateCredentials(url, viewModel.getUsername(), viewModel.getPassword());
+                downloadFormListTask.setAlternateCredentials(viewModel.getUrl(), viewModel.getUsername(), viewModel.getPassword());
             }
 
             downloadFormListTask.execute();
@@ -361,7 +358,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         if (viewModel.isDownloadOnlyMode()) {
             // String can be stored and retrieved
             outState.putStringArray(FORM_IDS_TO_DOWNLOAD, formIdsToDownload);
-            outState.putString(URL, url);
             outState.putStringArrayList(FORMS_FOUND, formsFound);
         }
     }
@@ -409,12 +405,12 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 viewModel.setAlertShowing(false);
 
                 AuthDialogUtility authDialogUtility = new AuthDialogUtility();
-                if (url != null && viewModel.getUsername() != null && viewModel.getPassword() != null) {
+                if (viewModel.getUrl() != null && viewModel.getUsername() != null && viewModel.getPassword() != null) {
                     authDialogUtility.setCustomUsername(viewModel.getUsername());
                     authDialogUtility.setCustomPassword(viewModel.getPassword());
                 }
 
-                return authDialogUtility.createDialog(this, this, url);
+                return authDialogUtility.createDialog(this, this, viewModel.getUrl());
             case CANCELLATION_DIALOG:
                 cancelDialog = new ProgressDialog(this);
                 cancelDialog.setTitle(getString(R.string.canceling));
@@ -511,11 +507,11 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask = new DownloadFormsTask();
             downloadFormsTask.setDownloaderListener(this);
 
-            if (url != null) {
+            if (viewModel.getUrl() != null) {
                 if (viewModel.getUsername() != null && viewModel.getPassword() != null) {
-                    webCredentialsUtils.saveCredentials(url, viewModel.getUsername(), viewModel.getPassword());
+                    webCredentialsUtils.saveCredentials(viewModel.getUrl(), viewModel.getUsername(), viewModel.getPassword());
                 } else {
-                    webCredentialsUtils.clearCredentials(url);
+                    webCredentialsUtils.clearCredentials(viewModel.getUrl());
                 }
             }
 
@@ -815,8 +811,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     public void updatedCredentials() {
         // If the user updated the custom credentials using the dialog, let us update our
         // variables holding the custom credentials
-        if (url != null) {
-            HttpCredentialsInterface httpCredentials = webCredentialsUtils.getCredentials(URI.create(url));
+        if (viewModel.getUrl() != null) {
+            HttpCredentialsInterface httpCredentials = webCredentialsUtils.getCredentials(URI.create(viewModel.getUrl()));
 
             if (httpCredentials != null) {
                 viewModel.setUsername(httpCredentials.getUsername());
@@ -846,12 +842,12 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     }
 
     private void cleanUpWebCredentials() {
-        if (url != null) {
-            String host = Uri.parse(url)
+        if (viewModel.getUrl() != null) {
+            String host = Uri.parse(viewModel.getUrl())
                     .getHost();
 
             if (host != null) {
-                webCredentialsUtils.clearCredentials(url);
+                webCredentialsUtils.clearCredentials(viewModel.getUrl());
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -664,7 +664,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     String formId = formDetails.getFormID();
 
                     if (viewModel.getFormResult().containsKey(formId)) {
-                        viewModel.addFormsFound(formId);
                         filesToDownload.add(formDetails);
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -96,7 +96,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
-    private static final String FORM_IDS_TO_DOWNLOAD = "formIdsToDownload";
     private static final String FORMS_FOUND = "formsFound";
 
     public static final String FORMNAME = "formname";
@@ -122,7 +121,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     private boolean displayOnlyUpdatedForms;
 
-    private String[] formIdsToDownload;
     private ArrayList<String> formsFound;
 
     private FormDownloadListViewModel viewModel;
@@ -174,9 +172,9 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
             if (bundle.containsKey(ApplicationConstants.BundleKeys.FORM_IDS)) {
                 viewModel.setDownloadOnlyMode(true);
-                formIdsToDownload = bundle.getStringArray(ApplicationConstants.BundleKeys.FORM_IDS);
+                viewModel.setFormIdsToDownload(bundle.getStringArray(ApplicationConstants.BundleKeys.FORM_IDS));
 
-                if (formIdsToDownload == null) {
+                if (viewModel.getFormIdsToDownload() == null) {
                     setReturnResult(false, "Form Ids is null", null);
                     finish();
                 }
@@ -239,7 +237,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             }
 
             if (viewModel.isDownloadOnlyMode()) {
-                formIdsToDownload = savedInstanceState.getStringArray(FORM_IDS_TO_DOWNLOAD);
                 formsFound = savedInstanceState.getStringArrayList(FORMS_FOUND);
                 formsFound = formsFound == null ? new ArrayList<>() : formsFound;
             }
@@ -357,7 +354,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
         if (viewModel.isDownloadOnlyMode()) {
             // String can be stored and retrieved
-            outState.putStringArray(FORM_IDS_TO_DOWNLOAD, formIdsToDownload);
             outState.putStringArrayList(FORMS_FOUND, formsFound);
         }
     }
@@ -676,7 +672,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             if (viewModel.isDownloadOnlyMode()) {
                 //1. First check if all form IDS could be found on the server - Register forms that could not be found
 
-                for (String formId: formIdsToDownload) {
+                for (String formId: viewModel.getFormIdsToDownload()) {
                     viewModel.putFormResult(formId, false);
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -180,8 +180,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             }
         }
 
-        viewModel.setAlertMsg(getString(R.string.please_wait));
-
         downloadButton = findViewById(R.id.add_button);
         downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
         downloadButton.setOnClickListener(new OnClickListener() {
@@ -233,7 +231,9 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormListTask = (DownloadFormListTask) getLastCustomNonConfigurationInstance();
             if (downloadFormListTask.getStatus() == AsyncTask.Status.FINISHED) {
                 try {
-                    progressDialog.dismiss();
+                    if (progressDialog != null && progressDialog.isShowing()) {
+                        progressDialog.dismiss();
+                    }
                     viewModel.setProgressDialogShowing(false);
                 } catch (IllegalArgumentException e) {
                     Timber.i("Attempting to close a dialog that was not previously opened");
@@ -244,7 +244,9 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask = (DownloadFormsTask) getLastCustomNonConfigurationInstance();
             if (downloadFormsTask.getStatus() == AsyncTask.Status.FINISHED) {
                 try {
-                    progressDialog.dismiss();
+                    if (progressDialog != null && progressDialog.isShowing()) {
+                        progressDialog.dismiss();
+                    }
                     viewModel.setProgressDialogShowing(false);
                 } catch (IllegalArgumentException e) {
                     Timber.i("Attempting to close a dialog that was not previously opened");
@@ -302,7 +304,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             viewModel.clearFormNamesAndURLs();
             if (progressDialog != null) {
                 // This is needed because onPrepareDialog() is broken in 1.6.
-                progressDialog.setMessage(getString(R.string.please_wait));
+                progressDialog.setMessage(viewModel.getProgressDialogMsg());
             }
             createProgressDialog();
 
@@ -467,7 +469,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask.setDownloaderListener(this);
         }
         if (viewModel.isAlertShowing()) {
-            createAlertDialog(viewModel.getAlertTitle(), viewModel.getAlertMsg(), viewModel.shouldExit());
+            createAlertDialog(viewModel.getAlertTitle(), viewModel.getAlertDialogMsg(), viewModel.shouldExit());
         }
         if (viewModel.isProgressDialogShowing() && (progressDialog == null || !progressDialog.isShowing())) {
             createProgressDialog();
@@ -654,7 +656,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         alertDialog.setCancelable(false);
         alertDialog.setButton(getString(R.string.ok), quitListener);
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
-        viewModel.setAlertMsg(message);
+        viewModel.setAlertDialogMsg(message);
         viewModel.setAlertTitle(title);
         viewModel.setAlertShowing(true);
         viewModel.setShouldExit(shouldExit);
@@ -693,7 +695,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                     }
                 };
         progressDialog.setTitle(getString(R.string.downloading_data));
-        progressDialog.setMessage(viewModel.getAlertMsg());
+        progressDialog.setMessage(viewModel.getProgressDialogMsg());
         progressDialog.setIcon(android.R.drawable.ic_dialog_info);
         progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
@@ -726,8 +728,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     @Override
     public void progressUpdate(String currentFile, int progress, int total) {
-        viewModel.setAlertMsg(getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total)));
-        progressDialog.setMessage(viewModel.getAlertMsg());
+        viewModel.setProgressDialogMsg(getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total)));
+        progressDialog.setMessage(viewModel.getProgressDialogMsg());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -98,7 +98,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
     private static final String FORM_IDS_TO_DOWNLOAD = "formIdsToDownload";
     private static final String URL = "url";
-    private static final String USERNAME = "username";
     private static final String FORMS_FOUND = "formsFound";
 
     public static final String FORMNAME = "formname";
@@ -126,7 +125,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     private String[] formIdsToDownload;
     private String url;
-    private String username;
     private ArrayList<String> formsFound;
 
     private FormDownloadListViewModel viewModel;
@@ -190,7 +188,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
                     if (bundle.containsKey(ApplicationConstants.BundleKeys.USERNAME)
                             && bundle.containsKey(ApplicationConstants.BundleKeys.PASSWORD)) {
-                        username = bundle.getString(ApplicationConstants.BundleKeys.USERNAME);
+                        viewModel.setUsername(bundle.getString(ApplicationConstants.BundleKeys.USERNAME));
                         viewModel.setPassword(bundle.getString(ApplicationConstants.BundleKeys.PASSWORD));
                     }
                 }
@@ -245,7 +243,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             if (viewModel.isDownloadOnlyMode()) {
                 formIdsToDownload = savedInstanceState.getStringArray(FORM_IDS_TO_DOWNLOAD);
                 url = savedInstanceState.getString(URL);
-                username = savedInstanceState.getString(USERNAME);
                 formsFound = savedInstanceState.getStringArrayList(FORMS_FOUND);
                 formsFound = formsFound == null ? new ArrayList<>() : formsFound;
             }
@@ -340,7 +337,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
             if (viewModel.isDownloadOnlyMode()) {
                 // Pass over the nulls -> They have no effect if even one of them is a null
-                downloadFormListTask.setAlternateCredentials(url, username, viewModel.getPassword());
+                downloadFormListTask.setAlternateCredentials(url, viewModel.getUsername(), viewModel.getPassword());
             }
 
             downloadFormListTask.execute();
@@ -365,7 +362,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             // String can be stored and retrieved
             outState.putStringArray(FORM_IDS_TO_DOWNLOAD, formIdsToDownload);
             outState.putString(URL, url);
-            outState.putString(USERNAME, username);
             outState.putStringArrayList(FORMS_FOUND, formsFound);
         }
     }
@@ -413,8 +409,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 viewModel.setAlertShowing(false);
 
                 AuthDialogUtility authDialogUtility = new AuthDialogUtility();
-                if (url != null && username != null && viewModel.getPassword() != null) {
-                    authDialogUtility.setCustomUsername(username);
+                if (url != null && viewModel.getUsername() != null && viewModel.getPassword() != null) {
+                    authDialogUtility.setCustomUsername(viewModel.getUsername());
                     authDialogUtility.setCustomPassword(viewModel.getPassword());
                 }
 
@@ -516,8 +512,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask.setDownloaderListener(this);
 
             if (url != null) {
-                if (username != null && viewModel.getPassword() != null) {
-                    webCredentialsUtils.saveCredentials(url, username, viewModel.getPassword());
+                if (viewModel.getUsername() != null && viewModel.getPassword() != null) {
+                    webCredentialsUtils.saveCredentials(url, viewModel.getUsername(), viewModel.getPassword());
                 } else {
                     webCredentialsUtils.clearCredentials(url);
                 }
@@ -823,7 +819,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             HttpCredentialsInterface httpCredentials = webCredentialsUtils.getCredentials(URI.create(url));
 
             if (httpCredentials != null) {
-                username = httpCredentials.getUsername();
+                viewModel.setUsername(httpCredentials.getUsername());
                 viewModel.setPassword(httpCredentials.getPassword());
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -128,8 +128,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     private static final boolean EXIT = true;
     private static final boolean DO_NOT_EXIT = false;
-    private boolean shouldExit;
-    private static final String SHOULD_EXIT = "shouldexit";
 
     private boolean displayOnlyUpdatedForms;
 
@@ -256,9 +254,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 downloadButton.setEnabled(savedInstanceState.getInt(BUNDLE_SELECTED_COUNT) > 0);
             }
 
-            if (savedInstanceState.containsKey(SHOULD_EXIT)) {
-                shouldExit = savedInstanceState.getBoolean(SHOULD_EXIT);
-            }
             if (savedInstanceState.containsKey(SELECTED_FORMS)) {
                 selectedForms = (LinkedHashSet<String>) savedInstanceState.getSerializable(SELECTED_FORMS);
             }
@@ -393,7 +388,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(BUNDLE_SELECTED_COUNT, listView.getCheckedItemCount());
-        outState.putBoolean(SHOULD_EXIT, shouldExit);
         outState.putSerializable(FORMLIST, formList);
         outState.putSerializable(SELECTED_FORMS, selectedForms);
 
@@ -599,7 +593,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask.setDownloaderListener(this);
         }
         if (viewModel.isAlertShowing()) {
-            createAlertDialog(viewModel.getAlertTitle(), viewModel.getAlertMsg(), shouldExit);
+            createAlertDialog(viewModel.getAlertTitle(), viewModel.getAlertMsg(), viewModel.shouldExit());
         }
         super.onResume();
     }
@@ -783,7 +777,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         viewModel.setAlertMsg(message);
         viewModel.setAlertTitle(title);
         viewModel.setAlertShowing(true);
-        this.shouldExit = shouldExit;
+        viewModel.setShouldExit(shouldExit);
         DialogUtils.showDialog(alertDialog, this);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -96,7 +96,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
-    private static final String DIALOG_TITLE = "dialogtitle";
     private static final String DIALOG_MSG = "dialogmsg";
     private static final String DIALOG_SHOWING = "dialogshowing";
     private static final String FORMLIST = "formlist";
@@ -118,7 +117,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     private String alertMsg;
     private boolean alertShowing;
-    private String alertTitle;
 
     private AlertDialog alertDialog;
     private ProgressDialog progressDialog;
@@ -263,10 +261,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 downloadButton.setEnabled(savedInstanceState.getInt(BUNDLE_SELECTED_COUNT) > 0);
             }
 
-            // to restore alert dialog.
-            if (savedInstanceState.containsKey(DIALOG_TITLE)) {
-                alertTitle = savedInstanceState.getString(DIALOG_TITLE);
-            }
             if (savedInstanceState.containsKey(DIALOG_MSG)) {
                 alertMsg = savedInstanceState.getString(DIALOG_MSG);
             }
@@ -410,7 +404,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(BUNDLE_SELECTED_COUNT, listView.getCheckedItemCount());
-        outState.putString(DIALOG_TITLE, alertTitle);
         outState.putString(DIALOG_MSG, alertMsg);
         outState.putBoolean(DIALOG_SHOWING, alertShowing);
         outState.putBoolean(SHOULD_EXIT, shouldExit);
@@ -619,7 +612,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
             downloadFormsTask.setDownloaderListener(this);
         }
         if (alertShowing) {
-            createAlertDialog(alertTitle, alertMsg, shouldExit);
+            createAlertDialog(viewModel.getAlertTitle(), alertMsg, shouldExit);
         }
         super.onResume();
     }
@@ -801,7 +794,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         alertDialog.setButton(getString(R.string.ok), quitListener);
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertMsg = message;
-        alertTitle = title;
+        viewModel.setAlertTitle(title);
         alertShowing = true;
         this.shouldExit = shouldExit;
         DialogUtils.showDialog(alertDialog, this);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -96,7 +96,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String DISPLAY_ONLY_UPDATED_FORMS = "displayOnlyUpdatedForms";
     private static final String BUNDLE_SELECTED_COUNT = "selectedcount";
-    private static final String DIALOG_SHOWING = "dialogshowing";
     private static final String FORMLIST = "formlist";
     private static final String SELECTED_FORMS = "selectedForms";
     private static final String IS_DOWNLOAD_ONLY_MODE = "isDownloadOnlyMode";
@@ -113,8 +112,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     public static final String FORM_ID_KEY = "formid";
     private static final String FORM_VERSION_KEY = "formversion";
-
-    private boolean alertShowing;
 
     private AlertDialog alertDialog;
     private ProgressDialog progressDialog;
@@ -259,9 +256,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 downloadButton.setEnabled(savedInstanceState.getInt(BUNDLE_SELECTED_COUNT) > 0);
             }
 
-            if (savedInstanceState.containsKey(DIALOG_SHOWING)) {
-                alertShowing = savedInstanceState.getBoolean(DIALOG_SHOWING);
-            }
             if (savedInstanceState.containsKey(SHOULD_EXIT)) {
                 shouldExit = savedInstanceState.getBoolean(SHOULD_EXIT);
             }
@@ -399,7 +393,6 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putInt(BUNDLE_SELECTED_COUNT, listView.getCheckedItemCount());
-        outState.putBoolean(DIALOG_SHOWING, alertShowing);
         outState.putBoolean(SHOULD_EXIT, shouldExit);
         outState.putSerializable(FORMLIST, formList);
         outState.putSerializable(SELECTED_FORMS, selectedForms);
@@ -458,7 +451,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 progressDialog.setButton(getString(R.string.cancel), loadingButtonListener);
                 return progressDialog;
             case AUTH_DIALOG:
-                alertShowing = false;
+                viewModel.setAlertShowing(false);
 
                 AuthDialogUtility authDialogUtility = new AuthDialogUtility();
                 if (url != null && username != null && password != null) {
@@ -605,7 +598,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         if (downloadFormsTask != null) {
             downloadFormsTask.setDownloaderListener(this);
         }
-        if (alertShowing) {
+        if (viewModel.isAlertShowing()) {
             createAlertDialog(viewModel.getAlertTitle(), viewModel.getAlertMsg(), shouldExit);
         }
         super.onResume();
@@ -774,7 +767,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 switch (i) {
                     case DialogInterface.BUTTON_POSITIVE: // ok
                         // just close the dialog
-                        alertShowing = false;
+                        viewModel.setAlertShowing(false);
                         // successful download, so quit
                         // Also quit if in download_mode only(called by another app/activity just to download)
                         if (shouldExit || isDownloadOnlyMode) {
@@ -789,7 +782,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         viewModel.setAlertMsg(message);
         viewModel.setAlertTitle(title);
-        alertShowing = true;
+        viewModel.setAlertShowing(true);
         this.shouldExit = shouldExit;
         DialogUtils.showDialog(alertDialog, this);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.activities;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
+import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -36,6 +37,7 @@ import android.widget.Button;
 import android.widget.ListView;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.activities.view_models.FormDownloadListViewModel;
 import org.odk.collect.android.adapters.FormDownloadListAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
@@ -149,6 +151,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
     private ArrayList<String> formsFound;
     private HashMap<String, Boolean> formResult;
 
+    private FormDownloadListViewModel viewModel;
+
     @Inject
     WebCredentialsUtils webCredentialsUtils;
 
@@ -159,6 +163,8 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
         setContentView(R.layout.form_download_list);
         getComponent().inject(this);
         setTitle(getString(R.string.get_forms));
+
+        viewModel = ViewModelProviders.of(this).get(FormDownloadListViewModel.class);
 
         // This activity is accessed directly externally
         new PermissionUtils(this).requestStoragePermissions(new PermissionListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -36,6 +36,8 @@ public class FormDownloadListViewModel extends ViewModel {
 
     private boolean alertShowing;
     private boolean shouldExit;
+    // Variables for the external app intent call
+    private boolean isDownloadOnlyMode;
 
     public HashMap<String, FormDetails> getFormNamesAndURLs() {
         return formNamesAndURLs;
@@ -115,5 +117,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void clearSelectedForms() {
         selectedForms.clear();
+    }
+
+    public boolean isDownloadOnlyMode() {
+        return isDownloadOnlyMode;
+    }
+
+    public void setDownloadOnlyMode(boolean downloadOnlyMode) {
+        isDownloadOnlyMode = downloadOnlyMode;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -18,5 +18,22 @@ package org.odk.collect.android.activities.view_models;
 
 import android.arch.lifecycle.ViewModel;
 
+import org.odk.collect.android.logic.FormDetails;
+
+import java.util.HashMap;
+
 public class FormDownloadListViewModel extends ViewModel {
+    private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
+
+    public HashMap<String, FormDetails> getFormNamesAndURLs() {
+        return formNamesAndURLs;
+    }
+
+    public void setFormNamesAndURLs(HashMap<String, FormDetails> formNamesAndURLs) {
+        this.formNamesAndURLs = formNamesAndURLs;
+    }
+
+    public void clearFormNamesAndURLs() {
+        formNamesAndURLs.clear();
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -22,11 +22,14 @@ import org.odk.collect.android.logic.FormDetails;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 
 public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
 
     private ArrayList<HashMap<String, String>> formList = new ArrayList<>();
+
+    private LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
     private String alertTitle;
     private String alertMsg;
@@ -92,5 +95,25 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void addFormList(int index, HashMap<String, String> item) {
         formList.add(index, item);
+    }
+
+    public LinkedHashSet<String> getSelectedForms() {
+        return selectedForms;
+    }
+
+    public void setSelectedForms(LinkedHashSet<String> selectedForms) {
+        this.selectedForms = selectedForms;
+    }
+
+    public void addSelectedForm(String form) {
+        selectedForms.add(form);
+    }
+
+    public void removeSelectedForm(String form) {
+        selectedForms.remove(form);
+    }
+
+    public void clearSelectedForms() {
+        selectedForms.clear();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -20,10 +20,13 @@ import android.arch.lifecycle.ViewModel;
 
 import org.odk.collect.android.logic.FormDetails;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
+
+    private ArrayList<HashMap<String, String>> formList = new ArrayList<>();
 
     private String alertTitle;
     private String alertMsg;
@@ -73,5 +76,21 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setShouldExit(boolean shouldExit) {
         this.shouldExit = shouldExit;
+    }
+
+    public ArrayList<HashMap<String, String>> getFormList() {
+        return formList;
+    }
+
+    public void clearFormList() {
+        formList.clear();
+    }
+
+    public void addFormList(HashMap<String, String> item) {
+        formList.add(item);
+    }
+
+    public void addFormList(int index, HashMap<String, String> item) {
+        formList.add(index, item);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -34,6 +34,7 @@ public class FormDownloadListViewModel extends ViewModel {
 
     private String alertTitle;
     private String alertMsg;
+    private String url;
     private String username;
     private String password;
 
@@ -152,5 +153,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -32,6 +32,8 @@ public class FormDownloadListViewModel extends ViewModel {
 
     private LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
+    private String[] formIdsToDownload;
+
     private String alertTitle;
     private String alertMsg;
     private String url;
@@ -161,5 +163,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String[] getFormIdsToDownload() {
+        return formIdsToDownload;
+    }
+
+    public void setFormIdsToDownload(String[] formIdsToDownload) {
+        this.formIdsToDownload = formIdsToDownload;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.activities.view_models;
+
+import android.arch.lifecycle.ViewModel;
+
+public class FormDownloadListViewModel extends ViewModel {
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -110,10 +110,6 @@ public class FormDownloadListViewModel extends ViewModel {
         return selectedForms;
     }
 
-    public void setSelectedForms(LinkedHashSet<String> selectedForms) {
-        this.selectedForms = selectedForms;
-    }
-
     public void addSelectedForm(String form) {
         selectedForms.add(form);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -34,6 +34,7 @@ public class FormDownloadListViewModel extends ViewModel {
 
     private String alertTitle;
     private String alertMsg;
+    private String password;
 
     private boolean alertShowing;
     private boolean shouldExit;
@@ -134,5 +135,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void putFormResult(String form, boolean reasult) {
         formResult.put(form, reasult);
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -28,6 +28,8 @@ public class FormDownloadListViewModel extends ViewModel {
     private String alertTitle;
     private String alertMsg;
 
+    private boolean alertShowing;
+
     public HashMap<String, FormDetails> getFormNamesAndURLs() {
         return formNamesAndURLs;
     }
@@ -54,5 +56,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setAlertMsg(String alertMsg) {
         this.alertMsg = alertMsg;
+    }
+
+    public boolean isAlertShowing() {
+        return alertShowing;
+    }
+
+    public void setAlertShowing(boolean alertShowing) {
+        this.alertShowing = alertShowing;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -34,6 +34,7 @@ public class FormDownloadListViewModel extends ViewModel {
 
     private String alertTitle;
     private String alertMsg;
+    private String username;
     private String password;
 
     private boolean alertShowing;
@@ -143,5 +144,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -29,6 +29,7 @@ public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, Boolean> formResult = new HashMap<>();
 
     private ArrayList<HashMap<String, String>> formList = new ArrayList<>();
+    private ArrayList<String> formsFound = new ArrayList<>();
 
     private LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
@@ -171,5 +172,9 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setFormIdsToDownload(String[] formIdsToDownload) {
         this.formIdsToDownload = formIdsToDownload;
+    }
+
+    public void addFormsFound(String formId) {
+        formsFound.add(formId);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 
 public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
+    private HashMap<String, Boolean> formResult = new HashMap<>();
 
     private ArrayList<HashMap<String, String>> formList = new ArrayList<>();
 
@@ -125,5 +126,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setDownloadOnlyMode(boolean downloadOnlyMode) {
         isDownloadOnlyMode = downloadOnlyMode;
+    }
+
+    public HashMap<String, Boolean> getFormResult() {
+        return formResult;
+    }
+
+    public void putFormResult(String form, boolean reasult) {
+        formResult.put(form, reasult);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -29,6 +29,7 @@ public class FormDownloadListViewModel extends ViewModel {
     private String alertMsg;
 
     private boolean alertShowing;
+    private boolean shouldExit;
 
     public HashMap<String, FormDetails> getFormNamesAndURLs() {
         return formNamesAndURLs;
@@ -64,5 +65,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setAlertShowing(boolean alertShowing) {
         this.alertShowing = alertShowing;
+    }
+
+    public boolean shouldExit() {
+        return shouldExit;
+    }
+
+    public void setShouldExit(boolean shouldExit) {
+        this.shouldExit = shouldExit;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
 
+    private String alertTitle;
+
     public HashMap<String, FormDetails> getFormNamesAndURLs() {
         return formNamesAndURLs;
     }
@@ -35,5 +37,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void clearFormNamesAndURLs() {
         formNamesAndURLs.clear();
+    }
+
+    public String getAlertTitle() {
+        return alertTitle;
+    }
+
+    public void setAlertTitle(String alertTitle) {
+        this.alertTitle = alertTitle;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/view_models/FormDownloadListViewModel.java
@@ -26,6 +26,7 @@ public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
 
     private String alertTitle;
+    private String alertMsg;
 
     public HashMap<String, FormDetails> getFormNamesAndURLs() {
         return formNamesAndURLs;
@@ -45,5 +46,13 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setAlertTitle(String alertTitle) {
         this.alertTitle = alertTitle;
+    }
+
+    public String getAlertMsg() {
+        return alertMsg;
+    }
+
+    public void setAlertMsg(String alertMsg) {
+        this.alertMsg = alertMsg;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -29,28 +29,28 @@ import java.util.LinkedHashSet;
 
 public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
-    private final HashMap<String, Boolean> formResult = new HashMap<>();
 
     private final ArrayList<HashMap<String, String>> formList = new ArrayList<>();
 
     private final LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
-    private String[] formIdsToDownload;
-
     private String alertTitle;
     private String progressDialogMsg;
     private String alertDialogMsg;
-    private String url;
-    private String username;
-    private String password;
 
     private boolean progressDialogShowing;
     private boolean alertShowing;
     private boolean cancelDialogShowing;
     private boolean shouldExit;
     private boolean loadingCanceled;
-    // Variables for the external app intent call
+
+    // Variables used when the activity is called from an external app
     private boolean isDownloadOnlyMode;
+    private String[] formIdsToDownload;
+    private String url;
+    private String username;
+    private String password;
+    private final HashMap<String, Boolean> formResults = new HashMap<>();
 
     public HashMap<String, FormDetails> getFormNamesAndURLs() {
         return formNamesAndURLs;
@@ -112,11 +112,11 @@ public class FormDownloadListViewModel extends ViewModel {
         formList.clear();
     }
 
-    public void addFormList(HashMap<String, String> item) {
+    public void addForm(HashMap<String, String> item) {
         formList.add(item);
     }
 
-    public void addFormList(int index, HashMap<String, String> item) {
+    public void addForm(int index, HashMap<String, String> item) {
         formList.add(index, item);
     }
 
@@ -144,12 +144,12 @@ public class FormDownloadListViewModel extends ViewModel {
         isDownloadOnlyMode = downloadOnlyMode;
     }
 
-    public HashMap<String, Boolean> getFormResult() {
-        return formResult;
+    public HashMap<String, Boolean> getFormResults() {
+        return formResults;
     }
 
     public void putFormResult(String formId, boolean result) {
-        formResult.put(formId, result);
+        formResults.put(formId, result);
     }
 
     public String getPassword() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -18,6 +18,8 @@ package org.odk.collect.android.activities.viewmodels;
 
 import android.arch.lifecycle.ViewModel;
 
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormDetails;
 
 import java.util.ArrayList;
@@ -36,7 +38,8 @@ public class FormDownloadListViewModel extends ViewModel {
     private String[] formIdsToDownload;
 
     private String alertTitle;
-    private String alertMsg;
+    private String progressDialogMsg;
+    private String alertDialogMsg;
     private String url;
     private String username;
     private String password;
@@ -69,12 +72,20 @@ public class FormDownloadListViewModel extends ViewModel {
         this.alertTitle = alertTitle;
     }
 
-    public String getAlertMsg() {
-        return alertMsg;
+    public String getProgressDialogMsg() {
+        return progressDialogMsg == null ? Collect.getInstance().getString(R.string.please_wait) : progressDialogMsg;
     }
 
-    public void setAlertMsg(String alertMsg) {
-        this.alertMsg = alertMsg;
+    public void setProgressDialogMsg(String progressDialogMsg) {
+        this.progressDialogMsg = progressDialogMsg;
+    }
+
+    public String getAlertDialogMsg() {
+        return alertDialogMsg;
+    }
+
+    public void setAlertDialogMsg(String alertDialogMsg) {
+        this.alertDialogMsg = alertDialogMsg;
     }
 
     public boolean isAlertShowing() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -134,8 +134,8 @@ public class FormDownloadListViewModel extends ViewModel {
         return formResult;
     }
 
-    public void putFormResult(String form, boolean reasult) {
-        formResult.put(form, reasult);
+    public void putFormResult(String formId, boolean result) {
+        formResult.put(formId, result);
     }
 
     public String getPassword() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
-package org.odk.collect.android.activities.view_models;
+package org.odk.collect.android.activities.viewmodels;
 
 import android.arch.lifecycle.ViewModel;
 
 import org.odk.collect.android.logic.FormDetails;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 
 public class FormDownloadListViewModel extends ViewModel {
     private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
-    private HashMap<String, Boolean> formResult = new HashMap<>();
+    private final HashMap<String, Boolean> formResult = new HashMap<>();
 
-    private ArrayList<HashMap<String, String>> formList = new ArrayList<>();
-    private ArrayList<String> formsFound = new ArrayList<>();
+    private final ArrayList<HashMap<String, String>> formList = new ArrayList<>();
+    private final ArrayList<String> formsFound = new ArrayList<>();
 
-    private LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
+    private final LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
     private String[] formIdsToDownload;
 
@@ -163,7 +164,7 @@ public class FormDownloadListViewModel extends ViewModel {
     }
 
     public String[] getFormIdsToDownload() {
-        return formIdsToDownload;
+        return Arrays.copyOf(formIdsToDownload, formIdsToDownload.length);
     }
 
     public void setFormIdsToDownload(String[] formIdsToDownload) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -41,8 +41,11 @@ public class FormDownloadListViewModel extends ViewModel {
     private String username;
     private String password;
 
+    private boolean progressDialogShowing;
     private boolean alertShowing;
+    private boolean cancelDialogShowing;
     private boolean shouldExit;
+    private boolean loadingCanceled;
     // Variables for the external app intent call
     private boolean isDownloadOnlyMode;
 
@@ -168,5 +171,29 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setFormIdsToDownload(String[] formIdsToDownload) {
         this.formIdsToDownload = formIdsToDownload;
+    }
+
+    public boolean isProgressDialogShowing() {
+        return progressDialogShowing;
+    }
+
+    public void setProgressDialogShowing(boolean progressDialogShowing) {
+        this.progressDialogShowing = progressDialogShowing;
+    }
+
+    public boolean isCancelDialogShowing() {
+        return cancelDialogShowing;
+    }
+
+    public void setCancelDialogShowing(boolean cancelDialogShowing) {
+        this.cancelDialogShowing = cancelDialogShowing;
+    }
+
+    public boolean wasLoadingCanceled() {
+        return loadingCanceled;
+    }
+
+    public void setLoadingCanceled(boolean loadingCanceled) {
+        this.loadingCanceled = loadingCanceled;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -30,7 +30,6 @@ public class FormDownloadListViewModel extends ViewModel {
     private final HashMap<String, Boolean> formResult = new HashMap<>();
 
     private final ArrayList<HashMap<String, String>> formList = new ArrayList<>();
-    private final ArrayList<String> formsFound = new ArrayList<>();
 
     private final LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
 
@@ -169,9 +168,5 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setFormIdsToDownload(String[] formIdsToDownload) {
         this.formIdsToDownload = formIdsToDownload;
-    }
-
-    public void addFormsFound(String formId) {
-        formsFound.add(formId);
     }
 }


### PR DESCRIPTION
Closes #2794 

#### Explanation
`TransactionTooLargeException is thrown when an Activity is in the process of stopping, that means that the Activity was trying to send its saved state Bundles to the system OS for safe keeping for restoration later (after a config change or process death) but that one or more of the Bundles it sent were too large. There is a maximum limit of about 1MB for all such transactions occurring at once and that limit can be reached even if no single Bundle exceeds that limit`

The stacktrace I attached to the issue doesn't tell us which activity cause the issue. But after reviewing values we safe in our activities and investigating logs from firebase I'm sure it must be the [FormDownloadList](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java) activity.

#### What has been done to verify that this works as intended?
I performed manual testing of the `FormDownloadList` activity.

#### Why is this the best possible solution? Were any other approaches considered?
First I considered using [frankiesardo/icepick](https://github.com/frankiesardo/icepick) + [livefront/bridge](https://github.com/livefront/bridge) libraries. It would allow us to fix the issue just in a few lines since the second mentioned library has been created to fix that problem (TransactionTooLargeException). Unfortunately, we would need to add two new dependencies. [frankiesardo/icepick](https://github.com/frankiesardo/icepick) is really popular and we would consider using that library to reduce boilerplate code but [livefront/bridge](https://github.com/livefront/bridge) has only 100 stars and might be not well tested.

I decided not to take a risk using two new dependencies. That's why I used ViewModel class.

https://developer.android.com/topic/libraries/architecture/viewmodel
`The ViewModel class is designed to store and manage UI-related data in a lifecycle conscious way. The ViewModel class allows data to survive configuration changes such as screen rotations.`

![viewmodel-lifecycle](https://user-images.githubusercontent.com/3276264/51213666-d7645900-191b-11e9-8973-7b72fb892f6b.png)

That means the class keeps our data until the activity is destroyed. If activity was destroyed we need to load available forms again - in this case so using ViewModel class seems reasonable. Activity is not destroyed once we rotate our device so in this case, nothing is going to change. The activity might be destroyed if we close the app using home button and our device has not much memory.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It introduces a lot of refactoring so the whole functionality that the `FormDownloadList` activity provides needs to be carefully tested. Please pay attention to dialogs that activity might display.

Everything should work as before apart from the behavior after destroying the activity. If activity was destroyed we need to load available forms again.
Using `Don't keep activities` option would be helpful here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)