### PR TITLE
Removed the limitation of 256 columns in Google Sheets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -570,11 +570,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         if (numberOfColumns == 0) {
             throw new UploadException(Collect.getInstance().getString(R.string.no_columns_to_upload));
         }
-
-        if (numberOfColumns > 256) {
-            throw new UploadException(Collect.getInstance().getString(R.string.sheets_max_columns,
-                    String.valueOf(numberOfColumns)));
-        }
     }
 
     private Integer getSheetId(String sheetTitle) {

--- a/collect_app/src/main/res/values-ar/strings.xml
+++ b/collect_app/src/main/res/values-ar/strings.xml
@@ -275,7 +275,6 @@
   <string name="google_search_browse">ابحث عن الاستمارات. أو اختار  \'My Drive\' من الاسفل لكي تتصفح</string>
   <string name="google_sheets_url">رابط اوراق جوجل</string>
   <string name="send_in_progress">خلفية الارسال تعمل. يرجى المحاولة مرة أخرى في وقت قريب</string>
-  <string name="sheets_max_columns">الحد الأقصى لعدد الأعمدة هو 255، استماراتك تحتوي على %s. غير قادر على تحميل الجدول.</string>
   <string name="invalid_sheet_id">رقم تعرفة الصفحة غير صحيح: %1$s</string>
   <string name="google_sheets_access_denied">تم رفض الوصول. الرجاء التأكد من منح مالك الجدول إذن الوصول لك.</string>
   <string name="google_sheets_missing_columns">الأعمدة التالية مفقودة من الجدول: %1$s </string>

--- a/collect_app/src/main/res/values-ca/strings.xml
+++ b/collect_app/src/main/res/values-ca/strings.xml
@@ -262,7 +262,6 @@
   <string name="change_server_url">URL Servidor</string>
   <string name="google_search_browse">Cerca de formularis. O selecciona \'Meu Drive\' a sota per visualitzar.</string>
   <string name="send_in_progress">Enviament funcionant, si us plau, re-intenteu en un moment.</string>
-  <string name="sheets_max_columns">Numero max de columnes = 255, el vostre formulari en te %s. No es pot carregar la fulla de càlcul.</string>
   <string name="invalid_sheet_id">id de fulla invàlid: %1$s</string>
   <string name="google_sheets_missing_columns">Falten de la fulla de càlcul les columnes: %1$s</string>
   <string name="password_error_whitespace">No es permeten espais davant o darrera una clau d\'accés</string>

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">Vyhledat formuláře. Nebo zvolit \"Můj disk\" pro procházení.</string>
   <string name="google_sheets_url">Záložní odesílací URL</string>
   <string name="send_in_progress">Odesílání na pozadí běží, zkuste to znovu</string>
-  <string name="sheets_max_columns">Maximální počet sloupců je 255, váš formulář má %s. Nelze nahrát do tabulky.</string>
   <string name="invalid_sheet_id">neplatné ID listu: %1$s</string>
   <string name="missing_submission_url">Chybí URL pro odeslání</string>
   <string name="google_sheets_access_denied">Přístup odepřen. Ujistěte se, že vám vlastník tabulky udělil oprávnění ke změnám.</string>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">Nach Formularen suchen. Oder \'My Drive\' wählen um zu browsen.</string>
   <string name="google_sheets_url">Ersatzspeicherort-URL</string>
   <string name="send_in_progress">Sendevorgang läuft im Hintergrund. Bitte versuchen Sie es später nochmal.</string>
-  <string name="sheets_max_columns">Max. Anzahl an Spalten ist 255. Ihr Formular hat %s Spalten. Tabelle konnte nicht hochgeladen werden.</string>
   <string name="invalid_sheet_id">Ungültige Sheet ID: %1$s</string>
   <string name="missing_submission_url">Fehlende Einsendungs-URL</string>
   <string name="google_sheets_access_denied">Zugriff verweigert. Bitte stellen Sie sicher, dass der Tabellen-Besitzer Ihnen eine Zugriffsberechtigung erteilt hat.</string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -295,7 +295,6 @@
   <string name="google_search_browse">Busca en formularios. O selecciona  \'My Drive\' debajo para visualizar.</string>
   <string name="google_sheets_url">URL alterno para envío</string>
   <string name="send_in_progress">Otro envío funcionando, reintentar en breve</string>
-  <string name="sheets_max_columns">Máximo de columnas = 255, su formulario tiene %s. No se puede subir la hoja.</string>
   <string name="invalid_sheet_id">id de hoja inválido:  %1$s</string>
   <string name="missing_submission_url">Falta URL para envío </string>
   <string name="google_sheets_access_denied">Acceso denegado. Por favor, asegúrese de que el propietario de la hoja de cálculo le ha concedido permisos de edición.</string>

--- a/collect_app/src/main/res/values-et/strings.xml
+++ b/collect_app/src/main/res/values-et/strings.xml
@@ -261,7 +261,6 @@
   <string name="change_server_url">Serveri veebiaadress</string>
   <string name="google_search_browse">Otsi vorme. Või vali sirvimiseks \"Minu Drive\".</string>
   <string name="send_in_progress">Taustal jookseb andmete saatmine. Palun proovige varsti uuesti</string>
-  <string name="sheets_max_columns">Maksimum tulpade arv on 255, teie vormis on %s. Arvutustabeli üleslaadimine keelatud.</string>
   <string name="invalid_sheet_id">Vale lehe id: %1$s</string>
   <string name="google_sheets_missing_columns">Arvutustabelist on puudu järgmised tulbad: %1$s</string>
   <string name="password_error_whitespace">Salasõna alguses või lõpus ei ole lubatud kasutada tühikut</string>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">Etsi lomakkeita. Tai valitse \'Oma Drive\' alla selataksesi.</string>
   <string name="google_sheets_url">Varalla oleva URL lähetystä varten</string>
   <string name="send_in_progress">Taustalähetys käynnissä, yritä hetken kuluttua uudestaan</string>
-  <string name="sheets_max_columns">Maksimimäärä sarakkeita on 255, lomakkeessasi on %s, eikä sitä voida lähettää työkirjaan. </string>
   <string name="invalid_sheet_id">Virheellinen lehden id: %1$s</string>
   <string name="missing_submission_url">Lähetykseen tarvittava URL puuttuu</string>
   <string name="google_sheets_access_denied">Pääsy estetty. Varmista että taulukon omistaja on myöntänyt muokkausoikeudet.</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">Rechercher des formulaires ou sélectionner \'Mon Drive\' ci-dessous pour parcourir des formulaires.</string>
   <string name="google_sheets_url">URL de secours pour soumission de données</string>
   <string name="send_in_progress">L\'envoi s\'exécute en tâche de fond, essayer plus tard.</string>
-  <string name="sheets_max_columns">Il est impossible de télécharger votre feuille de calcul. Le nombre maximum de colonnes est de 255. Votre formulaire en a %s. </string>
   <string name="invalid_sheet_id">Identifiant %1$s du tableur n\'est pas valable.</string>
   <string name="missing_submission_url">URL de soumission manquante</string>
   <string name="google_sheets_access_denied">Accès refusé. Assurez-vous que le propriétaire de la feuille de calcul vous a accordé la permission de modification.</string>

--- a/collect_app/src/main/res/values-hi/strings.xml
+++ b/collect_app/src/main/res/values-hi/strings.xml
@@ -273,7 +273,6 @@
   <string name="google_search_browse">फ़ॉर्म के लिए खोजें. या ब्राउज़ करने के लिए नीचे \'माय ड्राइव\' चुनें।</string>
   <string name="google_sheets_url">फ़ॉलबैक सबमिशन URL</string>
   <string name="send_in_progress">पृष्ठभूमि में भेजना जारी, कृपया शीघ्र पुनः प्रयास करें</string>
-  <string name="sheets_max_columns">कॉलम की अधिकतम संख्या 255 है, आपके फॉर्म में%sहैं. स्प्रैडशीट पर अपलोड करने में असमर्थ</string>
   <string name="invalid_sheet_id">अमान्य शीट आईडी: %1$s</string>
   <string name="google_sheets_access_denied">पहुंच अस्वीकृत। कृपया सुनिश्चित करें कि स्प्रैडशीट ओनर ने आपको संपादन अधिकार दिए हैं।</string>
   <string name="google_sheets_missing_columns">स्प्रेडशीट में निम्न कॉलम लापता हैं: %1$s</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">Mencari formulir. Atau memilih \'My Drive\' di bawah ini untuk browse.</string>
   <string name="google_sheets_url">URL kembali setelah pengiriman</string>
   <string name="send_in_progress">Pengiriman sedang berlangsung, cobalah beberapa saat lagi</string>
-  <string name="sheets_max_columns">Jumlah kolom maksimum adalah 255, formulir anda memiliki %s. Tidak dapat mengunggah pada spreadsheet.</string>
   <string name="invalid_sheet_id">id sheet tidak valid: %1$s</string>
   <string name="missing_submission_url">URL tujuan tidak ditemukan</string>
   <string name="google_sheets_access_denied">Akses ditolak. Pastikan kepemilikan spreadsheet mempunyai akses untuk mengubah.</string>

--- a/collect_app/src/main/res/values-it/strings.xml
+++ b/collect_app/src/main/res/values-it/strings.xml
@@ -284,7 +284,6 @@
   <string name="google_search_browse">Ricerca per form o seleziona \'My Drive\' in basso.</string>
   <string name="google_sheets_url">URL di destinazione predefinito</string>
   <string name="send_in_progress">Invio in background in corso, perpiacere riprova più tardi</string>
-  <string name="sheets_max_columns">Numero massimo di colonne ammesse è 255, la tua form ha %s. Impossibile caricare il foglio.</string>
   <string name="invalid_sheet_id">Il foglio ha un ID non valido: %1$s</string>
   <string name="google_sheets_access_denied">Accesso negato. Per favore, verifica che il proprietario del documento ti abbia dato i permessi di modifica.</string>
   <string name="google_sheets_missing_columns">Il foglio è mancante delle seguenti colonne: %1$s</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">フォームを検索するか、次の \'マイ ドライブ\' を選択して表示します。</string>
   <string name="google_sheets_url">フォールバック送信 URL</string>
   <string name="send_in_progress">バックグラウンド送信が実行中です。しばらくして再度お試しください</string>
-  <string name="sheets_max_columns">列の最大数は 255 ですが、フォームは %s あります。スプレッドシートにアップロードできません。</string>
   <string name="invalid_sheet_id">無効なシート ID: %1$s</string>
   <string name="missing_submission_url">送信 URL が見つかりません</string>
   <string name="google_sheets_access_denied">アクセスが拒否されました。スプレッドシートの所有者がアクセス許可を与えていることを確認してください。</string>

--- a/collect_app/src/main/res/values-km/strings.xml
+++ b/collect_app/src/main/res/values-km/strings.xml
@@ -284,7 +284,6 @@
   <string name="google_search_browse">ការ​​ស្វែង​​រក​​សម្រាប់​​សំណុំ​​​បែប​​​បទ​។ ឬ​​រើស​ \'ថាស​​របស់​​ខ្ញុំ\' ខាង​​ក្រោម​​ដើម្បី​​រក​មើល</string>
   <string name="google_sheets_url">URL ដែលបានដាក់ស្នើ Fallback</string>
   <string name="send_in_progress">កំពុងផ្ញើផ្នែកខាងក្រោយ, សូមព្យាយាមម្តងទៀតក្នុងរយះពេលខ្លី</string>
-  <string name="sheets_max_columns">ចំនួន​​អតិបរមា​​នៃ​​ជួរ​​ឈរ​​គឺ 255, សំណុំ​​​បែប​​​បទ​​របស់​​អ្នក​​មាន​ %s​ ។ មិន​អាច​ផ្ទុក​ ទៅ​សៀវ​ភៅ​បញ្ជី​បាន​ទេ។</string>
   <string name="invalid_sheet_id">លេខសម្គាល់សន្លឹកកិច្ចការមិនត្រឹមត្រូវ៖ %1$s</string>
   <string name="google_sheets_access_denied">ដំណើរ​ការ​ត្រូវ​បាន​បដិសេធ។ សូមធ្វើឱ្យប្រាកដថាម្ចាស់សៀវភៅបញ្ជីប្រោសប្រណីអនុញ្ញាតឲ្យអ្នកកែសម្រួល។</string>
   <string name="google_sheets_missing_columns">សៀវភៅបញ្ជីគឺបាត់បង់ជួរឈ: %1$s</string>

--- a/collect_app/src/main/res/values-mr/strings.xml
+++ b/collect_app/src/main/res/values-mr/strings.xml
@@ -268,7 +268,6 @@
   <string name="google_search_browse">फॉर्म शोधा किंवा ब्राउझ करण्यासाठी खालील \'माझे ड्राइव्ह\' निवडा.</string>
   <string name="google_sheets_url">फॉलबॅक सबमिशन युरएल</string>
   <string name="send_in_progress">पार्श्वभूमी पाठविणे चालू आहे, कृपया लवकरच पुन्हा प्रयत्न करा</string>
-  <string name="sheets_max_columns">स्तंभांची कमाल संख्या 255 आहे, आपल्या फॉर्ममध्ये  %s आहे. स्प्रेडशीटवर अपलोड करण्यास अक्षम</string>
   <string name="invalid_sheet_id">अवैध पत्रक id: %1$s</string>
   <string name="google_sheets_access_denied">प्रवेश नाकारला. कृपया स्प्रेडशीटच्या मालकास आपल्याला संपादन परवानगी मंजूर केल्याची खात्री करा.</string>
   <string name="google_sheets_missing_columns">स्प्रेडशीटमध्ये खालील स्तंभ गहाळ आहेत:%1$s</string>

--- a/collect_app/src/main/res/values-ne-rNP/strings.xml
+++ b/collect_app/src/main/res/values-ne-rNP/strings.xml
@@ -276,7 +276,6 @@
   <string name="change_server_url">सर्भर URL</string>
   <string name="google_search_browse">फारम सर्च गर्नुहोस् वा ब्राउज गर्न तल \'My Drive\' मा सेलेक्ट गर्नुहोस्</string>
   <string name="send_in_progress">पृष्‍ठभूमीमा send सन्चालित हुँदै , कृपया फेरी प्रयास गर्नुहोस् ।</string>
-  <string name="sheets_max_columns">अधिकतम पंक्ती (column) संख्या २५५ हो , तपाईंको फारममा %s छ । स्प्रेडसिट मा अपलोड गर्न असमर्थ ।</string>
   <string name="invalid_sheet_id">अमान्य शीट नम्बर 1 %1$s</string>
   <string name="google_sheets_access_denied">अस्वीकृत । स्प्रेडशीट धनीबाट तपाईंले सम्पादन गर्ने अनुमति प्राप्त गर्नुपर्दछ । </string>
   <string name="google_sheets_missing_columns">स्प्रेडशीटमा निम्न पंक्ती (column) हरु छैनन् : %1$s</string>

--- a/collect_app/src/main/res/values-no/strings.xml
+++ b/collect_app/src/main/res/values-no/strings.xml
@@ -254,7 +254,6 @@
   <string name="change_server_url">Server URL</string>
   <string name="google_search_browse">Søk etter skjemaer.  Eller velg \'Min disk\' nedenfor for å bla igjennom.</string>
   <string name="send_in_progress">Bakgrunnssending kjører, vennligst prøv igjen senere</string>
-  <string name="sheets_max_columns">Maks antall kolonner er 255, ditt skjema har %s. Det er ikke mulig å laste opp dette regnearket.</string>
   <string name="invalid_sheet_id">Ugyldig ark id: %1$s</string>
   <string name="google_sheets_missing_columns">Regnearket mangler følgende kolonner: %1$s</string>
   <string name="password_error_whitespace">Mellomrom er ikke tillatt før eller etter passord</string>

--- a/collect_app/src/main/res/values-pl/strings.xml
+++ b/collect_app/src/main/res/values-pl/strings.xml
@@ -293,7 +293,6 @@
   <string name="google_search_browse">Wyszukaj formularze. Lub wybierz poniżej \'Mój Dysk\' by przejrzeć</string>
   <string name="google_sheets_url">Alternatywny URL przesyłania</string>
   <string name="send_in_progress">Trwa wysyłka w tle, spróbuj wkrótce ponownie</string>
-  <string name="sheets_max_columns">Maksymalna liczba kolumn wynosi 255, twój formularz posiada %s. Nie można załadować do arkusza kalkulacyjnego.</string>
   <string name="invalid_sheet_id">niepoprawne id arkusza: %1$s</string>
   <string name="missing_submission_url">Brak URL przesyłania</string>
   <string name="google_sheets_access_denied">Odmowa dostępu. Upewnij się, że właścicieil arkusza nadał Ci uprawnienia do edytowania.</string>

--- a/collect_app/src/main/res/values-pt/strings.xml
+++ b/collect_app/src/main/res/values-pt/strings.xml
@@ -284,7 +284,6 @@ Escolher Imagem</string>
   <string name="google_search_browse">Procure pelos formulários. Ou selecione \'My Drive\' para procurar.</string>
   <string name="google_sheets_url">Retornou da submissão da URL</string>
   <string name="send_in_progress">Envio automático em segundo plano sendo executado, por favor tente novamente em alguns instantes</string>
-  <string name="sheets_max_columns">O número máximo de colunas é 255, seu formulário possui %s. Não foi possível carregar para planilha.</string>
   <string name="invalid_sheet_id">Nome do id: %1$s da guia incorreto</string>
   <string name="google_sheets_access_denied">Acesso negado. Por favor, certifique-se que o proprietário da planilha possui a permissão de edição.</string>
   <string name="google_sheets_missing_columns">Estão faltando as seguintes colunas na planilha: %1$s</string>

--- a/collect_app/src/main/res/values-ro/strings.xml
+++ b/collect_app/src/main/res/values-ro/strings.xml
@@ -256,7 +256,6 @@
   <string name="change_server_url">URL server</string>
   <string name="google_search_browse">Căutați formulare. Sau selectați mai jos \'Discul meu\' pentru a naviga. </string>
   <string name="send_in_progress">Trimiterea în fundal rulează, vă rugăm să încercați din nou mai târziu.</string>
-  <string name="sheets_max_columns">Numărul maxim de coloane este 255, formularul dumneavoastră are %s. Nu am putut încărca datele în tabel.</string>
   <string name="invalid_sheet_id">ID foaie invalid: %1$s</string>
   <string name="google_sheets_missing_columns">Din foaia de calcul lipsesc următoarele coloane: %1$s</string>
   <string name="password_error_whitespace">Nu sunt permise spații în parole</string>

--- a/collect_app/src/main/res/values-ru/strings.xml
+++ b/collect_app/src/main/res/values-ru/strings.xml
@@ -289,7 +289,6 @@
   <string name="google_search_browse">Поиск опросников. Или выберите \'Мой диск\' ниже для просмотра.</string>
   <string name="google_sheets_url">Резервный URL-отправки</string>
   <string name="send_in_progress">Выполняется отправка в фоне, попробуйте снова через некоторое время.</string>
-  <string name="sheets_max_columns">Наибольшее допустимое количество столбцов 255 - в вашем опросе их %s. Не удалось загрузить в таблицу.</string>
   <string name="invalid_sheet_id">Неверный идентификатор листа: %1$s</string>
   <string name="google_sheets_access_denied">Доступ запрещен. Пожалуйста, удостоверьтесь, что владелец таблицы выдал вам разрешение на редактирование.</string>
   <string name="google_sheets_missing_columns">Таблица не содержит следующие столбцы: %1$s</string>

--- a/collect_app/src/main/res/values-sl/strings.xml
+++ b/collect_app/src/main/res/values-sl/strings.xml
@@ -282,7 +282,6 @@
   <string name="notification_error">Napaka pri prikazu obvestila</string>
   <string name="google_sheets_url">URL za nadomestno predložitev</string>
   <string name="send_in_progress">Pošiljanja se izvaja v ozadju, prosim poskusite znova cez malo časa</string>
-  <string name="sheets_max_columns">Največje število stolpcev je 255, obrazec pa ima %s. Ni mogoče prenesti v preglednico.</string>
   <string name="google_sheets_access_denied">Dostop zavrnjen. Prosim, prepričajte se, da je lastnik preglednice odobril urejanje.</string>
   <string name="google_sheets_missing_columns">Preglednici manjkajo naslednji stolpci: %1$s</string>
   <string name="password_error_whitespace">Presledki na začetku ali na koncu gesla niso dovoljeni</string>

--- a/collect_app/src/main/res/values-sq/strings.xml
+++ b/collect_app/src/main/res/values-sq/strings.xml
@@ -257,7 +257,6 @@
   <string name="change_server_url">URL e serverit</string>
   <string name="google_search_browse">Kërko për formularë. Ose përzgjidh \'My Drive\' më poshtë dhe kërkoni manualisht.</string>
   <string name="send_in_progress">Një dërgim po ekzekutohet në background, lutemi provoni sërish pas pak.</string>
-  <string name="sheets_max_columns">Numri maksimal i kolonave është 255, formulari juaj ka %s. Spreadsheet nuk mund të ngarkohet.</string>
   <string name="invalid_sheet_id">Numri i identifikimit të tabelës: %1$s i pavlefshëm.</string>
   <string name="google_sheets_access_denied">Ju është mohuar aksesi. Lutemi, sigurohuni që zotëruesi i spreadsheet-it ju ka dhënë të drejtën për të modifikuar.</string>
   <string name="google_play_services_error_occured">E pamundur të aksesohen Google Maps. A është i instaluar Google Play Services?</string>

--- a/collect_app/src/main/res/values-sv-rSE/strings.xml
+++ b/collect_app/src/main/res/values-sv-rSE/strings.xml
@@ -285,7 +285,6 @@
   <string name="google_search_browse">Sök efter formulär eller välj \'My Drive\' nedan för att bläddra.</string>
   <string name="google_sheets_url">Reserv-URL för uppladdning</string>
   <string name="send_in_progress">Sändning pågår i bakgrunden, vänligen försök igen senare</string>
-  <string name="sheets_max_columns">Max tillåtet antal kolumner är 255, ditt formulär har %s. Uppladdning till kalkylark är inte möjligt.</string>
   <string name="invalid_sheet_id">Ogiltigt ID för ark: %1$s</string>
   <string name="google_sheets_access_denied">Åtkomst nekad. Vänligen se till att kalkylarkets ägare har gett dig åtkomsträttigheter.</string>
   <string name="google_sheets_missing_columns">Kalkylarket saknar följande kolumner: %1$s</string>

--- a/collect_app/src/main/res/values-sw/strings.xml
+++ b/collect_app/src/main/res/values-sw/strings.xml
@@ -290,7 +290,6 @@
   <string name="google_search_browse">Tafuta fomu. Au chagua \'Hifadhi yangu\' hapa chini kuzipekua.</string>
   <string name="google_sheets_url">Uwasilishaji wa URL ulio chelewa</string>
   <string name="send_in_progress">Utumaji unaendelea kwa nyuma, jaribu tena baada ya muda mfupi</string>
-  <string name="sheets_max_columns">Namba ya juu ya safu ni 255, fomu yako ina %s. Haiwezi kupakia lahajedwali \"spreadsheet\".</string>
   <string name="invalid_sheet_id">KItambulisho cha karatasi ni batilii%1$s</string>
   <string name="google_sheets_access_denied">Ruhusa imekatazwa. Tafadhali hakikisha mwenye programu ya lahajedwali \"spreadsheet\" amekuruhusu kufanya mabadiliko.</string>
   <string name="google_sheets_missing_columns">Lahajedwali \"Spreadsheet\" zinakosa safu zifuatazo: %1$s</string>

--- a/collect_app/src/main/res/values-th-rTH/strings.xml
+++ b/collect_app/src/main/res/values-th-rTH/strings.xml
@@ -252,7 +252,6 @@
   <string name="change_server_url">URL ของเซิร์ฟเวอร์</string>
   <string name="google_search_browse">ค้นหาแบบฟอร์ม หรือเลือก \'My Drive\' ด้านล่างเพื่อค้นหา</string>
   <string name="send_in_progress">กำลังส่งข้อมูล โปรดลองใหม่อีกครั้ง</string>
-  <string name="sheets_max_columns">จำนวนคอลัมน์สูงสุดคือ 255 แบบฟอร์มของคุณมี %s ไม่สามารถอัพโหลดไปที่  spreadsheet ได้</string>
   <string name="invalid_sheet_id">หมายเลขชีทไม่ถุกต้อง: %1$s</string>
   <string name="google_sheets_missing_columns">ไม่มี Spreadsheet ของคอลัมภ์: %1$s</string>
   <string name="password_error_whitespace">ไม่สามารถใช้ช่องว่างนำหน้าและตามหลังรหัสผ่าน</string>

--- a/collect_app/src/main/res/values-uk/strings.xml
+++ b/collect_app/src/main/res/values-uk/strings.xml
@@ -291,7 +291,6 @@
   <string name="google_search_browse">Шукайте анкети. Або натисніть \'Мій диск\' для навігації.</string>
   <string name="google_sheets_url">Запасний URL для надсилання</string>
   <string name="send_in_progress">Зпущений тіньовий процес відправки, будь ласка, спробуйте знову пізніше</string>
-  <string name="sheets_max_columns">Максимальна кількість колонок - 255, ваша анкета містить %s. Неможливо вивантажити в Сторінки.</string>
   <string name="invalid_sheet_id">пошкоджена сторінка id: %1$s</string>
   <string name="missing_submission_url">Відсутній URL для надсилання</string>
   <string name="google_sheets_access_denied">Відмова доступу. Будь ласка, переконайтесь, що власник Сторінок надав вам дозвіл на внесення змін.</string>

--- a/collect_app/src/main/res/values-ur/strings.xml
+++ b/collect_app/src/main/res/values-ur/strings.xml
@@ -290,7 +290,6 @@
   <string name="google_search_browse">فارم تلاش کریں. یا  \'مائی ڈرائیو\' کو منتخب کریں.</string>
   <string name="google_sheets_url">فال بیک  جمع کرانے کی یو آر ایل</string>
   <string name="send_in_progress">پس منظر چل رہا ہے، براہ مہربانی دوبارہ کوشش کریں</string>
-  <string name="sheets_max_columns">کالموں کی زیادہ سے زیادہ تعداد 255 ہے، آپ کا فارم کے کالم%s۔ اسپریڈ شیٹ میں اپ لوڈ کرنے میں ناکام</string>
   <string name="invalid_sheet_id">غلط شیٹ ID:%1$s</string>
   <string name="google_sheets_access_denied">رسائی مسترد کر دی . براہ کرم یقینی بنائیں کہ اسپریڈ شیٹ مالک نے آپ کو ترمیم کی  اجازت دی ہے</string>
   <string name="google_sheets_missing_columns">اسپریڈ شیٹ میں مندرجہ بالا کالم غائب ہیں:%1$s</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -298,7 +298,6 @@
     <string name="google_search_browse">Search for forms. Or select \'My Drive\' below to browse.</string>
     <string name="google_sheets_url">Fallback submission URL</string>
     <string name="send_in_progress">Background send running, please try again shortly</string>
-    <string name="sheets_max_columns">Max number of columns is 255, your form has %s. Unable to upload to spreadsheet.</string>
     <string name="invalid_sheet_id">invalid sheet id: %1$s</string>
     <string name="missing_submission_url">Missing submission URL</string>
     <string name="google_sheets_access_denied">Access denied. Please make sure the spreadsheet owner has granted you edit permission.</string>


### PR DESCRIPTION
Closes #2888 

#### What has been done to verify that this works as intended?
I tested a form with one thousand questions:
[OneThousandQuestions.xml.txt](https://github.com/opendatakit/collect/files/2888845/OneThousandQuestions.xml.txt)

#### Why is this the best possible solution? Were any other approaches considered?
I just removed a limitation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It just removes the limitation of 256 columns. Now we are able to send bigger forms to Google Sheets.
It's not risky, we just need to test forms with many questions like the one I attached.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)