### PR TITLE
Fixed wrong Slovenian translation

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/FileArrayAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/FileArrayAdapter.java
@@ -36,6 +36,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 public class FileArrayAdapter extends ArrayAdapter<DriveListItem> {
 
     private final List<DriveListItem> items;
@@ -61,9 +63,13 @@ public class FileArrayAdapter extends ArrayAdapter<DriveListItem> {
         void onBind(DriveListItem item) {
             String dateModified = null;
             if (item.getDate() != null) {
-                dateModified = new SimpleDateFormat(getContext().getString(
-                        R.string.modified_on_date_at_time), Locale.getDefault())
-                        .format(new Date(item.getDate().getValue()));
+                try {
+                    dateModified = new SimpleDateFormat(getContext().getString(
+                            R.string.modified_on_date_at_time), Locale.getDefault())
+                            .format(new Date(item.getDate().getValue()));
+                } catch (IllegalArgumentException e) {
+                    Timber.e(e);
+                }
             }
 
             if (item.getType() == DriveListItem.FILE) {

--- a/collect_app/src/main/res/values-sl/strings.xml
+++ b/collect_app/src/main/res/values-sl/strings.xml
@@ -266,7 +266,7 @@
   <string name="google_drive">Google Drive</string>
   <string name="go_drive">My Drive</string>
   <string name="go_shared">Deljeno z menoj</string>
-  <string name="modified_on_date_at_time">Spremenjeno \'EEE,MMM dd, yyyy\' ob HH:mm</string>
+  <string name="modified_on_date_at_time">\'Spremenjeno\' EEE, MMM dd, yyyy \'ob\' HH:mm</string>
   <string name="aggregate_preferences">ODK Aggregate nastavitve</string>
   <string name="sms_submission_preferences">Nastavitve za predložitev preko SMS sporočil</string>
   <string name="submission_transport_types_title">Predloži preko</string>


### PR DESCRIPTION
Closes #3007 

#### What has been done to verify that this works as intended?
I confirmed that the problem with Slovenian language is fixed. Additionally I confirmed that the case with wrong `modified_on_date_at_time` strings is now catched so we are safe if any wrong translation occur in the future.

#### Why is this the best possible solution? Were any other approaches considered?
I just fixed the string and adeed a catch to avoid such problems in the future. It's the only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No visual changes here. This pr just fix the wrong Slovenian translation and additionaly catch an exception if any any wrong translation occur in the future.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)