### PR TITLE
Re-enable use of user certificate authorities CAs for Android 7 and up.

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -86,7 +86,8 @@ the specific language governing permissions and limitations under the License.
         android:installLocation="auto"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/collect_app/src/main/res/xml/network_security_config.xml
+++ b/collect_app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Android 7 introduced a behavior to ignore user defined Certificate Authorities.

This is needed to be able to connect OpenRosa servers running in TLS using custom CAs (in my case Brazillian Public Key Infrastructure, https://www.iti.gov.br/icp-brasil).

This PR is a proposal to re-enable a behavior ODK Collect has in Android versions prior to 7.

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

1. Pointed ODK Collect to a server that uses some custom CAs.
1. Tried to 'Get a Blank Form' (retrieve a list of forms) and get  the following error: ![ca_error](https://user-images.githubusercontent.com/555994/57959259-5b821980-78d9-11e9-89e5-a1d4fa549324.png)

1. Installed user certificates in Android (https://support.google.com/nexus/answer/2844832?hl=en);
1. Tried to 'Get a Blank Form' again, this time without `java.security.cert.CertPathValidationException: Trust anchor for certification path not found` error.


#### Why is this the best possible solution? Were any other approaches considered?

The procedure applied is described at these docs [Android Network security configuration](https://webcache.googleusercontent.com/search?q=cache:hOONLxvMTwYJ:https://developer.android.com/training/articles/security-config+&cd=4&hl=en&ct=clnk&gl=br).

Other alternative than re-enable user certificates would be forking ODK Collect an redistribute a version to include your own certificates in the App, which is not feasible for end users.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This was tested in emulators running Android 9, 6 and 5. Haven't tested in other versions.

There was this lint warning, apparently won't be a problem in older devices.

![Screenshot from 2019-05-17 19-52-44](https://user-images.githubusercontent.com/555994/57960143-99813c80-78dd-11e9-9c9c-fb9b0cb839fa.png)


#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No doc updates needed.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

