### PR TITLE
GeoShape: Consolidate UI updates into updateUi().

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoShapeActivity.java
@@ -179,9 +179,6 @@ public class GeoShapeActivity extends BaseGeoMapActivity implements IRegisterRec
             points = restoredPoints;
         }
         featureId = map.addDraggablePoly(points, true);
-        zoomButton.setEnabled(!points.isEmpty());
-        backspaceButton.setEnabled(!points.isEmpty());
-        clearButton.setEnabled(!points.isEmpty());
 
         map.setGpsLocationEnabled(true);
         if (restoredMapCenter != null && restoredMapZoom != null) {
@@ -191,35 +188,33 @@ public class GeoShapeActivity extends BaseGeoMapActivity implements IRegisterRec
         } else {
             map.runOnGpsLocationReady(this::onGpsLocationReady);
         }
+        updateUi();
     }
 
     @SuppressWarnings("unused")  // the "map" parameter is intentionally unused
     private void onGpsLocationReady(MapFragment map) {
-        zoomButton.setEnabled(true);
         if (getWindow().isActive()) {
             map.zoomToPoint(map.getGpsLocation(), true);
+            updateUi();
         }
     }
 
     private void onLongPress(MapPoint point) {
         map.appendPointToPoly(featureId, point);
-        backspaceButton.setEnabled(true);
-        clearButton.setEnabled(true);
-        zoomButton.setEnabled(true);
+        updateUi();
     }
 
     private void removeLastPoint() {
         if (featureId != -1) {
             map.removePolyLastPoint(featureId);
-            backspaceButton.setEnabled(!map.getPolyPoints(featureId).isEmpty());
+            updateUi();
         }
     }
 
     private void clear() {
         map.clearFeatures();
         featureId = map.addDraggablePoly(new ArrayList<>(), true);
-        backspaceButton.setEnabled(false);
-        clearButton.setEnabled(false);
+        updateUi();
     }
 
     private void showClearDialog() {
@@ -254,6 +249,16 @@ public class GeoShapeActivity extends BaseGeoMapActivity implements IRegisterRec
         setResult(RESULT_OK, new Intent().putExtra(
             FormEntryActivity.GEOSHAPE_RESULTS, formatPoints(points)));
         finish();
+    }
+
+    /** Updates the state of various UI widgets to reflect internal state. */
+    private void updateUi() {
+        final int numPoints = map.getPolyPoints(featureId).size();
+        final MapPoint location = map.getGpsLocation();
+
+        zoomButton.setEnabled(location != null);
+        backspaceButton.setEnabled(numPoints > 0);
+        clearButton.setEnabled(numPoints > 0);
     }
 
     /**
@@ -305,7 +310,7 @@ public class GeoShapeActivity extends BaseGeoMapActivity implements IRegisterRec
         return result.trim();
     }
 
-    @VisibleForTesting public boolean isGpsButtonEnabled() {
+    @VisibleForTesting public boolean isZoomButtonEnabled() {
         return zoomButton != null && zoomButton.isEnabled();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoTraceActivity.java
@@ -526,7 +526,7 @@ public class GeoTraceActivity extends BaseGeoMapActivity implements IRegisterRec
         updateUi();
     }
 
-    /** Updates the visibility and enabled state of buttons to reflect internal state. */
+    /** Updates the state of various UI widgets to reflect internal state. */
     private void updateUi() {
         final int numPoints = map.getPolyPoints(featureId).size();
         final MapPoint location = map.getGpsLocation();

--- a/collect_app/src/test/java/org/odk/collect/android/location/activities/GeoShapeActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/location/activities/GeoShapeActivityTest.java
@@ -52,11 +52,11 @@ public class GeoShapeActivityTest extends BaseGeoActivityTest {
         assertTrue(fakeLocationClient.isRunning());
 
         // Initially, the location button should be disabled.
-        assertFalse(activity.isGpsButtonEnabled());
+        assertFalse(activity.isZoomButtonEnabled());
 
         // A location fix should enable the location button.
         fakeLocationClient.receiveFix(createLocation("GPS", 1, 2, 3, 4f));
-        assertTrue(activity.isGpsButtonEnabled());
+        assertTrue(activity.isZoomButtonEnabled());
 
         // Stopping the activity should stop the location client.
         controller.stop();


### PR DESCRIPTION
Closes #2908 and #2909.


#### What has been done to verify that this works as intended?
I ran the app in an emulator and confirmed that #2908 and #2909 no longer occur.  Because all calls to `setEnabled()` are gathered in one method, `updateUi()`, it is much easier to verify by examining the code that the correct invariants are preserved.

#### Why is this the best possible solution? Were any other approaches considered?
I considered making more individual changes to fix these bugs, but I think it's better to move all the updates into `updateUi()` to prevent any more bugs like this from popping up in the future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change touches the enabled/disabled state of the backspace, trash, and zoom buttons.

#### Do we need any specific form for testing your changes? If so, please attach one.
Use the GeoShape widget in the "All Widgets" form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)