### PR TITLE
Fix bin icon not showing up for some repeat instances

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -219,7 +219,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = screenIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();
-        boolean isInRepeat = !isAtBeginning && formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT;
+        boolean isInRepeat = formController.indexContainsRepeatableGroup();
         boolean isGroupSizeLocked = shouldShowPicker
                 ? isGroupSizeLocked(repeatGroupPickerIndex) : isGroupSizeLocked(screenIndex);
 


### PR DESCRIPTION
Fixes https://github.com/opendatakit/collect/issues/2821

Now uses the same logic as `FormEntryActivity` to detect repeats. A regression caused the bin icon to be hidden for repeat instances nested inside groups, because the groups themselves are skipped over in the hierarchy view.

See issue for verification steps.