### PR TITLE
In GeoTrace, do not add an extra point to close the polygon if it is already closed.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceActivity.java
@@ -250,9 +250,14 @@ public class GeoTraceActivity extends BaseGeoMapActivity implements IRegisterRec
 
         Button polygonSave = polygonOrPolylineView.findViewById(R.id.polygon_save);
         polygonSave.setOnClickListener(v -> {
-            if (map.getPointsOfPoly(featureId).size() > 2) {
-                // Close the polygon.
-                map.appendPointToPoly(featureId, map.getPointsOfPoly(featureId).get(0));
+            List<MapPoint> points = map.getPointsOfPoly(featureId);
+            if (points.size() > 2) {
+                // Close the polygon, unless it's already closed.
+                MapPoint firstPoint = points.get(0);
+                MapPoint lastPoint = points.get(points.size() - 1);
+                if (!lastPoint.equals(firstPoint)) {
+                    map.appendPointToPoly(featureId, firstPoint);
+                }
                 polygonOrPolylineDialog.dismiss();
                 finishWithResult();
             } else {


### PR DESCRIPTION
Closes #2868.

### Note to reviewers

The choice to "Save as Polyline" or "Save as Polygon" is about to be removed soon (see Phase 3 of the [Geo improvement roadmap](https://docs.google.com/document/d/1r3wJrOVDeFQkk4kWMoW29LtLI1vbBChqJ65w1Jyg4YU/edit)), which will make #2868 obsolete and this change unnecessary.  Feel free to reject and close this PR if desired.

#### What has been done to verify that this works as intended?
I started the GeoTrace activity, added three points to make a triangle, tapped the Save button, and selected "Polygon".  The result had 4 points (the first point was repeated as the last point), which is correct.  I then started the activity again and saved as a polygon again, and the 4 points remained unchanged.  Repeatedly opening and saving as a polygon did not add any more points.

#### Why is this the best possible solution? Were any other approaches considered?
This approach is simple and addresses the problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only visible change in behaviour is that #2868 does not occur anymore.

#### Do we need any specific form for testing your changes? If so, please attach one.
The GeoTrace widget in the "All Widgets" form will do.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)