### PR TITLE
Removed duplicated call notifyDataSetChanged

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -299,7 +299,6 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             adapter.notifyDataSetChanged();
         }
 
-        adapter.notifyDataSetChanged();
         checkPreviouslyCheckedItems();
     }
 


### PR DESCRIPTION
Closes #2928 

#### What has been done to verify that this works as intended?
I tested the GD list manual to confirm it works well.

#### Why is this the best possible solution? Were any other approaches considered?
It's a long-standing issue. unfortunately, I wasn't able to reproduce it but my gut says it has something to do with calling `notifyDataSetChanged()` two times (it's called https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2928?expand=1#diff-4843e9d988e60283c4c8967d83b05c0bR299 and that's enough).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's rather not risky. The line I removed was redundant but to be sure we can perform some manual testing as well.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)