### PR TITLE
Fixed IllegalArgumentException in InstanceListCursorAdapter.java line 83

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
@@ -33,6 +33,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 public class InstanceListCursorAdapter extends SimpleCursorAdapter {
     private final Context context;
     private final boolean shouldCheckDisabled;
@@ -79,8 +81,13 @@ public class InstanceListCursorAdapter extends SimpleCursorAdapter {
             String disabledMessage;
 
             if (date != 0) {
-                String deletedTime = context.getString(R.string.deleted_on_date_at_time);
-                disabledMessage = new SimpleDateFormat(deletedTime, Locale.getDefault()).format(new Date(date));
+                try {
+                    String deletedTime = context.getString(R.string.deleted_on_date_at_time);
+                    disabledMessage = new SimpleDateFormat(deletedTime, Locale.getDefault()).format(new Date(date));
+                } catch (IllegalArgumentException e) {
+                    Timber.e(e);
+                    disabledMessage = context.getString(R.string.submission_deleted);
+                }
             } else if (!formExists) {
                 disabledMessage = context.getString(R.string.deleted_form);
             } else {

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -191,7 +191,7 @@
   <!--http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
   <string name="sending_failed_on_date_at_time">\'Odesílání selhalo\' EEE, dd MMM, yyyy \'v\' HH:mm</string>
   <!--http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html-->
-  <string name="deleted_on_date_at_time">Smazáno \"EEE, MMM dd, yyyy \' v \' HH:mm</string>
+  <string name="deleted_on_date_at_time">\'Smazáno\' EEE, MMM dd, yyyy \'v\' HH:mm</string>
   <string name="version">Verze:</string>
   <string name="parent_form_not_present">Tento uložený dotazník nelze editovat, protože jeho předloha chybí nebo byla smazána.\n\n ID dotazníku: %1$s</string>
   <string name="launch_app">Spustit</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="sent_on_date_at_time">\'Sent on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
     <string name="sending_failed_on_date_at_time">\'Sending failed on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
     <string name="deleted_on_date_at_time">\'Deleted on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <string name="submission_deleted">Submission deleted</string>
     <string name="version">Version:</string>
     <string name="parent_form_not_present">Unable to edit this saved form because the corresponding blank form is not present or was deleted.\n\nForm ID: %1$s</string>
     <string name="launch_app">Launch</string>


### PR DESCRIPTION
Closes #3005 

The problem is in `View Sent Forms` list if we have at least one deleted submission. Then if a string used to display deleted date is corrupted (like the one in translations for the Czech Republic) the app is crashed.

#### What has been done to verify that this works as intended?
I tested the `View Sent Forms` list  with bad strings like the one fixed in https://github.com/opendatakit/collect/commit/5580cc0484afa3b3fee0e0036bfe9cc3435dcebc

#### Why is this the best possible solution? Were any other approaches considered?
First of all, I fixed the string what is obvious: https://github.com/opendatakit/collect/commit/5580cc0484afa3b3fee0e0036bfe9cc3435dcebc
The second thing is catching `IllegalArgumentException` in order to avoid such problems in the future - strings are added using Transifex and it's difficult to catch such bugs doing code review.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The pr should just catch bad strings like the one fixed in https://github.com/opendatakit/collect/commit/5580cc0484afa3b3fee0e0036bfe9cc3435dcebc to avoid crashing. The only visible change is a default message displayed if the mentioned string is corrupted 
https://github.com/opendatakit/collect/pull/3006/commits/2c2a83abab6c88b8bea5b5b3db1a9e02ad94e791#diff-45784e92e63c347573773596b6912771R200

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)