### PR TITLE
Catch null formPath

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -121,6 +121,12 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         errorMsg = null;
 
         final String formPath = path[0];
+        if (formPath == null) {
+            Timber.e("formPath is null");
+            errorMsg = "formPath is null, please post on the forum with a description of what you were doing when this happened.";
+            return null;
+        }
+
         final File formXml = new File(formPath);
         final File formMediaDir = FileUtils.getFormMediaDir(formXml);
 


### PR DESCRIPTION
Closes #3019 

#### What has been done to verify that this works as intended?
I hardcoded null value to check what happens - a form is just closed in a safe way.

#### Why is this the best possible solution? Were any other approaches considered?
The crash takes place if `formPath` is null so I just added a null check. If that happens the form is closed. It's a rare crash up to 10 appearances per each version and has something to do with reloading forms so it's very difficult to reproduce. Closing the form and letting a user open it again seems fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a null check no other changes so I think testing is not required, just code review.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)