### PR TITLE
Update the widget button label when GeoTrace or GeoShape returns data.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -97,9 +97,9 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void setBinaryData(Object answer) {
-        String s = answer.toString();
-        answerDisplay.setText(s);
-
+        String answerText = answer.toString();
+        answerDisplay.setText(answerText);
+        updateButtonLabelsAndVisibility(!answerText.isEmpty());
         widgetValueChanged();
     }
 
@@ -116,7 +116,6 @@ public class GeoShapeWidget extends QuestionWidget implements BinaryWidget {
     public void clearAnswer() {
         answerDisplay.setText(null);
         updateButtonLabelsAndVisibility(false);
-
         widgetValueChanged();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -97,7 +97,9 @@ public class GeoTraceWidget extends QuestionWidget implements BinaryWidget {
 
     @Override
     public void setBinaryData(Object answer) {
-        answerDisplay.setText(answer.toString());
+        String answerText = answer.toString();
+        answerDisplay.setText(answerText);
+        updateButtonLabelsAndVisibility(!answerText.isEmpty());
         widgetValueChanged();
     }
 


### PR DESCRIPTION
Issues: Closes #3104.
Scope: GeoTraceWidget, GeoShapeWidget.
Requested reviewers: @grzesiek2010

#### User-visible changes

When the user saves a valid trace (from `GeoTraceActivity`) or shape (from `GeoShapeActivity`), the button label updates as it should, saying "View or Change GeoTrace" / "View or Change GeoShape" instead of the original label, "Start GeoTrace" / "Start GeoShape".  The button label is supposed to change; this fixes #3104, which discovered that it wasn't changing.

#### Notes for reviewers

The fix is fairly obvious when you compare `GeoTraceWidget` and `GeoShapeWidget` to `GeoPointWidget`, which doesn't exhibit this problem.

In `GeoPointWidget`, there is a call to `updateButtonLabelAndVisibility` in the `setBinaryData` method (which receives the result).  This call is missing in  `GeoTraceWidget` and `GeoShapeWidget`.  Adding this call, to make these widgets match `GeoPointWidget`, fixes the problem.

#### Verification performed

First, I replicated the issue in #3104.  Then I built with this change, opened a GeoTrace widget, saw that the button was initially "Start GeoTrace", saved a trace, and confirmed that the button label changed to "View or Change GeoTrace"; and then deleted the trace and confirmed that the button label changed back to "Start GeoTrace".  I repeated the same testing procedure for `GeoShape` and saw the expected (correct) behaviour.
