### PR TITLE
Fixed RankWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
@@ -20,6 +20,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
+import android.support.v4.widget.NestedScrollView;
 import android.support.v7.app.AlertDialog.Builder;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -30,7 +31,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
-import android.widget.ScrollView;
 import android.widget.TextView;
 
 import org.javarosa.core.model.FormIndex;
@@ -106,14 +106,14 @@ public class RankingWidgetDialog extends DialogFragment {
         super.onSaveInstanceState(outState);
     }
 
-    private ScrollView setUpRankingLayout(List<String> values, FormIndex formIndex) {
+    private NestedScrollView setUpRankingLayout(List<String> values, FormIndex formIndex) {
         LinearLayout rankingLayout = new LinearLayout(getContext());
         rankingLayout.setOrientation(LinearLayout.HORIZONTAL);
         rankingLayout.addView(setUpPositionsLayout(values));
         rankingLayout.addView(setUpRecyclerView(values, formIndex));
         rankingLayout.setPadding(10, 0, 10, 0);
 
-        ScrollView scrollView = new ScrollView(getContext());
+        NestedScrollView scrollView = new NestedScrollView(getContext());
         scrollView.addView(rankingLayout);
         return scrollView;
     }


### PR DESCRIPTION
Closes #2980 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue on different devices.

#### Why is this the best possible solution? Were any other approaches considered?
We use nested scrollable elements in `RankWIdget` so we should use NestedScrollView for that, not ordinary ScrollView which works well only on older devices.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change should just fix the issue. It's only related to `RankWidget` so testing that widget would be enough. 

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)