### PR TITLE
Use material bottom navigation in FormDownloadList

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
@@ -118,6 +118,16 @@ abstract class AppListActivity extends CollectAbstractActivity {
         }
     }
 
+    public static void toggleButtonLabel(MenuItem toggleButton, ListView lv) {
+        if (lv.getCheckedItemCount() != lv.getCount()) {
+            toggleButton.setTitle(R.string.select_all);
+            toggleButton.setIcon(R.drawable.ic_check_box_outline);
+        } else {
+            toggleButton.setTitle(R.string.clear_all);
+            toggleButton.setIcon(R.drawable.ic_check_box);
+        }
+    }
+
     @Override
     public void setContentView(@LayoutRes int layoutResID) {
         super.setContentView(layoutResID);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderList.java
@@ -186,7 +186,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
             // items selected
             uploadSelectedFiles(button.getId());
             setAllToCheckedState(listView, false);
-            toggleButtonLabel(findViewById(R.id.toggle_button), listView);
+            toggleButtonLabel((Button) findViewById(R.id.toggle_button), listView);
             uploadButton.setEnabled(false);
             smsUploadButton.setEnabled(false);
         } else {
@@ -474,7 +474,7 @@ public class InstanceUploaderList extends InstanceListActivity implements
         hideProgressBarIfAllowed();
         listAdapter.changeCursor(cursor);
         checkPreviouslyCheckedItems();
-        toggleButtonLabel(findViewById(R.id.toggle_button), listView);
+        toggleButtonLabel((Button) findViewById(R.id.toggle_button), listView);
     }
 
     @Override

--- a/collect_app/src/main/res/drawable/ic_check_box.xml
+++ b/collect_app/src/main/res/drawable/ic_check_box.xml
@@ -1,0 +1,4 @@
+<vector android:height="36dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?iconColor" android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.11,0 2,-0.9 2,-2L21,5c0,-1.1 -0.89,-2 -2,-2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/ic_check_box_outline.xml
+++ b/collect_app/src/main/res/drawable/ic_check_box_outline.xml
@@ -1,0 +1,4 @@
+<vector android:height="36dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?iconColor" android:pathData="M19,5v14H5V5h14m0,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/ic_file_download.xml
+++ b/collect_app/src/main/res/drawable/ic_file_download.xml
@@ -1,0 +1,4 @@
+<vector android:height="36dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?iconColor" android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/ic_refresh.xml
+++ b/collect_app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,4 @@
+<vector android:height="36dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?iconColor" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/collect_app/src/main/res/layout/form_download_list.xml
+++ b/collect_app/src/main/res/layout/form_download_list.xml
@@ -58,7 +58,6 @@ the License.
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:visibility="gone"
             android:background="?colorPrimary"
             app:itemTextAppearanceActive="@style/TextAppearance.MaterialComponents.Body2"
             app:itemTextAppearanceInactive="@style/TextAppearance.MaterialComponents.Body2"

--- a/collect_app/src/main/res/layout/form_download_list.xml
+++ b/collect_app/src/main/res/layout/form_download_list.xml
@@ -1,101 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2009 University of Washington
-
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
-
 http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 -->
-<RelativeLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
 
     <include layout="@layout/toolbar"/>
 
     <include
-            layout="@layout/toolbar_action_bar_shadow"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/toolbar"/>
+        layout="@layout/toolbar_action_bar_shadow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/toolbar"/>
 
     <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/toolbar">
-
-        <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:layout_above="@+id/buttonholder">
+            android:orientation="vertical"
+            android:layout_above="@+id/bottom_navigation">
 
             <ListView
-                    android:id="@android:id/list"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:layout_weight="1"
-                    android:paddingTop="8dp"
-                    android:paddingBottom="8dp"
-                    android:clipToPadding="false"
-                    android:scrollbarStyle="outsideOverlay"
-                    android:divider="?dividerCompat"/>
+                android:id="@android:id/list"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:clipToPadding="false"
+                android:scrollbarStyle="outsideOverlay"
+                android:divider="?dividerCompat"/>
 
             <TextView
-                    android:id="@android:id/empty"
-                    style="@style/emptyViewStyle"
-                    android:text="@string/no_items_display"/>
+                android:id="@android:id/empty"
+                style="@style/emptyViewStyle"
+                android:text="@string/no_items_display"/>
 
         </LinearLayout>
 
-        <LinearLayout
-                android:id="@+id/buttonholder"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentBottom="true"
-                android:orientation="horizontal"
-                android:weightSum="3">
-
-            <Button
-                    android:id="@+id/toggle_button"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="12dp"
-                    android:text="@string/select_all"
-                    android:textAllCaps="false"
-                    android:textSize="16sp"/>
-
-            <Button
-                    android:id="@+id/refresh_button"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="12dp"
-                    android:text="@string/refresh"
-                    android:textAllCaps="false"
-                    android:textSize="16sp"/>
-
-            <Button
-                    android:id="@+id/add_button"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:padding="12dp"
-                    android:text="@string/download"
-                    android:textAllCaps="false"
-                    android:textSize="16sp"/>
-
-        </LinearLayout>
-
+        <android.support.design.widget.BottomNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:visibility="gone"
+            android:background="?colorPrimary"
+            app:itemTextAppearanceActive="@style/TextAppearance.MaterialComponents.Body2"
+            app:itemTextAppearanceInactive="@style/TextAppearance.MaterialComponents.Body2"
+            app:itemTextColor="?bottomMenuItemColor"
+            app:itemIconTint="?bottomMenuItemColor"
+            app:menu="@menu/form_download_menu" />
     </RelativeLayout>
-
 </RelativeLayout>

--- a/collect_app/src/main/res/menu/form_download_menu.xml
+++ b/collect_app/src/main/res/menu/form_download_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/toggle"
+        android:title="@string/select_all" />
+    <item
+        android:id="@+id/refresh"
+        android:icon="@drawable/ic_refresh"
+        android:title="@string/refresh" />
+    <item
+        android:id="@+id/download_selected"
+        android:icon="@drawable/ic_file_download"
+        android:title="@string/download" />
+</menu>

--- a/collect_app/src/main/res/menu/form_download_menu.xml
+++ b/collect_app/src/main/res/menu/form_download_menu.xml
@@ -2,6 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/toggle"
+        android:enabled="false"
+        android:icon="@drawable/ic_check_box_outline"
         android:title="@string/select_all" />
     <item
         android:id="@+id/refresh"

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -4,6 +4,7 @@
         <attr name="primaryTextColor" format="color" />
         <attr name="secondaryTextColor" format="color" />
         <attr name="iconColor" format="color" />
+        <attr name="bottomMenuItemColor" format="color" />
         <attr name="dividerColor" format="color" />
         <attr name="warningColor" format="color" />
         <attr name="rankItemColor" format="color" />

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -22,6 +22,7 @@
         <item name="android:panelBackground">@android:color/white</item>
         <item name="searchViewStyle">@style/SearchViewTheme.Dark</item>
         <item name="iconColor">@color/defaultDarkIconColor</item>
+        <item name="bottomMenuItemColor">@color/dark_theme_tint_list</item>
         <item name="dividerColor">@color/darkDividerColor</item>
         <item name="rankItemColor">@color/darkRankItemColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
@@ -74,6 +75,7 @@
         <item name="alertDialogTheme">@style/AlertDialogTheme.Light</item>
         <item name="searchViewStyle">@style/SearchViewTheme.Light</item>
         <item name="iconColor">@color/defaultLightIconColor</item>
+        <item name="bottomMenuItemColor">@color/light_theme_tint_list</item>
         <item name="dividerColor">@color/lightDividerColor</item>
         <item name="rankItemColor">@color/lightRankItemColor</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested manually the activity.

#### Why is this the best possible solution? Were any other approaches considered?
I followed https://material.io/design/components/bottom-navigation.html

| Master  | This branch | This branch |
| ------------- | ------------- | ------------- |
| ![screenshot_2019-03-08-00-56-17](https://user-images.githubusercontent.com/3276264/53997588-0be6db00-413d-11e9-927e-5ac3c8a3a6df.png) | ![screenshot_2019-03-08-00-50-10](https://user-images.githubusercontent.com/3276264/53997485-b3afd900-413c-11e9-9f29-0086f378de33.png)  | ![screenshot_2019-03-08-00-49-44](https://user-images.githubusercontent.com/3276264/53997484-b3afd900-413c-11e9-9399-6c356db83c01.png)  |

it's just a first step beacuse we can use such a bottom navigation in other places as well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It implements changes in `FormDownloadList` so the functionality should be tested.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)