### PR TITLE
Fix ANR when navigating up to initial page

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -690,11 +690,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             formController.jumpToIndex(currentIndex);
 
-            // Prevent a redundant middle screen (common on some forms).
+            // Prevent a redundant middle screen (common on many forms
+            // that use presentation groups to display labels).
             if (isDisplayingSingleGroup()) {
                 if (isGoingUp) {
-                    // Back out once more.
-                    goUpLevel();
+                    if (!screenIndex.isBeginningOfFormIndex()) {
+                        // Back out once more.
+                        goUpLevel();
+                    }
                 } else {
                     // Enter automatically.
                     formController.jumpToIndex(elementsToDisplay.get(0).getFormIndex());


### PR DESCRIPTION
Fixes https://github.com/opendatakit/collect/issues/2824

Previously it would try to step **back** once more, but `refreshView` steps **forward** automatically from the beginning of the form, which led to an infinite loop.

See issue for verification steps. cc @grzesiek2010 