### PR TITLE
Use non-alpha 27 with fix for license acceptance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,7 @@ references:
   accept_licenses : &accept_licenses
     run:
       name: Accept licenses
-      command: yes | sdkmanager --licenses 
-    run:
-      name: Update installed packages
-      command: yes | sdkmanager --update || exit 0
+      command: yes | sdkmanager --licenses || true
 
   ## Workspace
 
@@ -72,7 +69,7 @@ references:
     docker:
       # This needs to be in line with the configuration from gradle file.
       # Otherwise an unnecessary platform update is performed on every build
-      - image: circleci/android:api-27-alpha
+      - image: circleci/android:api-27
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:


### PR DESCRIPTION
Closes #2811

#### What has been done to verify that this works as intended?
Ran it on CircleCI branch. Hoping it works for master!

#### Why is this the best possible solution? Were any other approaches considered?
Suggested fix from https://discuss.circleci.com/t/android-platform-28-sdk-license-not-accepted/27768/11

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No user change. This is just for infrastructure.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)