### PR TITLE
Show questions with empty labels in FormHierarchy even if they are read-only

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -593,14 +593,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                         FormEntryPrompt fp = formController.getQuestionPrompt();
                         String label = fp.getShortText();
-                        if (!fp.isReadOnly() || (label != null && label.length() > 0)) {
-                            // show the question if it is an editable field.
-                            // or if it is read-only and the label is not blank.
-                            String answerDisplay = FormEntryPromptUtils.getAnswerText(fp, this, formController);
-                            elementsToDisplay.add(
-                                    new HierarchyElement(FormEntryPromptUtils.markQuestionIfIsRequired(label, fp.isRequired()), answerDisplay, null,
-                                            HierarchyElement.Type.QUESTION, fp.getIndex()));
-                        }
+                        String answerDisplay = FormEntryPromptUtils.getAnswerText(fp, this, formController);
+                        elementsToDisplay.add(
+                                new HierarchyElement(FormEntryPromptUtils.markQuestionIfIsRequired(label, fp.isRequired()), answerDisplay, null,
+                                        HierarchyElement.Type.QUESTION, fp.getIndex()));
                         break;
                     }
                     case FormEntryController.EVENT_GROUP: {


### PR DESCRIPTION
Closes #2836 

#### What has been done to verify that this works as intended?
I tested the attached form.

#### Why is this the best possible solution? Were any other approaches considered?
It's a result of our discussion form #2836 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a bug fix, it's safe and shouldn't affect anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used: 
[Test-2836.xml.txt](https://github.com/opendatakit/collect/files/2812609/Test-2836.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)