### PR TITLE
Bind SLF4J to Timber rather than Android Log

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -227,7 +227,6 @@ dependencies {
     }
     implementation "com.karumi:dexter:5.0.0"
     implementation "org.osmdroid:osmdroid-android:5.6.4"
-    implementation "org.slf4j:slf4j-android:1.6.1-RC1"
     implementation("com.google.api-client:google-api-client-android:1.22.0") {
         exclude group: 'org.apache.httpcomponents'
         exclude group: 'com.google.guava'
@@ -241,7 +240,11 @@ dependencies {
         exclude group: 'com.google.guava'
 
     }
-    implementation "com.jakewharton.timber:timber:4.7.0"
+
+    implementation "com.jakewharton.timber:timber:4.7.1"
+    implementation "org.slf4j:slf4j-api:1.7.26"
+    implementation "com.arcao:slf4j-timber:3.1@aar"
+
     implementation "com.google.zxing:core:3.3.0"
     implementation "com.journeyapps:zxing-android-embedded:3.5.0"
     implementation "net.danlew:android.joda:2.9.9"

--- a/collect_app/src/main/assets/open_source_licenses.html
+++ b/collect_app/src/main/assets/open_source_licenses.html
@@ -160,6 +160,9 @@ limitations under the License.
         <b>RxRelay</b>
     </li>
     <li>
+        <b>slf4j-timber</b>
+    </li>
+    <li>
         <b>Timber</b>
     </li>
     <li>


### PR DESCRIPTION
Closes #3034

#### What has been done to verify that this works as intended?
Added https://github.com/opendatakit/collect/commit/cc776933ef1727ee0f4c0fc9c16f6eeb93655293 to force using the `CrashReportingTree`, ran `adb logcat | grep XPath`, opened 
[nigeria_wards_internal.xml.zip](https://github.com/opendatakit/collect/files/3105633/nigeria_wards_internal.xml.zip) and verified that no log output is produced.

#### Why is this the best possible solution? Were any other approaches considered?
I considered writing the binding implementation myself but decided to use https://github.com/arcao/slf4j-timber since it's already done and tested. I also considered https://github.com/patrickfav/slf4j-timber but there's less evidence of it being in use.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users might experience a small performance improvement but that should be the only user-visible change. Maybe some users enjoyed the extreme chattiness of the logs but that seems very unlikely.

There's also a risk that the library will be abandoned and become out of date but it's small enough that we can roll our own at that time.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form will do.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)