### PR TITLE
Auto-close file input stream

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDefCache.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDefCache.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.utilities;
 
+import android.support.annotation.Nullable;
+
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.odk.collect.android.application.Collect;
@@ -107,23 +109,17 @@ public class FormDefCache {
                 FileUtils.getMd5Hash(formXml) + ".formdef");
     }
 
+    @Nullable
     private static FormDef deserializeFormDef(File serializedFormDef) {
-        FileInputStream fis;
-        FormDef fd;
-        try {
-            // create new form def
-            fd = new FormDef();
-            fis = new FileInputStream(serializedFormDef);
-            DataInputStream dis = new DataInputStream(fis);
-
+        try (DataInputStream dis = new DataInputStream(new FileInputStream(serializedFormDef))) {
+            FormDef fd = new FormDef();
             // read serialized formdef into new formdef
             fd.readExternal(dis, ExtUtil.defaultPrototypes());
-            dis.close();
+            return fd;
         } catch (Exception e) {
             Timber.e(e);
-            fd = null;
         }
 
-        return fd;
+        return null;
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Tested by loading a form

#### Why is this the best possible solution? Were any other approaches considered?
FileInputStream wasn't being closed after usage. Converting to `try-with-resources` auto-closes the input stream.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No effect

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form can be used

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)