### PR TITLE
Fixed sending forms with repeat groups to Google Sheets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -145,7 +145,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             if (hasRepeatableGroups(instanceElement)) {
                 createSheetsIfNeeded(instanceElement);
             }
-            String key = getInstanceID(getChildElements(instanceElement));
+            String key = getInstanceID(getChildElements(instanceElement, false));
             if (key == null) {
                 key = PropertyUtils.genUUID();
             }
@@ -176,8 +176,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         insertRow(instance, element, parentKey, key, instanceFile, sheetTitle);
 
         int repeatIndex = 0;
-        for (int i = 0; i < element.getNumChildren(); i++) {
-            TreeElement child = element.getChildAt(i);
+        for (TreeElement child : getChildElements(element, true)) {
             if (child.isRepeatable() && child.getMultiplicity() != TreeReference.INDEX_TEMPLATE) {
                 insertRows(instance, child, key, getKeyBasedOnParentKey(key, child.getName(), repeatIndex++), instanceFile, getElementTitle(child));
             }
@@ -312,8 +311,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
     }
 
     private boolean hasRepeatableGroups(TreeElement element) {
-        for (int i = 0; i < element.getNumChildren(); i++) {
-            TreeElement childElement = element.getChildAt(i);
+        for (TreeElement childElement : getChildElements(element, false)) {
             if (childElement.isRepeatable()) {
                 return true;
             }
@@ -338,8 +336,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
     private Set<String> getSheetTitles(TreeElement element) {
         Set<String> sheetTitles = new HashSet<>();
-        for (int i = 0; i < element.getNumChildren(); i++) {
-            TreeElement childElement = element.getChildAt(i);
+        for (TreeElement childElement : getChildElements(element, false)) {
             if (childElement.isRepeatable()) {
                 sheetTitles.add(getElementTitle(childElement));
                 sheetTitles.addAll(getSheetTitles(childElement));
@@ -351,7 +348,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
     private HashMap<String, String> getAnswers(Instance instance, TreeElement element, List<Object> columnTitles, File instanceFile, String parentKey, String key)
             throws UploadException {
         HashMap<String, String> answers = new HashMap<>();
-        for (TreeElement childElement : getChildElements(element)) {
+        for (TreeElement childElement : getChildElements(element, false)) {
             String elementTitle = getElementTitle(childElement);
             if (childElement.isRepeatable()) {
                 answers.put(elementTitle, getHyperlink(getSheetUrl(getSheetId(elementTitle)), elementTitle));
@@ -420,7 +417,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
     private List<Object> getColumnTitles(TreeElement element, boolean newSheet) {
         List<Object> columnTitles = new ArrayList<>();
-        for (TreeElement child : getChildElements(element)) {
+        for (TreeElement child : getChildElements(element, false)) {
             final String elementTitle = getElementTitle(child);
             columnTitles.add(elementTitle);
             if (newSheet && child.getDataType() == org.javarosa.core.model.Constants.DATATYPE_GEOPOINT) {
@@ -475,15 +472,12 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                 .toString();
     }
 
-    private List<TreeElement> getChildElements(TreeElement element) {
+    private List<TreeElement> getChildElements(TreeElement element, boolean includeAllRepeats) {
         List<TreeElement> elements = new ArrayList<>();
         TreeElement prior = null;
         for (int i = 0; i < element.getNumChildren(); ++i) {
             TreeElement current = element.getChildAt(i);
-            // avoid duplicated elements https://github.com/opendatakit/javarosa/issues/248
-            if ((prior != null) && (prior.getName().equals(current.getName()))) {
-                prior = current;
-            } else {
+            if (includeAllRepeats || !nextInstanceOfTheSameRepeatableGroup(prior, current)) {
                 switch (current.getDataType()) {
                     case org.javarosa.core.model.Constants.DATATYPE_TEXT:
                     case org.javarosa.core.model.Constants.DATATYPE_INTEGER:
@@ -509,7 +503,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                         } else if (current.getNumChildren() == 0) { // assume fields that don't have children are string fields
                             elements.add(current);
                         } else { // one or more children - this is a group
-                            elements.addAll(getChildElements(current));
+                            elements.addAll(getChildElements(current, includeAllRepeats));
                         }
                         break;
                 }
@@ -517,6 +511,10 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             }
         }
         return elements;
+    }
+
+    private boolean nextInstanceOfTheSameRepeatableGroup(TreeElement prior, TreeElement current) {
+        return prior != null && prior.getName().equals(current.getName());
     }
 
     private List<Object> prepareListOfValues(List<Object> columnHeaders, List<Object> columnTitles,


### PR DESCRIPTION
Closes #2896 

#### What has been done to verify that this works as intended?
I tested a form with repeat groups inside a regular group.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug that has existed from the beginning. We missed the case when a repeat group is inside a regular group.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The pr introduces some changes to `InstanceGoogleSheetsUploader` so sending forms to Google Sheets should be tested. @mmarciniak90 I count on you and as I described below please test some complex forms: forms with repeat groups, repeat groups inside regular groups, nested repeat groups etc.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with repeat groups, repeat groups inside regular groups, nested repeat groups etc.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)