### PR TITLE
Include “Number Picker” in transifex

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/NumberPickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/NumberPickerDialog.java
@@ -76,7 +76,7 @@ public class NumberPickerDialog extends DialogFragment {
         numberPicker.setValue(((String[]) getArguments().getSerializable(DISPLAYED_VALUES)).length - 1 - getArguments().getInt(PROGRESS));
 
         return new AlertDialog.Builder(getActivity())
-                .setTitle("Number Picker")
+                .setTitle(R.string.number_picker_title)
                 .setView(view)
                 .setPositiveButton(R.string.ok,
                         new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -664,4 +664,5 @@
     <string name="background_location_disabled">This form wants to track your location but tracking is disabled. Please enable in the \u0020\u0020⋮\u0020\u0020 menu above.</string>
     <string name="background_location_enabled">This form tracks your location. You can disable tracking in the \u0020\u0020⋮\u0020\u0020 menu above.</string>
     <string name="open_file">Open file</string>
+    <string name="number_picker_title">Number Picker</string>
 </resources>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've tested the `All widgets` form which contains a `NumberPicker` widget and confirmed that the title is the same.

#### Why is this the best possible solution? Were any other approaches considered?
It's requested by users on the forum https://forum.opendatakit.org/t/include-number-picker-in-transifex/17824

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't change anything at this moment. We just allow translating the title visible in number picker dialog.
It doesn't require much testing, just opening any form with a `NumberPicker` widget and confirming that nothing has changed.

#### Do we need any specific form for testing your changes? If so, please attach one.
We can use the `All widgets` form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)