### PR TITLE
Ignore test that fails on Firebase Test Lab

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formfilling/FieldListUpdateTest.java
@@ -28,6 +28,7 @@ import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.R;
@@ -254,6 +255,7 @@ public class FieldListUpdateTest {
     //        onView(withText("A1B")).check(doesNotExist());
     //    }
 
+    @Ignore("Fails on Firebase Test Lab Nexus 5, Virtual, API Level 21 for unknown reasons")
     @Test
     public void selectionChangeAtOneCascadeLevelWithMinimalAppearance_ShouldUpdateNextLevels() {
         jumpToGroupWithText("Cascading select minimal");


### PR DESCRIPTION
It's not good to have a failing build on an ongoing basis because we could miss real issues. I took another look at the stacktrace on Test Lab and can't figure it out so let's ignore the test for now.