### PR TITLE
Test for effectiveVisibility when question might scroll off screen

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.GrantPermissionRule;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -59,6 +60,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasFocus;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
@@ -321,7 +323,7 @@ public class FieldListUpdateTest {
 
         onView(withId(R.id.capture_image)).perform(click());
 
-        onView(withText("Target10-15")).check(matches(isDisplayed()));
+        onView(withText("Target10-15")).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)));
         onView(withId(R.id.capture_image)).check(matches(isCompletelyDisplayed()));
     }
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I run the test on an emulator which I was able to reproduce the issue on.

#### Why is this the best possible solution? Were any other approaches considered?
In this test, we have field-list (multiple questions on one screen). According to https://medium.com/@rutgurk/testing-visibility-of-views-with-espresso-f68c32abfff8

`If you scroll down in the app until that specific item in the list is not visible on screen anymore, the isDisplayed() check would fail`

In the test, we have an image question and It's the last question so the view is scrolled down automatically after receiving an answer and rest of the questions might not be visible despite the fact they exist.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a small change in tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)