### PR TITLE
Use the same form_state_blank icon in GD list like in other lists

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/FileArrayAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/FileArrayAdapter.java
@@ -67,7 +67,7 @@ public class FileArrayAdapter extends ArrayAdapter<DriveListItem> {
             }
 
             if (item.getType() == DriveListItem.FILE) {
-                Drawable d = ContextCompat.getDrawable(getContext(), R.drawable.ic_file_download);
+                Drawable d = ContextCompat.getDrawable(getContext(), R.drawable.form_state_blank);
                 imageView.setImageDrawable(d);
                 checkBox.setVisibility(View.VISIBLE);
             } else {

--- a/collect_app/src/main/res/drawable/ic_file_download.xml
+++ b/collect_app/src/main/res/drawable/ic_file_download.xml
@@ -1,6 +1,0 @@
-<vector android:height="36dp" android:viewportHeight="24.0"
-    android:viewportWidth="24.0" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path
-        android:fillColor="?iconColor"
-        android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z" />
-</vector>


### PR DESCRIPTION
| Before  | Now | List of forms from Aggregate |
| ------------- | ------------- | ------------- |
| ![screenshot_2019-02-20-16-15-38](https://user-images.githubusercontent.com/3276264/53102079-4cced500-352b-11e9-8dfd-466e69e4da8c.png) | ![screenshot_2019-02-20-16-19-02](https://user-images.githubusercontent.com/3276264/53102080-4cced500-352b-11e9-9d65-c8acef410b8b.png)  | ![screenshot_2019-02-20-16-13-28](https://user-images.githubusercontent.com/3276264/53102172-71c34800-352b-11e9-9fe1-de718a3d153b.png) |

#### What has been done to verify that this works as intended?
I tested the icons in GD.

#### Why is this the best possible solution? Were any other approaches considered?
I think that forms in GD list should have the same icon as those we download from Aggregate.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It just change the icon we display with forms from GD. It's a simple change which doesn't require testing. @cooperka if you accept we can merge. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)