### PR TITLE
Catch NullPointerException in QRCodeUtils.getBinaryBitmap(QRCodeUtils.java:78)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -235,6 +235,7 @@ public class ShowQRCodeFragment extends Fragment {
         if (requestCode == SELECT_PHOTO) {
             if (resultCode == Activity.RESULT_OK) {
                 try {
+                    boolean qrCodeFound = false;
                     final Uri imageUri = data.getData();
                     if (imageUri != null) {
                         final InputStream imageStream = getActivity().getContentResolver()
@@ -244,12 +245,12 @@ public class ShowQRCodeFragment extends Fragment {
                         if (bitmap != null) {
                             String response = QRCodeUtils.decodeFromBitmap(bitmap);
                             if (response != null) {
+                                qrCodeFound = true;
                                 applySettings(response);
-                            } else {
-                                ToastUtils.showLongToast(R.string.qr_code_not_found);
                             }
                         }
-                    } else {
+                    }
+                    if (!qrCodeFound) {
                         ToastUtils.showLongToast(R.string.qr_code_not_found);
                     }
                 } catch (FormatException | NotFoundException | ChecksumException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -236,13 +236,21 @@ public class ShowQRCodeFragment extends Fragment {
             if (resultCode == Activity.RESULT_OK) {
                 try {
                     final Uri imageUri = data.getData();
-                    final InputStream imageStream = getActivity().getContentResolver()
-                            .openInputStream(imageUri);
+                    if (imageUri != null) {
+                        final InputStream imageStream = getActivity().getContentResolver()
+                                .openInputStream(imageUri);
 
-                    final Bitmap bitmap = BitmapFactory.decodeStream(imageStream);
-                    String response = QRCodeUtils.decodeFromBitmap(bitmap);
-                    if (response != null) {
-                        applySettings(response);
+                        final Bitmap bitmap = BitmapFactory.decodeStream(imageStream);
+                        if (bitmap != null) {
+                            String response = QRCodeUtils.decodeFromBitmap(bitmap);
+                            if (response != null) {
+                                applySettings(response);
+                            } else {
+                                ToastUtils.showLongToast("QR Code not found in the selected image");
+                            }
+                        }
+                    } else {
+                        ToastUtils.showLongToast("QR Code not found in the selected image");
                     }
                 } catch (FormatException | NotFoundException | ChecksumException e) {
                     Timber.i(e);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -246,15 +246,15 @@ public class ShowQRCodeFragment extends Fragment {
                             if (response != null) {
                                 applySettings(response);
                             } else {
-                                ToastUtils.showLongToast("QR Code not found in the selected image");
+                                ToastUtils.showLongToast(R.string.qr_code_not_found);
                             }
                         }
                     } else {
-                        ToastUtils.showLongToast("QR Code not found in the selected image");
+                        ToastUtils.showLongToast(R.string.qr_code_not_found);
                     }
                 } catch (FormatException | NotFoundException | ChecksumException e) {
                     Timber.i(e);
-                    ToastUtils.showLongToast("QR Code not found in the selected image");
+                    ToastUtils.showLongToast(R.string.qr_code_not_found);
                 } catch (DataFormatException | IOException | OutOfMemoryError e) {
                     Timber.e(e);
                     ToastUtils.showShortToast(getString(R.string.invalid_qrcode));

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -694,4 +694,5 @@
     <string name="too_complex_form">This form is too complex for this device. Try simplifying expressions or ask for help on the forum.</string>
     <string name="reading_files">Reading files</string>
     <string name="copying_media_files_failed">Copying media files failed</string>
+    <string name="qr_code_not_found">QR Code not found in the selected image</string>
 </resources>


### PR DESCRIPTION
Closes #3015 

#### What has been done to verify that this works as intended?
Nothing just reviewed implemented changes since it's pretty simple but the problem really difficult to reproduce.

#### Why is this the best possible solution? Were any other approaches considered?
Just added null check to avoid crashing. The problem is not our fault so it's the only thing we can do.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I just added null checks so I don't think it requires testing. Code review should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)