### PR TITLE
Show a warning instead of crashing if Mapbox cannot be initialized.

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -149,6 +149,10 @@ android {
         pickFirst 'META-INF/services/javax.ws.rs.ext.MessageBodyReader'
         pickFirst 'META-INF/services/javax.ws.rs.ext.MessageBodyWriter'
 
+        // To ensure that ODK Collect is installable on all devices, we don't use
+        // abiFilters to exclude any ABIs; but to keep the APK slim, we include
+        // the Mapbox native library only for armeabi-v7a (which works on all
+        // ARMv7+ 32-bit and 64-bit devices), and omit it for all the other ABIs.
         exclude 'lib/arm64-v8a/libmapbox-gl.so'
         exclude 'lib/x86/libmapbox-gl.so'
         exclude 'lib/x86_64/libmapbox-gl.so'
@@ -187,7 +191,12 @@ configurations.all {
 }
 
 dependencies {
+    // To make ODK Collect is installable on all devices even though the Mapbox
+    // native library is missing for some ABIs, we include an .aar dependency
+    // named "nbi-stubs", which causes there to be at least one .so library
+    // present for every ABI (armeabi, armeabi-v7a, arm64-v8a, x86, x86_64).
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'com.google.android.material:material:1.1.0-alpha05'

--- a/collect_app/src/main/java/org/odk/collect/android/map/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MapboxMapFragment.java
@@ -12,7 +12,6 @@ import com.mapbox.android.core.location.LocationEngineCallback;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.location.LocationEngineResult;
-import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -110,11 +109,12 @@ public class MapboxMapFragment extends MapFragment implements org.odk.collect.an
     @VisibleForTesting public static boolean testMode;
 
     @Override public void addTo(@NonNull FragmentActivity activity, int containerId, @Nullable ReadyListener listener) {
-        // To use the Mapbox base maps, we have to initialize the Mapbox SDK with
-        // an access token. Configure this token in collect_app/secrets.properties.
-        // If no token is defined, we use the OSM base map; see getDesiredStyleBuilder().
-        if (!testMode) {
-            Mapbox.getInstance(Collect.getInstance(), BuildConfig.MAPBOX_ACCESS_TOKEN);
+        if (MapboxUtils.initMapbox() == null) {
+            MapboxUtils.warnMapboxUnsupported(Collect.getInstance());
+            if (listener != null) {
+                listener.onReady(null);
+            }
+            return;
         }
         activity.getSupportFragmentManager()
             .beginTransaction().replace(containerId, this).commitNow();

--- a/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
@@ -1,0 +1,48 @@
+package org.odk.collect.android.map;
+
+import android.content.Context;
+import android.os.Build;
+import android.widget.Toast;
+
+import com.mapbox.mapboxsdk.Mapbox;
+
+import org.odk.collect.android.BuildConfig;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+
+public class MapboxUtils {
+    private static boolean initAttempted = false;
+    private static Mapbox mapbox = null;
+
+    /** Attempts to initialize Mapbox; returns the singleton Mapbox if successful. */
+    public static Mapbox initMapbox() {
+        if (initAttempted) {
+            return mapbox;
+        }
+
+        // To use the Mapbox base maps, we have to initialize the Mapbox SDK with
+        // an access token. Configure this token in collect_app/secrets.properties.
+        try {
+            mapbox = Mapbox.getInstance(Collect.getInstance(), BuildConfig.MAPBOX_ACCESS_TOKEN);
+        } catch (ExceptionInInitializerError e) {
+            // Initialization failed (usually because the Mapbox native library for
+            // the current architecture could not be found or loaded).
+            mapbox = null;
+        }
+
+        // It's not safe to call Mapbox.getInstance() more than once.  It can fail on
+        // the first call and then succeed on the second call, returning an invalid,
+        // crashy Mapbox object.  We trust only the result of the first attempt.
+        initAttempted = true;
+        return mapbox;
+    }
+
+    /** Shows a warning that Mapbox is not supported by this device. */
+    public static void warnMapboxUnsupported(Context context) {
+        Toast.makeText(
+            context,
+            context.getString(R.string.mapbox_unsupported_warning, Build.CPU_ABI),
+            Toast.LENGTH_LONG
+        ).show();
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
@@ -11,8 +11,12 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 
 public class MapboxUtils {
-    private static boolean initAttempted = false;
-    private static Mapbox mapbox = null;
+    private static boolean initAttempted;
+    private static Mapbox mapbox;
+
+    private MapboxUtils() {
+
+    }
 
     /** Attempts to initialize Mapbox; returns the singleton Mapbox if successful. */
     public static Mapbox initMapbox() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ObjectArrays;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.map.MapboxUtils;
 import org.odk.collect.android.spatial.MapHelper;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -224,6 +225,11 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
                 onlineLayerEntries1 = getResources().getStringArray(R.array.map_osm_basemap_selector_entries);
                 mapBasemap.setValue(OSM_MAPS_BASEMAP_DEFAULT);
             } else if (value.equals(MAPBOX_BASEMAP_KEY)) {
+                if (MapboxUtils.initMapbox() == null) {
+                    // This settings code will be rewritten very soon (planned for r1.23),
+                    // so let's just warn for now instead of trying to disable the option.
+                    MapboxUtils.warnMapboxUnsupported(getActivity());
+                }
                 onlineLayerEntryValues1 = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entry_values);
                 onlineLayerEntries1 = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entries);
                 mapBasemap.setValue(MAPBOX_BASEMAP_DEFAULT);

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -701,4 +701,5 @@
     <string name="copying_media_files_failed">Copying media files failed</string>
     <string name="qr_code_not_found">QR Code not found in the selected image</string>
     <string name="not_granted_permission">The activity you are trying to start requires a permission which is not granted.</string>
+    <string name="mapbox_unsupported_warning"><![CDATA[Mapbox is not supported on this device (%s).  Please choose another mapping SDK in General Settings > User interface.]]></string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -701,5 +701,5 @@
     <string name="copying_media_files_failed">Copying media files failed</string>
     <string name="qr_code_not_found">QR Code not found in the selected image</string>
     <string name="not_granted_permission">The activity you are trying to start requires a permission which is not granted.</string>
-    <string name="mapbox_unsupported_warning"><![CDATA[Mapbox is not supported on this device (%s).  Please choose another mapping SDK in General Settings > User interface.]]></string>
+    <string name="mapbox_unsupported_warning">Mapbox is not supported on this device (%s).  Please choose another mapping SDK in General Settings &gt; User interface.</string>
 </resources>


### PR DESCRIPTION
Issues: Closes #3115
Scope: MapboxMapFragment, UserInterfacePreferences
Requested reviewers: @lognaturel 

#### User-visible changes

When the user tries to launch a map with the Mapbox SDK selected, on a device that does not support the included Mapbox binary (`armeabi-v7a`), the app no longer crashes (as it did without this change).  Instead, a warning message appears.

When the user selects "Mapbox SDK" in the settings, a warning message appears.  The "Mapbox SDK" option is not disabled or omitted; it just generates a warning.

#### Notes for reviewers

I didn't bother to disable or remove the "Mapbox SDK" option because we're about to rewrite the map settings screens very soon.

In a first attempt, I had the `initMapbox()` method simply call `Mapbox.getInstance()` each time and catch the exception.  However, I discovered that after it fails the first time, it can be called a second time and it will return a non-null, but invalid, `Mapbox` instance without throwing an exception; any attempt to instantiate a map then results in a crash.  Therefore, `initMapbox()` remembers the result of the first attempt and does not try twice.

#### Verification performed

I built and ran the APK on an emulated x86-based device.  I went to the settings screen and selected "Mapbox SDK", and confirmed that I saw the warning message.  I went to a GeoPoint question and tried to open the map, and confirmed that it didn't crash and I saw the warning message.

