### PR TITLE
Moves media player related functionalities to Media Widget class

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GuidanceHint.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GuidanceHint.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.preferences;
 
+import android.support.annotation.NonNull;
+
 public enum GuidanceHint {
     Yes("yes"),
     YesCollapsed("yes_collapsed"),
@@ -11,6 +13,7 @@ public enum GuidanceHint {
         name = s;
     }
 
+    @NonNull
     public static GuidanceHint get(String name) {
         for (GuidanceHint hint : GuidanceHint.values()) {
             if (hint.name.equals(name)) {
@@ -18,9 +21,10 @@ public enum GuidanceHint {
             }
         }
 
-        return null;
+        return No;
     }
 
+    @NonNull
     public String toString() {
         return this.name;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -186,20 +186,20 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
         flContainer.addView(viewText);
     }
 
-    public void setAVT(String audioURI, String imageURI, String videoURI, String bigImageURI, MediaPlayer player) {
-        this.bigImageURI = bigImageURI;
+    public void setAVT(String audioUri, String imageUri, String videoUri, String bigImageUri, MediaPlayer player) {
+        this.bigImageURI = bigImageUri;
         this.player = player;
-        this.videoURI = videoURI;
+        this.videoURI = videoUri;
 
         // Setup audio button
-        if (audioURI != null) {
+        if (audioUri != null) {
             audioButton.setVisibility(VISIBLE);
-            audioButton.init(audioURI, player);
+            audioButton.init(audioUri, player);
             audioButton.setOnClickListener(this);
         }
 
         // Setup video button
-        if (videoURI != null) {
+        if (videoUri != null) {
             videoButton.setVisibility(VISIBLE);
             Bitmap b = BitmapFactory.decodeResource(getResources(), android.R.drawable.ic_media_play);
             videoButton.setImageBitmap(b);
@@ -208,9 +208,9 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
 
         // Setup image view
         String errorMsg = null;
-        if (imageURI != null) {
+        if (imageUri != null) {
             try {
-                String imageFilename = referenceManager.DeriveReference(imageURI).getLocalURI();
+                String imageFilename = referenceManager.DeriveReference(imageUri).getLocalURI();
                 final File imageFile = new File(imageFilename);
                 if (imageFile.exists()) {
                     DisplayMetrics metrics = getResources().getDisplayMetrics();

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -178,15 +178,18 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
         }
     }
 
-    public void setAVT(TextView text, String audioURI, String imageURI, String videoURI,
-                       String bigImageURI, MediaPlayer player) {
-        this.bigImageURI = bigImageURI;
-        this.player = player;
-        this.videoURI = videoURI;
-
+    public void setLabelTextView(TextView text) {
         viewText = text;
         originalText = text.getText();
         viewText.setId(ViewIds.generateViewId());
+        flContainer.removeAllViews();
+        flContainer.addView(viewText);
+    }
+
+    public void setAVT(String audioURI, String imageURI, String videoURI, String bigImageURI, MediaPlayer player) {
+        this.bigImageURI = bigImageURI;
+        this.player = player;
+        this.videoURI = videoURI;
 
         // Setup audio button
         if (audioURI != null) {
@@ -237,9 +240,6 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
                 Timber.e(e, "Invalid image reference due to %s ", e.getMessage());
             }
         }
-
-        flContainer.removeAllViews();
-        flContainer.addView(viewText);
     }
 
     public TextView getView_Text() {

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -222,10 +222,8 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
             final String playOption = mediaWidget.getFormEntryPrompt().getFormElement().getAdditionalAttribute(null, "autoplay");
             if (playOption != null) {
                 new Handler().postDelayed(() -> {
-                    if (playOption.equalsIgnoreCase("audio")) {
-                        mediaWidget.playAudio();
-                    } else if (playOption.equalsIgnoreCase("video")) {
-                        mediaWidget.playVideo();
+                    if (playOption.equalsIgnoreCase("audio") || playOption.equalsIgnoreCase("video")) {
+                        mediaWidget.playAllPromptText(playOption);
                     }
                 }, 150);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -217,19 +217,15 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
 
         // see if there is an autoplay option.
         // Only execute it during forward swipes through the form
-        if (advancingPage && widgets.size() == 1) {
-            final String playOption = widgets.get(
-                    0).getFormEntryPrompt().getFormElement().getAdditionalAttribute(null, "autoplay");
+        if (advancingPage && widgets.size() == 1 && widgets.get(0) instanceof MediaWidget) {
+            MediaWidget mediaWidget = ((MediaWidget) widgets.get(0));
+            final String playOption = mediaWidget.getFormEntryPrompt().getFormElement().getAdditionalAttribute(null, "autoplay");
             if (playOption != null) {
-                Handler handler = new Handler();
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        if (playOption.equalsIgnoreCase("audio")) {
-                            widgets.get(0).playAudio();
-                        } else if (playOption.equalsIgnoreCase("video")) {
-                            widgets.get(0).playVideo();
-                        }
+                new Handler().postDelayed(() -> {
+                    if (playOption.equalsIgnoreCase("audio")) {
+                        mediaWidget.playAudio();
+                    } else if (playOption.equalsIgnoreCase("video")) {
+                        mediaWidget.playVideo();
                     }
                 }, 150);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2011 University of Washington
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -55,6 +55,7 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.ViewIds;
+import org.odk.collect.android.widgets.MediaWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.WidgetFactory;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
@@ -86,7 +87,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
     public static final String FIELD_LIST = "field-list";
 
     public ODKView(Context context, final FormEntryPrompt[] questionPrompts,
-            FormEntryCaption[] groups, boolean advancingPage) {
+                   FormEntryCaption[] groups, boolean advancingPage) {
         super(context);
 
         inflate(getContext(), R.layout.nested_scroll_view, this); // keep in an xml file to enable the vertical scrollbar
@@ -299,7 +300,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
     /**
      * Builds a string representing the 'path' of the list of groups.
      * Each level is separated by `>`.
-     *
+     * <p>
      * Some views (e.g. the repeat picker) may want to hide the multiplicity of the last item,
      * i.e. show `Friends` instead of `Friends > 1`.
      */
@@ -350,7 +351,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
                     } catch (Exception e) {
                         Timber.e(e);
                         ToastUtils.showLongToast(getContext().getString(R.string.error_attaching_binary_file,
-                                        e.getMessage()));
+                                e.getMessage()));
                     }
                     set = true;
                     break;
@@ -415,12 +416,12 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
 
         if (count != 1) {
             Timber.w("Attempting to cancel waiting for binary data to a widget or set of widgets "
-                            + "not looking for data");
+                    + "not looking for data");
         }
     }
 
     public boolean suppressFlingGesture(MotionEvent e1, MotionEvent e2, float velocityX,
-            float velocityY) {
+                                        float velocityY) {
         for (QuestionWidget q : widgets) {
             if (q.suppressFlingGesture(e1, e2, velocityX, velocityY)) {
                 return true;
@@ -469,7 +470,9 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
     }
 
     public void stopAudio() {
-        widgets.get(0).stopAudio();
+        if (widgets.get(0) instanceof MediaWidget) {
+            ((MediaWidget) widgets.get(0)).stopAudio();
+        }
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -218,7 +218,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
         // see if there is an autoplay option.
         // Only execute it during forward swipes through the form
         if (advancingPage && widgets.size() == 1 && widgets.get(0) instanceof MediaWidget) {
-            MediaWidget mediaWidget = ((MediaWidget) widgets.get(0));
+            MediaWidget mediaWidget = (MediaWidget) widgets.get(0);
             final String playOption = mediaWidget.getFormEntryPrompt().getFormElement().getAdditionalAttribute(null, "autoplay");
             if (playOption != null) {
                 new Handler().postDelayed(() -> {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -54,7 +54,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
  */
 
 @SuppressLint("ViewConstructor")
-public class AudioWidget extends QuestionWidget implements FileWidget {
+public class AudioWidget extends MediaWidget implements FileWidget {
 
     @NonNull
     private FileUtil fileUtil;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
@@ -64,7 +64,7 @@ import timber.log.Timber;
  * @author Jeff Beorse (jeff@beorse.net)
  */
 @SuppressLint("ViewConstructor")
-public class GridMultiWidget extends QuestionWidget implements MultiChoiceWidget {
+public class GridMultiWidget extends MediaWidget implements MultiChoiceWidget {
 
     private final int bgOrange = getResources().getColor(R.color.highContrastHighlight);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridWidget.java
@@ -64,7 +64,7 @@ import timber.log.Timber;
  * @author Jeff Beorse (jeff@beorse.net)
  */
 @SuppressLint("ViewConstructor")
-public class GridWidget extends QuestionWidget implements MultiChoiceWidget {
+public class GridWidget extends MediaWidget implements MultiChoiceWidget {
 
     private final int bgOrange = getResources().getColor(R.color.highContrastHighlight);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.media.MediaPlayer;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
@@ -18,5 +19,9 @@ public abstract class MediaWidget extends QuestionWidget {
             player.release();
             player = null;
         }
+    }
+
+    public MediaPlayer getPlayer() {
+        return player;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -50,14 +50,14 @@ public abstract class MediaWidget extends QuestionWidget implements AudioPlayLis
     }
 
     private void attachMediaToLayout() {
-        String imageURI = this instanceof SelectImageMapWidget ? null : getFormEntryPrompt().getImageText();
-        String audioURI = getFormEntryPrompt().getAudioText();
-        String videoURI = getFormEntryPrompt().getSpecialFormQuestionText("video");
+        String imageUri = this instanceof SelectImageMapWidget ? null : getFormEntryPrompt().getImageText();
+        String audioUri = getFormEntryPrompt().getAudioText();
+        String videoUri = getFormEntryPrompt().getSpecialFormQuestionText("video");
 
         // shown when image is clicked
-        String bigImageURI = getFormEntryPrompt().getSpecialFormQuestionText("big-image");
+        String bigImageUri = getFormEntryPrompt().getSpecialFormQuestionText("big-image");
 
-        getQuestionMediaLayout().setAVT(audioURI, imageURI, videoURI, bigImageURI, player);
+        getQuestionMediaLayout().setAVT(audioUri, imageUri, videoUri, bigImageUri, player);
         getQuestionMediaLayout().setAudioListener(this);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -1,15 +1,47 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.media.MediaPlayer;
 import android.support.annotation.CallSuper;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
+import timber.log.Timber;
+
 public abstract class MediaWidget extends QuestionWidget {
+
+    private int playColor;
 
     public MediaWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
+
+        String imageURI = this instanceof SelectImageMapWidget ? null : prompt.getImageText();
+        String audioURI = prompt.getAudioText();
+        String videoURI = prompt.getSpecialFormQuestionText("video");
+
+        // shown when image is clicked
+        String bigImageURI = prompt.getSpecialFormQuestionText("big-image");
+
+        getQuestionMediaLayout().setAVT(audioURI, imageURI, videoURI, bigImageURI, player);
+        getQuestionMediaLayout().setAudioListener(this);
+
+        initPlayColor();
+    }
+
+    private void initPlayColor() {
+        playColor = themeUtils.getAccentColor();
+
+        String playColorString = getFormEntryPrompt().getFormElement().getAdditionalAttribute(null, "playColor");
+        if (playColorString != null) {
+            try {
+                playColor = Color.parseColor(playColorString);
+            } catch (IllegalArgumentException e) {
+                Timber.e(e, "Argument %s is incorrect", playColorString);
+            }
+        }
+
+        getQuestionMediaLayout().setPlayTextColor(playColor);
     }
 
     @Override
@@ -50,5 +82,9 @@ public abstract class MediaWidget extends QuestionWidget {
 
     public MediaPlayer getPlayer() {
         return player;
+    }
+
+    public int getPlayColor() {
+        return playColor;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -1,0 +1,12 @@
+package org.odk.collect.android.widgets;
+
+import android.content.Context;
+
+import org.javarosa.form.api.FormEntryPrompt;
+
+public abstract class MediaWidget extends QuestionWidget {
+
+    public MediaWidget(Context context, FormEntryPrompt prompt) {
+        super(context, prompt);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -6,10 +6,11 @@ import android.media.MediaPlayer;
 import android.support.annotation.CallSuper;
 
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.listeners.AudioPlayListener;
 
 import timber.log.Timber;
 
-public abstract class MediaWidget extends QuestionWidget {
+public abstract class MediaWidget extends QuestionWidget implements AudioPlayListener {
 
     private int playColor;
 
@@ -42,6 +43,16 @@ public abstract class MediaWidget extends QuestionWidget {
         }
 
         getQuestionMediaLayout().setPlayTextColor(playColor);
+    }
+
+    @Override
+    public void resetQuestionTextColor() {
+        getQuestionMediaLayout().resetTextFormatting();
+    }
+
+    @Override
+    public void resetAudioButtonImage() {
+        getQuestionMediaLayout().resetAudioButtonBitmap();
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -69,7 +69,7 @@ public abstract class MediaWidget extends QuestionWidget implements AudioPlayLis
             try {
                 playColor = Color.parseColor(playColorString);
             } catch (IllegalArgumentException e) {
-                Timber.e(e, "Argument %s is incorrect", playColorString);
+                Timber.e(e, "Argument %s to Color.parseColor is incorrect", playColorString);
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 import android.media.MediaPlayer;
+import android.support.annotation.CallSuper;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
@@ -28,12 +29,16 @@ public abstract class MediaWidget extends QuestionWidget {
         }
     }
 
-    public void playVideo() {
-        getQuestionMediaLayout().playVideo();
-    }
-
-    public void playAudio() {
-        playAllPromptText();
+    /*
+     * Prompts with items must override this
+     */
+    @CallSuper
+    public void playAllPromptText(String playOption) {
+        if (playOption.equalsIgnoreCase("audio")) {
+            getQuestionMediaLayout().playAudio();
+        } else if (playOption.equalsIgnoreCase("video")) {
+            getQuestionMediaLayout().playVideo();
+        }
     }
 
     public void stopAudio() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (C) 2019 Shobhit Agarwal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.odk.collect.android.widgets;
 
 import android.content.Context;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -28,6 +28,14 @@ public abstract class MediaWidget extends QuestionWidget {
         }
     }
 
+    public void playVideo() {
+        getQuestionMediaLayout().playVideo();
+    }
+
+    public void playAudio() {
+        playAllPromptText();
+    }
+
     public void stopAudio() {
         if (player != null && player.isPlaying()) {
             player.stop();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -9,4 +9,14 @@ public abstract class MediaWidget extends QuestionWidget {
     public MediaWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
     }
+
+    @Override
+    public void release() {
+        super.release();
+
+        if (player != null) {
+            player.release();
+            player = null;
+        }
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -21,6 +21,20 @@ public abstract class MediaWidget extends QuestionWidget {
         }
     }
 
+    @Override
+    protected void onWindowVisibilityChanged(int visibility) {
+        if (visibility == INVISIBLE || visibility == GONE) {
+            stopAudio();
+        }
+    }
+
+    public void stopAudio() {
+        if (player != null && player.isPlaying()) {
+            player.stop();
+            player.reset();
+        }
+    }
+
     public MediaPlayer getPlayer() {
         return player;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/MediaWidget.java
@@ -13,21 +13,38 @@ import timber.log.Timber;
 public abstract class MediaWidget extends QuestionWidget implements AudioPlayListener {
 
     private int playColor;
+    private MediaPlayer player;
 
     public MediaWidget(Context context, FormEntryPrompt prompt) {
         super(context, prompt);
 
-        String imageURI = this instanceof SelectImageMapWidget ? null : prompt.getImageText();
-        String audioURI = prompt.getAudioText();
-        String videoURI = prompt.getSpecialFormQuestionText("video");
+        initMediaPlayer();
+        attachMediaToLayout();
+        initPlayColor();
+    }
+
+    private void initMediaPlayer() {
+        player = new MediaPlayer();
+        player.setOnCompletionListener(mediaPlayer -> {
+            getQuestionMediaLayout().resetTextFormatting();
+            mediaPlayer.reset();
+        });
+        player.setOnErrorListener((mp, what, extra) -> {
+            Timber.e("Error occurred in MediaPlayer. what = %d, extra = %d", what, extra);
+            return false;
+        });
+    }
+
+    private void attachMediaToLayout() {
+        String imageURI = this instanceof SelectImageMapWidget ? null : getFormEntryPrompt().getImageText();
+        String audioURI = getFormEntryPrompt().getAudioText();
+        String videoURI = getFormEntryPrompt().getSpecialFormQuestionText("video");
 
         // shown when image is clicked
-        String bigImageURI = prompt.getSpecialFormQuestionText("big-image");
+        String bigImageURI = getFormEntryPrompt().getSpecialFormQuestionText("big-image");
 
         getQuestionMediaLayout().setAVT(audioURI, imageURI, videoURI, bigImageURI, player);
         getQuestionMediaLayout().setAudioListener(this);
-
-        initPlayColor();
     }
 
     private void initPlayColor() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -467,13 +467,6 @@ public abstract class QuestionWidget
         }
     }
 
-    /*
-     * Prompts with items must override this
-     */
-    public void playAllPromptText() {
-        getQuestionMediaLayout().playAudio();
-    }
-
     public void resetQuestionTextColor() {
         getQuestionMediaLayout().resetTextFormatting();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -23,6 +23,7 @@ import android.graphics.drawable.Drawable;
 import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.IdRes;
 import android.support.annotation.Nullable;
 import android.text.method.LinkMovementMethod;
@@ -45,9 +46,9 @@ import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GuidanceHint;
-import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.utilities.AnimateUtils;
 import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
@@ -76,7 +77,7 @@ public abstract class QuestionWidget
     private final int questionFontSize;
     private final FormEntryPrompt formEntryPrompt;
     private final MediaLayout questionMediaLayout;
-    private MediaPlayer player;
+    protected MediaPlayer player;
     private final TextView helpTextView;
     private final TextView guidanceTextView;
     private final View helpTextLayout;
@@ -218,14 +219,10 @@ public abstract class QuestionWidget
         return guidanceTextView;
     }
 
-    /**
-     * Releases resources held by this widget
-     */
+    @CallSuper
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     public void release() {
-        if (player != null) {
-            player.release();
-            player = null;
-        }
+        // Release resources held by this widget
     }
 
     //source::https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -43,7 +43,6 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.listeners.AudioPlayListener;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
@@ -69,9 +68,7 @@ import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import timber.log.Timber;
 
-public abstract class QuestionWidget
-        extends RelativeLayout
-        implements Widget, AudioPlayListener {
+public abstract class QuestionWidget extends RelativeLayout implements Widget {
 
     private final int questionFontSize;
     private final FormEntryPrompt formEntryPrompt;
@@ -444,14 +441,6 @@ public abstract class QuestionWidget
         if (getHelpTextView() != null) {
             getHelpTextView().cancelLongPress();
         }
-    }
-
-    public void resetQuestionTextColor() {
-        getQuestionMediaLayout().resetTextFormatting();
-    }
-
-    public void resetAudioButtonImage() {
-        getQuestionMediaLayout().resetAudioButtonBitmap();
     }
 
     public void showWarning(String warningBody) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -107,7 +107,7 @@ public abstract class QuestionWidget
         }
 
         player = new MediaPlayer();
-        getPlayer().setOnCompletionListener(new OnCompletionListener() {
+        player.setOnCompletionListener(new OnCompletionListener() {
             @Override
             public void onCompletion(MediaPlayer mediaPlayer) {
                 getQuestionMediaLayout().resetTextFormatting();
@@ -272,7 +272,7 @@ public abstract class QuestionWidget
         // Create the layout for audio, image, text
         MediaLayout questionMediaLayout = new MediaLayout(getContext());
         questionMediaLayout.setId(ViewIds.generateViewId()); // assign random id
-        questionMediaLayout.setAVT(questionText, audioURI, imageURI, videoURI, bigImageURI, getPlayer());
+        questionMediaLayout.setAVT(questionText, audioURI, imageURI, videoURI, bigImageURI, player);
         questionMediaLayout.setAudioListener(this);
 
         String playColorString = prompt.getFormElement().getAdditionalAttribute(null, "playColor");
@@ -659,10 +659,6 @@ public abstract class QuestionWidget
 
     public MediaLayout getQuestionMediaLayout() {
         return questionMediaLayout;
-    }
-
-    public MediaPlayer getPlayer() {
-        return player;
     }
 
     public int getPlayColor() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -495,21 +495,6 @@ public abstract class QuestionWidget
         warningText.setText(warningBody);
     }
 
-    @Override
-    protected void onWindowVisibilityChanged(int visibility) {
-        if (visibility == INVISIBLE || visibility == GONE) {
-            stopAudio();
-        }
-    }
-
-    public void stopAudio() {
-        if (player != null && player.isPlaying()) {
-            Timber.i("stopAudio " + player);
-            player.stop();
-            player.reset();
-        }
-    }
-
     protected Button getSimpleButton(String text, @IdRes final int withId) {
         final Button button = new Button(getContext());
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -272,7 +272,8 @@ public abstract class QuestionWidget
         // Create the layout for audio, image, text
         MediaLayout questionMediaLayout = new MediaLayout(getContext());
         questionMediaLayout.setId(ViewIds.generateViewId()); // assign random id
-        questionMediaLayout.setAVT(questionText, audioURI, imageURI, videoURI, bigImageURI, player);
+        questionMediaLayout.setLabelTextView(questionText);
+        questionMediaLayout.setAVT(audioURI, imageURI, videoURI, bigImageURI, player);
         questionMediaLayout.setAudioListener(this);
 
         String playColorString = prompt.getFormElement().getAdditionalAttribute(null, "playColor");

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -16,7 +16,6 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
@@ -89,13 +88,11 @@ public abstract class QuestionWidget
     private AtomicBoolean expanded;
     private Bundle state;
     protected ThemeUtils themeUtils;
-    private int playColor;
 
     public QuestionWidget(Context context, FormEntryPrompt prompt) {
         super(context);
 
         themeUtils = new ThemeUtils(context);
-        playColor = themeUtils.getAccentColor();
 
         if (context instanceof FormEntryActivity) {
             state = ((FormEntryActivity) context).getState();
@@ -132,7 +129,7 @@ public abstract class QuestionWidget
         setGravity(Gravity.TOP);
         setPadding(0, 7, 0, 0);
 
-        questionMediaLayout = createQuestionMediaLayout(prompt);
+        questionMediaLayout = createQuestionLayout(prompt);
         helpTextLayout = createHelpTextLayout();
         helpTextLayout.setId(ViewIds.generateViewId());
         guidanceTextLayout = helpTextLayout.findViewById(R.id.guidance_text_layout);
@@ -243,7 +240,7 @@ public abstract class QuestionWidget
         //dependencies for the widget will be wired here.
     }
 
-    private MediaLayout createQuestionMediaLayout(FormEntryPrompt prompt) {
+    private MediaLayout createQuestionLayout(FormEntryPrompt prompt) {
         String promptText = prompt.getLongText();
         // Add the text view. Textview always exists, regardless of whether there's text.
         TextView questionText = new TextView(getContext());
@@ -262,29 +259,10 @@ public abstract class QuestionWidget
             questionText.setVisibility(GONE);
         }
 
-        String imageURI = this instanceof SelectImageMapWidget ? null : prompt.getImageText();
-        String audioURI = prompt.getAudioText();
-        String videoURI = prompt.getSpecialFormQuestionText("video");
-
-        // shown when image is clicked
-        String bigImageURI = prompt.getSpecialFormQuestionText("big-image");
-
         // Create the layout for audio, image, text
         MediaLayout questionMediaLayout = new MediaLayout(getContext());
         questionMediaLayout.setId(ViewIds.generateViewId()); // assign random id
         questionMediaLayout.setLabelTextView(questionText);
-        questionMediaLayout.setAVT(audioURI, imageURI, videoURI, bigImageURI, player);
-        questionMediaLayout.setAudioListener(this);
-
-        String playColorString = prompt.getFormElement().getAdditionalAttribute(null, "playColor");
-        if (playColorString != null) {
-            try {
-                playColor = Color.parseColor(playColorString);
-            } catch (IllegalArgumentException e) {
-                Timber.e(e, "Argument %s is incorrect", playColorString);
-            }
-        }
-        questionMediaLayout.setPlayTextColor(getPlayColor());
 
         return questionMediaLayout;
     }
@@ -630,10 +608,6 @@ public abstract class QuestionWidget
 
     public MediaLayout getQuestionMediaLayout() {
         return questionMediaLayout;
-    }
-
-    public int getPlayColor() {
-        return playColor;
     }
 
     public PermissionUtils getPermissionUtils() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -292,14 +292,6 @@ public abstract class QuestionWidget
         return helpTextView;
     }
 
-    public void playAudio() {
-        playAllPromptText();
-    }
-
-    public void playVideo() {
-        getQuestionMediaLayout().playVideo();
-    }
-
     public FormEntryPrompt getFormEntryPrompt() {
         return formEntryPrompt;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -19,8 +19,6 @@ import android.graphics.Bitmap;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.media.MediaPlayer;
-import android.media.MediaPlayer.OnCompletionListener;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.IdRes;
@@ -73,7 +71,6 @@ public abstract class QuestionWidget extends RelativeLayout implements Widget {
     private final int questionFontSize;
     private final FormEntryPrompt formEntryPrompt;
     private final MediaLayout questionMediaLayout;
-    protected MediaPlayer player;
     private final TextView helpTextView;
     private final TextView guidanceTextView;
     private final View helpTextLayout;
@@ -99,25 +96,6 @@ public abstract class QuestionWidget extends RelativeLayout implements Widget {
         if (context instanceof DependencyProvider) {
             injectDependencies((DependencyProvider) context);
         }
-
-        player = new MediaPlayer();
-        player.setOnCompletionListener(new OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mediaPlayer) {
-                getQuestionMediaLayout().resetTextFormatting();
-                mediaPlayer.reset();
-            }
-
-        });
-
-        player.setOnErrorListener(new MediaPlayer.OnErrorListener() {
-            @Override
-            public boolean onError(MediaPlayer mp, int what, int extra) {
-                Timber.e("Error occured in MediaPlayer. what = %d, extra = %d",
-                        what, extra);
-                return false;
-            }
-        });
 
         questionFontSize = Collect.getQuestionFontsize();
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -84,16 +84,19 @@ public abstract class SelectWidget extends MediaWidget {
     }
 
     @Override
-    public void playAllPromptText() {
-        // set up to play the items when the
-        // question text is finished
-        getPlayer().setOnCompletionListener(mediaPlayer -> {
-            resetQuestionTextColor();
-            mediaPlayer.reset();
-            playNextSelectItem();
-        });
-        // plays the question text
-        super.playAllPromptText();
+    public void playAllPromptText(String playOption) {
+        if (playOption.equalsIgnoreCase("audio")) {
+
+            // set up to play the items when the question text is finished
+            getPlayer().setOnCompletionListener(mediaPlayer -> {
+                resetQuestionTextColor();
+                mediaPlayer.reset();
+                playNextSelectItem();
+            });
+
+            // plays the question text
+            super.playAllPromptText(playOption);
+        }
     }
 
     protected void readItems() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -140,8 +140,6 @@ public abstract class SelectWidget extends MediaWidget {
      * Pull media from the current item and add it to the media layout.
      */
     public void addMediaFromChoice(MediaLayout mediaLayout, int index, TextView textView) {
-        String audioURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
-
         String imageURI;
         if (items.get(index) instanceof ExternalSelectChoice) {
             imageURI = ((ExternalSelectChoice) items.get(index)).getImage();
@@ -152,6 +150,7 @@ public abstract class SelectWidget extends MediaWidget {
 
         textView.setGravity(Gravity.CENTER_VERTICAL);
 
+        String audioURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
         String videoURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "video");
         String bigImageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "big-image");
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -155,7 +155,8 @@ public abstract class SelectWidget extends MediaWidget {
         String videoURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "video");
         String bigImageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "big-image");
 
-        mediaLayout.setAVT(textView, audioURI, imageURI, videoURI, bigImageURI, getPlayer());
+        mediaLayout.setLabelTextView(textView);
+        mediaLayout.setAVT(audioURI, imageURI, videoURI, bigImageURI, getPlayer());
     }
 
     protected RecyclerView setUpRecyclerView() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -39,7 +39,7 @@ import org.odk.collect.android.views.MediaLayout;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class SelectWidget extends QuestionWidget {
+public abstract class SelectWidget extends MediaWidget {
 
     /**
      * A list of choices can have thousands of items. To increase loading and scrolling performance,

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectWidget.java
@@ -140,22 +140,22 @@ public abstract class SelectWidget extends MediaWidget {
      * Pull media from the current item and add it to the media layout.
      */
     public void addMediaFromChoice(MediaLayout mediaLayout, int index, TextView textView) {
-        String imageURI;
+        String imageUri;
         if (items.get(index) instanceof ExternalSelectChoice) {
-            imageURI = ((ExternalSelectChoice) items.get(index)).getImage();
+            imageUri = ((ExternalSelectChoice) items.get(index)).getImage();
         } else {
-            imageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index),
+            imageUri = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index),
                     FormEntryCaption.TEXT_FORM_IMAGE);
         }
 
         textView.setGravity(Gravity.CENTER_VERTICAL);
 
-        String audioURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
-        String videoURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "video");
-        String bigImageURI = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "big-image");
+        String audioUri = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), FormEntryCaption.TEXT_FORM_AUDIO);
+        String videoUri = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "video");
+        String bigImageUri = getFormEntryPrompt().getSpecialFormSelectChoiceText(items.get(index), "big-image");
 
         mediaLayout.setLabelTextView(textView);
-        mediaLayout.setAVT(audioURI, imageURI, videoURI, bigImageURI, getPlayer());
+        mediaLayout.setAVT(audioUri, imageUri, videoUri, bigImageUri, getPlayer());
     }
 
     protected RecyclerView setUpRecyclerView() {

--- a/collect_app/src/test/java/org/odk/collect/android/views/MediaLayoutTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/MediaLayoutTest.java
@@ -30,9 +30,9 @@ public class MediaLayoutTest {
 
     private static final String RANDOM_URI = "randomMediaURI";
 
-    private final String audioURI;
-    private final String imageURI;
-    private final String videoURI;
+    private final String audioUri;
+    private final String imageUri;
+    private final String videoUri;
 
     private MediaPlayer mediaPlayer;
     private ReferenceManager referenceManager;
@@ -46,10 +46,10 @@ public class MediaLayoutTest {
     private ImageView divider;
     private boolean isReferenceManagerStubbed;
 
-    public MediaLayoutTest(String audioURI, String imageURI, String videoURI) {
-        this.audioURI = audioURI;
-        this.imageURI = imageURI;
-        this.videoURI = videoURI;
+    public MediaLayoutTest(String audioUri, String imageUri, String videoUri) {
+        this.audioUri = audioUri;
+        this.imageUri = imageUri;
+        this.videoUri = videoUri;
     }
 
     @ParameterizedRobolectricTestRunner.Parameters()
@@ -95,13 +95,13 @@ public class MediaLayoutTest {
         Assert.assertEquals(VISIBLE, mediaLayout.getVisibility());
         assertVisibility(GONE, audioButton, videoButton, imageView, missingImage, divider);
 
-        mediaLayout.setAVT(audioURI, imageURI, videoURI, null, mediaPlayer);
+        mediaLayout.setAVT(audioUri, imageUri, videoUri, null, mediaPlayer);
 
         // we do not check for the validity of the URIs for the audio and video while loading MediaLayout
-        assertVisibility(audioURI == null ? GONE : VISIBLE, audioButton);
-        assertVisibility(videoURI == null ? GONE : VISIBLE, videoButton);
+        assertVisibility(audioUri == null ? GONE : VISIBLE, audioButton);
+        assertVisibility(videoUri == null ? GONE : VISIBLE, videoButton);
 
-        if (imageURI == null || !isReferenceManagerStubbed) {
+        if (imageUri == null || !isReferenceManagerStubbed) {
             // either the URI wasn't provided or it encountered InvalidReferenceException
             assertVisibility(GONE, imageView, missingImage);
         } else {

--- a/collect_app/src/test/java/org/odk/collect/android/views/MediaLayoutTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/MediaLayoutTest.java
@@ -42,7 +42,6 @@ public class MediaLayoutTest {
     private AudioButton audioButton;
     private AppCompatImageButton videoButton;
     private ImageView imageView;
-    private TextView textView;
     private TextView missingImage;
     private ImageView divider;
     private boolean isReferenceManagerStubbed;
@@ -72,7 +71,6 @@ public class MediaLayoutTest {
         mediaPlayer = mock(MediaPlayer.class);
         reference = mock(FileReference.class);
         referenceManager = mock(ReferenceManager.class);
-        textView = new TextView(RuntimeEnvironment.application);
 
         mediaLayout = new MediaLayout(RuntimeEnvironment.application);
 
@@ -97,7 +95,7 @@ public class MediaLayoutTest {
         Assert.assertEquals(VISIBLE, mediaLayout.getVisibility());
         assertVisibility(GONE, audioButton, videoButton, imageView, missingImage, divider);
 
-        mediaLayout.setAVT(textView, audioURI, imageURI, videoURI, null, mediaPlayer);
+        mediaLayout.setAVT(audioURI, imageURI, videoURI, null, mediaPlayer);
 
         // we do not check for the validity of the URIs for the audio and video while loading MediaLayout
         assertVisibility(audioURI == null ? GONE : VISIBLE, audioButton);


### PR DESCRIPTION
Closes #1640 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Tested manually on Redmi Note 4 and compared the `All-Widgets` and `Birds` forms before and after the changes.

Tests performed:
 - Swiping next while the audio is running stops the audio
 - Text color changes to tint color (blue) when playing audio
 - Minimizing the app while the audio is running stops the audio
 - Select Widget / Grid Widget / Grid Multi Widget and Audio Widgets are functioning properly

#### Why is this the best possible solution? Were any other approaches considered?
This PR is aimed at moving all of the media player related functionalities into an abstract class `MediaWidget`. This also performs minor refactors such as conversion of anonymous inner classes into lambda and minor code cleanup. This reduces the size of `QuestionWidget` by 100 lines.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This PR changes the way layout which contains the question text and other media (audio, video, image) is initialized and the methods controlling media are moved to another class. So, all of the changes must be closely reviewed in order to prevent any regressions.

#### Do we need any specific form for testing your changes? If so, please attach one.
I tested using the `All-Widgets` and `Birds` form

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)