### PR TITLE
Fixed crash after sending an email

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -53,6 +53,7 @@ import java.util.Map;
 
 import timber.log.Timber;
 
+import static android.content.Intent.ACTION_SENDTO;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
@@ -274,8 +275,12 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
                         getFormEntryPrompt().getIndex().getReference());
 
                 waitForData();
-                fireActivity(i);
-
+                // ACTION_SENDTO used for sending text messages or emails doesn't require any results
+                if (ACTION_SENDTO.equals(i.getAction())) {
+                    getContext().startActivity(i);
+                } else {
+                    fireActivity(i);
+                }
             } catch (ExternalParamsException | ActivityNotFoundException e) {
                 Timber.d(e);
                 onException(e.getMessage());


### PR DESCRIPTION
Closes #2820 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
This problem is not straightforward...
We use external widgets to send text messages or emails, external widgets were originally used in order to start another apps and retrieve a value (that's why they use `startActivityForResult()` method not just `startActivity()`). We don't need any value in case of text messages and email we just need to send them.
The crash took place in `onActivityResult()` which shouldn't be called at all in case of sms/email because as I said we don't expect any value. Maybe we should create a separate widget for such operations instead of mixing both but it's a separate topic and it would require many changes.

So my fix just checks if an action requires any returned value. If not like in the case of `ACTION_SENDTO` we use just `startActivity()` and then `onActivityResult()` is not called at all.

Why the crash takes place only on some devices? Because it returns different `resultCodes` in `onActivityResult()` sometimes it's RESULT_CANCELED and then the line that caused the crash is not called at all and sometimes it's `RESULT_OK` and then it tries to read a value. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should be safe and not affect anything else. Just a bug fix, but please test external widgets just in case, you can use the [Counter](https://github.com/opendatakit/counter) app for example.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)