### PR TITLE
Fixed the case when last group in nested repeat group is removed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -708,8 +708,11 @@ public class FormController {
      * Returns true if the index is either a repeatable group or a visible group.
      */
     public boolean isDisplayableGroup(FormIndex index) {
-        return getEvent(index) == FormEntryController.EVENT_REPEAT ||
-                (getEvent(index) == FormEntryController.EVENT_GROUP && isPresentationGroup(index) && isLogicalGroup(index));
+        int event = getEvent(index);
+        return event == FormEntryController.EVENT_REPEAT
+                || event == FormEntryController.EVENT_PROMPT_NEW_REPEAT
+                || (event == FormEntryController.EVENT_GROUP
+                && isPresentationGroup(index) && isLogicalGroup(index));
     }
 
     /**


### PR DESCRIPTION
Closes #2942 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue and some others with repeat groups.

#### Why is this the best possible solution? Were any other approaches considered?
It's the only solution. If we have nested repeat groups during removing las group EVENT_PROMPT_NEW_REPEAT event might be returned but it's still an event which comes from a group so it should be treated as a part of a group.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This pr should just fix the bug, no other visible changes.
I don't think it's a risky change but we have discovered many bugs in the hierarchy so far so every change should be tested carefully.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)