### PR TITLE
Group the external API definition together

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -87,14 +87,7 @@ the specific language governing permissions and limitations under the License.
         android:label="@string/app_name"
         android:largeHeap="true"
         android:supportsRtl="true">
-        <provider
-            android:name=".provider.FormsProvider"
-            android:authorities="org.odk.collect.android.provider.odk.forms"
-            android:exported="true" />
-        <provider
-            android:name=".provider.InstanceProvider"
-            android:authorities="org.odk.collect.android.provider.odk.instances"
-            android:exported="true" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
@@ -114,20 +107,6 @@ the specific language governing permissions and limitations under the License.
             android:stateNotNeeded="true"
             android:windowSoftInputMode="stateAlwaysHidden" />
         <activity
-            android:name=".activities.FormEntryActivity"
-            android:configChanges="orientation"
-            android:windowSoftInputMode="adjustResize">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:mimeType="vnd.android.cursor.item/vnd.odk.form" />
-                <data android:mimeType="vnd.android.cursor.item/vnd.odk.instance" />
-            </intent-filter>
-        </activity>
-        <activity
             android:name=".activities.NotificationActivity"
             android:excludeFromRecents="true"
             android:launchMode="singleTask"
@@ -140,34 +119,6 @@ the specific language governing permissions and limitations under the License.
             android:name=".activities.GoogleDriveActivity"
             android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="stateHidden" />
-        <activity android:name=".activities.InstanceChooserList">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
-            </intent-filter>
-        </activity>
-        <activity android:name=".activities.FormChooserList">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
-                <action android:name="android.intent.action.PICK" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.form" />
-            </intent-filter>
-        </activity>
-        <activity android:name=".activities.FormDownloadList">
-            <intent-filter>
-                <action android:name="org.odk.collect.android.FORM_DOWNLOAD" />
-                <category android:name="android.intent.category.DEFAULT"/>
-                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.form" />
-            </intent-filter>
-        </activity>
         <activity
             android:name=".activities.FileManagerTabs"
             android:configChanges="orientation|screenSize" />
@@ -176,26 +127,8 @@ the specific language governing permissions and limitations under the License.
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".activities.InstanceUploaderListActivity"
-            android:configChanges="orientation|screenSize">
-        </activity>
-        <activity-alias
-            android:name=".activities.InstanceUploaderList"
-            android:targetActivity=".activities.InstanceUploaderListActivity" >
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
+            android:configChanges="orientation|screenSize" />
 
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </activity-alias>
-        <activity
-            android:name=".activities.InstanceUploaderActivity">
-            <intent-filter>
-                <action android:name="org.odk.collect.android.INSTANCE_UPLOAD" />
-                <category android:name="android.intent.category.DEFAULT"/>
-                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
-            </intent-filter>
-        </activity>
         <activity android:name=".activities.AboutActivity" />
         <activity android:name=".preferences.PreferencesActivity" />
         <activity android:name=".preferences.AdminPreferencesActivity" />
@@ -209,29 +142,11 @@ the specific language governing permissions and limitations under the License.
             android:name=".activities.GeoPolyActivity"
             android:configChanges="orientation" />
         <activity android:name=".activities.BearingActivity" />
-        <activity
-            android:name=".activities.SplashScreenActivity"
-            android:theme="@android:style/Theme.Dialog">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-        <!-- Enable Shortcuts for Command Actions -->
-        <activity
-            android:name=".activities.AndroidShortcuts"
-            android:label="ODK Form"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-            <intent-filter>
-                <action android:name="android.intent.action.CREATE_SHORTCUT" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </activity>
         <activity android:name=".activities.CaptureSelfieActivity" />
         <activity android:name=".activities.CaptureSelfieActivityNewApi" />
+        <activity android:name=".activities.WebViewActivity" />
+        <activity android:name=".activities.CaptureSelfieVideoActivity" />
+        <activity android:name=".activities.CaptureSelfieVideoActivityNewApi" />
 
         <!--
         Register AnalyticsReceiver and AnalyticsService to support background
@@ -267,8 +182,112 @@ the specific language governing permissions and limitations under the License.
             android:name="com.google.android.maps"
             android:required="false" />
 
-        <activity android:name=".activities.WebViewActivity" />
-        <activity android:name=".activities.CaptureSelfieVideoActivity" />
-        <activity android:name=".activities.CaptureSelfieVideoActivityNewApi" />
+        <!--
+             ******************External API, DO NOT CHANGE BEFORE DISCUSSING***********************
+             * The providers and activities below are available for external applications to      *
+             * integrate with and are actively in use. If one of these needs to change for some   *
+             * reason, it needs to be placed on a deprecation path so users can adapt before the  *
+             * change. If an activity needs to be renamed internally, use an activity-alias. If   *
+             * the external API needs to be expanded, introduce carefully-named actions.          *
+             **************************************************************************************
+         -->
+
+        <provider
+            android:name=".provider.FormsProvider"
+            android:authorities="org.odk.collect.android.provider.odk.forms"
+            android:exported="true" />
+        <provider
+            android:name=".provider.InstanceProvider"
+            android:authorities="org.odk.collect.android.provider.odk.instances"
+            android:exported="true" />
+
+        <activity
+            android:name=".activities.FormEntryActivity"
+            android:configChanges="orientation"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="vnd.android.cursor.item/vnd.odk.form" />
+                <data android:mimeType="vnd.android.cursor.item/vnd.odk.instance" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name=".activities.InstanceChooserList">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name=".activities.FormChooserList">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+                <action android:name="android.intent.action.PICK" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.form" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name=".activities.FormDownloadList">
+            <intent-filter>
+                <action android:name="org.odk.collect.android.FORM_DOWNLOAD" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.form" />
+            </intent-filter>
+        </activity>
+
+        <activity-alias
+            android:name=".activities.InstanceUploaderList"
+            android:targetActivity=".activities.InstanceUploaderListActivity" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.EDIT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity-alias>
+
+        <activity
+            android:name=".activities.InstanceUploaderActivity">
+            <intent-filter>
+                <action android:name="org.odk.collect.android.INSTANCE_UPLOAD" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".activities.SplashScreenActivity"
+            android:theme="@android:style/Theme.Dialog">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- Enable Shortcuts for Command Actions -->
+        <activity
+            android:name=".activities.AndroidShortcuts"
+            android:label="ODK Form"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -107,6 +107,10 @@ the specific language governing permissions and limitations under the License.
             android:stateNotNeeded="true"
             android:windowSoftInputMode="stateAlwaysHidden" />
         <activity
+            android:name=".activities.FormEntryActivity"
+            android:configChanges="orientation"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name=".activities.NotificationActivity"
             android:excludeFromRecents="true"
             android:launchMode="singleTask"
@@ -119,6 +123,9 @@ the specific language governing permissions and limitations under the License.
             android:name=".activities.GoogleDriveActivity"
             android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="stateHidden" />
+        <activity android:name=".activities.InstanceChooserList" />
+        <activity android:name=".activities.FormChooserList" />
+        <activity android:name=".activities.FormDownloadList" />
         <activity
             android:name=".activities.FileManagerTabs"
             android:configChanges="orientation|screenSize" />
@@ -128,7 +135,7 @@ the specific language governing permissions and limitations under the License.
         <activity
             android:name=".activities.InstanceUploaderListActivity"
             android:configChanges="orientation|screenSize" />
-
+        <activity android:name=".activities.InstanceUploaderActivity" />
         <activity android:name=".activities.AboutActivity" />
         <activity android:name=".preferences.PreferencesActivity" />
         <activity android:name=".preferences.AdminPreferencesActivity" />
@@ -142,6 +149,9 @@ the specific language governing permissions and limitations under the License.
             android:name=".activities.GeoPolyActivity"
             android:configChanges="orientation" />
         <activity android:name=".activities.BearingActivity" />
+        <activity
+            android:name=".activities.SplashScreenActivity"
+            android:theme="@android:style/Theme.Dialog" />
         <activity android:name=".activities.CaptureSelfieActivity" />
         <activity android:name=".activities.CaptureSelfieActivityNewApi" />
         <activity android:name=".activities.WebViewActivity" />
@@ -201,10 +211,9 @@ the specific language governing permissions and limitations under the License.
             android:authorities="org.odk.collect.android.provider.odk.instances"
             android:exported="true" />
 
-        <activity
+        <activity-alias
             android:name=".activities.FormEntryActivity"
-            android:configChanges="orientation"
-            android:windowSoftInputMode="adjustResize">
+            android:targetActivity=".activities.FormEntryActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
@@ -214,9 +223,11 @@ the specific language governing permissions and limitations under the License.
                 <data android:mimeType="vnd.android.cursor.item/vnd.odk.form" />
                 <data android:mimeType="vnd.android.cursor.item/vnd.odk.instance" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
-        <activity android:name=".activities.InstanceChooserList">
+        <activity-alias
+            android:name=".activities.InstanceChooserList"
+            android:targetActivity=".activities.InstanceChooserList">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
@@ -225,9 +236,11 @@ the specific language governing permissions and limitations under the License.
 
                 <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
-        <activity android:name=".activities.FormChooserList">
+        <activity-alias
+            android:name=".activities.FormChooserList"
+            android:targetActivity=".activities.FormChooserList">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
@@ -237,15 +250,17 @@ the specific language governing permissions and limitations under the License.
 
                 <data android:mimeType="vnd.android.cursor.dir/vnd.odk.form" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
-        <activity android:name=".activities.FormDownloadList">
+        <activity-alias
+            android:name=".activities.FormDownloadList"
+            android:targetActivity=".activities.FormDownloadList">
             <intent-filter>
                 <action android:name="org.odk.collect.android.FORM_DOWNLOAD" />
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:mimeType="vnd.android.cursor.dir/vnd.odk.form" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <activity-alias
             android:name=".activities.InstanceUploaderList"
@@ -258,25 +273,26 @@ the specific language governing permissions and limitations under the License.
             </intent-filter>
         </activity-alias>
 
-        <activity
-            android:name=".activities.InstanceUploaderActivity">
+        <activity-alias
+            android:name=".activities.InstanceUploaderActivity"
+            android:targetActivity=".activities.InstanceUploaderActivity">
             <intent-filter>
                 <action android:name="org.odk.collect.android.INSTANCE_UPLOAD" />
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:mimeType="vnd.android.cursor.dir/vnd.odk.instance" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
-        <activity
+        <activity-alias
             android:name=".activities.SplashScreenActivity"
-            android:theme="@android:style/Theme.Dialog">
+            android:targetActivity=".activities.SplashScreenActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <!-- Enable Shortcuts for Command Actions -->
         <activity


### PR DESCRIPTION
Closes #3040

While #3044 narrowly fixes the issue that @ekigamba has run into, this attempts to make accidental changes to the public API less likely in the future by giving developers and reviewers some context. Once #3044 is merged and released, this can be rebased on top of master and merged for future release. I did them separately because this is too risky to go in a point release.

@seadowg and @shobhitagarwal1612, please see if you think this will be helpful. This has come up again because d8031b9 included a rename of an activity that was publicly accessible and that broke one of @onaio's integrations. This is not the first time Collect's public API has been accidentally changed so I want to make sure all reviewers are aware that it's a concern.

#### What has been done to verify that this works as intended?
Visually verified that all expected blocks remain in the new config.

#### Why is this the best possible solution? Were any other approaches considered?
This helps communicate what the Collect public API is and reminds devs to think about it when proposing or reviewing changes. I also considered adding something to the readme but it doesn't seem most people read it carefully. This puts the information right where developers need it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no user-visible changes. If I made a mistake, the risks are that a certain activity would not be available at all anymore.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)