### PR TITLE
Remove unused analytics

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
@@ -110,12 +110,6 @@ public final class ExternalDataUtil {
 
         Matcher matcher = SEARCH_FUNCTION_REGEX.matcher(appearance);
         if (matcher.find()) {
-            Collect.getInstance().getDefaultTracker()
-                    .send(new HitBuilders.EventBuilder()
-                            .setCategory("ExternalData")
-                            .setAction("search()")
-                            .setLabel(Collect.getCurrentFormIdentifierHash())
-                            .build());
 
             String function = matcher.group(0);
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/external/handler/ExternalDataHandlerPull.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/handler/ExternalDataHandlerPull.java
@@ -71,12 +71,6 @@ public class ExternalDataHandlerPull extends ExternalDataHandlerBase {
 
     @Override
     public Object eval(Object[] args, EvaluationContext ec) {
-        Collect.getInstance().getDefaultTracker()
-                .send(new HitBuilders.EventBuilder()
-                        .setCategory("ExternalData")
-                        .setAction("pulldata()")
-                        .setLabel(Collect.getCurrentFormIdentifierHash())
-                        .build());
 
         if (args.length != 4) {
             Timber.e("4 arguments are needed to evaluate the %s function", HANDLER_NAME);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -1220,12 +1220,6 @@ public class FormController {
             // timing element...
             v = e.getChildrenWithName(AUDIT);
             if (v.size() == 1) {
-                Collect.getInstance().getDefaultTracker()
-                        .send(new HitBuilders.EventBuilder()
-                                .setCategory("AuditLogging")
-                                .setAction("Enabled")
-                                .setLabel(Collect.getCurrentFormIdentifierHash())
-                                .build());
 
                 TreeElement auditElement = v.get(0);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -130,13 +130,6 @@ public class WidgetFactory {
                         String query = fep.getQuestion().getAdditionalAttribute(null, "query");
                         if (query != null) {
                             questionWidget = new ItemsetWidget(context, fep, appearance.startsWith("quick"));
-
-                            Collect.getInstance().getDefaultTracker()
-                                    .send(new HitBuilders.EventBuilder()
-                                            .setCategory("ExternalData")
-                                            .setAction("External itemset")
-                                            .setLabel(Collect.getCurrentFormIdentifierHash())
-                                            .build());
                         } else if (appearance.startsWith("printer")) {
                             questionWidget = new ExPrinterWidget(context, fep);
                         } else if (appearance.startsWith("ex:")) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -298,12 +298,6 @@ public class WidgetFactory {
                             String actionName = predicate.toString().contains("func-expr:current") ?
                                     "CurrentPredicate" : "NonCurrentPredicate";
 
-                            Collect.getInstance().getDefaultTracker()
-                                    .send(new HitBuilders.EventBuilder()
-                                    .setCategory("Itemset")
-                                    .setAction(actionName)
-                                    .setLabel(Collect.getCurrentFormIdentifierHash())
-                                    .build());
                         }
                     }
                 }


### PR DESCRIPTION
Closes #2916 

#### What has been done to verify that this works as intended?
Searched codebase for all `setCategory` and removed the calls to the events that generate the most hits (ExternalData, Itemset) or are top events and are not actionable (AuditLogging).

#### Why is this the best possible solution? Were any other approaches considered?
Narrowest change possible

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no user-facing changes

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [X] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [X] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)