### PR TITLE
Add quotes to answer only if it contains a comma

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/AuditEventSaveTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/AuditEventSaveTaskTest.java
@@ -137,7 +137,9 @@ public class AuditEventSaveTaskTest {
                 "form exit,,1548108909730,,54.4112062,18.5896652,30.716999053955078\n" +
                 "form finalize,,1548108909731,,54.4112062,18.5896652,30.716999053955078\n" +
                 "form resume,,1548108900606,,54.4112062,18.5896652,30.716999053955078,,\n" +
-                "question,,1548108900700,,54.4112062,18.5896652,30.716999053955078,\"Old value\",\"New value\"\n" +
+                "question,,1548108900700,,54.4112062,18.5896652,30.716999053955078,Old value,New value\n" +
+                "question,,1548108903100,,54.4112062,18.5896652,30.716999053955078,\"Old value, with comma\",New value\n" +
+                "question,,1548108904200,,54.4112062,18.5896652,30.716999053955078,Old value,\"New value, with comma\"\n" +
                 "form save,,1548108909730,,54.4112062,18.5896652,30.716999053955078,,\n" +
                 "form exit,,1548108909730,,54.4112062,18.5896652,30.716999053955078,,\n" +
                 "form finalize,,1548108909731,,54.4112062,18.5896652,30.716999053955078,,\n";
@@ -177,7 +179,7 @@ public class AuditEventSaveTaskTest {
                 "location tracking enabled,,548108908250,,,\n" +
                 "location permissions granted,,548108908255,,,\n" +
                 "location providers enabled,,548108908259,,,\n" +
-                "question,/data/q1,1548106927323,1548106930112,54.4112062,18.5896652,30.716999053955078,\"Old value\",\"New Value\"\n" +
+                "question,/data/q1,1548106927323,1548106930112,54.4112062,18.5896652,30.716999053955078,Old value,New Value\n" +
                 "add repeat,/data/g1[1],1548106930118,1548106931611,54.4112062,18.5896652,30.716999053955078,,\n" +
                 "end screen,,1548106949448,1548106953601,54.4112062,18.5896652,30.716999053955078,,\n" +
                 "form save,,1548106953600,,54.4112062,18.5896652,30.716999053955078,,\n" +
@@ -255,6 +257,14 @@ public class AuditEventSaveTaskTest {
         event = new AuditEvent(1548108900700L, QUESTION, true, null, "Old value");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value");
+        auditEvents.add(event);
+        event = new AuditEvent(1548108903100L, QUESTION, true, null, "Old value, with comma");
+        event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
+        event.recordValueChange("New value");
+        auditEvents.add(event);
+        event = new AuditEvent(1548108904200L, QUESTION, true, null, "Old value");
+        event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
+        event.recordValueChange("New value, with comma");
         auditEvents.add(event);
         event = new AuditEvent(1548108909730L, FORM_SAVE, true, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");

--- a/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
@@ -147,9 +147,14 @@ public class AuditEvent {
             this.newValue = "";
         }
 
-        // some answers might contain commas so wrap all of them in quotes just in case
-        this.oldValue = "\"" + this.oldValue + "\"";
-        this.newValue = "\"" + this.newValue + "\"";
+        // Wrap values that have commas in quotes
+        if (this.oldValue.contains(",")) {
+            this.oldValue = "\"" + this.oldValue + "\"";
+        }
+
+        if (this.newValue.contains(",")) {
+            this.newValue = "\"" + this.newValue + "\"";
+        }
     }
 
     /*

--- a/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
@@ -92,7 +92,7 @@ public class AuditEventTest {
         assertTrue(auditEvent.isEndTimeSet());
         assertFalse(auditEvent.hasLocation());
         auditEvent.recordValueChange("Second answer");
-        assertEquals("question,/data/text1,1545392727685,1545392728527,\"First answer\",\"Second answer\"", auditEvent.toString());
+        assertEquals("question,/data/text1,1545392727685,1545392728527,First answer,Second answer", auditEvent.toString());
     }
 
     @Test
@@ -105,8 +105,8 @@ public class AuditEventTest {
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
         assertTrue(auditEvent.hasLocation());
-        auditEvent.recordValueChange("Second answer");
-        assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10,\"First answer\",\"Second answer\"", auditEvent.toString());
+        auditEvent.recordValueChange("Second, answer");
+        assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10,First answer,\"Second, answer\"", auditEvent.toString());
     }
 
     @Test


### PR DESCRIPTION
Addresses https://github.com/opendatakit/collect/pull/3072#discussion_r286715334 by only escaping a value in double quotes if it contains a comma.

#### What has been done to verify that this works as intended?
I changed the tests and verified that they failed. Then I changed the code, ran the tests, and verified the tests passed.

#### Why is this the best possible solution? Were any other approaches considered?
This is the smallest change possible.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This only changes old and new values in the audit log. The worst thing that could happen is that those get corrupt in some way.

#### Do we need any specific form for testing your changes? If so, please attach one.
[trackingChangesTestForm.xml.txt](https://github.com/opendatakit/collect/files/3191321/trackingChangesTestForm.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
https://github.com/opendatakit/docs/issues/1035

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)