### PR TITLE
Move the Google API key into secrets.properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,19 @@ When you first run Collect, it is set to download forms from [https://opendataki
 
 ## Using APIs for local development
 
-To run functionality that makes API calls from your debug-signed builds, you may need to get an API key or otherwise authorize your app. The API keys included in the source code are the ones used for releases and they only work with release builds signed with the release keys.
+Certain functions in ODK Collect depend on cloud services that require API keys or authorization steps to work.  Here are the steps you need to take in order to use these functions in your development builds.
 
-**Google Drive and Sheets APIs** - Follow the instructions in the "Generate the signing certificate fingerprint and register your application" section from [here](https://developers.google.com/drive/android/auth). Enable the Google Drive API [here](https://console.developers.google.com/apis/api/drive.googleapis.com). Enable the Google Sheets API [here](https://console.developers.google.com/apis/api/sheets.googleapis.com).
+**Google Drive and Sheets APIs**: When the "Google Drive, Google Sheets" option is selected in the "Server" settings, ODK Collect uses these APIs to store submitted form data in Google Sheets and submitted media in Google Drive.  To enable these APIs:
+  - Follow [these instructions to generate a signing certificate fingerprint and register the application with the Google API Console](https://developers.google.com/drive/android/auth#generate_the_signing_certificate_fingerprint_and_register_your_application).
+  - [Enable the Google Drive API](https://console.developers.google.com/apis/api/drive.googleapis.com).
+  - [Enable the Google Sheets API](https://console.developers.google.com/apis/api/sheets.googleapis.com).
 
-**Google Maps API** - Getting a Google Maps API key now requires providing a credit card number. As of October 2018, there is some free API usage provided and the card will not be charged without explicit user approval. You should carefully read the terms before providing a credit card number. Once you have created a billing account, follow the instructions [here](https://developers.google.com/maps/documentation/android-api/signup) and paste your key in the `AndroidManifest` as the value for `com.google.android.geo.API_KEY`. Please be sure not to commit your personal API key to a branch that you will submit a pull request for.
-
+**Google Maps API**: When the "Google Maps SDK" option is selected in the "User interface" settings, ODK Collect uses the Google Maps API for displaying maps in the geospatial widgets (GeoPoint, GeoTrace, and GeoShape).  To enable this API:
+  - [Get a Google Maps API key](https://developers.google.com/maps/documentation/android-api/signup).  Note that this requires a credit card number, though the card will not be charged immediately; some free API usage is permitted.  You should carefully read the terms before providing a credit card number.
+  - Edit or create `collect_app/secrets.properties` and set the `GOOGLE_MAPS_API_KEY` property to your API key.  You should end up with a line that looks like this:
+    ```
+    GOOGLE_MAPS_API_KEY=AIbzvW8e0ub...
+    ```
 
 ## Debugging JavaRosa
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -63,6 +63,7 @@ def secrets = new Properties()
 if (secretsFile.exists()) {
     secrets.load(new FileInputStream(secretsFile))
 }
+def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 
 android {
     compileSdkVersion(28)
@@ -99,6 +100,7 @@ android {
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             resValue("bool", "FIREBASE_CRASHLYTICS_ENABLED", "false")
+            resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
         }
         // Release build for the official ODK Collect app
         odkCollectRelease {
@@ -108,11 +110,13 @@ android {
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             resValue("bool", "FIREBASE_CRASHLYTICS_ENABLED", "true")
+            resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
         }
         debug {
             debuggable(true)
             testCoverageEnabled(true)
             resValue("bool", "FIREBASE_CRASHLYTICS_ENABLED", "false")
+            resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
         }
     }
 

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -176,9 +176,10 @@ the specific language governing permissions and limitations under the License.
             android:exported="false" />
         <!-- ... -->
 
+        <!-- Configure this key by setting GOOGLE_MAPS_API_KEY in collect_app/secrets.properties. -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyBS-JQ-dnaZ_8qsbvSyr_I3rTPFd5fJsYI" />
+            android:value="@string/GOOGLE_MAPS_API_KEY" />
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version"


### PR DESCRIPTION
This is a developer-facing change only.

Today, developers have to put their personal Google Maps API key in `AndroidManifest.xml` to use the Google Maps functionality in ODK Collect.  Edits to `AndroidManifest.xml` are tracked in Git, so we have to be careful not to commit our personal keys to the Git repo by mistake, and various Git operations require that we `git stash` this edit first, and then we have to remember to `git stash apply` to make the build use our personal API key again.

With this change, developers configure their Google Maps API key by setting `GOOGLE_MAPS_API_KEY` in the `collect_app/secrets.properties` file instead, which is not checked into the Git repository.  This way there is no risk of committing the API key accidentally, and each developer is free to maintain their own personal copy of `secrets.properties`.