### PR TITLE
Use our themes to fix the default tintMode to SRC_IN.

### DIFF
--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -27,6 +27,15 @@
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="warningColor">@color/red_500</item>
         <item name="dividerCompat">@android:drawable/divider_horizontal_dark</item>
+        <!--
+            The default tint mode for ImageViews is SRC_ATOP, which produces
+            incorrect blending results when tinting images with a colour that
+            has an alpha channel (for example, the alpha channel is used to
+            turn disabled buttons grey).  The correct tint mode is SRC_IN,
+            which is the default tint mode in Android everywhere else.  See:
+            https://developer.android.com/reference/android/widget/ImageView.html#attr_android:tint
+        -->
+        <item name="android:tintMode" tools:targetApi="21">src_in</item>
     </style>
 
     <style name="AppTheme.SettingsTheme.Dark" parent="BaseDarkAppTheme">
@@ -69,6 +78,7 @@
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="warningColor">@color/red_500</item>
         <item name="dividerCompat">@android:drawable/divider_horizontal_bright</item>
+        <item name="android:tintMode" tools:targetApi="21">src_in</item>
     </style>
 
     <style name="AlertDialogTheme.Light" parent="Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
### Overview

As of https://github.com/opendatakit/collect/tree/db01cdcf, all disabled image buttons appear the same as enabled image buttons.

This appearance change occurred when `colors.xml` was edited in https://github.com/opendatakit/collect/commit/b41b817f4678a39a804bc9a14763544d83a2c0e0#diff-1f517f1a91abad16231a83752cef21a4 to change the icon colors for disabled buttons (`lightIconColorDisabled` and `darkIconColorDisabled`) from solid grey `#aaaaaa` to partial-opacity-black `#61000000` or partial-opacity-white `#61ffffff`.

The actual cause is that Android uses an [incorrect default blending mode for image colour tints](https://developer.android.com/reference/android/widget/ImageView.html#attr_android:tint).

The blending mode should be `SRC_IN`, which is the default blending mode everywhere else in Android.  However, `ImageView` uses the default mode `SRC_ATOP`, which ignores the alpha channel when drawing the icon image.

To fix this problem across our entire app, this PR sets the `android:tintMode` attribute to `src_in` in our two themes, light and dark.

#### What has been done to verify that this works as intended?
I built the app at `db01cdcf` and ran it in an emulator running Android 6.0, and confirmed that the problem existed (disabled buttons appear black in GeoTrace and GeoShape).

I then built the app with this change and ran it in an emulator running Android 6.0, and confirmed that disabled buttons now appear grey, and they change between grey and black as they should when enabled and disabled.  I also tested the dark theme, and the buttons were grey when disabled and white when enabled, as expected.

The tint mode functionality was introduced in Android 5.0, so I also tested the app both with and without this change in an emulator running Android 4.1.1 (API 16, the lowest level we support).  Instead of turning grey, the disabled buttons become semitransparent when disabled, and that remains the case both with and without this change.  Only the square background of the button becomes semitransparent; the icon remains solid black or solid white.  This was also the case in version 1.19.0, before any alpha values were specified in `colors.xml`.

#### Why is this the best possible solution? Were any other approaches considered?
I considered the following possible alternative approaches:

1. Add `android:tintMode="src_in"` attributes to all `<AppCompatButton>` tags in our layout XML files.  There are 24 occurrences across 5 files.
2. Extend `AppCompatButton` with a subclass that calls `setImageTintMode(SRC_IN)` upon initialization, and use the subclass everywhere instead of `AppCompatButton`.
3. Extend `AppCompatButton` with a subclass that overrides `setEnabled` to call `setImageAlpha` with a hardcoded alpha value, and use the subclass everywhere instead of `AppCompatButton`.

All three of these options involve touching every XML file that uses an image button, and wouldn't solve the problem for future image buttons (though, for Options 2 and 3, we could establish a convention that we always use our subclass instead of AppCompatButton, and even enforce that convention with a lint check).

Options 1 and 2 would have the same visible effect as this PR: buttons turn grey in Android 5.0 and higher, buttons turn semitransparent in Android 4.x.

Option 3 is the only solution I can think of that would actually turn the icon itself grey in all versions of Android.  However, it is also by far the most expensive change, and we've lived with semitransparent non-grey buttons in Android 4.x so far, so it doesn't seem worth it.

Editing the theme, as this PR does, is the cheapest option that gets us back to the button appearance that we had in v1.19.0.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is a bug fix.  Users shouldn't notice any changes.

#### Do we need any specific form for testing your changes? If so, please attach one.
You can use the Geo map widgets in the "All Widgets" form to see some enabled and disabled image buttons.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)