### PR TITLE
Fixed OutOfMemoryError during importing settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -247,7 +247,7 @@ public class ShowQRCodeFragment extends Fragment {
                 } catch (FormatException | NotFoundException | ChecksumException e) {
                     Timber.i(e);
                     ToastUtils.showLongToast("QR Code not found in the selected image");
-                } catch (DataFormatException | IOException e) {
+                } catch (DataFormatException | IOException | OutOfMemoryError e) {
                     Timber.e(e);
                     ToastUtils.showShortToast(getString(R.string.invalid_qrcode));
                 }


### PR DESCRIPTION
Closes #2984 

#### What has been done to verify that this works as intended?
I tested importing the image attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
It's the easiest solution. QR codes we generate are small 400x400px so it can't cause this crash. The crash takes place only if a user chooses a really big image (probably by mistake), so in this case, I just decided to catch the exception.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The solution is safe and shouldn't cause any visible changes. The fix should just catch ChecksumException thrown if a big image is selected during importing settings.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)