### PR TITLE
Fix date time tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.utilities;
 import android.content.Context;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +43,8 @@ public class DateTimeUtilsTest {
     private DatePickerDetails bikramSambatDatePickerDetails;
 
     private Context context;
+    private Locale defaultLocale;
+    private TimeZone defaultTimezone;
 
     @Before
     public void setUp() {
@@ -52,6 +55,8 @@ public class DateTimeUtilsTest {
         bikramSambatDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.SPINNERS);
 
         context = Collect.getInstance();
+        defaultLocale = Locale.getDefault();
+        defaultTimezone = TimeZone.getDefault();
     }
 
     @Test
@@ -78,5 +83,11 @@ public class DateTimeUtilsTest {
 
         assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, false, context));
         assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, true, context));
+    }
+
+    @After
+    public void resetTimeZone() {
+        Locale.setDefault(defaultLocale);
+        TimeZone.setDefault(defaultTimezone);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -17,7 +17,6 @@
 package org.odk.collect.android.utilities;
 
 import android.content.Context;
-import android.support.test.filters.Suppress;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Before;
@@ -54,7 +53,6 @@ public class DateTimeUtilsTest {
     }
 
     @Test
-    @Suppress
     public void getDateTimeLabelTest() {
         long dateInMilliseconds = 687967200000L; // 20 Oct 1991 14:00
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -73,8 +73,8 @@ public class DateTimeUtilsTest {
         assertEquals("9 Paopi 1708 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, copticDatePickerDetails, false, context));
         assertEquals("9 Paopi 1708, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, copticDatePickerDetails, true, context));
 
-        assertEquals("11 Rabī‘ ath-thānī 1412 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, islamicDatePickerDetails, false, context));
-        assertEquals("11 Rabī‘ ath-thānī 1412, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, islamicDatePickerDetails, true, context));
+        assertEquals("11 Rabi' al-thani 1412 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, islamicDatePickerDetails, false, context));
+        assertEquals("11 Rabi' al-thani 1412, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, islamicDatePickerDetails, true, context));
 
         assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, false, context));
         assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, true, context));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -27,6 +27,7 @@ import org.odk.collect.android.logic.DatePickerDetails;
 
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
@@ -55,6 +56,7 @@ public class DateTimeUtilsTest {
     @Test
     public void getDateTimeLabelTest() {
         Locale.setDefault(Locale.ENGLISH);
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
 
         long dateInMilliseconds = 687967200000L; // 20 Oct 1991 14:00
         Date date = new Date(dateInMilliseconds);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.DatePickerDetails;
 
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -58,8 +59,10 @@ public class DateTimeUtilsTest {
         Locale.setDefault(Locale.ENGLISH);
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
 
-        long dateInMilliseconds = 687967200000L; // 20 Oct 1991 14:00
-        Date date = new Date(dateInMilliseconds);
+        // 20 Oct 1991 14:00 GMT
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(1991, 9, 20, 14, 0, 0);
+        Date date = calendar.getTime();
 
         assertEquals("Oct 20, 1991", DateTimeUtils.getDateTimeLabel(date, gregorianDatePickerDetails, false, context));
         assertEquals("Oct 20, 1991, 14:00", DateTimeUtils.getDateTimeLabel(date, gregorianDatePickerDetails, true, context));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -54,26 +54,24 @@ public class DateTimeUtilsTest {
 
     @Test
     public void getDateTimeLabelTest() {
+        Locale.setDefault(Locale.ENGLISH);
+
         long dateInMilliseconds = 687967200000L; // 20 Oct 1991 14:00
+        Date date = new Date(dateInMilliseconds);
 
-        Locale.setDefault(Locale.ENGLISH);
-        assertEquals("Oct 20, 1991", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), gregorianDatePickerDetails, false, context));
-        assertEquals("Oct 20, 1991, 14:00", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), gregorianDatePickerDetails, true, context));
+        assertEquals("Oct 20, 1991", DateTimeUtils.getDateTimeLabel(date, gregorianDatePickerDetails, false, context));
+        assertEquals("Oct 20, 1991, 14:00", DateTimeUtils.getDateTimeLabel(date, gregorianDatePickerDetails, true, context));
 
-        Locale.setDefault(Locale.ENGLISH);
-        assertEquals("9 Tikimt 1984 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), ethiopianDatePickerDetails, false, context));
-        assertEquals("9 Tikimt 1984, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), ethiopianDatePickerDetails, true, context));
+        assertEquals("9 Tikimt 1984 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, ethiopianDatePickerDetails, false, context));
+        assertEquals("9 Tikimt 1984, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, ethiopianDatePickerDetails, true, context));
 
-        Locale.setDefault(Locale.ENGLISH);
-        assertEquals("9 Paopi 1708 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), copticDatePickerDetails, false, context));
-        assertEquals("9 Paopi 1708, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), copticDatePickerDetails, true, context));
+        assertEquals("9 Paopi 1708 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, copticDatePickerDetails, false, context));
+        assertEquals("9 Paopi 1708, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, copticDatePickerDetails, true, context));
 
-        Locale.setDefault(Locale.ENGLISH);
-        assertEquals("11 Rabī‘ ath-thānī 1412 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), islamicDatePickerDetails, false, context));
-        assertEquals("11 Rabī‘ ath-thānī 1412, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), islamicDatePickerDetails, true, context));
+        assertEquals("11 Rabī‘ ath-thānī 1412 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, islamicDatePickerDetails, false, context));
+        assertEquals("11 Rabī‘ ath-thānī 1412, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, islamicDatePickerDetails, true, context));
 
-        Locale.setDefault(Locale.ENGLISH);
-        assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), bikramSambatDatePickerDetails, false, context));
-        assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(new Date(dateInMilliseconds), bikramSambatDatePickerDetails, true, context));
+        assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, false, context));
+        assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, true, context));
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Tested on Nexus 5

#### Why is this the best possible solution? Were any other approaches considered?
The expected date format was in GMT but if the tests were running on a device with different timezone, then the tests were failing. So, setting the timezone as GMT solves the problem

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No change

#### Do we need any specific form for testing your changes? If so, please attach one.
Not needed as this PR does not change any source code

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)