### PR TITLE
Collect logs if a user changes default splash screen image

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -25,10 +25,12 @@ import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.view.View;
 
+import com.google.android.gms.analytics.HitBuilders;
 import com.google.common.collect.ObjectArrays;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.spatial.MapHelper;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -251,6 +253,13 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
 
                 // setting image path
                 setSplashPath(sourceMediaPath);
+
+                Collect.getInstance().getDefaultTracker()
+                        .send(new HitBuilders.EventBuilder()
+                                .setCategory("SplashScreen")
+                                .setAction("newImageSelected")
+                                .setLabel(Collect.getCurrentFormIdentifierHash())
+                                .build());
                 break;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -32,9 +32,11 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.spatial.MapHelper;
+import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.TreeMap;
 
@@ -251,14 +253,16 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
                 String sourceMediaPath = MediaUtils.getPathFromUri(getActivity(), selectedMedia,
                         MediaStore.Images.Media.DATA);
 
+                String sourceMediaPathHash = FileUtils.getMd5Hash(new ByteArrayInputStream(sourceMediaPath.getBytes()));
+
                 // setting image path
                 setSplashPath(sourceMediaPath);
 
                 Collect.getInstance().getDefaultTracker()
                         .send(new HitBuilders.EventBuilder()
-                                .setCategory("SplashScreen")
-                                .setAction("newImageSelected")
-                                .setLabel(Collect.getCurrentFormIdentifierHash())
+                                .setCategory("PreferenceChange")
+                                .setAction("Selected splash image")
+                                .setLabel(sourceMediaPathHash)
                                 .build());
                 break;
         }


### PR DESCRIPTION
I created this pr because I thin the option that allows us to set splash screen image is useless. There is also one issue https://github.com/opendatakit/collect/issues/2390 which is not easy to solve https://github.com/opendatakit/collect/pull/2768 so I think the best option is just removing that option at all but thirst we need to check.

@yanokwa It would be good to add this pr to v1.19

#### What has been done to verify that this works as intended?
Nothing special, it's just a new log.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a new log to get to know if that option is used.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't affect anything. It also doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)