### PR TITLE
Fixed getFileExtensionFromUri() method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -858,7 +858,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                                     + File.separator
                                     + System.currentTimeMillis()
                                     + "."
-                                    + ContentResolverHelper.getFileExtensionFromUri(mediaUri);
+                                    + ContentResolverHelper.getFileExtensionFromUri(this, mediaUri);
                     try {
                         InputStream inputStream = getContentResolver().openInputStream(mediaUri);
                         if (inputStream != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/ContentResolverHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/ContentResolverHelper.java
@@ -15,9 +15,11 @@
 package org.odk.collect.android.dao.helpers;
 
 import android.content.ContentResolver;
+import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
+import android.webkit.MimeTypeMap;
 
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormInfo;
@@ -78,15 +80,21 @@ public final class ContentResolverHelper {
      * @param fileUri Whose name we want to get
      * @return The file's extension
      */
-    public static String getFileExtensionFromUri(Uri fileUri) {
+    public static String getFileExtensionFromUri(Context context, Uri fileUri) {
         try (Cursor returnCursor = getContentResolver().query(fileUri, null, null, null, null)) {
             if (returnCursor != null && returnCursor.getCount() > 0) {
+                String filename = null;
                 int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
-                returnCursor.moveToFirst();
-                String filename = returnCursor.getString(nameIndex);
-                // If the file's name contains extension , we cut it down for latter use (copy a new file).
-                if (filename.lastIndexOf('.') != -1) {
+                if (nameIndex != -1) {
+                    returnCursor.moveToFirst();
+                    filename = returnCursor.getString(nameIndex);
+                }
+                if (filename != null && filename.lastIndexOf('.') != -1) {
                     return filename.substring(filename.lastIndexOf('.'));
+                } else {
+                    return fileUri.getScheme() != null && fileUri.getScheme().equals(ContentResolver.SCHEME_CONTENT)
+                            ? MimeTypeMap.getSingleton().getExtensionFromMimeType(context.getContentResolver().getType(fileUri))
+                            : MimeTypeMap.getFileExtensionFromUrl(fileUri.toString());
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -53,7 +53,7 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
             instanceFile = formController.getInstanceFile();
             if (instanceFile != null) {
                 String instanceFolder = instanceFile.getParent();
-                String extension = ContentResolverHelper.getFileExtensionFromUri(uris[0]);
+                String extension = ContentResolverHelper.getFileExtensionFromUri(formEntryActivity.get(), uris[0]);
                 String destMediaPath = instanceFolder + File.separator + System.currentTimeMillis() + extension;
 
                 try {


### PR DESCRIPTION
Closes #2822 

In the description, I said that I'm not able to reproduce the issue but then I realized my wife uses Xiomi which is the most popular device in reports and bingo :smile: 
I doubt Marzena and Kasia have a device to reproduce the issue and I can't share my wife's one of course so looks like you have to believe me it's fixed.

#### What has been done to verify that this works as intended?
I tested the fix on Xiomi Redmi 4A which I was able to reproduce the issue on.

#### Why is this the best possible solution? Were any other approaches considered?
I decided not to remove the original way of receiving a file extension since in most cases it works well (only a few reports). So I use the new way only if the first approach fails (I can't be sure it's perfect that's why I use it as a last resort).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't change anything, it should just fix the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `AudioWidget` like `AllWidgets` form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)