### PR TITLE
Allows to again select Google Account without recreating activity.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -85,6 +85,11 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
     private List<String> urlList;
     private Preference selectedGoogleAccountPreference;
     private GoogleAccountsManager accountsManager;
+
+    public void setAllowClickSelectedGoogleAccountPreference(boolean allowClickSelectedGoogleAccountPreference) {
+        this.allowClickSelectedGoogleAccountPreference = allowClickSelectedGoogleAccountPreference;
+    }
+
     private boolean allowClickSelectedGoogleAccountPreference = true;
 
     @Inject

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
@@ -137,7 +137,7 @@ public class GoogleAccountsManager {
                     if (activity instanceof GoogleSheetsUploaderActivity || activity instanceof GoogleDriveActivity) {
                         activity.finish();
                     }
-                    if(fragment instanceof ServerPreferencesFragment){
+                    if (fragment instanceof ServerPreferencesFragment) {
                         ((ServerPreferencesFragment) fragment).setAllowClickSelectedGoogleAccountPreference(true);
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/gdrive/GoogleAccountsManager.java
@@ -137,6 +137,9 @@ public class GoogleAccountsManager {
                     if (activity instanceof GoogleSheetsUploaderActivity || activity instanceof GoogleDriveActivity) {
                         activity.finish();
                     }
+                    if(fragment instanceof ServerPreferencesFragment){
+                        ((ServerPreferencesFragment) fragment).setAllowClickSelectedGoogleAccountPreference(true);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Closes #2852 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Tested on Android 8.1
#### Why is this the best possible solution? Were any other approaches considered?
First Approach - I found that boolean variable ```allowClicksSelectedGoogleAccountPreference``` is blocking from reopening the permission dialog box, and actually, this variable has no use. So, I first prefered to remove it.

Second approach - to change the return value of ```chooseAccountAndRequestPermissionIfNeeded()``` method to true, in case of successful selection of google account and false, in case of failure in between. But these changes can cause misbehavior as this method is also used in other parts of the app.

Third approach - Introduce a new method to change the value of the variable to true in case of denial of permission. 

First, I had used the first approach, but it was wrong as pointed out by @grzesiek2010 in comments.
So, I changed my approach from first to third. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)