### PR TITLE
Fixed enabled but grayed out rows

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
@@ -96,10 +96,18 @@ public class InstanceListCursorAdapter extends SimpleCursorAdapter {
     }
 
     private void setEnabled(View view) {
+        final TextView formTitle = view.findViewById(R.id.form_title);
+        final TextView formSubtitle = view.findViewById(R.id.form_subtitle);
         final TextView disabledCause = view.findViewById(R.id.form_subtitle2);
+        final ImageView imageView = view.findViewById(R.id.image);
 
         view.setEnabled(true);
         disabledCause.setVisibility(View.GONE);
+
+        formTitle.setAlpha(1f);
+        formSubtitle.setAlpha(1f);
+        disabledCause.setAlpha(1f);
+        imageView.setAlpha(1f);
     }
 
     private void setDisabled(View view, String disabledMessage) {


### PR DESCRIPTION
Closes #2956 

#### What has been done to verify that this works as intended?
I tested the list of sent forms.

#### Why is this the best possible solution? Were any other approaches considered?
The issue takes place because rows in `ListView` are reused that means if we have a few disabled rows (with grayed out elements) the same element might be reused for another element which is enabled. That's why we need to set alpha every time. The list of sent forms is the one that might be really big I guess in contrast to the list of blank/filled forms, so it could work slowly. This solution fixes the problem but in the feature, we should use RecyclerView instead (I'll file an issue). 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Implemented changes are only related to the list of sent forms so testing that list would be enough. It's not risky.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)