### PR TITLE
Don't allow opeaning more than one dialog in widgets if there are many widgets on one page

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -530,7 +530,7 @@ public abstract class QuestionWidget
             button.setLayoutParams(params);
 
             button.setOnClickListener(v -> {
-                if (Collect.allowClick(getClass().getName())) {
+                if (Collect.allowClick(QuestionWidget.class.getName())) {
                     ((ButtonWidget) this).onButtonClick(withId);
                 }
             });


### PR DESCRIPTION
Closes #3009 

#### What has been done to verify that this works as intended?
I tested the case described in the issue.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that the previous solution used to avoid multiple clicks on widget buttons used `getClass().getName()` it worked if we clicked on the same button multiple times but if we have a widget like DateTime or many widgets on one page then the value returned by `getClass().getName()` is different eg. `TimeWidget` and `DateWidget` so it didn't prevent form clicking on more than one button. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a small and not risky change. The bug should be fixed and no other changes should be visible.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)