### PR TITLE
Ignore javarosa subdirectory if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ out/
 .navigation/
 captures/
 
+# Submodules
+javarosa/
+
 # Config for the official ODK Collect build
 collect_app/src/odkCollectRelease/


### PR DESCRIPTION
Directory is added automatically when following the [Debugging JavaRosa](https://github.com/opendatakit/collect#debugging-javarosa) steps in the README. It's annoying to have this directory uncommitted (especially when switching back and forth between branches, some of which don't use local javarosa).
