### PR TITLE
Allow clicking on the marker

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/GoogleMapFragment.java
@@ -59,7 +59,7 @@ import timber.log.Timber;
 public class GoogleMapFragment extends SupportMapFragment implements
     MapFragment, LocationListener, LocationClient.LocationClientListener,
     GoogleMap.OnMapClickListener, GoogleMap.OnMapLongClickListener,
-    GoogleMap.OnMarkerDragListener {
+    GoogleMap.OnMarkerDragListener, GoogleMap.OnMarkerClickListener {
     public static final LatLng INITIAL_CENTER = new LatLng(0, -30);
     public static final float INITIAL_ZOOM = 2;
     public static final float POINT_ZOOM = 16;
@@ -108,6 +108,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
             this.map = map;
             map.setOnMapClickListener(this);
             map.setOnMapLongClickListener(this);
+            map.setOnMarkerClickListener(this);
             map.setOnMarkerDragListener(this);
             map.getUiSettings().setCompassEnabled(true);
             // Don't show the blue dot on the map; we'll draw crosshairs instead.
@@ -379,6 +380,11 @@ public class GoogleMapFragment extends SupportMapFragment implements
         if (longPressListener != null) {
             longPressListener.onPoint(fromLatLng(latLng));
         }
+    }
+
+    @Override public boolean onMarkerClick(Marker marker) {
+        onMapClick(marker.getPosition());
+        return true;
     }
 
     @Override public void onMarkerDragStart(Marker marker) {


### PR DESCRIPTION
Closes #2991 

#### What has been done to verify that this works as intended?
I tested the case mentioned in the issue.

#### Why is this the best possible solution? Were any other approaches considered?
It's not a perfect solution, unfortunately. Now we can add points clicking on the marker but the point is added using [marker.getPosition()](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-2991?expand=1#diff-0e15c84b36d975d9f4f85397e863507eR386) that means new points are added in the center of the marker every time even if you clicked a little nex to the center point.

Unfortunately looks as if there is no way to disable `onMarkerClick()` at all and force `onMapClick()` to be called.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change. Testing adding points with GoogleMaps would be enough here.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with Geotrace/Geoshape widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)