### PR TITLE
Fix for Android 28 licenses not being accepted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,10 @@ references:
   accept_licenses : &accept_licenses
     run:
       name: Accept licenses
-      command: yes | sdkmanager --licenses || true
+      command: yes | sdkmanager --licenses 
+    run:
+      name: Update installed packages
+      command: yes | sdkmanager --update || exit 0
 
   ## Workspace
 


### PR DESCRIPTION
Addresses  #2762

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
It builds on CI

#### Why is this the best possible solution? Were any other approaches considered?
It’s what CircleCI forums recommend 
https://discuss.circleci.com/t/android-platform-28-sdk-license-not-accepted/27768/11

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)