### PR TITLE
 Display progress bar only form forms that are being sent via SMS

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -75,9 +75,6 @@ public class InstanceUploaderAdapter extends CursorAdapter {
     public void bindView(View view, Context context, Cursor cursor) {
         ViewHolder viewHolder = (ViewHolder) view.getTag();
 
-        viewHolder.progressBar.setVisibility(View.VISIBLE);
-        viewHolder.progressBar.setProgressPercent(0, false);
-
         viewHolder.formTitle.setText(cursor.getString(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_NAME)));
         viewHolder.formSubtitle.setText(cursor.getString(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_SUBTEXT)));
 
@@ -105,6 +102,7 @@ public class InstanceUploaderAdapter extends CursorAdapter {
         }
 
         if (isSmsSubmission) {
+            viewHolder.progressBar.setVisibility(View.VISIBLE);
             viewHolder.progressBar.setProgressPercent((int) model.getCompletion().getPercentage(), false);
 
             int smsStatus = submissionManager.checkNextMessageResultCode(String.valueOf(instanceId));
@@ -120,12 +118,6 @@ public class InstanceUploaderAdapter extends CursorAdapter {
 
             setupCloseButton(viewHolder, smsStatus);
             viewHolder.closeButton.setOnClickListener(v -> smsService.cancelFormSubmission(String.valueOf(instanceId)));
-        } else {
-            if (status.equals(STATUS_SUBMITTED)) {
-                viewHolder.progressBar.setProgressPercent(100, false);
-            } else if (status.equals(STATUS_SUBMISSION_FAILED)) {
-                viewHolder.progressBar.setProgressPercent(50, false);
-            }
         }
 
         compositeDisposable.add(eventBus.register(SmsRxEvent.class)


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested the form list.

#### Why is this the best possible solution? Were any other approaches considered?
This pr https://github.com/opendatakit/collect/pull/2825 introduced new icons for each form state. Those icons indicate if a form has been sent, so now we need the progress bar for forms that are being sent via SMS.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pr just removes the redundant progress bar. It's not risky and testing the form list (just it's layout) would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)