### PR TITLE
Swipe up until desired view is visible

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
@@ -24,6 +24,7 @@ import android.graphics.BitmapFactory;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.BeforeClass;
@@ -42,8 +43,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import java.util.UUID;
-
-import androidx.test.espresso.matcher.ViewMatchers;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -387,7 +386,7 @@ public class FieldListUpdateTest {
         onView(withId(R.id.menu_goto)).perform(click());
         onView(withId(R.id.menu_go_up)).perform(click());
         onView(withId(R.id.list)).perform(repeatedlyUntil(swipeUp(),
-                hasDescendant(withText(text)), MAX_HIERARCHY_SWIPE_ATTEMPTS));
+                hasDescendant(allOf(isDisplayed(), withText(text))), MAX_HIERARCHY_SWIPE_ATTEMPTS));
         onView(allOf(isDisplayed(), withText(text))).perform(click());
     }
 }


### PR DESCRIPTION
Fixes broken Espresso tests (I hope). I believe the problem was that in the hierarchy view, we only scrolled until the item we were looking for appeared on the screen at all but when clicking we required 90% visibility. That made it possible for scrolling to stop but clicking to fail.

#### What has been done to verify that this works as intended?
I confirmed that the tests still run locally.

#### Why is this the best possible solution? Were any other approaches considered?
This makes the conditions required when scrolling the same as the conditions used to identify the item for clicking. This should mean that we always scroll far enough.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Not at all -- it's a test-only change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)