### PR TITLE
Avoid NullPointerException in findExistingOrCreateNewUri() method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -266,7 +266,6 @@ public class FormDownloader {
      * @return a {@link UriResult} object
      */
     private UriResult findExistingOrCreateNewUri(File formFile, Map<String, String> formInfo) {
-        Cursor cursor = null;
         final Uri uri;
         final String formFilePath = formFile.getAbsolutePath();
         String mediaPath = FileUtils.constructMediaPath(formFilePath);
@@ -274,8 +273,7 @@ public class FormDownloader {
 
         FileUtils.checkMediaPath(new File(mediaPath));
 
-        try {
-            cursor = formsDao.getFormsCursorForFormFilePath(formFile.getAbsolutePath());
+        try (Cursor cursor = formsDao.getFormsCursorForFormFilePath(formFile.getAbsolutePath())) {
             isNew = cursor.getCount() <= 0;
 
             if (isNew) {
@@ -285,10 +283,6 @@ public class FormDownloader {
                 uri = Uri.withAppendedPath(FormsProviderAPI.FormsColumns.CONTENT_URI,
                         cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns._ID)));
                 mediaPath = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH));
-            }
-        } finally {
-            if (cursor != null) {
-                cursor.close();
             }
         }
 

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -693,4 +693,5 @@
     <string name="number_picker_title">Number Picker</string>
     <string name="too_complex_form">This form is too complex for this device. Try simplifying expressions or ask for help on the forum.</string>
     <string name="reading_files">Reading files</string>
+    <string name="copying_media_files_failed">Copying media files failed</string>
 </resources>


### PR DESCRIPTION
Closes #2995 

#### What has been done to verify that this works as intended?
I tested the fix with the last commit [Just for testing](https://github.com/opendatakit/collect/commit/9c7a4d341f8c3ee1cac12c4d5af6dfb4bb0a381a) because otherwise, it's very difficult to reproduce since the crash is rare.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a null check so it's the only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should change anything. NullPointerException should be caught and that case handled. It might happen if a form with media files is being downloaded. Then such form is not saved and an appropriate message is displayed.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)