### PR TITLE
Issue #620 pr2 add okhttp3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.google.gms:google-services:4.0.1'         
+        classpath 'com.google.gms:google-services:4.0.1'
         classpath 'org.ow2.asm:asm:6.0' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.0'
         classpath 'io.fabric.tools:gradle:1.25.4'
@@ -52,4 +52,5 @@ ext {
     daggerVersion = '2.16'
     rxLifecycleVersion = '2.2.1'
     workManagerVersion = "1.0.0-alpha10"
+    okhttp3Version = '3.11.0'
 }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     implementation "com.android.support:cardview-v7:${rootProject.supportLibraryVersion}"
     implementation "com.android.support:exifinterface:${rootProject.supportLibraryVersion}"
     implementation "com.android.support:multidex:1.0.3"
-    
+
     implementation "com.google.android.gms:play-services-analytics:16.0.1"
     implementation "com.google.android.gms:play-services-auth:16.0.0"
     implementation "com.google.android.gms:play-services-maps:15.0.1"
@@ -211,6 +211,9 @@ dependencies {
     implementation("com.google.oauth-client:google-oauth-client:1.22.0") {
         exclude group: 'org.apache.httpcomponents'
     }
+
+    implementation "com.squareup.okhttp3:okhttp:${rootProject.okhttp3Version}"
+    implementation 'com.burgstaller:okhttp-digest:1.18'
 
     implementation 'bikramsambat:bikram-sambat:1.1.0'
     implementation "com.evernote:android-job:1.2.5"
@@ -317,7 +320,7 @@ dependencies {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
-    androidTestImplementation "com.squareup.okhttp3:mockwebserver:3.9.0"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.okhttp3Version}"
 
     androidTestImplementation "android.arch.work:work-testing:${rootProject.workManagerVersion}"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/CollectServerClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/CollectServerClient.java
@@ -99,7 +99,7 @@ public class CollectServerClient {
             throw new Exception("Invalid server URL (no hostname): " + downloadUrl);
         }
 
-        return httpInterface.get(uri, contentType, webCredentialsUtils.getCredentials(uri));
+        return httpInterface.executeGetRequest(uri, contentType, webCredentialsUtils.getCredentials(uri));
     }
 
     public static String getPlainTextMimeType() {

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
@@ -26,7 +26,6 @@ import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.android.utilities.ResponseMessageParser;
 import org.opendatakit.httpclientandroidlib.Header;
 import org.opendatakit.httpclientandroidlib.HttpEntity;
 import org.opendatakit.httpclientandroidlib.HttpHost;
@@ -383,7 +382,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                 HttpEntity httpEntity = response.getEntity();
                 Timber.i("Response code:%d", responseCode);
 
-                postResult = new HttpPostResult(EntityUtils.toString(httpEntity),responseCode,response.getStatusLine().getReasonPhrase());
+                postResult = new HttpPostResult(EntityUtils.toString(httpEntity), responseCode, response.getStatusLine().getReasonPhrase());
 
                 discardEntityBytes(response);
 
@@ -419,13 +418,12 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
      * HttpPostResult - This is just stubbed out for now, implemented when we move to OkHttpConnection
      * @param uri of which to post
      * @param credentials to use on this post request
-     * @return
-     * @throws Exception
+     * @return null
+     * @throws Exception not used
      */
     public HttpPostResult executePostRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
-        return null;
+        return new HttpPostResult("", 0, "");
     }
-
 
     private void addCredentialsForHost(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) {
         if (credentials != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
@@ -150,7 +150,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
 
     @Override
     public @NonNull
-    HttpGetResult get(@NonNull URI uri, @Nullable final String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable final String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
         addCredentialsForHost(uri, credentials);
         clearCookieStore();
 
@@ -233,7 +233,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     }
 
     @Override
-    public @NonNull HttpHeadResult head(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    public @NonNull HttpHeadResult executeHeadRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
         addCredentialsForHost(uri, credentials);
         clearCookieStore();
 
@@ -295,10 +295,10 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
 
     @Override
     public @NonNull ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList,
-                                                      @NonNull File submissionFile,
-                                                      @NonNull URI uri,
-                                                      @Nullable HttpCredentialsInterface credentials,
-                                                      @NonNull long contentLength) throws IOException {
+                                                               @NonNull File submissionFile,
+                                                               @NonNull URI uri,
+                                                               @Nullable HttpCredentialsInterface credentials,
+                                                               @NonNull long contentLength) throws IOException {
         addCredentialsForHost(uri, credentials);
         clearCookieStore();
 

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpClientConnection.java
@@ -294,11 +294,11 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
     }
 
     @Override
-    public @NonNull ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList,
-                                                               @NonNull File submissionFile,
-                                                               @NonNull URI uri,
-                                                               @Nullable HttpCredentialsInterface credentials,
-                                                               @NonNull long contentLength) throws IOException {
+    public @NonNull HttpPostResult uploadSubmissionFile(@NonNull List<File> fileList,
+                                                        @NonNull File submissionFile,
+                                                        @NonNull URI uri,
+                                                        @Nullable HttpCredentialsInterface credentials,
+                                                        @NonNull long contentLength) throws IOException {
         addCredentialsForHost(uri, credentials);
         clearCookieStore();
 
@@ -309,7 +309,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
             enablePreemptiveBasicAuth(uri.getHost());
         }
 
-        ResponseMessageParser messageParser = null;
+        HttpPostResult postResult = null;
 
         boolean first = true;
         int fileIndex = 0;
@@ -383,10 +383,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                 HttpEntity httpEntity = response.getEntity();
                 Timber.i("Response code:%d", responseCode);
 
-                messageParser = new ResponseMessageParser(
-                        EntityUtils.toString(httpEntity),
-                        responseCode,
-                        response.getStatusLine().getReasonPhrase());
+                postResult = new HttpPostResult(EntityUtils.toString(httpEntity),responseCode,response.getStatusLine().getReasonPhrase());
 
                 discardEntityBytes(response);
 
@@ -395,7 +392,7 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
                 }
 
                 if (responseCode != HttpStatus.SC_CREATED && responseCode != HttpStatus.SC_ACCEPTED) {
-                    return messageParser;
+                    return postResult;
                 }
 
             } catch (IOException e) {
@@ -415,8 +412,20 @@ public class HttpClientConnection implements OpenRosaHttpInterface {
             }
         }
 
-        return messageParser;
+        return postResult;
     }
+
+    /**
+     * HttpPostResult - This is just stubbed out for now, implemented when we move to OkHttpConnection
+     * @param uri of which to post
+     * @param credentials to use on this post request
+     * @return
+     * @throws Exception
+     */
+    public HttpPostResult executePostRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
+        return null;
+    }
+
 
     private void addCredentialsForHost(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) {
         if (credentials != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentials.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentials.java
@@ -6,8 +6,8 @@ public class HttpCredentials implements HttpCredentialsInterface {
     private final String password;
 
     public HttpCredentials(String username, String password) {
-        this.username = username;
-        this.password = password;
+        this.username = (username == null) ? "" : username;
+        this.password = (password == null) ? "" : password;
     }
 
     @Override
@@ -19,4 +19,11 @@ public class HttpCredentials implements HttpCredentialsInterface {
     public String getPassword() {
         return password;
     }
+
+    @Override
+    public boolean equals(HttpCredentialsInterface credentialsInterface) {
+        return getUsername().equals(credentialsInterface.getUsername()) &&
+                getPassword().equals(credentialsInterface.getPassword());
+    }
+
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentials.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentials.java
@@ -30,8 +30,8 @@ public class HttpCredentials implements HttpCredentialsInterface {
             return true;
         }
 
-        return (((HttpCredentials)obj).getUsername().equals(getUsername()) &&
-                ((HttpCredentials)obj).getPassword().equals(getPassword()));
+        return ((HttpCredentials) obj).getUsername().equals(getUsername()) &&
+                ((HttpCredentials) obj).getPassword().equals(getPassword());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentials.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentials.java
@@ -21,9 +21,21 @@ public class HttpCredentials implements HttpCredentialsInterface {
     }
 
     @Override
-    public boolean equals(HttpCredentialsInterface credentialsInterface) {
-        return getUsername().equals(credentialsInterface.getUsername()) &&
-                getPassword().equals(credentialsInterface.getPassword());
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (super.equals(obj)) {
+            return true;
+        }
+
+        return (((HttpCredentials)obj).getUsername().equals(getUsername()) &&
+                ((HttpCredentials)obj).getPassword().equals(getPassword()));
     }
 
+    @Override
+    public int hashCode() {
+        return (getUsername() + getPassword()).hashCode();
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentialsInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentialsInterface.java
@@ -4,6 +4,4 @@ public interface HttpCredentialsInterface {
     String getUsername();
 
     String getPassword();
-
-    boolean equals(HttpCredentialsInterface credentialsInterface);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentialsInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpCredentialsInterface.java
@@ -4,4 +4,6 @@ public interface HttpCredentialsInterface {
     String getUsername();
 
     String getPassword();
+
+    boolean equals(HttpCredentialsInterface credentialsInterface);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/HttpPostResult.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/HttpPostResult.java
@@ -1,0 +1,26 @@
+package org.odk.collect.android.http;
+
+public class HttpPostResult {
+
+    private final String httpResponse;
+    private final int responseCode;
+    private final String reasonPhrase;
+
+    public HttpPostResult(String httpResponse, int responseCode, String reasonPhrase) {
+        this.httpResponse = httpResponse;
+        this.responseCode = responseCode;
+        this.reasonPhrase = reasonPhrase;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    public String getReasonPhrase() {
+        return reasonPhrase;
+    }
+
+    public String getHttpResponse() {
+        return httpResponse;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -283,9 +283,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     private boolean sameCredentials(HttpCredentialsInterface credentials) {
         if (httpCredentials == null && credentials == null) {
             return true;
-        } else if (httpCredentials == null && credentials != null) {
-            return false;
-        } else if (httpCredentials != null && credentials == null) {
+        } else if (httpCredentials == null || credentials == null) {
             return false;
         } else if (httpCredentials.equals(credentials)) {
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -237,7 +237,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
                 // we've added at least one attachment to the request...
                 if (fileIndex + 1 < fileList.size()) {
                     if ((fileIndex - lastFileIndex + 1 > 100) || (byteCount + fileList.get(fileIndex + 1).length()
-                            > 10000000L)) {
+                            > contentLength)) {
                         // the next file would exceed the 10MB threshold...
                         Timber.i("Extremely long post is being split into multiple posts");
                         multipartBuilder.addPart(MultipartBody.Part.createFormData("*isIncomplete*", "yes"));

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -46,8 +46,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okio.GzipSource;
-import okio.InflaterSource;
 import timber.log.Timber;
 
 public class OkHttpConnection implements OpenRosaHttpInterface {
@@ -119,10 +117,8 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
         Map<String, String> responseHeaders = new HashMap<>();
         Headers headers = response.headers();
 
-        if (headers.size() > 0) {
-            for (int i = 0; i < headers.size(); i++) {
-                responseHeaders.put(headers.name(i), headers.value(i));
-            }
+        for (int i = 0; i < headers.size(); i++) {
+            responseHeaders.put(headers.name(i), headers.value(i));
         }
 
         return new HttpGetResult(downloadStream, responseHeaders, hash, statusCode);
@@ -261,7 +257,9 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
         OkHttpClient.Builder builder;
 
         if (httpClient != null) {
-            if (sameCredentials(credentials)) { return httpClient; }
+            if (sameCredentials(credentials)) {
+                return httpClient;
+            }
             builder = httpClient.newBuilder();
         } else {
             builder = new OkHttpClient.Builder();

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -66,7 +66,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
 
     @NonNull
     @Override
-    public HttpGetResult get(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    public HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
         OkHttpClient client = createOkHttpClient(credentials);
         Request request = getRequest(uri);
 
@@ -126,7 +126,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
 
     @NonNull
     @Override
-    public HttpHeadResult head(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    public HttpHeadResult executeHeadRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
         Map<String, String> responseHeaders = new HashMap<>();
 
         int statusCode;

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -1,0 +1,381 @@
+package org.odk.collect.android.http;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.format.DateFormat;
+import android.webkit.MimeTypeMap;
+
+import com.burgstaller.okhttp.AuthenticationCacheInterceptor;
+import com.burgstaller.okhttp.CachingAuthenticatorDecorator;
+import com.burgstaller.okhttp.DispatchingAuthenticator;
+import com.burgstaller.okhttp.basic.BasicAuthenticator;
+import com.burgstaller.okhttp.digest.CachingAuthenticator;
+
+import org.apache.commons.io.IOUtils;
+import org.odk.collect.android.BuildConfig;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.android.utilities.ResponseMessageParser;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import com.burgstaller.okhttp.digest.Credentials;
+import com.burgstaller.okhttp.digest.DigestAuthenticator;
+
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.GzipSource;
+import okio.InflaterSource;
+import timber.log.Timber;
+
+public class OkHttpConnection implements OpenRosaHttpInterface {
+
+    private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final int CONNECTION_TIMEOUT = 30000;
+    private static final int WRITE_CONNECTION_TIMEOUT = 60000; // it can take up to 27 seconds to spin up an Aggregate
+    private static final int READ_CONNECTION_TIMEOUT = 60000; // it can take up to 27 seconds to spin up an Aggregate
+    private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
+    private static final String CONTENT_ENCODING = "gzip,deflate";
+    private static final String OPEN_ROSA_VERSION_HEADER = "X-OpenRosa-Version";
+    private static final String OPEN_ROSA_VERSION = "1.0";
+    private static final String DATE_HEADER = "Date";
+    private static final String HTTP_CONTENT_TYPE_TEXT_XML = "text/xml";
+
+    private static OkHttpClient httpClient;
+    private static HttpCredentialsInterface httpCredentials;
+
+    @NonNull
+    @Override
+    public HttpGetResult get(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
+        OkHttpClient client = createOkHttpClient(credentials);
+        Request request = getRequest(uri);
+
+        Response response = client.newCall(request).execute();
+        int statusCode = response.code();
+
+        if (statusCode != HttpURLConnection.HTTP_OK) {
+            discardEntityBytes(response);
+            String errMsg = Collect
+                    .getInstance()
+                    .getString(R.string.file_fetch_failed, uri.toString(), response.message(), String.valueOf(statusCode));
+
+            Timber.e(errMsg);
+            return new HttpGetResult(null, new HashMap<String, String>(), "", statusCode);
+        }
+
+        ResponseBody body = response.body();
+
+        if (body == null) {
+            throw new Exception("No entity body returned from: " + uri.toString());
+        }
+
+        if (contentType != null && contentType.length() > 0) {
+            MediaType type = body.contentType();
+
+            if (type != null && !type.toString().toLowerCase(Locale.ENGLISH).contains(contentType)) {
+                discardEntityBytes(response);
+
+                String error = "ContentType: " + type.toString() + " returned from: "
+                        + uri.toString() + " is not " + contentType
+                        + ".  This is often caused by a network proxy.  Do you need "
+                        + "to login to your network?";
+
+                throw new Exception(error);
+            }
+        }
+
+        InputStream downloadStream = body.byteStream();
+
+        String hash = "";
+
+        if (HTTP_CONTENT_TYPE_TEXT_XML.equals(contentType)) {
+            byte[] bytes = IOUtils.toByteArray(downloadStream);
+            downloadStream = new ByteArrayInputStream(bytes);
+            hash = FileUtils.getMd5Hash(new ByteArrayInputStream(bytes));
+        }
+
+        Map<String, String> responseHeaders = new HashMap<>();
+        Headers headers = response.headers();
+
+        if (headers.size() > 0) {
+            for (int i = 0; i < headers.size(); i++) {
+                responseHeaders.put(headers.name(i), headers.value(i));
+            }
+        }
+
+        return new HttpGetResult(downloadStream, responseHeaders, hash, statusCode);
+    }
+
+    @NonNull
+    @Override
+    public HttpHeadResult head(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        int statusCode;
+
+        try {
+            Timber.i("Issuing HEAD request to: %s", uri.toString());
+
+            OkHttpClient client = createOkHttpClient(credentials);
+            Request request = headRequest(uri);
+
+            Response response = client.newCall(request).execute();
+            statusCode = response.code();
+
+            if (statusCode == HttpURLConnection.HTTP_NO_CONTENT) {
+                Headers headers = response.headers();
+
+                for (String headerName : headers.names()) {
+                    responseHeaders.put(headerName, headers.get(headerName));
+                }
+            }
+
+            discardEntityBytes(response);
+
+        } catch (IOException | IllegalStateException e) {
+            String errorMessage = "";
+
+            if (e instanceof MalformedURLException) {
+                errorMessage = "Malformed URL Exception";
+            } else if (e instanceof IllegalStateException) {
+                errorMessage = "Illegal State Exception";
+            }
+
+            throw new Exception(errorMessage);
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg == null) {
+                msg = e.toString();
+            }
+
+            throw new Exception("Generic Exception: " + msg);
+        }
+
+        return new HttpHeadResult(statusCode, responseHeaders);
+    }
+
+    @NonNull
+    @Override
+    public ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList, @NonNull File submissionFile, @NonNull URI uri, @Nullable HttpCredentialsInterface credentials, @NonNull long contentLength) throws IOException {
+        ResponseMessageParser messageParser = null;
+
+        boolean first = true;
+        int fileIndex = 0;
+        int lastFileIndex;
+        while (fileIndex < fileList.size() || first) {
+            lastFileIndex = fileIndex;
+            first = false;
+
+            MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
+
+            long byteCount = 0L;
+
+            RequestBody requestBody = RequestBody.create(MediaType.parse(HTTP_CONTENT_TYPE_TEXT_XML), submissionFile);
+
+            MultipartBody.Builder multipartBuilder = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addPart(MultipartBody.Part.createFormData("xml_submission_file", submissionFile.getName(), requestBody));
+
+            Timber.i("added xml_submission_file: %s", submissionFile.getName());
+            byteCount += submissionFile.length();
+
+            for (; fileIndex < fileList.size(); fileIndex++) {
+                File file = fileList.get(fileIndex);
+
+                String mime = mimeTypeMap.getMimeTypeFromExtension(FileUtils.getFileExtension(file.getName()));
+
+                RequestBody fileRequestBody = RequestBody.create(MediaType.parse(mime), file);
+
+                multipartBuilder.addPart(MultipartBody.Part.create(fileRequestBody));
+
+                byteCount += file.length();
+                Timber.i("added file of type '%s' %s", mime, file.getName());
+
+                // we've added at least one attachment to the request...
+                if (fileIndex + 1 < fileList.size()) {
+                    if ((fileIndex - lastFileIndex + 1 > 100) || (byteCount + fileList.get(fileIndex + 1).length()
+                            > 10000000L)) {
+                        // the next file would exceed the 10MB threshold...
+                        Timber.i("Extremely long post is being split into multiple posts");
+                        multipartBuilder.addPart(MultipartBody.Part.createFormData("*isIncomplete*", "yes"));
+                        ++fileIndex; // advance over the last attachment added...
+                        break;
+                    }
+                }
+            }
+
+            MultipartBody multipartBody = multipartBuilder.build();
+
+            try {
+                OkHttpClient client = createOkHttpClient(credentials);
+                Request request = postRequest(uri, multipartBody);
+                Response response = client.newCall(request).execute();
+
+                messageParser = new ResponseMessageParser(
+                        response.toString(),
+                        response.code(),
+                        response.message());
+
+                discardEntityBytes(response);
+
+                if (response.code() != HttpURLConnection.HTTP_CREATED && response.code() != HttpURLConnection.HTTP_ACCEPTED) {
+                    return messageParser;
+                }
+            } catch (IOException e) {
+                Timber.e(e);
+                String msg = e.getMessage();
+                if (msg == null) {
+                    msg = e.toString();
+                }
+
+                throw new IOException(msg);
+            }
+        }
+
+        return messageParser;
+    }
+
+    private OkHttpClient createOkHttpClient(@Nullable HttpCredentialsInterface credentials) {
+        OkHttpClient.Builder builder;
+
+        if (httpClient != null) {
+            if (sameCredentials(credentials)) { return httpClient; }
+            builder = httpClient.newBuilder();
+        } else {
+            builder = new OkHttpClient.Builder();
+        }
+
+        addCredentials(builder, credentials);
+        httpCredentials = credentials;
+
+        httpClient = builder
+                .connectTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(WRITE_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(READ_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .followRedirects(true)
+                .build();
+
+        return httpClient;
+    }
+
+    private boolean sameCredentials(HttpCredentialsInterface credentials) {
+        if (httpCredentials == null && credentials == null) {
+            return true;
+        } else if (httpCredentials == null && credentials != null) {
+            return false;
+        } else if (httpCredentials != null && credentials == null) {
+            return false;
+        } else if (httpCredentials.equals(credentials)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private void addCredentials(OkHttpClient.Builder builder, @Nullable HttpCredentialsInterface credentials) {
+        if (credentials != null) {
+            final Map<String, CachingAuthenticator> authCache = new ConcurrentHashMap<>();
+            Credentials cred = new Credentials(credentials.getUsername(), credentials.getPassword());
+
+            BasicAuthenticator basicAuthenticator = new BasicAuthenticator(cred);
+            DigestAuthenticator digestAuthenticator = new DigestAuthenticator(cred);
+
+            DispatchingAuthenticator authenticator = new DispatchingAuthenticator.Builder()
+                    .with("digest", digestAuthenticator)
+                    .with("basic", basicAuthenticator)
+                    .build();
+
+            builder.authenticator(new CachingAuthenticatorDecorator(authenticator, authCache))
+                    .addInterceptor(new AuthenticationCacheInterceptor(authCache));
+        }
+    }
+
+    private Request getRequest(@NonNull URI uri) throws MalformedURLException {
+        return new Request.Builder()
+                .url(uri.toURL())
+                .addHeader(ACCEPT_ENCODING_HEADER, CONTENT_ENCODING)
+                .addHeader(USER_AGENT_HEADER, getUserAgentString())
+                .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
+                .addHeader(DATE_HEADER, getHeaderDate())
+                .get()
+                .build();
+    }
+
+    private Request headRequest(@NonNull URI uri) throws MalformedURLException {
+        return new Request.Builder()
+                .url(uri.toURL())
+                .addHeader(ACCEPT_ENCODING_HEADER, CONTENT_ENCODING)
+                .addHeader(USER_AGENT_HEADER, getUserAgentString())
+                .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
+                .addHeader(DATE_HEADER, getHeaderDate())
+                .head()
+                .build();
+    }
+
+    private Request postRequest(@NonNull URI uri, RequestBody body) throws MalformedURLException {
+        return new Request.Builder()
+                .url(uri.toURL())
+                .addHeader(ACCEPT_ENCODING_HEADER, CONTENT_ENCODING)
+                .addHeader(USER_AGENT_HEADER, getUserAgentString())
+                .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
+                .addHeader(DATE_HEADER, getHeaderDate())
+                .post(body)
+                .build();
+    }
+
+    private String getUserAgentString() {
+        return String.format("%s %s/%s",
+                System.getProperty("http.agent"),
+                BuildConfig.APPLICATION_ID,
+                BuildConfig.VERSION_NAME);
+    }
+
+    private String getHeaderDate() {
+        GregorianCalendar g = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
+        g.setTime(new Date());
+        return DateFormat.format("E, dd MMM yyyy hh:mm:ss zz", g).toString();
+    }
+
+    /**
+     * Utility to ensure that the entity stream of a response is drained of
+     * bytes.
+     * Apparently some servers require that we manually read all data from the
+     * stream to allow its re-use.  Please add more details or bug ID here if
+     * you know them.
+     */
+    private void discardEntityBytes(Response response) {
+        ResponseBody body = response.body();
+        if (body != null) {
+            try (InputStream is = body.byteStream()) {
+                while (is.read() != -1) {
+                    // loop until all bytes read
+                }
+            } catch (Exception e) {
+                Timber.i(e);
+            }
+        }
+    }
+
+}

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -287,6 +287,8 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
 
         DispatchingAuthenticator authenticator = daBuilder.build();
 
+        initializeHttpClient(); // Need to initalise the http client again to get rid of the cached credentials
+
         httpClient = httpClient.newBuilder().authenticator(new CachingAuthenticatorDecorator(authenticator, authCache))
                 .addInterceptor(new AuthenticationCacheInterceptor(authCache)).build();
 

--- a/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
@@ -19,8 +19,6 @@ package org.odk.collect.android.http;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import org.odk.collect.android.utilities.ResponseMessageParser;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;

--- a/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
@@ -33,21 +33,23 @@ public interface OpenRosaHttpInterface {
      *
      * @param uri of the stream
      * @param contentType check the returned Mime Type to ensure it matches. "text/xml" causes a Hash to be calculated
+     * @param credentials to use for this executeGetRequest request
      * @return HttpGetResult - An object containing the Stream, Hash and Headers
-     * @throws Exception a multitude of Exceptions such as IOException can be thrown
+     * @throws Exception various Exceptions such as IOException can be thrown
      */
     @NonNull
-    HttpGetResult get(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception;
+    HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception;
 
     /**
      * Performs a Http Head request.
      *
      * @param uri of which to perform a Http head
+     * @param credentials to use for this head request
      * @return HttpHeadResult containing status code and headers
-     * @throws Exception a multitude of Exceptions such as IOException can be thrown
+     * @throws Exception various Exceptions such as IOException can be thrown
      */
     @NonNull
-    HttpHeadResult head(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception;
+    HttpHeadResult executeHeadRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception;
 
     /**
      * Uploads files to a Server.

--- a/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OpenRosaHttpInterface.java
@@ -52,6 +52,17 @@ public interface OpenRosaHttpInterface {
     HttpHeadResult executeHeadRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception;
 
     /**
+     * Performs a Http Post Request.
+     *
+     * @param uri of which to post
+     * @param credentials to use on this post request
+     * @return HttpPostResult containing response code and response message
+     * @throws Exception various Exceptions such as IOException can be thrown
+     */
+    @NonNull
+    HttpPostResult executePostRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception;
+
+    /**
      * Uploads files to a Server.
      *
      * @param fileList List of Files to be uploaded
@@ -62,10 +73,10 @@ public interface OpenRosaHttpInterface {
      * @throws IOException can be thrown if files do not exist
      */
     @NonNull
-    ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList,
-                                               @NonNull File submissionFile,
-                                               @NonNull URI uri,
-                                               @Nullable HttpCredentialsInterface credentials,
-                                               @NonNull long contentLength) throws IOException;
+    HttpPostResult uploadSubmissionFile(@NonNull List<File> fileList,
+                                        @NonNull File submissionFile,
+                                        @NonNull URI uri,
+                                        @Nullable HttpCredentialsInterface credentials,
+                                        @NonNull long contentLength) throws Exception;
 
 }

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -31,7 +31,6 @@ import org.odk.collect.android.utilities.ResponseMessageParser;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -196,7 +196,6 @@ public class InstanceServerUploader extends InstanceUploader {
             postResult = httpInterface.uploadSubmissionFile(files, submissionFile, uri,
                     webCredentialsUtils.getCredentials(uri), contentLength);
 
-
             int responseCode = postResult.getResponseCode();
             messageParser.setMessageResponse(postResult.getHttpResponse());
 

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -100,7 +100,7 @@ public class InstanceServerUploader extends InstanceUploader {
             HttpHeadResult headResult;
             Map<String, String> responseHeaders;
             try {
-                headResult = httpInterface.head(uri, webCredentialsUtils.getCredentials(uri));
+                headResult = httpInterface.executeHeadRequest(uri, webCredentialsUtils.getCredentials(uri));
                 responseHeaders = headResult.getHeaders();
 
                 if (responseHeaders.containsKey("X-OpenRosa-Accept-Content-Length")) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResponseMessageParser.java
@@ -12,73 +12,38 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import timber.log.Timber;
 
-/**
- * Created by Jon Nordling on 2/21/17.
- * The purpose of this class is to handle the XML parsing
- * of the server responses
- */
-
 public class ResponseMessageParser {
+
     private static final String MESSAGE_XML_TAG = "message";
-    private final String httpResponse;
-    private final int responseCode;
-    private final String reasonPhrase;
 
-    public boolean isValid;
-    public String messageResponse;
-
-    public ResponseMessageParser(String httpResponse, int responseCode, String reasonPhrase) {
-        this.httpResponse = httpResponse;
-        this.responseCode = responseCode;
-        this.reasonPhrase = reasonPhrase;
-        this.messageResponse = parseXMLMessage();
-        if (messageResponse != null) {
-            this.isValid = true;
-        }
-    }
+    private boolean isValid;
+    private String messageResponse;
 
     public boolean isValid() {
         return this.isValid;
     }
 
     public String getMessageResponse() {
-        return this.messageResponse;
+        return messageResponse;
     }
 
-    public String parseXMLMessage() {
-        String message = null;
-        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder;
+    public void setMessageResponse(String response) {
+        isValid = false;
         try {
-            builder = dbFactory.newDocumentBuilder();
-            Document doc = null;
-
-            if (httpResponse.contains("OpenRosaResponse")) {
-                doc = builder.parse(new ByteArrayInputStream(httpResponse.getBytes()));
+            if (response.contains("OpenRosaResponse")) {
+                DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                Document doc = builder.parse(new ByteArrayInputStream(response.getBytes()));
                 doc.getDocumentElement().normalize();
 
                 if (doc.getElementsByTagName(MESSAGE_XML_TAG).item(0) != null) {
-                    message = doc.getElementsByTagName(MESSAGE_XML_TAG).item(0).getTextContent();
-                } else {
-                    isValid = false;
+                    messageResponse = doc.getElementsByTagName(MESSAGE_XML_TAG).item(0).getTextContent();
+                    isValid = true;
                 }
             }
 
-            return message;
-
         } catch (SAXException | IOException | ParserConfigurationException e) {
             Timber.e(e, "Error parsing XML message due to %s ", e.getMessage());
-            isValid = false;
         }
-
-        return message;
     }
 
-    public int getResponseCode() {
-        return responseCode;
-    }
-
-    public String getReasonPhrase() {
-        return reasonPhrase;
-    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
@@ -58,7 +58,8 @@ public class MockHttpClientConnection implements OpenRosaHttpInterface {
     @NonNull
     @Override
     public HttpPostResult executePostRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
-        return new HttpPostResult("",0,"");
+        return new HttpPostResult("", 0, "");
+
     }
 
 

--- a/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
@@ -8,7 +8,6 @@ import org.odk.collect.android.http.HttpGetResult;
 import org.odk.collect.android.http.HttpHeadResult;
 import org.odk.collect.android.http.HttpPostResult;
 import org.odk.collect.android.http.OpenRosaHttpInterface;
-import org.odk.collect.android.utilities.ResponseMessageParser;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -52,7 +51,7 @@ public class MockHttpClientConnection implements OpenRosaHttpInterface {
     @NonNull
     @Override
     public HttpPostResult uploadSubmissionFile(@NonNull List<File> fileList, @NonNull File submissionFile, @NonNull URI uri, @Nullable HttpCredentialsInterface credentials, @NonNull long contentLength) throws IOException {
-        return null;
+        return new HttpPostResult("", 0, "");
     }
 
     @NonNull
@@ -61,7 +60,4 @@ public class MockHttpClientConnection implements OpenRosaHttpInterface {
         return new HttpPostResult("", 0, "");
 
     }
-
-
-
 }

--- a/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import org.odk.collect.android.http.HttpCredentialsInterface;
 import org.odk.collect.android.http.HttpGetResult;
 import org.odk.collect.android.http.HttpHeadResult;
+import org.odk.collect.android.http.HttpPostResult;
 import org.odk.collect.android.http.OpenRosaHttpInterface;
 import org.odk.collect.android.utilities.ResponseMessageParser;
 
@@ -50,7 +51,16 @@ public class MockHttpClientConnection implements OpenRosaHttpInterface {
 
     @NonNull
     @Override
-    public ResponseMessageParser uploadSubmissionFile(@NonNull List<File> fileList, @NonNull File submissionFile, @NonNull URI uri, @Nullable HttpCredentialsInterface credentials, @NonNull long contentLength) throws IOException {
+    public HttpPostResult uploadSubmissionFile(@NonNull List<File> fileList, @NonNull File submissionFile, @NonNull URI uri, @Nullable HttpCredentialsInterface credentials, @NonNull long contentLength) throws IOException {
         return null;
     }
+
+    @NonNull
+    @Override
+    public HttpPostResult executePostRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
+        return new HttpPostResult("",0,"");
+    }
+
+
+
 }

--- a/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnection.java
@@ -23,15 +23,15 @@ public class MockHttpClientConnection implements OpenRosaHttpInterface {
 
     @Override
     @NonNull
-    public HttpGetResult get(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    public HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
 
         String xml =
-        "<forms>" +
-        "<form url=\"https://opendatakit.appspot.com/formXml?formId=CascadingSelect\">Cascading Select Form</form>" +
-        "<form url=\"https://opendatakit.appspot.com/formXml?formId=widgets\">Widgets</form>" +
-        "<form url=\"https://opendatakit.appspot.com/formXml?formId=NewWidgets\">New Widgets</form>" +
-        "<form url=\"https://opendatakit.appspot.com/formXml?formId=sample\">sample</form>" +
-        "</forms>";
+                "<forms>" +
+                        "<form url=\"https://opendatakit.appspot.com/formXml?formId=CascadingSelect\">Cascading Select Form</form>" +
+                        "<form url=\"https://opendatakit.appspot.com/formXml?formId=widgets\">Widgets</form>" +
+                        "<form url=\"https://opendatakit.appspot.com/formXml?formId=NewWidgets\">New Widgets</form>" +
+                        "<form url=\"https://opendatakit.appspot.com/formXml?formId=sample\">sample</form>" +
+                        "</forms>";
 
         InputStream is = new ByteArrayInputStream(xml.getBytes());
 
@@ -44,7 +44,7 @@ public class MockHttpClientConnection implements OpenRosaHttpInterface {
 
     @NonNull
     @Override
-    public HttpHeadResult head(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    public HttpHeadResult executeHeadRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception {
         return new HttpHeadResult(0, new HashMap<String, String>());
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnectionError.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/mock/MockHttpClientConnectionError.java
@@ -12,7 +12,7 @@ public class MockHttpClientConnectionError extends MockHttpClientConnection {
 
     @Override
     @NonNull
-    public HttpGetResult get(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
+    public HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception {
         return null;
     }
 }


### PR DESCRIPTION
Closes #620 

This PR replaces the original pull request https://github.com/opendatakit/collect/pull/2595. It contains the new OkHttp3 implementation of OpenRosaHttpInterface but as an interim step the app still uses the legacy httpclient.

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested this on a local VM Aggregate instance with both Digest and Basic authentication.

#### Why is this the best possible solution? Were any other approaches considered?

The use of okhttp3 seemed to be the most obvious choice due to its popularity and ease of use. Most of the ground work has been done in #2257

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Currently, the existing http client is still used. Therefore, no behaviour changes for users.

#### Do we need any specific form for testing your changes? If so, please attach one.

No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)