### PR TITLE
Fixed text color in settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -330,7 +330,7 @@ public class PermissionUtils {
     }
 
     private void showAdditionalExplanation(int title, int message, int drawable, @NonNull PermissionListener action) {
-        AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.Theme_AppCompat_Light_Dialog)
+        AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.PermissionAlertDialogTheme)
                 .setTitle(title)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> action.denied())

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -28,6 +28,7 @@
     </style>
 
     <style name="AppTheme.SettingsTheme.Dark" parent="BaseDarkAppTheme">
+        <item name="android:textColor">?primaryTextColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:textSize">18sp</item>
         <item name="android:listDivider">@null</item>
@@ -72,6 +73,7 @@
     </style>
 
     <style name="AppTheme.SettingsTheme.Light" parent="BaseLightAppTheme">
+        <item name="android:textColor">?primaryTextColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:textSize">18sp</item>
         <item name="android:listDivider">@null</item>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -72,6 +72,10 @@
         <item name="colorAccent">@color/lightAccentColor</item>
     </style>
 
+    <style name="PermissionAlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="android:textColor">@android:color/black</item>
+    </style>
+
     <style name="AppTheme.SettingsTheme.Light" parent="BaseLightAppTheme">
         <item name="android:textColor">?primaryTextColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>


### PR DESCRIPTION
Closes #2893 

#### What has been done to verify that this works as intended?
I tested settings and dialogs we display once permission is denied.

#### Why is this the best possible solution? Were any other approaches considered?
The problem is caused by this pr: https://github.com/opendatakit/collect/pull/2802
So the first commit reverts changes implemented in that pr and the second one fixes the bug that pr addressed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is related to dialogs we display once permission is denied, so those dialogs should be tested in both themes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)