### PR TITLE
Fixed the problem with finding an instance file during sending a form to GoogleSheets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -407,7 +407,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
     }
 
-    public static void importData(File instanceFile, FormEntryController fec) {
+    public static void importData(File instanceFile, FormEntryController fec) throws RuntimeException {
         // convert files into a byte array
         byte[] fileBytes = FileUtils.getFileAsBytes(instanceFile);
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -178,7 +178,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
             final long start = System.currentTimeMillis();
             usedSavepoint = initializeForm(formDef, fec);
             Timber.i("Form initialized in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
-        } catch (RuntimeException e) {
+        } catch (IOException | RuntimeException e) {
             Timber.e(e);
             if (e.getCause() instanceof XPathTypeMismatchException) {
                 // this is a case of
@@ -296,7 +296,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
     }
 
-    private boolean initializeForm(FormDef formDef, FormEntryController fec) {
+    private boolean initializeForm(FormDef formDef, FormEntryController fec) throws IOException {
         final InstanceInitializationFactory instanceInit = new InstanceInitializationFactory();
         boolean usedSavepoint = false;
 
@@ -320,7 +320,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
                     publishProgress(Collect.getInstance().getString(R.string.survey_loading_reading_data_message));
                     importData(instanceXml, fec);
                     formDef.initialize(false, instanceInit);
-                } catch (RuntimeException e) {
+                } catch (IOException | RuntimeException e) {
                     Timber.e(e);
 
                     // Skip a savepoint file that is corrupted or 0-sized
@@ -407,9 +407,9 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
     }
 
-    public static void importData(File instanceFile, FormEntryController fec) throws RuntimeException {
+    public static void importData(File instanceFile, FormEntryController fec) throws IOException, RuntimeException {
         // convert files into a byte array
-        byte[] fileBytes = FileUtils.getFileAsBytes(instanceFile);
+        byte[] fileBytes = org.apache.commons.io.FileUtils.readFileToByteArray(instanceFile);
 
         // get the root of the saved and template instances
         TreeElement savedRoot = XFormParser.restoreDataModel(fileBytes, null).getRoot();

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -50,7 +50,6 @@ import org.odk.collect.android.utilities.gdrive.SheetsHelper;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -304,7 +303,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         try {
             formDef = XFormUtils.getFormFromInputStream(new FileInputStream(new File(formFilePath)));
             FormLoaderTask.importData(instanceFile, new FormEntryController(new FormEntryModel(formDef)));
-        } catch (FileNotFoundException | RuntimeException e) {
+        } catch (IOException | RuntimeException e) {
             throw new UploadException(e);
         }
         return formDef.getMainInstance().getRoot();

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -303,10 +303,10 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         FormDef formDef;
         try {
             formDef = XFormUtils.getFormFromInputStream(new FileInputStream(new File(formFilePath)));
-        } catch (FileNotFoundException e) {
+            FormLoaderTask.importData(instanceFile, new FormEntryController(new FormEntryModel(formDef)));
+        } catch (FileNotFoundException | RuntimeException e) {
             throw new UploadException(e);
         }
-        FormLoaderTask.importData(instanceFile, new FormEntryController(new FormEntryModel(formDef)));
         return formDef.getMainInstance().getRoot();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -82,49 +82,6 @@ public class FileUtils {
         return dir.exists() || dir.mkdirs();
     }
 
-    public static byte[] getFileAsBytes(File file) {
-        try (InputStream is = new FileInputStream(file)) {
-
-            // Get the size of the file
-            long length = file.length();
-            if (length > Integer.MAX_VALUE) {
-                Timber.e("File %s is too large", file.getName());
-                return null;
-            }
-
-            // Create the byte array to hold the data
-            byte[] bytes = new byte[(int) length];
-
-            // Read in the bytes
-            int offset = 0;
-            int read = 0;
-            try {
-                while (offset < bytes.length && read >= 0) {
-                    read = is.read(bytes, offset, bytes.length - offset);
-                    offset += read;
-                }
-            } catch (IOException e) {
-                Timber.e(e, "Cannot read file %s", file.getName());
-                return null;
-            }
-
-            // Ensure all the bytes have been read in
-            if (offset < bytes.length) {
-                try {
-                    throw new IOException("Could not completely read file " + file.getName());
-                } catch (IOException e) {
-                    Timber.e(e);
-                    return null;
-                }
-            }
-
-            return bytes;
-        } catch (IOException e) {
-            Timber.e(e);
-        }
-        return new byte[0];
-    }
-
     public static String getMd5Hash(File file) {
         final InputStream is;
         try {


### PR DESCRIPTION
Closes #2847 

It's a second pull request that addresses issue #2847. The first one #2848 fixed two cases that might cause the issue but I can still see reports so I reopened the issue and created this pr.

#### What has been done to verify that this works as intended?
I tested editing saved forms and sending forms to Google Sheets - two cases that use the edited `importData()` method.

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue in real life. Generally, the crash takes place if during sending a for to Google Sheets [fileBytes](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2847_2?expand=1#diff-69dd5bc6a607234a5cd93b751727553eR412) array is empty. We handle this case when we open a saved form, then we catch `RuntimeException` and display a dialog so in the first commit I did the same for the second case - sending forms to GS.

It avoids crashing but I wonder why sometimes an empty array is returned there. Maybe [the method](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2847_2?expand=1#diff-7f825a8c77110cae6eb54336627d425fL85) for reading bytes from a file is not perfect. It's a really old method and now such methods are available for example in `org.apache.commons.io.FileUtils` so I decided to get rid of our own old method and used that one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not very risky.  As I said the method I edited is used in two cases:
- Editing a saved form
- Sending forms to GS
testing those two cases would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)