### PR TITLE
Remove unnecessary padding below GeoTrace buttons.

### DIFF
--- a/collect_app/src/main/res/layout/geotrace_layout.xml
+++ b/collect_app/src/main/res/layout/geotrace_layout.xml
@@ -62,8 +62,7 @@
                 android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingTop="0dip"
-                android:paddingBottom="60dip">
+                android:paddingTop="0dip">
 
                 <android.support.v7.widget.AppCompatImageButton
                     android:id="@+id/play"


### PR DESCRIPTION
This fixes the stray scrollbar problem reported by @mmarciniak90 in this comment:
https://github.com/opendatakit/collect/pull/2891#issuecomment-466045527

#### What has been done to verify that this works as intended?
I tested this in an emulator running Android 6.0, using a phone device with a small enough screen that the scrollbar appears on `master`.  I confirmed that the scrollbar was present before this change and went away after this change.

#### Why is this the best possible solution? Were any other approaches considered?
It's a simple issue; I have no idea why that huge padding was there in the first place.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Minimal risk; it's a one-attribute change.

#### Do we need any specific form for testing your changes? If so, please attach one.
Use GeoTrace in the "All Widgets" form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)