### PR TITLE
Remove unused analytics

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
@@ -20,8 +20,6 @@ package org.odk.collect.android.external;
 
 import android.widget.Toast;
 
-import com.google.android.gms.analytics.HitBuilders;
-
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.FormInstance;
@@ -110,12 +108,6 @@ public final class ExternalDataUtil {
 
         Matcher matcher = SEARCH_FUNCTION_REGEX.matcher(appearance);
         if (matcher.find()) {
-            Collect.getInstance().getDefaultTracker()
-                    .send(new HitBuilders.EventBuilder()
-                            .setCategory("ExternalData")
-                            .setAction("search()")
-                            .setLabel(Collect.getCurrentFormIdentifierHash())
-                            .build());
 
             String function = matcher.group(0);
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/external/handler/ExternalDataHandlerPull.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/handler/ExternalDataHandlerPull.java
@@ -22,11 +22,8 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 
-import com.google.android.gms.analytics.HitBuilders;
-
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.xpath.expr.XPathFuncExpr;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalDataManager;
 import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.external.ExternalSQLiteOpenHelper;
@@ -71,12 +68,6 @@ public class ExternalDataHandlerPull extends ExternalDataHandlerBase {
 
     @Override
     public Object eval(Object[] args, EvaluationContext ec) {
-        Collect.getInstance().getDefaultTracker()
-                .send(new HitBuilders.EventBuilder()
-                        .setCategory("ExternalData")
-                        .setAction("pulldata()")
-                        .setLabel(Collect.getCurrentFormIdentifierHash())
-                        .build());
 
         if (args.length != 4) {
             Timber.e("4 arguments are needed to evaluate the %s function", HANDLER_NAME);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -17,8 +17,6 @@ package org.odk.collect.android.logic;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.google.android.gms.analytics.HitBuilders;
-
 import org.javarosa.core.model.CoreModelModule;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
@@ -49,7 +47,6 @@ import org.javarosa.model.xform.XPathReference;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xpath.XPathParseTool;
 import org.javarosa.xpath.expr.XPathExpression;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.utilities.AuditEventLogger;
 import org.odk.collect.android.utilities.RegexUtils;
@@ -1220,12 +1217,6 @@ public class FormController {
             // timing element...
             v = e.getChildrenWithName(AUDIT);
             if (v.size() == 1) {
-                Collect.getInstance().getDefaultTracker()
-                        .send(new HitBuilders.EventBuilder()
-                                .setCategory("AuditLogging")
-                                .setAction("Enabled")
-                                .setLabel(Collect.getCurrentFormIdentifierHash())
-                                .build());
 
                 TreeElement auditElement = v.get(0);
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -25,18 +25,14 @@ import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.view.View;
 
-import com.google.android.gms.analytics.HitBuilders;
 import com.google.common.collect.ObjectArrays;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.spatial.MapHelper;
-import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
 
-import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.TreeMap;
 
@@ -253,17 +249,9 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
                 String sourceMediaPath = MediaUtils.getPathFromUri(getActivity(), selectedMedia,
                         MediaStore.Images.Media.DATA);
 
-                String sourceMediaPathHash = FileUtils.getMd5Hash(new ByteArrayInputStream(sourceMediaPath.getBytes()));
-
                 // setting image path
                 setSplashPath(sourceMediaPath);
 
-                Collect.getInstance().getDefaultTracker()
-                        .send(new HitBuilders.EventBuilder()
-                                .setCategory("PreferenceChange")
-                                .setAction("Selected splash image")
-                                .setLabel(sourceMediaPathHash)
-                                .build());
                 break;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -130,13 +130,6 @@ public class WidgetFactory {
                         String query = fep.getQuestion().getAdditionalAttribute(null, "query");
                         if (query != null) {
                             questionWidget = new ItemsetWidget(context, fep, appearance.startsWith("quick"));
-
-                            Collect.getInstance().getDefaultTracker()
-                                    .send(new HitBuilders.EventBuilder()
-                                            .setCategory("ExternalData")
-                                            .setAction("External itemset")
-                                            .setLabel(Collect.getCurrentFormIdentifierHash())
-                                            .build());
                         } else if (appearance.startsWith("printer")) {
                             questionWidget = new ExPrinterWidget(context, fep);
                         } else if (appearance.startsWith("ex:")) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -16,17 +16,10 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 
-import com.google.android.gms.analytics.HitBuilders;
-
 import org.javarosa.core.model.Constants;
-import org.javarosa.core.model.ItemsetBinding;
-import org.javarosa.core.model.QuestionDef;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.javarosa.xpath.expr.XPathExpression;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalDataUtil;
 
-import java.util.List;
 import java.util.Locale;
 
 import timber.log.Timber;
@@ -210,7 +203,6 @@ public class WidgetFactory {
                 } else {
                     questionWidget = new SelectOneWidget(context, fep, appearance.contains("quick"));
                 }
-                logChoiceFilterAnalytics(fep.getQuestion());
                 break;
             case Constants.CONTROL_SELECT_MULTI:
                 // search() appearance/function (not part of XForms spec) added by SurveyCTO gets
@@ -246,7 +238,6 @@ public class WidgetFactory {
                 } else {
                     questionWidget = new SelectMultiWidget(context, fep);
                 }
-                logChoiceFilterAnalytics(fep.getQuestion());
                 break;
             case Constants.CONTROL_RANK:
                 questionWidget = new RankingWidget(context, fep);
@@ -278,36 +269,5 @@ public class WidgetFactory {
         }
 
         return questionWidget;
-    }
-
-    /**
-     * Log analytics event each time a question with a choice filter is accessed, identifying
-     * choice filters with relative expressions. This was initially introduced to inform messaging
-     * around a long-standing bug in JavaRosa: https://github.com/opendatakit/javarosa/issues/293
-     */
-    private static void logChoiceFilterAnalytics(QuestionDef question) {
-        ItemsetBinding itemsetBinding = question.getDynamicChoices();
-
-        if (itemsetBinding != null && itemsetBinding.nodesetRef != null) {
-            if (itemsetBinding.nodesetRef.hasPredicates()) {
-                for (int level = 0; level < itemsetBinding.nodesetRef.size(); level++) {
-                    List<XPathExpression> predicates = itemsetBinding.nodesetRef.getPredicate(level);
-
-                    if (predicates != null) {
-                        for (XPathExpression predicate : predicates) {
-                            String actionName = predicate.toString().contains("func-expr:current") ?
-                                    "CurrentPredicate" : "NonCurrentPredicate";
-
-                            Collect.getInstance().getDefaultTracker()
-                                    .send(new HitBuilders.EventBuilder()
-                                    .setCategory("Itemset")
-                                    .setAction(actionName)
-                                    .setLabel(Collect.getCurrentFormIdentifierHash())
-                                    .build());
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes #2916 

#### What has been done to verify that this works as intended?
Searched codebase for all `setCategory` and removed the calls to the events that generate the most hits (ExternalData, Itemset) or are top events and are not actionable (AuditLogging). 

I did not verify on a device or Google Analytics that these events are not being sent.

#### Why is this the best possible solution? Were any other approaches considered?
Narrowest change possible

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no user-facing changes

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [X] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [X] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)