### PR TITLE
Detach location listener to prevent a memory leak.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -322,7 +322,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
         showGpsDisabledAlert();
     }
 
-    @Override public void onClientStop() { }
+    @Override public void onClientStop() {
+        locationClient.stopLocationUpdates();
+    }
 
     protected void showGpsDisabledAlert() {
         gpsErrorDialog = new AlertDialog.Builder(getActivity())


### PR DESCRIPTION
Closes #1646

All the Geo activities leak memory by registering themselves to receive GPS location events (`requestLocationUpdates()`) and never unregistering, thus staying attached as listeners forever.  This was true before the MapFragment refactor, and remains true after the refactor (I tried to preserve exact behaviour during the refactor, and didn't notice this bug).

The fix is straightforward: unregister with `stopLocationUpdates()` when the activity stops.

#### What has been done to verify that this works as intended?
I ran the Android Profiler (in Android Studio) on an APK built from `master`, opened the Memory Profiler and used it to capture some heap dumps.  After launching and backing out of GeoPointMapActivity, the heap dump showed that there was still 1 GeoPointMapActivity on the heap.  I launched and backed out of the activity a few more times, then forced a garbage collection, and the heap dump still showed 4 GeoPointMapActivities on the heap.

I then did the same thing with an APK built with this change, and none of these lingering GeoPointMapActivities were left on the heap anymore.

#### Why is this the best possible solution? Were any other approaches considered?
It's simple and obvious.  I didn't consider any other solutions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no visible changes for users.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with a GeoPoint widget will do.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)