### PR TITLE
Fixed read-only option in RatingWidget and some select widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -126,7 +126,6 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
         button.setTextSize(TypedValue.COMPLEX_UNIT_DIP, Collect.getQuestionFontsize());
         button.setText(FormEntryPromptUtils.getItemText(widget.getFormEntryPrompt(), filteredItems.get(index)));
         button.setTag(items.indexOf(filteredItems.get(index)));
-        button.setEnabled(!widget.getFormEntryPrompt().isReadOnly());
         button.setGravity(isRTL() ? Gravity.END : Gravity.START);
         button.setOnLongClickListener((ODKView) widget.getParent().getParent().getParent());
     }
@@ -186,6 +185,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
         }
 
         view.setOnClickListener(v -> onItemClick(selectChoice.selection(), v));
+        view.setEnabled(!widget.getFormEntryPrompt().isReadOnly());
         return view;
     }
 
@@ -214,6 +214,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
                 view.addView(setUpNoButtonsView(index));
             } else {
                 widget.addMediaFromChoice(mediaLayout, index, setUpButton(index), filteredItems);
+                mediaLayout.setEnabled(!widget.getFormEntryPrompt().isReadOnly());
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MediaLayout.java
@@ -261,6 +261,12 @@ public class MediaLayout extends RelativeLayout implements View.OnClickListener 
         }
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        viewText.setEnabled(enabled);
+        imageView.setEnabled(enabled);
+    }
+
     private void openImage() {
         if (bigImageURI != null) {
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
@@ -90,9 +90,11 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
     private void setUpItems() {
         for (int i = 0; i < items.size(); i++) {
             setUpAudioHandler(i);
-            itemViews[i] = measureItem(noButtonsMode ? setUpNoButtonsItem(i) : setUpButtonsItem(i), i);
+            View view = measureItem(noButtonsMode ? setUpNoButtonsItem(i) : setUpButtonsItem(i), i);
             int index = i;
-            itemViews[i].setOnClickListener(v -> onItemClick(index));
+            view.setOnClickListener(v -> onItemClick(index));
+            view.setEnabled(!getFormEntryPrompt().isReadOnly());
+            itemViews[i] = view;
         }
     }
 
@@ -155,7 +157,6 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         item.setTextSize(TypedValue.COMPLEX_UNIT_DIP, Collect.getQuestionFontsize());
         item.setText(FormEntryPromptUtils.getItemText(getFormEntryPrompt(), items.get(index)));
         item.setTag(items.indexOf(items.get(index)));
-        item.setEnabled(!getFormEntryPrompt().isReadOnly());
         item.setGravity(isRTL() ? Gravity.END : Gravity.START);
         return item;
     }
@@ -195,7 +196,6 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         gridView.setGravity(Gravity.CENTER);
         gridView.setScrollContainer(false);
         gridView.setStretchMode(GridView.NO_STRETCH);
-        gridView.setEnabled(!getFormEntryPrompt().isReadOnly());
         gridView.setAdapter(new ImageAdapter());
         addAnswerView(gridView);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RatingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RatingWidget.java
@@ -58,6 +58,7 @@ public class RatingWidget extends QuestionWidget {
             imageButton.setId(total);
             imageButton.setPadding(0, 0, 0, 0);
             imageButton.setBackground(null);
+            imageButton.setEnabled(!getFormEntryPrompt().isReadOnly());
             imageButton.setOnClickListener(view -> {
                 int position = view.getId();
                 for (int i = 0; i < numberOfStarsToShow; i++) {


### PR DESCRIPTION
Closes #3103 

#### What has been done to verify that this works as intended?
I tested the forms attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
I was thinking about one general method in QuestionWidget class which would make a widget (and all its children) disabled if needed, something like:
https://stackoverflow.com/a/19800494/5479029
to avoid doing that in every single widget. But it turned out not to be a perfect solution. It doesn't work in some cases. For example, it wouldn't work in select widgets where we use adapters, it wouldn't work in selectImageMap widgets as well. And it would be risky because it would disable all children but we may need some like audio/video buttons to be enabled. So it would reduce the code a bit maybe but it would require handling some exceptions and I decided to follow the current approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The changes are not risky, testing mentioned widgets using the attached forms would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)