### PR TITLE
Fixed Espresso test for external app in field list

### DIFF
--- a/collect_app/src/androidTest/assets/fieldlist-updates.xml
+++ b/collect_app/src/androidTest/assets/fieldlist-updates.xml
@@ -576,7 +576,7 @@
         <label>Target13</label>
       </input>
     </group>
-    <group ref="/fieldlist-updates/external_app">
+    <group appearance="field-list" ref="/fieldlist-updates/external_app">
       <label>External app</label>
       <input appearance="ex:org.fake.app(fake=&quot;fake&quot;)" ref="/fieldlist-updates/external_app/source14">
         <label>Source14</label>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
@@ -40,6 +40,7 @@ import org.odk.collect.android.test.FormLoadingUtils;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Random;
 import java.util.UUID;
 
 import androidx.test.espresso.matcher.ViewMatchers;
@@ -375,7 +376,7 @@ public class FieldListUpdateTest {
         onView(withText(startsWith("Source14"))).perform(click());
 
         onView(withText(startsWith("Launch"))).perform(click());
-        onView(withClassName(endsWith("EditText"))).perform(replaceText(UUID.randomUUID().toString()));
+        onView(withClassName(endsWith("EditText"))).perform(replaceText(String.valueOf(new Random().nextInt())));
 
         onView(withText("Target14")).check(matches(isDisplayed()));
     }


### PR DESCRIPTION
Closes #2917 

#### What has been done to verify that this works as intended?
I confirmed that the test works as expected.

#### Why is this the best possible solution? Were any other approaches considered?
The first problem was with the form which didn't have `field-list `appearance.
The second problem was that we used `UUID.randomUUID()` where results were like: `8e8d2cc7-e5e7-48f3-8169-60408bea85be` but it's an integer widget so we expect numbers only.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)