### PR TITLE
Allow using commas in parameters

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
@@ -41,8 +41,10 @@ import org.odk.collect.android.exception.ExternalParamsException;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -81,15 +83,34 @@ public class ExternalAppsUtils {
                 : exString.substring(leftParIndex + 1);
 
         Map<String, String> parameters = new LinkedHashMap<>();
-        String[] paramsPairs = paramsStr.trim().split("(?<!\\\\),");
+        List<String> paramsPairs = getParamPairs(paramsStr.trim());
         for (String paramsPair : paramsPairs) {
-            paramsPair = paramsPair.replaceAll("\\\\,", ",");
             String[] keyValue = paramsPair.trim().split("=");
             if (keyValue.length == 2) {
                 parameters.put(keyValue[0].trim(), keyValue[1].trim());
             }
         }
         return parameters;
+    }
+
+    private static List<String> getParamPairs(String paramsStr) {
+        List<String> paramPairs = new ArrayList<>();
+        int startPos = 0;
+        boolean inQuotes = false;
+        for (int current = 0; current < paramsStr.length(); current++) {
+            if (paramsStr.charAt(current) == '\'') {
+                inQuotes = !inQuotes;
+            }
+
+            if (current == paramsStr.length() - 1) {
+                paramPairs.add(paramsStr.substring(startPos));
+            } else if (paramsStr.charAt(current) == ',' && !inQuotes) {
+                paramPairs.add(paramsStr.substring(startPos, current));
+                startPos = current + 1;
+            }
+        }
+
+        return paramPairs;
     }
 
     public static void populateParameters(Intent intent, Map<String, String> exParams,

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
@@ -56,20 +56,16 @@ public class ExternalAppsUtils {
     private static final String RIGHT_PARENTHESIS = ")";
 
     private ExternalAppsUtils() {
-
     }
 
     public static String extractIntentName(String exString) {
         if (!exString.contains(LEFT_PARENTHESIS)) {
-            if (exString.contains(RIGHT_PARENTHESIS)) {
-                return exString.substring(0, exString.indexOf(RIGHT_PARENTHESIS)).trim();
-            } else {
-                return exString;
-            }
+            return exString.contains(RIGHT_PARENTHESIS)
+                    ? exString.substring(0, exString.indexOf(RIGHT_PARENTHESIS)).trim()
+                    : exString;
         }
 
-        int leftParIndex = exString.indexOf(LEFT_PARENTHESIS);
-        return exString.substring(0, leftParIndex).trim();
+        return exString.substring(0, exString.indexOf(LEFT_PARENTHESIS)).trim();
     }
 
     public static Map<String, String> extractParameters(String exString) {
@@ -80,14 +76,11 @@ public class ExternalAppsUtils {
             return Collections.emptyMap();
         }
 
-        String paramsStr;
-        if (exString.endsWith(")")) {
-            paramsStr = exString.substring(leftParIndex + 1, exString.lastIndexOf(')'));
-        } else {
-            paramsStr = exString.substring(leftParIndex + 1, exString.length());
-        }
+        String paramsStr = exString.endsWith(")")
+                ? exString.substring(leftParIndex + 1, exString.lastIndexOf(')'))
+                : exString.substring(leftParIndex + 1);
 
-        Map<String, String> parameters = new LinkedHashMap<String, String>();
+        Map<String, String> parameters = new LinkedHashMap<>();
         String[] paramsPairs = paramsStr.trim().split(",");
         for (String paramsPair : paramsPairs) {
             String[] keyValue = paramsPair.trim().split("=");
@@ -103,7 +96,6 @@ public class ExternalAppsUtils {
         if (exParams != null) {
             for (Map.Entry<String, String> paramEntry : exParams.entrySet()) {
                 String paramEntryValue = paramEntry.getValue();
-
                 try {
                     Object result = getValueRepresentedBy(paramEntry.getValue(), reference);
 
@@ -126,21 +118,15 @@ public class ExternalAppsUtils {
                 reference);
 
         if (text.startsWith("'")) {
-            // treat this as a constant parameter
-            // but not require an ending quote
-            if (text.endsWith("'")) {
-                return text.substring(1, text.length() - 1);
-            } else {
-                return text.substring(1, text.length());
-            }
+            // treat this as a constant parameter but not require an ending quote
+            return text.endsWith("'") ? text.substring(1, text.length() - 1) : text.substring(1);
         } else if (text.startsWith("/")) {
             // treat this is an xpath
             XPathPathExpr pathExpr = XPathReference.getPathExpr(text);
             XPathNodeset xpathNodeset = pathExpr.eval(formInstance, evaluationContext);
             return XPathFuncExpr.unpack(xpathNodeset);
         } else if (text.equals("instanceProviderID()")) {
-            // instanceProviderID returns -1 if the current instance has not been
-            // saved to disk already
+            // instanceProviderID returns -1 if the current instance has not been saved to disk already
             String path = Collect.getInstance().getFormController().getInstanceFile()
                     .getAbsolutePath();
 
@@ -158,18 +144,13 @@ public class ExternalAppsUtils {
             return instanceProviderID;
         } else {
             // treat this as a function
-            XPathExpression xpathExpression = XPathParseTool.parseXPath(
-                    text);
+            XPathExpression xpathExpression = XPathParseTool.parseXPath(text);
             return xpathExpression.eval(formInstance, evaluationContext);
         }
     }
 
     public static StringData asStringData(Object value) {
-        if (value == null) {
-            return null;
-        } else {
-            return new StringData(value.toString());
-        }
+        return value == null ? null : new StringData(value.toString());
     }
 
     public static IntegerData asIntegerData(Object value) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
@@ -81,8 +81,9 @@ public class ExternalAppsUtils {
                 : exString.substring(leftParIndex + 1);
 
         Map<String, String> parameters = new LinkedHashMap<>();
-        String[] paramsPairs = paramsStr.trim().split(",");
+        String[] paramsPairs = paramsStr.trim().split("(?<!\\\\),");
         for (String paramsPair : paramsPairs) {
+            paramsPair = paramsPair.replaceAll("\\\\,", ",");
             String[] keyValue = paramsPair.trim().split("=");
             if (keyValue.length == 2) {
                 parameters.put(keyValue[0].trim(), keyValue[1].trim());

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppUtilsTest.java
@@ -76,6 +76,17 @@ public class ExternalAppUtilsTest {
 
         assertEquals("/send-sms-or-email-in-form/message", result.get("sms_body"));
         assertEquals("/send-sms-or-email-in-form/send_to", result.get("uri_data"));
+
+        // Real sample from a user: https://forum.opendatakit.org/t/external-app-with-intent-parameters/20125/5?u=grzesiek2010
+        result = ExternalAppsUtils.extractParameters("ex:ch.novelt.odkcompanion.OPEN(current_value=/afp_report/group_mini_cif/cn, match='^[0-9]{4}W[0-9]{2}-[0-9]{1\\,5}$', filter='^AFP:([0-9]{4}W[0-9]{2}-[0-9]{1\\,5})')");
+        assertEquals(3, result.size());
+        assertTrue(result.keySet().contains("current_value"));
+        assertTrue(result.keySet().contains("match"));
+        assertTrue(result.keySet().contains("filter"));
+
+        assertEquals("/afp_report/group_mini_cif/cn", result.get("current_value"));
+        assertEquals("'^[0-9]{4}W[0-9]{2}-[0-9]{1,5}$'", result.get("match"));
+        assertEquals("'^AFP:([0-9]{4}W[0-9]{2}-[0-9]{1,5})'", result.get("filter"));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppUtilsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.utilities;
+
+import org.junit.Test;
+import org.odk.collect.android.external.ExternalAppsUtils;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ExternalAppUtilsTest {
+
+    @Test
+    public void extractIntentNameTest() {
+        assertEquals("org.opendatakit.counter", ExternalAppsUtils.extractIntentName("org.opendatakit.counter(form_id='counter-form', form_name='Counter Form', question_id='1', question_name='Counter 1', increment=true())"));
+        assertEquals("org.opendatakit.counter", ExternalAppsUtils.extractIntentName("org.opendatakit.counter()"));
+        assertEquals("org.opendatakit.counter", ExternalAppsUtils.extractIntentName("org.opendatakit.counter"));
+    }
+
+    @Test
+    public void extractParametersTest() {
+        // Simple case
+        Map<String, String> result = ExternalAppsUtils.extractParameters("org.opendatakit.counter(form_id='counter-form', form_name='Counter Form', question_id='1', question_name='Counter 1', increment=true())");
+        assertCounterAppParameters(result);
+
+        // No spaces at all
+        result = ExternalAppsUtils.extractParameters("org.opendatakit.counter(form_id='counter-form',form_name='Counter Form',question_id='1',question_name='Counter 1',increment=true())");
+        assertCounterAppParameters(result);
+
+        // Spaces everywhere
+        result = ExternalAppsUtils.extractParameters("   org.opendatakit.counter ( form_id = 'counter-form' , form_name = 'Counter Form' , question_id = '1' , question_name = 'Counter 1' , increment = true()   )   ");
+        assertCounterAppParameters(result);
+
+        // Commas in values
+        result = ExternalAppsUtils.extractParameters("org.companyX.appX(parameter1='value1', parameter2='value2a\\, value2b'");
+        assertEquals(2, result.size());
+        assertTrue(result.keySet().contains("parameter1"));
+        assertTrue(result.keySet().contains("parameter2"));
+
+        assertEquals("'value1'", result.get("parameter1"));
+        assertEquals("'value2a, value2b'", result.get("parameter2"));
+
+        // Regex with commas
+        result = ExternalAppsUtils.extractParameters("org.companyX.appX(regex1='/^([a-z0-9_\\.-]+)@([\\da-z\\.-]+)\\.([a-z\\.]{2\\,6})$/', regex2='/^[a-z0-9_-]{6\\,18}$/', regex3='/^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2\\,6})([\\/\\w \\.-]*)*\\/?$/'");
+        assertEquals(3, result.size());
+        assertTrue(result.keySet().contains("regex1"));
+        assertTrue(result.keySet().contains("regex2"));
+        assertTrue(result.keySet().contains("regex3"));
+
+        assertEquals("'/^([a-z0-9_\\.-]+)@([\\da-z\\.-]+)\\.([a-z\\.]{2,6})$/'", result.get("regex1"));
+        assertEquals("'/^[a-z0-9_-]{6,18}$/'", result.get("regex2"));
+        assertEquals("'/^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$/'", result.get("regex3"));
+
+        // Values populated from a form
+        result = ExternalAppsUtils.extractParameters("android.intent.action.SENDTO(sms_body= /send-sms-or-email-in-form/message , uri_data= /send-sms-or-email-in-form/send_to )");
+        assertEquals(2, result.size());
+        assertTrue(result.keySet().contains("sms_body"));
+        assertTrue(result.keySet().contains("uri_data"));
+
+        assertEquals("/send-sms-or-email-in-form/message", result.get("sms_body"));
+        assertEquals("/send-sms-or-email-in-form/send_to", result.get("uri_data"));
+    }
+
+    @Test
+    public void asStringDataTest() {
+        assertNull(ExternalAppsUtils.asStringData(null));
+        assertEquals("Test Value", ExternalAppsUtils.asStringData("Test Value").getValue().toString());
+        assertEquals("TestValue", ExternalAppsUtils.asStringData("TestValue").getValue().toString());
+        assertEquals("Test Value 3", ExternalAppsUtils.asStringData("Test Value 3").getValue().toString());
+        assertEquals(" Test Value 4 ", ExternalAppsUtils.asStringData(" Test Value 4 ").getValue().toString());
+    }
+
+    @Test
+    public void asIntegerDataTest() {
+        assertNull(ExternalAppsUtils.asIntegerData(null));
+        assertNull(ExternalAppsUtils.asIntegerData(""));
+        assertNull(ExternalAppsUtils.asIntegerData("5.4"));
+        assertEquals("5", ExternalAppsUtils.asIntegerData("5").getValue().toString());
+        assertEquals("-5", ExternalAppsUtils.asIntegerData("-5").getValue().toString());
+        assertEquals("125", ExternalAppsUtils.asIntegerData("125").getValue().toString());
+    }
+
+    @Test
+    public void asDecimalDataTest() {
+        assertNull(ExternalAppsUtils.asDecimalData(null));
+        assertNull(ExternalAppsUtils.asDecimalData(""));
+        assertNull(ExternalAppsUtils.asDecimalData("5..24"));
+        assertNull(ExternalAppsUtils.asDecimalData("5.24c"));
+        assertEquals("5.0", ExternalAppsUtils.asDecimalData("5").getValue().toString());
+        assertEquals("5.0", ExternalAppsUtils.asDecimalData("5.00").getValue().toString());
+        assertEquals("5.0", ExternalAppsUtils.asDecimalData("05").getValue().toString());
+        assertEquals("5.24", ExternalAppsUtils.asDecimalData("5.24").getValue().toString());
+        assertEquals("5.24", ExternalAppsUtils.asDecimalData("5.240").getValue().toString());
+        assertEquals("5.204", ExternalAppsUtils.asDecimalData("5.204").getValue().toString());
+        assertEquals("-5.0", ExternalAppsUtils.asDecimalData("-5").getValue().toString());
+        assertEquals("-27.333", ExternalAppsUtils.asDecimalData("-27.333").getValue().toString());
+    }
+
+    private void assertCounterAppParameters(Map<String, String> result) {
+        assertEquals(5, result.size());
+        assertTrue(result.keySet().contains("form_id"));
+        assertTrue(result.keySet().contains("form_name"));
+        assertTrue(result.keySet().contains("question_id"));
+        assertTrue(result.keySet().contains("question_name"));
+        assertTrue(result.keySet().contains("increment"));
+
+        assertEquals("'counter-form'", result.get("form_id"));
+        assertEquals("'Counter Form'", result.get("form_name"));
+        assertEquals("'1'", result.get("question_id"));
+        assertEquals("'Counter 1'", result.get("question_name"));
+        assertEquals("true()", result.get("increment"));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppUtilsTest.java
@@ -49,7 +49,7 @@ public class ExternalAppUtilsTest {
         assertCounterAppParameters(result);
 
         // Commas in values
-        result = ExternalAppsUtils.extractParameters("org.companyX.appX(parameter1='value1', parameter2='value2a\\, value2b'");
+        result = ExternalAppsUtils.extractParameters("org.companyX.appX(parameter1='value1', parameter2='value2a, value2b'");
         assertEquals(2, result.size());
         assertTrue(result.keySet().contains("parameter1"));
         assertTrue(result.keySet().contains("parameter2"));
@@ -58,7 +58,7 @@ public class ExternalAppUtilsTest {
         assertEquals("'value2a, value2b'", result.get("parameter2"));
 
         // Regex with commas
-        result = ExternalAppsUtils.extractParameters("org.companyX.appX(regex1='/^([a-z0-9_\\.-]+)@([\\da-z\\.-]+)\\.([a-z\\.]{2\\,6})$/', regex2='/^[a-z0-9_-]{6\\,18}$/', regex3='/^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2\\,6})([\\/\\w \\.-]*)*\\/?$/'");
+        result = ExternalAppsUtils.extractParameters("org.companyX.appX(regex1='/^([a-z0-9_\\.-]+)@([\\da-z\\.-]+)\\.([a-z\\.]{2,6})$/', regex2='/^[a-z0-9_-]{6,18}$/', regex3='/^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$/'");
         assertEquals(3, result.size());
         assertTrue(result.keySet().contains("regex1"));
         assertTrue(result.keySet().contains("regex2"));
@@ -78,7 +78,7 @@ public class ExternalAppUtilsTest {
         assertEquals("/send-sms-or-email-in-form/send_to", result.get("uri_data"));
 
         // Real sample from a user: https://forum.opendatakit.org/t/external-app-with-intent-parameters/20125/5?u=grzesiek2010
-        result = ExternalAppsUtils.extractParameters("ex:ch.novelt.odkcompanion.OPEN(current_value=/afp_report/group_mini_cif/cn, match='^[0-9]{4}W[0-9]{2}-[0-9]{1\\,5}$', filter='^AFP:([0-9]{4}W[0-9]{2}-[0-9]{1\\,5})')");
+        result = ExternalAppsUtils.extractParameters("ex:ch.novelt.odkcompanion.OPEN(current_value=/afp_report/group_mini_cif/cn, match='^[0-9]{4}W[0-9]{2}-[0-9]{1,5}$', filter='^AFP:([0-9]{4}W[0-9]{2}-[0-9]{1,5})')");
         assertEquals(3, result.size());
         assertTrue(result.keySet().contains("current_value"));
         assertTrue(result.keySet().contains("match"));


### PR DESCRIPTION
Closes #3114 

#### What has been done to verify that this works as intended?
I tested the attached forms and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
We still use commas to split parameters, the change is that now we can use commas in values as well but they should be preceded by `\`.
For example:
`abcd\, efgh`

The user that reported the issue wanted to use regex with commas like:
`/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/')`
so it would need to add just one `\`
`/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2\,6})$/')`

I couldn't come up with an easier solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is only related to external widgets, testing the attached forms would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used:
[counter.xml.txt](https://github.com/opendatakit/collect/files/3238338/counter.xml.txt)
[dial-number.xml.txt](https://github.com/opendatakit/collect/files/3238339/dial-number.xml.txt)
[send-sms-or-email-in-form.xml.txt](https://github.com/opendatakit/collect/files/3238340/send-sms-or-email-in-form.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Yes, I'll create an issue once the approach is accepted.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)