### PR TITLE
Prevent NullPointerExceptions when the activity is null

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -327,7 +327,10 @@ public class GoogleMapFragment extends SupportMapFragment implements
         if (gpsLocationListener != null) {
             gpsLocationListener.onPoint(lastLocationFix);
         }
-        updateLocationIndicator(toLatLng(lastLocationFix), location.getAccuracy());
+
+        if (getActivity() != null) {
+            updateLocationIndicator(toLatLng(lastLocationFix), location.getAccuracy());
+        }
     }
 
     protected void updateLocationIndicator(LatLng loc, double radius) {
@@ -483,7 +486,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     protected Marker createMarker(GoogleMap map, MapPoint point, boolean draggable) {
-        if (map == null) {  // during Robolectric tests, map will be null
+        if (map == null || getActivity() == null) {  // during Robolectric tests, map will be null
             return null;
         }
         // A Marker's position is a LatLng with just latitude and longitude


### PR DESCRIPTION
Closes #2979

#### What has been done to verify that this works as intended?
I rotated the screen quickly on first launch of a geo widget using Google Maps and kept doing it over and over again. I believe the issue could occur not just when first launching the question but whenever a location update was received at the same time as an orientation change. It's just easiest to reproduce on first launch.

#### Why is this the best possible solution? Were any other approaches considered?
I considered doing the check on `getActivity()` being null deeper in the code but this ended up making the most sense to me: only update the location indicator if the activity exists. The other null check in `createMarker` is probably not strictly necessary but I couldn't quickly convince myself that the activity could never be null there so I figured it's better to be defensive.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It only fixes the bug. If the activity is null, users can't see anything anyway so this won't affect them.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with geo widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)