### PR TITLE
Fixed answers saved in wrong cells if GPS is disabled.

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/AuditEventSaveTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/AuditEventSaveTaskTest.java
@@ -102,9 +102,9 @@ public class AuditEventSaveTaskTest {
                 "form finalize,,1548106953601,\n" +
                 "form resume,,1548108900606,,54.4112062,18.5896652,30.716999053955078\n" +
                 "jump,,1548108906276,1548108908206,54.4112062,18.5896652,30.716999053955078\n" +
-                "location tracking enabled,,548108908250,\n" +
-                "location permissions granted,,548108908255,\n" +
-                "location providers enabled,,548108908259,\n" +
+                "location tracking enabled,,548108908250,,,,\n" +
+                "location permissions granted,,548108908255,,,,\n" +
+                "location providers enabled,,548108908259,,,,\n" +
                 "end screen,,1548108908285,1548108909730,54.4112062,18.5896652,30.716999053955078\n" +
                 "form save,,1548108909730,,54.4112062,18.5896652,30.716999053955078\n" +
                 "form exit,,1548108909730,,54.4112062,18.5896652,30.716999053955078\n" +
@@ -129,9 +129,9 @@ public class AuditEventSaveTaskTest {
                 "form finalize,,1548106953601,\n" +
                 "form resume,,1548108900606,,54.4112062,18.5896652,30.716999053955078\n" +
                 "jump,,1548108906276,1548108908206,54.4112062,18.5896652,30.716999053955078\n" +
-                "location tracking enabled,,548108908250,\n" +
-                "location permissions granted,,548108908255,\n" +
-                "location providers enabled,,548108908259,\n" +
+                "location tracking enabled,,548108908250,,,,\n" +
+                "location permissions granted,,548108908255,,,,\n" +
+                "location providers enabled,,548108908259,,,,\n" +
                 "end screen,,1548108908285,1548108909730,54.4112062,18.5896652,30.716999053955078\n" +
                 "form save,,1548108909730,,54.4112062,18.5896652,30.716999053955078\n" +
                 "form exit,,1548108909730,,54.4112062,18.5896652,30.716999053955078\n" +
@@ -152,10 +152,10 @@ public class AuditEventSaveTaskTest {
         auditEventSaveTask.execute(getSampleAuditEventsWithLocations().toArray(new AuditEvent[0])).get();
         String expectedAuditContent = FileUtils.readFileToString(testFile);
         String expectedData = "event, node, start, end, latitude, longitude, accuracy\n" +
-                "form start,,1548106927319,\n" +
-                "location tracking enabled,,548108908250,\n" +
-                "location permissions granted,,548108908255,\n" +
-                "location providers enabled,,548108908259,\n" +
+                "form start,,1548106927319,,,,\n" +
+                "location tracking enabled,,548108908250,,,,\n" +
+                "location permissions granted,,548108908255,,,,\n" +
+                "location providers enabled,,548108908259,,,,\n" +
                 "question,/data/q1,1548106927323,1548106930112,54.4112062,18.5896652,30.716999053955078\n" +
                 "add repeat,/data/g1[1],1548106930118,1548106931611,54.4112062,18.5896652,30.716999053955078\n" +
                 "question,/data/g1[1]/q2,1548106931612,1548106937122,54.4112062,18.5896652,30.716999053955078\n" +
@@ -175,10 +175,10 @@ public class AuditEventSaveTaskTest {
         auditEventSaveTask.execute(getSampleAuditEventsWithLocationsAndTrackingChanges().toArray(new AuditEvent[0])).get();
         String expectedAuditContent = FileUtils.readFileToString(testFile);
         String expectedData = "event, node, start, end, latitude, longitude, accuracy, old-value, new-value\n" +
-                "form start,,1548106927319,,,\n" +
-                "location tracking enabled,,548108908250,,,\n" +
-                "location permissions granted,,548108908255,,,\n" +
-                "location providers enabled,,548108908259,,,\n" +
+                "form start,,1548106927319,,,,,,\n" +
+                "location tracking enabled,,548108908250,,,,,,\n" +
+                "location permissions granted,,548108908255,,,,,,\n" +
+                "location providers enabled,,548108908259,,,,,,\n" +
                 "question,/data/q1,1548106927323,1548106930112,54.4112062,18.5896652,30.716999053955078,Old value,New Value\n" +
                 "add repeat,/data/g1[1],1548106930118,1548106931611,54.4112062,18.5896652,30.716999053955078,,\n" +
                 "end screen,,1548106949448,1548106953601,54.4112062,18.5896652,30.716999053955078,,\n" +
@@ -192,22 +192,22 @@ public class AuditEventSaveTaskTest {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
         auditEvents.add(new AuditEvent(1548106927319L, FORM_START));
-        event = new AuditEvent(1548106927323L, QUESTION, false, getMockedFormIndex("/data/q1"), "");
+        event = new AuditEvent(1548106927323L, QUESTION, false, false, getMockedFormIndex("/data/q1"), "");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, false, getMockedFormIndex("/data/g1[1]"), "");
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, false, false, getMockedFormIndex("/data/g1[1]"), "");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106931612L, QUESTION, false, getMockedFormIndex("/data/g1[1]/q2[1]"), "");
+        event = new AuditEvent(1548106931612L, QUESTION, false, false, getMockedFormIndex("/data/g1[1]/q2[1]"), "");
         event.setEnd(1548106937122L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, false, getMockedFormIndex("/data/g1[2]"), "");
+        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, false, false, getMockedFormIndex("/data/g1[2]"), "");
         event.setEnd(1548106938276L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106938277L, QUESTION, false, getMockedFormIndex("/data/g1[2]/q2[1]"), "");
+        event = new AuditEvent(1548106938277L, QUESTION, false, false, getMockedFormIndex("/data/g1[2]/q2[1]"), "");
         event.setEnd(1548106948127L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, false, getMockedFormIndex("/data/g1[3]"), "");
+        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, false, false, getMockedFormIndex("/data/g1[3]"), "");
         event.setEnd(1548106949446L);
         auditEvents.add(event);
         event = new AuditEvent(1548106949448L, END_OF_FORM);
@@ -222,27 +222,33 @@ public class AuditEventSaveTaskTest {
     private ArrayList<AuditEvent> getMoreSampleAuditEventsWithLocations() {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
-        event = new AuditEvent(1548108900606L, FORM_RESUME);
+        event = new AuditEvent(1548108900606L, FORM_RESUME, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108906276L, HIERARCHY);
+        event = new AuditEvent(1548108906276L, HIERARCHY, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548108908206L);
         auditEvents.add(event);
-        auditEvents.add(new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED));
-        auditEvents.add(new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED));
-        auditEvents.add(new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED));
-        event = new AuditEvent(1548108908285L, END_OF_FORM);
+        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(1548108908285L, END_OF_FORM, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548108909730L);
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_SAVE);
+        event = new AuditEvent(1548108909730L, FORM_SAVE, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_EXIT);
+        event = new AuditEvent(1548108909730L, FORM_EXIT, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909731L, FORM_FINALIZE);
+        event = new AuditEvent(1548108909731L, FORM_FINALIZE, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;
@@ -251,28 +257,28 @@ public class AuditEventSaveTaskTest {
     private ArrayList<AuditEvent> getMoreSampleAuditEventsWithLocationsAndTrackingChanges() {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
-        event = new AuditEvent(1548108900606L, FORM_RESUME, true, null, null);
+        event = new AuditEvent(1548108900606L, FORM_RESUME, true, true);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108900700L, QUESTION, true, null, "Old value");
-        event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
-        event.recordValueChange("New value");
-        auditEvents.add(event);
-        event = new AuditEvent(1548108903100L, QUESTION, true, null, "Old value, with comma");
+        event = new AuditEvent(1548108900700L, QUESTION, true, true, null, "Old value");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value");
         auditEvents.add(event);
-        event = new AuditEvent(1548108904200L, QUESTION, true, null, "Old value");
+        event = new AuditEvent(1548108903100L, QUESTION, true, true, null, "Old value, with comma");
+        event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
+        event.recordValueChange("New value");
+        auditEvents.add(event);
+        event = new AuditEvent(1548108904200L, QUESTION, true, true, null, "Old value");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value, with comma");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_SAVE, true, null, null);
+        event = new AuditEvent(1548108909730L, FORM_SAVE, true, true);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_EXIT, true, null, null);
+        event = new AuditEvent(1548108909730L, FORM_EXIT, true, true);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909731L, FORM_FINALIZE, true, null, null);
+        event = new AuditEvent(1548108909731L, FORM_FINALIZE, true, true);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;
@@ -280,46 +286,54 @@ public class AuditEventSaveTaskTest {
 
     private ArrayList<AuditEvent> getSampleAuditEventsWithLocations() {
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
-        auditEvents.add(new AuditEvent(1548106927319L, FORM_START));
-        auditEvents.add(new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED));
-        auditEvents.add(new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED));
-        auditEvents.add(new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED));
         AuditEvent event;
-        event = new AuditEvent(1548106927323L, QUESTION, false, getMockedFormIndex("/data/q1"), "");
+        event = new AuditEvent(1548106927319L, FORM_START, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, false);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(1548106927323L, QUESTION, true,  false, getMockedFormIndex("/data/q1"), "");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, false, getMockedFormIndex("/data/g1[1]"), "");
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, false, getMockedFormIndex("/data/g1[1]"), "");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106931612L, QUESTION, false, getMockedFormIndex("/data/g1[1]/q2[1]"), "");
+        event = new AuditEvent(1548106931612L, QUESTION, true, false, getMockedFormIndex("/data/g1[1]/q2[1]"), "");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106937122L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, false, getMockedFormIndex("/data/g1[2]"), "");
+        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, true, false, getMockedFormIndex("/data/g1[2]"), "");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106938276L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106938277L, QUESTION, false, getMockedFormIndex("/data/g1[2]/q2[1]"), "");
+        event = new AuditEvent(1548106938277L, QUESTION, true, false, getMockedFormIndex("/data/g1[2]/q2[1]"), "");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106948127L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, false, getMockedFormIndex("/data/g1[3]"), "");
+        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, true, false, getMockedFormIndex("/data/g1[3]"), "");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106949446L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106949448L, END_OF_FORM);
+        event = new AuditEvent(1548106949448L, END_OF_FORM, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106953601L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106953600L, FORM_SAVE);
+        event = new AuditEvent(1548106953600L, FORM_SAVE, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_EXIT);
+        event = new AuditEvent(1548106953601L, FORM_EXIT, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_FINALIZE);
+        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;
@@ -327,31 +341,39 @@ public class AuditEventSaveTaskTest {
 
     private ArrayList<AuditEvent> getSampleAuditEventsWithLocationsAndTrackingChanges() {
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
-        auditEvents.add(new AuditEvent(1548106927319L, FORM_START, true, null, null));
-        auditEvents.add(new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, null, null));
-        auditEvents.add(new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, null, null));
-        auditEvents.add(new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, null, null));
         AuditEvent event;
-        event = new AuditEvent(1548106927323L, QUESTION, true, getMockedFormIndex("/data/q1"), "Old value");
+        event = new AuditEvent(1548106927319L, FORM_START, true, true);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, true);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, true);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, true);
+        event.setLocationCoordinates("", "", "");
+        auditEvents.add(event);
+        event = new AuditEvent(1548106927323L, QUESTION, true, true, getMockedFormIndex("/data/q1"), "Old value");
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New Value");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, getMockedFormIndex("/data/g1[1]"), null);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, true, getMockedFormIndex("/data/g1[1]"), null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106949448L, END_OF_FORM, true, null, null);
+        event = new AuditEvent(1548106949448L, END_OF_FORM, true, true, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106953601L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106953600L, FORM_SAVE, true, null, null);
+        event = new AuditEvent(1548106953600L, FORM_SAVE, true, true, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_EXIT, true, null, null);
+        event = new AuditEvent(1548106953601L, FORM_EXIT, true, true, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, null, null);
+        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, true, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;

--- a/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
@@ -69,6 +69,7 @@ public class AuditEvent {
     @NonNull private String newValue = "";
     private long end;
     private boolean endTimeSet;
+    private boolean isTrackingLocationsEnabled;
     private boolean isTrackingChangesEnabled;
     private FormIndex formIndex;
 
@@ -76,13 +77,14 @@ public class AuditEvent {
      * Create a new event
      */
     public AuditEvent(long start, AuditEventType auditEventType) {
-        this(start, auditEventType, false, null, null);
+        this(start, auditEventType, false, false, null, null);
     }
 
-    public AuditEvent(long start, AuditEventType auditEventType, boolean isTrackingChangesEnabled,
-                      FormIndex formIndex, String oldValue) {
+    public AuditEvent(long start, AuditEventType auditEventType, boolean isTrackingLocationsEnabled,
+                      boolean isTrackingChangesEnabled, FormIndex formIndex, String oldValue) {
         this.start = start;
         this.auditEventType = auditEventType;
+        this.isTrackingLocationsEnabled = isTrackingLocationsEnabled;
         this.isTrackingChangesEnabled = isTrackingChangesEnabled;
         this.formIndex = formIndex;
         this.oldValue = oldValue == null ? "" : oldValue;
@@ -171,9 +173,9 @@ public class AuditEvent {
         }
 
         String event;
-        if (hasLocation() && isTrackingChangesEnabled) {
+        if (isTrackingLocationsEnabled && isTrackingChangesEnabled) {
             event = String.format("%s,%s,%s,%s,%s,%s,%s,%s,%s", auditEventType.getValue(), node, start, end != 0 ? end : "", latitude, longitude, accuracy, oldValue, newValue);
-        } else if (hasLocation()) {
+        } else if (isTrackingLocationsEnabled) {
             event = String.format("%s,%s,%s,%s,%s,%s,%s", auditEventType.getValue(), node, start, end != 0 ? end : "", latitude, longitude, accuracy);
         } else if (isTrackingChangesEnabled) {
             event = String.format("%s,%s,%s,%s,%s,%s", auditEventType.getValue(), node, start, end != 0 ? end : "", oldValue, newValue);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
@@ -128,7 +128,7 @@ public class AuditEvent {
         return !oldValue.equals(newValue);
     }
 
-    public boolean hasLocation() {
+    public boolean isLocationAlreadySet() {
         return latitude != null && !latitude.isEmpty()
                 && longitude != null && !longitude.isEmpty()
                 && accuracy != null && !accuracy.isEmpty();

--- a/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
@@ -80,6 +80,10 @@ public class AuditEvent {
         this(start, auditEventType, false, false, null, null);
     }
 
+    public AuditEvent(long start, AuditEventType auditEventType,  boolean isTrackingLocationsEnabled, boolean isTrackingChangesEnabled) {
+        this(start, auditEventType, isTrackingLocationsEnabled, isTrackingChangesEnabled, null, null);
+    }
+
     public AuditEvent(long start, AuditEventType auditEventType, boolean isTrackingLocationsEnabled,
                       boolean isTrackingChangesEnabled, FormIndex formIndex, String oldValue) {
         this.start = start;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuditEventLogger.java
@@ -105,7 +105,7 @@ public class AuditEventLogger {
         String latitude = location != null ? Double.toString(location.getLatitude()) : "";
         String longitude = location != null ? Double.toString(location.getLongitude()) : "";
         String accuracy = location != null ? Double.toString(location.getAccuracy()) : "";
-        if (!auditEvent.hasLocation()) {
+        if (!auditEvent.isLocationAlreadySet()) {
             auditEvent.setLocationCoordinates(latitude, longitude, accuracy);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuditEventLogger.java
@@ -105,9 +105,7 @@ public class AuditEventLogger {
         String latitude = location != null ? Double.toString(location.getLatitude()) : "";
         String longitude = location != null ? Double.toString(location.getLongitude()) : "";
         String accuracy = location != null ? Double.toString(location.getAccuracy()) : "";
-        if (!auditEvent.isLocationAlreadySet()) {
-            auditEvent.setLocationCoordinates(latitude, longitude, accuracy);
-        }
+        auditEvent.setLocationCoordinates(latitude, longitude, accuracy);
     }
 
     private void addNewValueToQuestionAuditEvent(AuditEvent aev, FormController formController) {
@@ -169,8 +167,10 @@ public class AuditEventLogger {
     }
 
     private void setIntervalEventFinalParameters(AuditEvent aev, long end) {
-        // Set location parameters
-        if (auditConfig.isLocationEnabled()) {
+        // Set location parameters.
+        // We try to add them here again (first attempt takes place when an event is being created),
+        // because coordinates might be not available at that time, so now we have another (last) chance.
+        if (auditConfig.isLocationEnabled() && !aev.isLocationAlreadySet()) {
             addLocationCoordinatesToAuditEvent(aev);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuditEventLogger.java
@@ -71,7 +71,7 @@ public class AuditEventLogger {
         if (isAuditEnabled() && !isDuplicateOfLastLocationEvent(eventType)) {
             Timber.i("AuditEvent recorded: %s", eventType);
 
-            AuditEvent newAuditEvent = new AuditEvent(getEventTime(), eventType,
+            AuditEvent newAuditEvent = new AuditEvent(getEventTime(), eventType, auditConfig.isLocationEnabled(),
                     auditConfig.isTrackingChangesEnabled(), formIndex, questionAnswer);
 
             if (isDuplicatedIntervalEvent(newAuditEvent)) {

--- a/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
@@ -65,7 +65,7 @@ public class AuditEventTest {
         assertFalse(auditEvent.isEndTimeSet());
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
-        assertFalse(auditEvent.hasLocation());
+        assertFalse(auditEvent.isLocationAlreadySet());
         assertEquals("question,/data/text1,1545392727685,1545392728527", auditEvent.toString());
     }
 
@@ -78,7 +78,7 @@ public class AuditEventTest {
         assertFalse(auditEvent.isEndTimeSet());
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
-        assertTrue(auditEvent.hasLocation());
+        assertTrue(auditEvent.isLocationAlreadySet());
         assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10", auditEvent.toString());
     }
 
@@ -90,7 +90,7 @@ public class AuditEventTest {
         assertFalse(auditEvent.isEndTimeSet());
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
-        assertFalse(auditEvent.hasLocation());
+        assertFalse(auditEvent.isLocationAlreadySet());
         auditEvent.recordValueChange("Second answer");
         assertEquals("question,/data/text1,1545392727685,1545392728527,First answer,Second answer", auditEvent.toString());
     }
@@ -104,7 +104,7 @@ public class AuditEventTest {
         assertFalse(auditEvent.isEndTimeSet());
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
-        assertTrue(auditEvent.hasLocation());
+        assertTrue(auditEvent.isLocationAlreadySet());
         auditEvent.recordValueChange("Second, answer");
         assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10,First answer,\"Second, answer\"", auditEvent.toString());
     }
@@ -118,7 +118,7 @@ public class AuditEventTest {
         assertFalse(auditEvent.isEndTimeSet());
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
-        assertFalse(auditEvent.hasLocation());
+        assertFalse(auditEvent.isLocationAlreadySet());
         auditEvent.recordValueChange("New value");
         assertEquals("question,/data/text1,1545392727685,1545392728527,,,,Old value,New value", auditEvent.toString());
     }

--- a/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
@@ -58,7 +58,7 @@ public class AuditEventTest {
 
     @Test
     public void testToString() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, getMockedFormIndex(), "");
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, false, getMockedFormIndex(), "");
         assertNotNull(auditEvent);
         assertTrue(auditEvent.isIntervalAuditEventType());
         assertEquals("question,/data/text1,1545392727685,", auditEvent.toString());
@@ -71,7 +71,7 @@ public class AuditEventTest {
 
     @Test
     public void testToStringWithLocationCoordinates() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, getMockedFormIndex(), "");
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, false, getMockedFormIndex(), "");
         assertNotNull(auditEvent);
         auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
         assertTrue(auditEvent.isIntervalAuditEventType());
@@ -84,7 +84,7 @@ public class AuditEventTest {
 
     @Test
     public void testToStringWithTrackingChanges() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, getMockedFormIndex(), "First answer");
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, true, getMockedFormIndex(), "First answer");
         assertNotNull(auditEvent);
         assertTrue(auditEvent.isIntervalAuditEventType());
         assertFalse(auditEvent.isEndTimeSet());
@@ -97,7 +97,7 @@ public class AuditEventTest {
 
     @Test
     public void testToStringWithLocationCoordinatesAndTrackingChanges() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, getMockedFormIndex(), "First answer");
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getMockedFormIndex(), "First answer");
         assertNotNull(auditEvent);
         auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
         assertTrue(auditEvent.isIntervalAuditEventType());
@@ -111,7 +111,7 @@ public class AuditEventTest {
 
     @Test
     public void testToStringNullValues() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, getMockedFormIndex(), "Old value");
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getMockedFormIndex(), "Old value");
         assertNotNull(auditEvent);
         auditEvent.setLocationCoordinates("", "", "");
         assertTrue(auditEvent.isIntervalAuditEventType());

--- a/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/logic/AuditEventTest.java
@@ -111,15 +111,16 @@ public class AuditEventTest {
 
     @Test
     public void testToStringNullValues() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION);
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, getMockedFormIndex(), "Old value");
         assertNotNull(auditEvent);
-        auditEvent.setLocationCoordinates(null, null, null);
+        auditEvent.setLocationCoordinates("", "", "");
         assertTrue(auditEvent.isIntervalAuditEventType());
         assertFalse(auditEvent.isEndTimeSet());
         auditEvent.setEnd(END_TIME);
         assertTrue(auditEvent.isEndTimeSet());
         assertFalse(auditEvent.hasLocation());
-        assertEquals("question,,1545392727685,1545392728527", auditEvent.toString());
+        auditEvent.recordValueChange("New value");
+        assertEquals("question,/data/text1,1545392727685,1545392728527,,,,Old value,New value", auditEvent.toString());
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/AuditEventLoggerTest.java
@@ -160,7 +160,7 @@ public class AuditEventLoggerTest {
         AuditEventLogger auditEventLogger = new AuditEventLogger(testInstanceFile, testAuditConfigWithNullValues);
 
         auditEventLogger.logEvent(END_OF_FORM, false);
-        assertFalse(auditEventLogger.getAuditEvents().get(0).hasLocation());
+        assertFalse(auditEventLogger.getAuditEvents().get(0).isLocationAlreadySet());
 
         auditEventLogger = new AuditEventLogger(testInstanceFile, testAuditConfig);
 
@@ -176,7 +176,7 @@ public class AuditEventLoggerTest {
 
         auditEventLogger.logEvent(END_OF_FORM, false);
 
-        assertTrue(auditEventLogger.getAuditEvents().get(0).hasLocation());
+        assertTrue(auditEventLogger.getAuditEvents().get(0).isLocationAlreadySet());
     }
 
     @Test


### PR DESCRIPTION
Closes #3101 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The main problem was in [toString()](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3101?expand=1#diff-b25f62214ddaa8161b77f62ab938dcaeL174) method. We used `hasLocation()` method to determine if locations tracking is enabled but that method just checked if coordinates are set.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It may affect the way we save event rows so the entire functionality should be tested. So if locations tracking was enabled but coordinates not set it assumed we don't need locations at all.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)