### PR TITLE
Keyboard appears and full submission name is not visible if submission name is not editable

### DIFF
--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -19,6 +19,8 @@ the specific language governing permissions and limitations under the License.
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
         android:padding="10dp">
 
         <View

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -55,7 +55,7 @@ the specific language governing permissions and limitations under the License.
             android:id="@+id/save_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"
+            android:inputType="textMultiLine"
             android:textSize="21sp" />
 
         <CheckBox


### PR DESCRIPTION
Closes #2819 

#### What has been done to verify that this works as intended?
I've tested rotating a device on the `end of form` screen and the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
The first commit is just a simple fix, the second one contains a fix that enables multiple lines to display an entire text.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pr brings two changes:
1. Fix the problem with appearing keyboard after rotating a device.
2. Enabling multiple lines in form name EdiText.

It should be safe and I can't see any big risk here or other cases that we should test.

#### Do we need any specific form for testing your changes? If so, please attach one.
One form is attached to the issue, apart from that we can use any form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)