### PR TITLE
Fix rare crash when screenIndex has not yet been initialized

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -215,6 +215,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             return;
         }
 
+        // onCreate() can call finish() if it finds the FormController to be null.
+        if (isFinishing()) {
+            return;
+        }
+
         FormController formController = Collect.getInstance().getFormController();
         boolean isAtBeginning = screenIndex.isBeginningOfFormIndex() && !shouldShowRepeatGroupPicker();
         boolean shouldShowPicker = shouldShowRepeatGroupPicker();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -209,8 +209,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     private void updateOptionsMenu() {
-        // Not ready yet. Menu will be updated automatically once it's been prepared.
-        if (optionsMenu == null) {
+        // Not ready yet.
+        // Menu will be updated automatically once it's been prepared, or during refreshView.
+        if (optionsMenu == null || screenIndex == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/opendatakit/collect/issues/2850. See issue for description.

If `screenIndex` is null, it previously would have crashed, but now it will simply not refresh the options menu. That could lead to a stale options menu for one cycle, but as soon as you navigate anywhere it will refresh. It's hard to know exactly why `screenIndex` is uninitialized in these rare cases.