### PR TITLE
Bug fixes for "visible groups"

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -219,7 +219,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = screenIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
-        boolean isInRepeat = !isAtBeginning && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
+        boolean isInRepeat = formController.indexContainsRepeatableGroup();
         boolean isGroupSizeLocked = shouldShowPicker
                 ? isGroupSizeLocked(repeatGroupPickerIndex) : isGroupSizeLocked(screenIndex);
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -696,11 +696,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             formController.jumpToIndex(currentIndex);
 
-            // Prevent a redundant middle screen (common on some forms).
+            // Prevent a redundant middle screen (common on many forms
+            // that use presentation groups to display labels).
             if (isDisplayingSingleGroup()) {
                 if (isGoingUp) {
-                    // Back out once more.
-                    goUpLevel();
+                    if (!screenIndex.isBeginningOfFormIndex()) {
+                        // Back out once more.
+                        goUpLevel();
+                    }
                 } else {
                     // Enter automatically.
                     formController.jumpToIndex(elementsToDisplay.get(0).getFormIndex());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -592,6 +592,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                 switch (event) {
                     case FormEntryController.EVENT_QUESTION: {
+                        // Nothing but repeat group instances should show up in the picker.
                         if (shouldShowRepeatGroupPicker()) {
                             break;
                         }
@@ -609,6 +610,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_GROUP: {
+                        // Nothing but repeat group instances should show up in the picker.
+                        if (shouldShowRepeatGroupPicker()) {
+                            break;
+                        }
+
                         FormIndex index = formController.getFormIndex();
 
                         // Only display groups with a specific appearance attribute.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -692,12 +692,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             // Prevent a redundant middle screen (common on many forms
             // that use presentation groups to display labels).
-            if (isDisplayingSingleGroup()) {
+            if (isDisplayingSingleGroup() && !screenIndex.isBeginningOfFormIndex()) {
                 if (isGoingUp) {
-                    if (!screenIndex.isBeginningOfFormIndex()) {
-                        // Back out once more.
-                        goUpLevel();
-                    }
+                    // Back out once more.
+                    goUpLevel();
                 } else {
                     // Enter automatically.
                     formController.jumpToIndex(elementsToDisplay.get(0).getFormIndex());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -119,7 +119,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
      */
     private Menu optionsMenu;
 
-    protected Button jumpPreviousButton;
     protected Button jumpBeginningButton;
     protected Button jumpEndButton;
     protected RecyclerView recyclerView;
@@ -152,7 +151,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         groupPathTextView = findViewById(R.id.pathtext);
 
-        jumpPreviousButton = findViewById(R.id.jumpPreviousButton);
         jumpBeginningButton = findViewById(R.id.jumpBeginningButton);
         jumpEndButton = findViewById(R.id.jumpEndButton);
 
@@ -295,8 +293,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
      * Configure the navigation buttons at the bottom of the screen.
      */
     void configureButtons(FormController formController) {
-        jumpPreviousButton.setOnClickListener(v -> goUpLevel());
-
         jumpBeginningButton.setOnClickListener(v -> {
             formController.getAuditEventLogger().exitView();
             formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
@@ -548,11 +544,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             if (event == FormEntryController.EVENT_BEGINNING_OF_FORM && !shouldShowRepeatGroupPicker()) {
                 // The beginning of form has no valid prompt to display.
                 groupPathTextView.setVisibility(View.GONE);
-                jumpPreviousButton.setEnabled(false);
             } else {
                 groupPathTextView.setVisibility(View.VISIBLE);
                 groupPathTextView.setText(getCurrentPath());
-                jumpPreviousButton.setEnabled(true);
             }
 
             // Refresh the current event in case we did step forward.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/ViewOnlyFormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/ViewOnlyFormHierarchyActivity.java
@@ -32,8 +32,6 @@ public class ViewOnlyFormHierarchyActivity extends FormHierarchyActivity {
      */
     @Override
     void configureButtons(FormController formController) {
-        jumpPreviousButton.setOnClickListener(v -> goUpLevel());
-
         Button exitButton = findViewById(R.id.exitButton);
         exitButton.setOnClickListener(v -> {
             setResult(RESULT_OK);

--- a/collect_app/src/main/res/layout/hierarchy_layout.xml
+++ b/collect_app/src/main/res/layout/hierarchy_layout.xml
@@ -34,16 +34,6 @@ the License.
         android:orientation="horizontal">
 
         <Button
-            android:id="@+id/jumpPreviousButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:padding="12dp"
-            android:text="@string/jump_to_previous"
-            android:textAllCaps="false"
-            android:textSize="16sp" />
-
-        <Button
             android:id="@+id/jumpBeginningButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -4,13 +4,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/menu_go_up"
-        android:icon="@drawable/arrow_up"
-        android:title="@string/jump_to_previous"
-        android:visible="false"
-        app:showAsAction="always" />
-
-    <item
         android:id="@+id/menu_delete_child"
         android:icon="@drawable/ic_delete"
         android:title="@string/delete_repeat"
@@ -21,6 +14,13 @@
         android:id="@+id/menu_add_child"
         android:icon="@drawable/ic_add_circle"
         android:title="@string/add_another_menu"
+        android:visible="false"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/menu_go_up"
+        android:icon="@drawable/arrow_up"
+        android:title="@string/jump_to_previous"
         android:visible="false"
         app:showAsAction="always" />
 


### PR DESCRIPTION
### Changes

#### Hide groups from repeat picker

Fixes a UI bug I found in the recently-merged https://github.com/opendatakit/collect/pull/2764. If a form had a visible group on the same screen as a repeat group, the visible group showed up inside the picker.

This simply adds a guard to make sure nothing shows up in a repeat picker except for repeat group instances.

Demo form: [repeat_group_form.xml](https://github.com/opendatakit/collect/files/2789289/repeat_group_form.xml.txt)

#### Fix ANR when navigating up to initial page

Fixes https://github.com/opendatakit/collect/issues/2824

Previously it would try to step **back** once more, but `refreshView` steps **forward** automatically from the beginning of the form, which led to an infinite loop.

See issue for verification steps.

#### Fix bin icon not showing up for some repeat instances

Fixes https://github.com/opendatakit/collect/issues/2821

Now uses the same logic as `FormEntryActivity` to detect repeats. A regression caused the bin icon to be hidden for repeat instances nested inside groups, because the groups themselves are skipped over in the hierarchy view.

See issue for verification steps.

#### Remove redundant bottom "go up" button

Resolves https://github.com/opendatakit/collect/issues/2831
