### PR TITLE
Geo: Use more precise map markers in geo activities.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -372,7 +372,12 @@ public class GoogleMapFragment extends SupportMapFragment implements
         }
     }
 
-    @Override public void onMarkerDragStart(Marker marker) { }
+    @Override public void onMarkerDragStart(Marker marker) {
+        // When dragging starts, GoogleMap makes the marker jump up to move it
+        // out from under the user's finger; whenever a marker moves, we have
+        // to update its corresponding feature.
+        updateFeature(findFeature(marker));
+    }
 
     @Override public void onMarkerDrag(Marker marker) {
         // When a marker is manually dragged, the position is no longer
@@ -542,6 +547,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
         final List<Marker> markers = new ArrayList<>();
         final boolean closedPolygon;
         Polyline polyline;
+        public static final int STROKE_WIDTH = 5;
 
         public PolyFeature(GoogleMap map, Iterable<MapPoint> points, boolean closedPolygon) {
             this.map = map;
@@ -570,11 +576,12 @@ public class GoogleMapFragment extends SupportMapFragment implements
             if (markers.isEmpty()) {
                 clearPolyline();
             } else if (polyline == null) {
-                PolylineOptions options = new PolylineOptions();
-                options.color(Color.RED);
-                options.zIndex(1);
-                options.addAll(latLngs);
-                polyline = map.addPolyline(options);
+                polyline = map.addPolyline(new PolylineOptions()
+                    .color(Color.RED)
+                    .zIndex(1)
+                    .width(STROKE_WIDTH)
+                    .addAll(latLngs)
+                );
             } else {
                 polyline.setPoints(latLngs);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -17,7 +17,6 @@ package org.odk.collect.android.map;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Intent;
-import android.graphics.Color;
 import android.location.Location;
 import android.os.Handler;
 import android.provider.Settings;
@@ -345,8 +344,8 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 .center(loc)
                 .radius(radius)
                 .strokeWidth(1)
-                .strokeColor(0x800099ff) // matches the fillColor in ic_crosshairs.xml
-                .fillColor(0x200099ff)
+                .strokeColor(R.color.locationAccuracyCircle)
+                .fillColor(R.color.locationAccuracyFill)
             );
         }
 
@@ -490,7 +489,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
             .position(toLatLng(point))
             .snippet(point.alt + ";" + point.sd)
             .draggable(draggable)
-            .icon(getBitmapDescriptor(R.drawable.ic_red_point))
+            .icon(getBitmapDescriptor(R.drawable.ic_map_point))
             .anchor(0.5f, 0.5f)  // center the icon on the position
         );
     }
@@ -580,7 +579,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 clearPolyline();
             } else if (polyline == null) {
                 polyline = map.addPolyline(new PolylineOptions()
-                    .color(Color.RED)
+                    .color(R.color.mapLine)
                     .zIndex(1)
                     .width(STROKE_WIDTH)
                     .addAll(latLngs)

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -496,9 +496,6 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     protected BitmapDescriptor getBitmapDescriptor(int drawableId) {
-        if (testMode) {
-            return null; // during Robolectric tests, BitmapDescriptorFactory doesn't work
-        }
         return BitmapDescriptorFactory.fromBitmap(
             IconUtils.getBitmap(getActivity(), drawableId));
     }

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -330,6 +330,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     protected void updateLocationIndicator(LatLng loc, double radius) {
+        if (map == null) {
+            return;
+        }
         if (locationCrosshairs == null) {
             locationCrosshairs = map.addMarker(new MarkerOptions()
                 .position(loc)
@@ -477,7 +480,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     protected Marker createMarker(GoogleMap map, MapPoint point, boolean draggable) {
-        if (map == null) {
+        if (map == null) {  // during Robolectric tests, map will be null
             return null;
         }
         // A Marker's position is a LatLng with just latitude and longitude
@@ -493,6 +496,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     protected BitmapDescriptor getBitmapDescriptor(int drawableId) {
+        if (testMode) {
+            return null; // during Robolectric tests, BitmapDescriptorFactory doesn't work
+        }
         return BitmapDescriptorFactory.fromBitmap(
             IconUtils.getBitmap(getActivity(), drawableId));
     }

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -32,6 +32,7 @@ import com.google.android.gms.maps.CameraUpdate;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.Marker;
@@ -42,6 +43,7 @@ import com.google.android.gms.maps.model.PolylineOptions;
 import org.odk.collect.android.R;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
+import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
 import java.util.ArrayList;
@@ -442,7 +444,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
         return new LatLng(point.lat, point.lon);
     }
 
-    protected static Marker createMarker(GoogleMap map, MapPoint point, boolean draggable) {
+    protected Marker createMarker(GoogleMap map, MapPoint point, boolean draggable) {
         if (map == null) {
             return null;
         }
@@ -453,6 +455,8 @@ public class GoogleMapFragment extends SupportMapFragment implements
             .position(toLatLng(point))
             .snippet(point.alt + ";" + point.sd)
             .draggable(draggable)
+            .icon(BitmapDescriptorFactory.fromBitmap(IconUtils.getBitmap(getActivity(), R.drawable.ic_red_point)))
+            .anchor(0.5f, 0.5f)  // center the icon on the position
         );
     }
 
@@ -477,7 +481,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
         void dispose();
     }
 
-    protected static class MarkerFeature implements MapFeature {
+    protected class MarkerFeature implements MapFeature {
         Marker marker;
 
         public MarkerFeature(GoogleMap map, MapPoint point, boolean draggable) {
@@ -501,7 +505,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     /** A polyline or polygon that can be manipulated by dragging markers at its vertices. */
-    protected static class PolyFeature implements MapFeature {
+    protected class PolyFeature implements MapFeature {
         final GoogleMap map;
         final List<Marker> markers = new ArrayList<>();
         final boolean closedPolygon;

--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -271,7 +271,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
 
     @Override public void clearFeatures() {
         if (map != null) {  // during Robolectric tests, map will be null
-            map.clear();
+            for (MapFeature feature : features.values()) {
+                feature.dispose();
+            }
         }
         features.clear();
     }
@@ -340,12 +342,14 @@ public class GoogleMapFragment extends SupportMapFragment implements
             );
         }
         if (accuracyCircle == null) {
+            int stroke = getResources().getColor(R.color.locationAccuracyCircle);
+            int fill = getResources().getColor(R.color.locationAccuracyFill);
             accuracyCircle = map.addCircle(new CircleOptions()
                 .center(loc)
                 .radius(radius)
                 .strokeWidth(1)
-                .strokeColor(R.color.locationAccuracyCircle)
-                .fillColor(R.color.locationAccuracyFill)
+                .strokeColor(stroke)
+                .fillColor(fill)
             );
         }
 
@@ -579,7 +583,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
                 clearPolyline();
             } else if (polyline == null) {
                 polyline = map.addPolyline(new PolylineOptions()
-                    .color(R.color.mapLine)
+                    .color(getResources().getColor(R.color.mapLine))
                     .zIndex(1)
                     .width(STROKE_WIDTH)
                     .addAll(latLngs)

--- a/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
@@ -18,7 +18,6 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.location.Location;
 import android.location.LocationManager;
@@ -416,7 +415,7 @@ public class OsmMapFragment extends Fragment implements MapFragment,
         marker.setPosition(toGeoPoint(point));
         marker.setSubDescription(Double.toString(point.sd));
         marker.setDraggable(feature != null);
-        marker.setIcon(ContextCompat.getDrawable(map.getContext(), R.drawable.ic_red_point));
+        marker.setIcon(ContextCompat.getDrawable(map.getContext(), R.drawable.ic_map_point));
         marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER);
 
         marker.setOnMarkerDragListener(new Marker.OnMarkerDragListener() {
@@ -522,7 +521,7 @@ public class OsmMapFragment extends Fragment implements MapFragment,
             this.map = map;
             this.closedPolygon = closedPolygon;
             polyline = new Polyline();
-            polyline.setColor(Color.RED);
+            polyline.setColor(R.color.mapLine);
             Paint paint = polyline.getPaint();
             paint.setStrokeWidth(STROKE_WIDTH);
             map.getOverlays().add(polyline);

--- a/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
@@ -117,6 +117,7 @@ public class OsmMapFragment extends Fragment implements MapFragment,
         myLocationOverlay.setDrawAccuracyEnabled(true);
         Bitmap crosshairs = IconUtils.getBitmap(getActivity(), R.drawable.ic_crosshairs);
         myLocationOverlay.setDirectionArrow(crosshairs, crosshairs);
+        myLocationOverlay.setPersonHotspot(crosshairs.getWidth() / 2.0f, crosshairs.getHeight() / 2.0f);
 
         locationClient = LocationClients.clientForContext(getActivity());
         locationClient.setListener(this);

--- a/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.map;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.location.Location;
@@ -39,6 +40,7 @@ import com.google.android.gms.location.LocationListener;
 import org.odk.collect.android.R;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
+import org.odk.collect.android.utilities.IconUtils;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.events.MapEventsReceiver;
 import org.osmdroid.events.MapListener;
@@ -113,6 +115,10 @@ public class OsmMapFragment extends Fragment implements MapFragment,
         map.getOverlays().add(new MapEventsOverlay(this));
         addMapLayoutChangeListener(map);
         myLocationOverlay = new MyLocationNewOverlay(map);
+        myLocationOverlay.setDrawAccuracyEnabled(true);
+        Bitmap crosshairs = IconUtils.getBitmap(getActivity(), R.drawable.ic_crosshairs);
+        myLocationOverlay.setDirectionArrow(crosshairs, crosshairs);
+
         locationClient = LocationClients.clientForContext(getActivity());
         locationClient.setListener(this);
         if (readyListener != null) {
@@ -410,8 +416,8 @@ public class OsmMapFragment extends Fragment implements MapFragment,
         marker.setPosition(toGeoPoint(point));
         marker.setSubDescription(Double.toString(point.sd));
         marker.setDraggable(feature != null);
-        marker.setIcon(ContextCompat.getDrawable(map.getContext(), R.drawable.ic_place_black));
-        marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
+        marker.setIcon(ContextCompat.getDrawable(map.getContext(), R.drawable.ic_red_point));
+        marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER);
 
         marker.setOnMarkerDragListener(new Marker.OnMarkerDragListener() {
             @Override public void onMarkerDragStart(Marker marker) { }

--- a/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/OsmMapFragment.java
@@ -521,7 +521,7 @@ public class OsmMapFragment extends Fragment implements MapFragment,
             this.map = map;
             this.closedPolygon = closedPolygon;
             polyline = new Polyline();
-            polyline.setColor(R.color.mapLine);
+            polyline.setColor(getResources().getColor(R.color.mapLine));
             Paint paint = polyline.getPaint();
             paint.setStrokeWidth(STROKE_WIDTH);
             map.getOverlays().add(polyline);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/IconUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/IconUtils.java
@@ -16,7 +16,12 @@
 
 package org.odk.collect.android.utilities;
 
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.support.v4.content.ContextCompat;
 
 import org.odk.collect.android.R;
 
@@ -28,5 +33,16 @@ public class IconUtils {
     public static int getNotificationAppIcon() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ?
                 R.drawable.ic_notes_white : R.drawable.ic_notes_white_png;
+    }
+
+    /** Renders a Drawable (such as a vector drawable) into a Bitmap. */
+    public static Bitmap getBitmap(Context context, int drawableId) {
+        Drawable drawable = ContextCompat.getDrawable(context, drawableId);
+        Bitmap bitmap = Bitmap.createBitmap(
+            drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bitmap;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/IconUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/IconUtils.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.utilities;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.v4.content.ContextCompat;
@@ -38,8 +39,18 @@ public class IconUtils {
     /** Renders a Drawable (such as a vector drawable) into a Bitmap. */
     public static Bitmap getBitmap(Context context, int drawableId) {
         Drawable drawable = ContextCompat.getDrawable(context, drawableId);
-        Bitmap bitmap = Bitmap.createBitmap(
-            drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        if (drawable instanceof BitmapDrawable) {  // shortcut if it's already a bitmap
+            Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if (bitmap != null) {
+                return bitmap;
+            }
+        }
+        int width = drawable.getIntrinsicWidth();
+        int height = drawable.getIntrinsicHeight();
+        if (width <= 0 || height <= 0) {  // negative if Drawable is a solid colour
+            width = height = 1;
+        }
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bitmap);
         drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
         drawable.draw(canvas);

--- a/collect_app/src/main/res/drawable/ic_crosshairs.xml
+++ b/collect_app/src/main/res/drawable/ic_crosshairs.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="48dp"
+        android:height="48dp"
+        android:viewportWidth="48"
+        android:viewportHeight="48">
+    <path
+        android:fillColor="#FF0099FF"
+        android:pathData="M18,23v2h-18v-2h18z m12,0h18v2h-18v-2z m-7,-5v-18h2v18h-2z m0,12h2v18h-2v-18z" />
+</vector>

--- a/collect_app/src/main/res/drawable/ic_crosshairs.xml
+++ b/collect_app/src/main/res/drawable/ic_crosshairs.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="48"
         android:viewportHeight="48">
     <path
-        android:fillColor="#FF0099FF"
+        android:fillColor="@color/locationCrosshairs"
         android:pathData="M18,23v2h-18v-2h18z m12,0h18v2h-18v-2z m-7,-5v-18h2v18h-2z m0,12h2v18h-2v-18z" />
 </vector>

--- a/collect_app/src/main/res/drawable/ic_map_point.xml
+++ b/collect_app/src/main/res/drawable/ic_map_point.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="36dp"
+        android:height="36dp"
+        android:viewportWidth="36"
+        android:viewportHeight="36">
+    <path android:fillColor="@color/mapPointCircle" android:pathData="M18,13c-2.77,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+    <path android:fillColor="@color/mapPointFill" android:pathData="M18,21.33c-1.84,0 -3.33,-1.5 -3.33,-3.33s1.5,-3.33 3.33,-3.33s3.33,1.5 3.33,3.33s-1.5,3.33 -3.33,3.33z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/ic_red_point.xml
+++ b/collect_app/src/main/res/drawable/ic_red_point.xml
@@ -1,8 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="36dp"
-        android:height="36dp"
-        android:viewportWidth="36"
-        android:viewportHeight="36">
-    <path android:fillColor="#ffff0000" android:pathData="M18,13c-2.77,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
-    <path android:fillColor="#ffffffff" android:pathData="M18,21.33c-1.84,0 -3.33,-1.5 -3.33,-3.33s1.5,-3.33 3.33,-3.33s3.33,1.5 3.33,3.33s-1.5,3.33 -3.33,3.33z"/>
-</vector>

--- a/collect_app/src/main/res/drawable/ic_red_point.xml
+++ b/collect_app/src/main/res/drawable/ic_red_point.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="36dp"
+        android:height="36dp"
+        android:viewportWidth="36"
+        android:viewportHeight="36">
+    <path android:fillColor="#ffff0000" android:pathData="M18,13c-2.77,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+    <path android:fillColor="#ffffffff" android:pathData="M18,21.33c-1.84,0 -3.33,-1.5 -3.33,-3.33s1.5,-3.33 3.33,-3.33s3.33,1.5 3.33,3.33s-1.5,3.33 -3.33,3.33z"/>
+</vector>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -48,4 +48,16 @@ the License.
     <color name="locationStatusSearching">#333333</color>
     <color name="locationStatusAcceptable">#337733</color>
     <color name="locationStatusUnacceptable">#773333</color>
+
+    <!-- Colors for location indicators on the map; chosen to resemble the -->
+    <!-- bright blue location dot on Google Maps and Apple Maps and the -->
+    <!-- shaded blue accuracy circle in OSMDroid. -->
+    <color name="locationCrosshairs">#ff0099ff</color>
+    <color name="locationAccuracyCircle">#800099ff</color>
+    <color name="locationAccuracyFill">#200099ff</color>
+
+    <!-- Colors for recorded points and lines drawn on the map. -->
+    <color name="mapPointCircle">#ffff0000</color>
+    <color name="mapPointFill">#ffffffff</color>
+    <color name="mapLine">#ffff0000</color>
 </resources>


### PR DESCRIPTION
Issues: This feature is part of the [Geo roadmap](https://docs.google.com/document/d/1r3wJrOVDeFQkk4kWMoW29LtLI1vbBChqJ65w1Jyg4YU/edit#).
Risk: Low
Code scope: MapFragment implementations
UX scope: GeoPoint, GeoTrace, GeoShape
- [x] `./gradlew checkCode` passed
- [x] UI elements follow [style guidelines](http://bit.ly/2XtluID)

Requested reviewers: @cooperka, @grzesiek2010 

#### User-visible changes <!-- Required.  If no user-visible changes, write "None." -->
In GeoPoint, GeoTrace, and GeoShape, the entered point or points are drawn as small red circles, instead of big red or black balloons.  The smaller icon makes it easier to see precisely where the points are.

The user's location is displayed using a set of crosshairs at the location, as well as a semitransparent blue circle showing the 68% confidence radius of the location fix.

#### Notes for reviewers <!-- Where should reviewers start?  What explanations or diffs might help them understand your changes?  Omit for small, obvious PRs. -->

I recommend reviewing these commits one by one.

#### Notes for testers <!-- What should testers focus on?  What are potential regression risks?  Omit if UX scope is small and risks are minimal. -->

This is intended to be a 100% cosmetic change.  Only icons change; no behaviour should change.

#### Verification performed <!-- What has been done to ensure this works?  Omit for documentation-only PRs. -->

I have tried using GeoPoint, GeoTrace, and GeoShape, both with OSM and with Google Maps.