### PR TITLE
Catch SecurityException in ExWidgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -26,10 +26,14 @@ import android.text.method.DigitsKeyListener;
 import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
 import org.odk.collect.android.external.ExternalAppsUtils;
+import org.odk.collect.android.utilities.ToastUtils;
 
 import java.text.NumberFormat;
 import java.util.Locale;
+
+import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
@@ -91,8 +95,12 @@ public class ExDecimalWidget extends ExStringWidget {
     @Override
     protected void fireActivity(Intent i) throws ActivityNotFoundException {
         i.putExtra("value", getDoubleAnswerValue());
-        ((Activity) getContext()).startActivityForResult(i,
-                RequestCodes.EX_DECIMAL_CAPTURE);
+        try {
+            ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_DECIMAL_CAPTURE);
+        } catch (SecurityException e) {
+            Timber.i(e);
+            ToastUtils.showLongToast(R.string.not_granted_permission);
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
@@ -25,9 +25,13 @@ import android.text.method.DigitsKeyListener;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
 import org.odk.collect.android.external.ExternalAppsUtils;
+import org.odk.collect.android.utilities.ToastUtils;
 
 import java.util.Locale;
+
+import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
@@ -80,8 +84,12 @@ public class ExIntegerWidget extends ExStringWidget {
     @Override
     protected void fireActivity(Intent i) throws ActivityNotFoundException {
         i.putExtra("value", getIntegerAnswerValue());
-        ((Activity) getContext()).startActivityForResult(i,
-                RequestCodes.EX_INT_CAPTURE);
+        try {
+            ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_INT_CAPTURE);
+        } catch (SecurityException e) {
+            Timber.i(e);
+            ToastUtils.showLongToast(R.string.not_granted_permission);
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -46,6 +46,7 @@ import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.DependencyProvider;
 import org.odk.collect.android.utilities.ObjectUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
+import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
 
@@ -165,7 +166,12 @@ public class ExStringWidget extends QuestionWidget implements BinaryWidget {
 
     protected void fireActivity(Intent i) throws ActivityNotFoundException {
         i.putExtra("value", getFormEntryPrompt().getAnswerText());
-        ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_STRING_CAPTURE);
+        try {
+            ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_STRING_CAPTURE);
+        } catch (SecurityException e) {
+            Timber.i(e);
+            ToastUtils.showLongToast(R.string.not_granted_permission);
+        }
     }
 
     @Override

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -696,4 +696,5 @@
     <string name="reading_files">Reading files</string>
     <string name="copying_media_files_failed">Copying media files failed</string>
     <string name="qr_code_not_found">QR Code not found in the selected image</string>
+    <string name="not_granted_permission">The activity you are trying to start requires a permission which is not granted.</string>
 </resources>


### PR DESCRIPTION
Closes #3061 

#### What has been done to verify that this works as intended?
Nothing since it's just a catch.

#### Why is this the best possible solution? Were any other approaches considered?
We can't do much here. It's up to our users what activity they start in our ExWidgets. If they start activities that require special permissions those activities should handle that case. Everything we can't do is just catching the exception.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing since I just added try-catch blocks.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)