### PR TITLE
Don't display not relevant groups and groups that don't contain any relevant questions in hierarchy

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -595,6 +595,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_GROUP: {
+                        if (!formController.isGroupRelevant()) {
+                            break;
+                        }
                         // Nothing but repeat group instances should show up in the picker.
                         if (shouldShowRepeatGroupPicker()) {
                             break;
@@ -631,6 +634,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_REPEAT: {
+                        if (!formController.isGroupRelevant()) {
+                            break;
+                        }
+
                         visibleGroupRef = currentRef;
 
                         FormEntryCaption fc = formController.getCaptionPrompt();

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -916,26 +916,41 @@ public class FormController {
      */
     private List<FormIndex> getIndicesForGroup(GroupDef gd) {
         return getIndicesForGroup(gd,
-                formEntryController.getModel().incrementIndex(getFormIndex(), true));
+                formEntryController.getModel().incrementIndex(getFormIndex(), true), false);
     }
 
-    private List<FormIndex> getIndicesForGroup(GroupDef gd, FormIndex currentChildIndex) {
+    private List<FormIndex> getIndicesForGroup(GroupDef gd, FormIndex currentChildIndex, boolean jumpIntoRepeatGroups) {
         List<FormIndex> indices = new ArrayList<>();
         for (int i = 0; i < gd.getChildren().size(); i++) {
             final FormEntryModel formEntryModel = formEntryController.getModel();
-            if (getEvent(currentChildIndex) == FormEntryController.EVENT_GROUP) {
+            if (getEvent(currentChildIndex) == FormEntryController.EVENT_GROUP
+                    || (jumpIntoRepeatGroups && getEvent(currentChildIndex) == FormEntryController.EVENT_REPEAT)) {
                 IFormElement nestedElement = formEntryModel.getForm().getChild(currentChildIndex);
                 if (nestedElement instanceof GroupDef) {
                     indices.addAll(getIndicesForGroup((GroupDef) nestedElement,
-                            formEntryModel.incrementIndex(currentChildIndex, true)));
+                            formEntryModel.incrementIndex(currentChildIndex, true), jumpIntoRepeatGroups));
                     currentChildIndex = formEntryModel.incrementIndex(currentChildIndex, false);
                 }
-            } else {
+            } else if (!jumpIntoRepeatGroups || getEvent(currentChildIndex) != FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
                 indices.add(currentChildIndex);
                 currentChildIndex = formEntryModel.incrementIndex(currentChildIndex, false);
             }
         }
         return indices;
+    }
+
+    /**
+     * @return true if a group contains at least one relevant question, otherwise false
+     */
+    public boolean isGroupRelevant() {
+        GroupDef groupDef = (GroupDef) getCaptionPrompt().getFormElement();
+        FormIndex currentChildIndex = formEntryController.getModel().incrementIndex(getFormIndex(), true);
+        for (FormIndex index : getIndicesForGroup(groupDef, currentChildIndex, true)) {
+            if (formEntryController.getModel().isIndexRelevant(index)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public FormEntryPrompt getQuestionPrompt(FormIndex index) {


### PR DESCRIPTION
Closes #2944 

#### What has been done to verify that this works as intended?
I tested various forms attached below.

#### Why is this the best possible solution? Were any other approaches considered?
Groups are not marked as not relevant if they contain only not relevant elements so I needed to check all elements inside to decide if a group should be displayed in the hierarchy.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue but I'm afraid of any change in that place so @mmarciniak90 again please be super careful and take all the time you need. No rush here because we have discovered many issues in the hierarchy and the code is not easy there.

#### Do we need any specific form for testing your changes? If so, please attach one.
All those forms show the bug:
[hiddenRepeatNetsted.xlsx](https://github.com/opendatakit/collect/files/3038485/hiddenRepeatNetsted.xlsx)
[hiddenRepeat.xlsx](https://github.com/opendatakit/collect/files/3038486/hiddenRepeat.xlsx)
[hidden.xlsx](https://github.com/opendatakit/collect/files/3038487/hidden.xlsx)
[testRepeatCount.xlsx](https://github.com/opendatakit/collect/files/3038503/testRepeatCount.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)