### PR TITLE
Auto-close cursor after checking if form is already downloaded

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DownloadFormListUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DownloadFormListUtils.java
@@ -316,8 +316,9 @@ public class DownloadFormListUtils {
     }
 
     private static boolean isThisFormAlreadyDownloaded(String formId) {
-        Cursor cursor = new FormsDao().getFormsCursorForFormId(formId);
-        return cursor == null || cursor.getCount() > 0;
+        try (Cursor cursor = new FormsDao().getFormsCursorForFormId(formId)) {
+            return cursor == null || cursor.getCount() > 0;
+        }
     }
 
     private ManifestFile getManifestFile(String manifestUrl) {


### PR DESCRIPTION
<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Downloaded a blank form from aggregate to check if no regressions are introduced

#### Why is this the best possible solution? Were any other approaches considered?
Auto-closes the cursor after use

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No effect

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form can be used for testing

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)