### PR TITLE
Fixed newlines visible in submission name

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -36,7 +36,6 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.text.Editable;
 import android.text.InputFilter;
-import android.text.Spanned;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
 import android.view.ContextMenu;
@@ -129,6 +128,7 @@ import org.odk.collect.android.utilities.ImageConverter;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
+import org.odk.collect.android.utilities.RegexUtils;
 import org.odk.collect.android.utilities.SnackbarUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
 import org.odk.collect.android.utilities.ToastUtils;
@@ -1218,18 +1218,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 final EditText saveAs = endView.findViewById(R.id.save_name);
 
                 // disallow carriage returns in the name
-                InputFilter returnFilter = new InputFilter() {
-                    public CharSequence filter(CharSequence source, int start,
-                                               int end, Spanned dest, int dstart, int dend) {
-                        String newText = source.toString().substring(start, end);
-                        String invalidCharRegex = "[\\p{Cntrl}]";
-
-                        // Replace invalid characters, only modifying the string if necessary.
-                        return newText.matches(invalidCharRegex)
-                                ? newText.replaceAll(invalidCharRegex, " ")
-                                : null;
-                    }
-                };
+                InputFilter returnFilter = (source, start, end, dest, dstart, dend)
+                        -> RegexUtils.normalizeFormName(source.toString().substring(start, end), true);
                 saveAs.setFilters(new InputFilter[]{returnFilter});
 
                 if (formController.getSubmissionMetadata().instanceName == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -52,6 +52,7 @@ import org.javarosa.xpath.expr.XPathExpression;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.utilities.AuditEventLogger;
+import org.odk.collect.android.utilities.RegexUtils;
 import org.odk.collect.android.views.ODKView;
 
 import java.io.File;
@@ -109,7 +110,7 @@ public class FormController {
 
         public InstanceMetadata(String instanceId, String instanceName, AuditConfig auditConfig) {
             this.instanceId = instanceId;
-            this.instanceName = instanceName;
+            this.instanceName = RegexUtils.normalizeFormName(instanceName, false);
             this.auditConfig = auditConfig;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/RegexUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/RegexUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexUtils {
+
+    private static final String CONTROL_CHAR_REGEX = "[\\p{Cntrl}]";
+    private static final Pattern CONTROL_CHAR_PATTERN = Pattern.compile(CONTROL_CHAR_REGEX);
+
+    private RegexUtils() {
+    }
+
+    public static String normalizeFormName(String formName, boolean returnNullIfNothingChanged) {
+        if (formName == null) {
+            return null;
+        }
+
+        Matcher matcher = CONTROL_CHAR_PATTERN.matcher(formName);
+        return matcher.find()
+                ? matcher.replaceAll(" ")
+                : (returnNullIfNothingChanged ? null : formName);
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/RegexUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/RegexUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.odk.collect.android.utilities.RegexUtils.normalizeFormName;
+
+public class RegexUtilsTest {
+
+    @Test
+    public void normalizeFormNameTest() {
+        assertNull(normalizeFormName(null, false));
+        assertEquals("Lorem", normalizeFormName("Lorem", false));
+        assertEquals("Lorem ipsum", normalizeFormName("Lorem ipsum", false));
+        assertEquals("Lorem ipsum", normalizeFormName("Lorem\nipsum", false));
+        assertEquals("Lorem  ipsum", normalizeFormName("Lorem\n\nipsum", false));
+        assertEquals(" Lorem ipsum ", normalizeFormName("\nLorem\nipsum\n", false));
+
+        assertNull(normalizeFormName(null, true));
+        assertNull(normalizeFormName("Lorem", true));
+        assertNull(normalizeFormName("Lorem ipsum", true));
+        assertEquals("Lorem ipsum", normalizeFormName("Lorem\nipsum", true));
+        assertEquals("Lorem  ipsum", normalizeFormName("Lorem\n\nipsum", true));
+        assertEquals(" Lorem ipsum ", normalizeFormName("\nLorem\nipsum\n", true));
+    }
+}


### PR DESCRIPTION
Closes #2913 #2656 

#### What has been done to verify that this works as intended?
I tested saving forms using the form attached to the issue and ordinary forms.

#### Why is this the best possible solution? Were any other approaches considered?
It's partly caused by this pr https://github.com/opendatakit/collect/pull/2653
The approach there is wrong - it should remove all newline chars but [here](https://github.com/opendatakit/collect/pull/2653/files#diff-03ff45091550285dd88b56927010c457R1155) a null value is always returned
Newline chars were not visible at the end of the form because the EditText we used had 
`android:inputType="text"`
but they were visible in the list of saved forms.

I changed it in https://github.com/grzesiek2010/collect/commit/95bbc24785400e0b6e3ff99a0e974082a6392838 and it revealed the issue.

This pr fixes the issue and now all new lines are properly replaced. They are not visible at the end of the form nor in the list of saved forms.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not very risky but saving forms should be tested carefully. The change is related only to form names - it removes newline chars.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue which generates a name and any ordinary form where we can add any name.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)