### PR TITLE
Clear the list if reading files canceled

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -608,6 +608,8 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             progressDialog.setButton(getString(R.string.cancel), (dialog, which) -> {
                 cancel(true);
                 rootButton.setEnabled(true);
+                driveList.clear();
+                updateAdapter();
             });
             progressDialog.show();
         }


### PR DESCRIPTION
Closes #2959 #2977 

#### What has been done to verify that this works as intended?
I tested canceling the task during reading files from GD.

#### Why is this the best possible solution? Were any other approaches considered?
@mmarciniak90 I was thinking about this issue. Initially, I agreed that `refresh` button would be good here as described in the issue but now I think that having not fully downloaded list of files and displaying sucha a list is misleading and might cause some strange exceptions in the future.
I think the easiest way to improve the current approach is clearing the list if a user cancels the task. Then a user can use `My Drive/Shared with me` buttons to read files again. I know that if he is deep in hierarchy of dirs it takes him to the main level but it's safer at least.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a small not risky change. testing canceling the task would be enough here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)