### PR TITLE
Catch IllegalArgumentException in FormsProvider

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.provider;
 import android.content.ContentProvider;
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.UriMatcher;
 import android.database.Cursor;
 import android.database.SQLException;
@@ -188,11 +189,7 @@ public class FormsProvider extends ContentProvider {
             }
 
             if (!values.containsKey(FormsColumns.DISPLAY_SUBTEXT)) {
-                Date today = new Date();
-                String ts = new SimpleDateFormat(getContext().getString(
-                        R.string.added_on_date_at_time), Locale.getDefault())
-                        .format(today);
-                values.put(FormsColumns.DISPLAY_SUBTEXT, ts);
+                values.put(FormsColumns.DISPLAY_SUBTEXT, getDisplaySubtext());
             }
 
             if (!values.containsKey(FormsColumns.DISPLAY_NAME)) {
@@ -442,11 +439,7 @@ public class FormsProvider extends ContentProvider {
 
                     // Make sure that the necessary fields are all set
                     if (values.containsKey(FormsColumns.DATE)) {
-                        Date today = new Date();
-                        String ts = new SimpleDateFormat(getContext().getString(
-                                R.string.added_on_date_at_time), Locale.getDefault())
-                                .format(today);
-                        values.put(FormsColumns.DISPLAY_SUBTEXT, ts);
+                        values.put(FormsColumns.DISPLAY_SUBTEXT, getDisplaySubtext());
                     }
 
                     count = db.update(FORMS_TABLE_NAME, values, where, whereArgs);
@@ -504,11 +497,7 @@ public class FormsProvider extends ContentProvider {
 
                             // Make sure that the necessary fields are all set
                             if (values.containsKey(FormsColumns.DATE)) {
-                                Date today = new Date();
-                                String ts = new SimpleDateFormat(getContext()
-                                        .getString(R.string.added_on_date_at_time),
-                                        Locale.getDefault()).format(today);
-                                values.put(FormsColumns.DISPLAY_SUBTEXT, ts);
+                                values.put(FormsColumns.DISPLAY_SUBTEXT, getDisplaySubtext());
                             }
 
                             count = db.update(
@@ -537,6 +526,20 @@ public class FormsProvider extends ContentProvider {
         }
 
         return count;
+    }
+
+    private String getDisplaySubtext() {
+        String displaySubtext = "";
+        try {
+            Context context = getContext();
+            if (context != null) {
+                displaySubtext = new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
+                        Locale.getDefault()).format(new Date());
+            }
+        } catch (IllegalArgumentException e) {
+            Timber.e(e);
+        }
+        return displaySubtext;
     }
 
     @NonNull


### PR DESCRIPTION
Closes #3011 

#### What has been done to verify that this works as intended?
I tested downloading new forms and displaying the subtext displayed in the list of blank forms (it's like: 
`Added on Tue, Apr 09, 2019 at 12:20`)

#### Why is this the best possible solution? Were any other approaches considered?
It's just a catch to avoid possible problems with new translations.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Confirming that the subtext in the list of blank forms works with no regression would be enough. There is no visible change anywhere.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)