### PR TITLE
Increase Gradle daemon memory heap size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+org.gradle.jvmargs=-Xmx1024m
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
I noticed that my builds, `./gradlew clean assembleOdkCollectRelease` were failing on my machine with this error: Expiring Daemon because JVM Tenured space is exhausted.

According to https://developer.android.com/studio/releases/gradle-plugin
> When using Gradle 5.0 and higher, the default Gradle daemon memory heap size decreases from 1 GB to 512 MB. This might result in a build performance regression. To override this default setting, specify the Gradle daemon heap size in your project's gradle.properties file.

I tried 512m but that didn't work. 1024m and greater did. I chose the lowest working value I tried. I don't want to go higher because seems rude to take up more resources than we need on someone's machine.