### PR TITLE
Fixed reading files from Downloads dir.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -479,6 +479,9 @@ public class MediaUtils {
                 // DownloadsProvider
 
                 final String id = DocumentsContract.getDocumentId(uri);
+                if (id.startsWith("raw:")) {
+                    return id.replaceFirst("raw:", "");
+                }
                 final Uri contentUri = ContentUris.withAppendedId(
                         Uri.parse("content://downloads/public_downloads"),
                         Long.parseLong(id));

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -28,16 +28,21 @@ import android.provider.MediaStore;
 import android.provider.MediaStore.Audio;
 import android.provider.MediaStore.Images;
 import android.provider.MediaStore.Video;
+import android.provider.OpenableColumns;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.apache.commons.io.IOUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.GDriveConnectionException;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -482,11 +487,37 @@ public class MediaUtils {
                 if (id.startsWith("raw:")) {
                     return id.replaceFirst("raw:", "");
                 }
-                final Uri contentUri = ContentUris.withAppendedId(
-                        Uri.parse("content://downloads/public_downloads"),
-                        Long.parseLong(id));
 
-                return getDataColumn(context, contentUri, null, null);
+                String[] contentUriPrefixesToTry = new String[]{
+                        "content://downloads/public_downloads",
+                        "content://downloads/my_downloads",
+                        "content://downloads/all_downloads"
+                };
+
+                for (String contentUriPrefix : contentUriPrefixesToTry) {
+                    Uri contentUri = ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.parseLong(id));
+                    try {
+                        String path = getDataColumn(context, contentUri, null, null);
+                        if (path != null) {
+                            return path;
+                        }
+                    } catch (Exception e) {
+                        Timber.w(e);
+                    }
+                }
+
+                // path could not be retrieved using ContentResolver, therefore copy file to accessible cache using streams
+                // https://github.com/coltoscosmin/FileUtils/blob/master/FileUtils.java
+                String fileName = getFileName(context, uri);
+                File cacheDir = getDocumentCacheDir(context);
+                File file = generateFileName(fileName, cacheDir);
+                String destinationPath = null;
+                if (file != null) {
+                    destinationPath = file.getAbsolutePath();
+                    saveFileFromUri(context, uri, destinationPath);
+                }
+
+                return destinationPath;
             } else if (isMediaDocument(uri)) {
                 // MediaProvider
                 final String docId = DocumentsContract.getDocumentId(uri);
@@ -650,5 +681,112 @@ public class MediaUtils {
             }
         }
         return null;
+    }
+
+    private static String getFileName(@NonNull Context context, Uri uri) {
+        String mimeType = context.getContentResolver().getType(uri);
+        String filename = null;
+
+        if (mimeType == null) {
+            String path = getPath(context, uri);
+            if (path == null) {
+                filename = getName(uri.toString());
+            } else {
+                File file = new File(path);
+                filename = file.getName();
+            }
+        } else {
+            Cursor returnCursor = context.getContentResolver().query(uri, null, null, null, null);
+            if (returnCursor != null) {
+                int nameIndex = returnCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                returnCursor.moveToFirst();
+                filename = returnCursor.getString(nameIndex);
+                returnCursor.close();
+            }
+        }
+
+        return filename;
+    }
+
+    private static String getName(String filename) {
+        if (filename == null) {
+            return null;
+        }
+        int index = filename.lastIndexOf('/');
+        return filename.substring(index + 1);
+    }
+
+    private static File getDocumentCacheDir(@NonNull Context context) {
+        File dir = new File(context.getCacheDir(), "documents");
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        return dir;
+    }
+
+    @Nullable
+    private static File generateFileName(@Nullable String name, File directory) {
+        if (name == null) {
+            return null;
+        }
+
+        File file = new File(directory, name);
+
+        if (file.exists()) {
+            String fileName = name;
+            String extension = "";
+            int dotIndex = name.lastIndexOf('.');
+            if (dotIndex > 0) {
+                fileName = name.substring(0, dotIndex);
+                extension = name.substring(dotIndex);
+            }
+
+            int index = 0;
+
+            while (file.exists()) {
+                index++;
+                name = fileName + '(' + index + ')' + extension;
+                file = new File(directory, name);
+            }
+        }
+
+        try {
+            if (!file.createNewFile()) {
+                return null;
+            }
+        } catch (IOException e) {
+            Timber.w(e);
+            return null;
+        }
+
+        return file;
+    }
+
+    private static void saveFileFromUri(Context context, Uri uri, String destinationPath) {
+        InputStream is = null;
+        BufferedOutputStream bos = null;
+        try {
+            is = context.getContentResolver().openInputStream(uri);
+            bos = new BufferedOutputStream(new FileOutputStream(destinationPath, false));
+            byte[] buf = new byte[1024];
+            is.read(buf);
+            do {
+                bos.write(buf);
+            } while (is.read(buf) != -1);
+        } catch (IOException e) {
+            Timber.w(e);
+        } finally {
+            try {
+                if (is != null) {
+                    is.close();
+                }
+                if (bos != null) {
+                    bos.close();
+                }
+            } catch (IOException e) {
+                Timber.w(e);
+            }
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -502,7 +502,7 @@ public class MediaUtils {
                             return path;
                         }
                     } catch (Exception e) {
-                        Timber.w(e);
+                        Timber.i(e);
                     }
                 }
 


### PR DESCRIPTION
Closes #2921, Closes #2923 

The pr contains fixes for two bugs. They are interrelated so I decided to create just one pr in order to facilitate testing. 

#2921 fixed in the first commit
#2923 fixed in the second commit

#### What has been done to verify that this works as intended?
#2921 I was able to reproduce the issue so I just confirmed that the fix works.
#2923 I wasn't able to reproduce the issue so I asked the user who reported it to help, he confirmed it works: https://forum.opendatakit.org/t/file-question-failure/18100

#### Why is this the best possible solution? Were any other approaches considered?
Both fixes are based on what I found on StackOverflow:
https://stackoverflow.com/questions/46442064/java-io-filenotfoundexception-caught-when-processing-request-document-raw-sto
https://stackoverflow.com/questions/52591936/i-am-getting-illegalargumentexception-during-picking-a-document-file-from-downlo

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is just related to reading/attaching files from `Downloads` dir, so we can test just that functionality.
As I said we are able to reproduce the first issue #2921 and it's not a risky change.
The second commit implements changes that are used only when the original approach fails so despite the fact we are not able to reproduce it I think it's pretty safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with the `FIleWIdget`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)