### PR TITLE
Fixed crashes when the user opens form with unexpected element in 'field-list'

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -511,7 +511,7 @@ public class FormController {
     public int stepToNextEvent(boolean stepIntoGroup) {
         if ((getEvent() == FormEntryController.EVENT_GROUP
                 || getEvent() == FormEntryController.EVENT_REPEAT)
-                && indexIsInFieldList() && getQuestionPrompts().length > 0 && !stepIntoGroup) {
+                && indexIsInFieldList() && !isGroupEmpty() && !stepIntoGroup) {
             return stepOverGroup();
         } else {
             return formEntryController.stepToNextEvent();
@@ -900,6 +900,11 @@ public class FormController {
         }
 
         return questions;
+    }
+
+    private boolean isGroupEmpty() {
+        GroupDef group = (GroupDef) formEntryController.getModel().getForm().getChild(getFormIndex());
+        return getIndicesForGroup(group).isEmpty();
     }
 
     /**


### PR DESCRIPTION
Closes #2828

#### What has been done to verify that this works as intended?
I tested forms attached below:

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that the previous approach we used to determine if a group is empty:
`getQuestionPrompts().length > 0`
throws an exception if a group contains not allowed elements but we don't care about it now we want to know if it contains any elements no matter they are valid or not.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the problem. It shouldn't affect anything else.
[emptyGroupFieldList.xml.txt](https://github.com/opendatakit/collect/files/2796370/emptyGroupFieldList.xml.txt)
[emptyGroupFieldList2.xml.txt](https://github.com/opendatakit/collect/files/2796371/emptyGroupFieldList2.xml.txt)
[g6Error.xml.txt](https://github.com/opendatakit/collect/files/2796372/g6Error.xml.txt)
[g6Error2.xml.txt](https://github.com/opendatakit/collect/files/2796373/g6Error2.xml.txt)


@mmarciniak90 please play with different forms a little bit because I noticed some strange behavior for example in form g6Error2.xml not related to this issue and it doesn't cause any crash but still it's strange and I think we need to add some improvements.
Eg. We need to swipe twice to skip a group that contains not allowed elements if that group is not at the beginning of a form. Maybe you can find something else.

#### Do we need any specific form for testing your changes? If so, please attach one.
I tested:


#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)