### PR TITLE
Display progres dialog during reading files from GD

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -593,8 +593,25 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             AsyncTask<String, HashMap<String, Object>, HashMap<String, Object>> {
         private TaskListener listener;
 
+        private ProgressDialog progressDialog;
+
         void setTaskListener(TaskListener tl) {
             listener = tl;
+        }
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            progressDialog = new ProgressDialog(GoogleDriveActivity.this);
+            progressDialog.setMessage(getString(R.string.reading_files));
+            progressDialog.setIndeterminate(true);
+            progressDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+            progressDialog.setCancelable(false);
+            progressDialog.setButton(getString(R.string.cancel), (dialog, which) -> {
+                cancel(true);
+                rootButton.setEnabled(true);
+            });
+            progressDialog.show();
         }
 
         @Override
@@ -674,6 +691,10 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
         @Override
         protected void onPostExecute(HashMap<String, Object> results) {
             super.onPostExecute(results);
+            if (progressDialog.isShowing()) {
+                progressDialog.dismiss();
+            }
+
             if (results == null) {
                 // was an auth request
                 return;

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -689,4 +689,5 @@
     <string name="read_details">Read details</string>
     <string name="google_sheets_encrypted_message">Encrypted forms can\'t be submitted to Google Sheets.</string>
     <string name="number_picker_title">Number Picker</string>
+    <string name="reading_files">Reading files</string>
 </resources>


### PR DESCRIPTION
Closes #2945 

#### What has been done to verify that this works as intended?
I tested the activity responsible for reading files from Google Drive.

#### Why is this the best possible solution? Were any other approaches considered?
I added a dialog which is displayed during reading files. As I said in the issue it was confusing when a list was empty and there was no info about the task being performed in the background.
Additionally keeping unblocked UI (during reading files) may be a cause of some strange and difficult to reproduce issues.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pr doesn't change a lot. The progress dialog should be tested. Additionally, I implemented small changes in the root button (`My Drive/Shared with me`), so please test that button as well.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)