### PR TITLE
Persian calendar

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -233,6 +233,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${rootProject.okhttp3Version}"
     implementation 'com.burgstaller:okhttp-digest:1.18'
 
+    implementation 'com.github.mohamadian:PersianJodaTime:1.2'
     implementation 'com.github.chanmratekoko:myanmar-calendar:1.0.6.RC3'
     implementation 'bikramsambat:bikram-sambat:1.1.0'
     implementation "com.evernote:android-job:1.2.5"

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -41,6 +41,7 @@ public class DateTimeUtilsTest {
     private DatePickerDetails copticDatePickerDetails;
     private DatePickerDetails islamicDatePickerDetails;
     private DatePickerDetails bikramSambatDatePickerDetails;
+    private DatePickerDetails myanmarDatePickerDetails;
     private DatePickerDetails persianDatePickerDetails;
 
     private Context context;
@@ -54,6 +55,7 @@ public class DateTimeUtilsTest {
         copticDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
         bikramSambatDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.SPINNERS);
+        myanmarDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.SPINNERS);
         persianDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.SPINNERS);
 
         context = Collect.getInstance();
@@ -85,6 +87,9 @@ public class DateTimeUtilsTest {
 
         assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, false, context));
         assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, true, context));
+
+        assertEquals("12 သီတင်းကျွတ် 1353 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, myanmarDatePickerDetails, false, context));
+        assertEquals("12 သီတင်းကျွတ် 1353, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, myanmarDatePickerDetails, true, context));
 
         assertEquals("28 Mehr 1370 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, persianDatePickerDetails, false, context));
         assertEquals("28 Mehr 1370, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, persianDatePickerDetails, true, context));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -41,6 +41,7 @@ public class DateTimeUtilsTest {
     private DatePickerDetails copticDatePickerDetails;
     private DatePickerDetails islamicDatePickerDetails;
     private DatePickerDetails bikramSambatDatePickerDetails;
+    private DatePickerDetails persianDatePickerDetails;
 
     private Context context;
     private Locale defaultLocale;
@@ -53,6 +54,7 @@ public class DateTimeUtilsTest {
         copticDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
         bikramSambatDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.SPINNERS);
+        persianDatePickerDetails = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.SPINNERS);
 
         context = Collect.getInstance();
         defaultLocale = Locale.getDefault();
@@ -83,6 +85,9 @@ public class DateTimeUtilsTest {
 
         assertEquals("3 कार्तिक 2048 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, false, context));
         assertEquals("3 कार्तिक 2048, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, bikramSambatDatePickerDetails, true, context));
+
+        assertEquals("28 Mehr 1370 (Oct 20, 1991)", DateTimeUtils.getDateTimeLabel(date, persianDatePickerDetails, false, context));
+        assertEquals("28 Mehr 1370, 14:00 (Oct 20, 1991, 14:00)", DateTimeUtils.getDateTimeLabel(date, persianDatePickerDetails, true, context));
     }
 
     @After

--- a/collect_app/src/main/assets/open_source_licenses.html
+++ b/collect_app/src/main/assets/open_source_licenses.html
@@ -145,7 +145,10 @@ limitations under the License.
         <b>OsmDroid</b>
     </li>
     <li>
-        Powermock
+        <b>PersianJodaTime</b>
+    </li>
+    <li>
+        <b>Powermock</b>
     </li>
     <li>
         <b>RxAndroid</b>

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/PersianDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/PersianDatePickerDialog.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.fragments.dialogs;
+
+import org.javarosa.core.model.FormIndex;
+import org.joda.time.LocalDateTime;
+import org.joda.time.chrono.PersianChronologyKhayyamBorkowski;
+import org.odk.collect.android.R;
+import org.odk.collect.android.logic.DatePickerDetails;
+import org.odk.collect.android.utilities.DateTimeUtils;
+
+import java.util.Arrays;
+
+public class PersianDatePickerDialog extends CustomDatePickerDialog {
+    private static final int MIN_SUPPORTED_YEAR = 1278; //1900 in Gregorian calendar
+    private static final int MAX_SUPPORTED_YEAR = 1478; //2100 in Gregorian calendar
+
+    private String[] monthsArray;
+
+    public static PersianDatePickerDialog newInstance(FormIndex formIndex, LocalDateTime date, DatePickerDetails datePickerDetails) {
+        PersianDatePickerDialog dialog = new PersianDatePickerDialog();
+        dialog.setArguments(getArgs(formIndex, date, datePickerDetails));
+
+        return dialog;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        monthsArray = getResources().getStringArray(R.array.persian_months);
+        setUpValues();
+    }
+
+    @Override
+    protected void updateDays() {
+        LocalDateTime localDateTime = getCurrentPersianDate();
+        setUpDayPicker(localDateTime.getDayOfMonth(), localDateTime.dayOfMonth().getMaximumValue());
+    }
+
+    @Override
+    protected LocalDateTime getOriginalDate() {
+        return getCurrentPersianDate();
+    }
+
+    private void setUpDatePicker() {
+        LocalDateTime persianDate = DateTimeUtils
+                .skipDaylightSavingGapIfExists(getDate())
+                .toDateTime()
+                .withChronology(PersianChronologyKhayyamBorkowski.getInstance())
+                .toLocalDateTime();
+        setUpDayPicker(persianDate.getDayOfMonth(), persianDate.dayOfMonth().getMaximumValue());
+        setUpMonthPicker(persianDate.getMonthOfYear(), monthsArray);
+        setUpYearPicker(persianDate.getYear(), MIN_SUPPORTED_YEAR, MAX_SUPPORTED_YEAR);
+    }
+
+    private void setUpValues() {
+        setUpDatePicker();
+        updateGregorianDateLabel();
+    }
+
+    private LocalDateTime getCurrentPersianDate() {
+        int persianDay = getDay();
+        int persianMonth = Arrays.asList(monthsArray).indexOf(getMonth());
+        int persianYear = getYear();
+
+        LocalDateTime persianDate = new LocalDateTime(persianYear, persianMonth + 1, 1, 0, 0, 0, 0, PersianChronologyKhayyamBorkowski.getInstance());
+        if (persianDay > persianDate.dayOfMonth().getMaximumValue()) {
+            persianDay = persianDate.dayOfMonth().getMaximumValue();
+        }
+
+        return new LocalDateTime(persianYear, persianMonth + 1, persianDay, 0, 0, 0, 0, PersianChronologyKhayyamBorkowski.getInstance());
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/logic/DatePickerDetails.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/DatePickerDetails.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 
 public class DatePickerDetails implements Serializable {
     public enum DatePickerType {
-        GREGORIAN, ETHIOPIAN, COPTIC, ISLAMIC, BIKRAM_SAMBAT, MYANMAR
+        GREGORIAN, ETHIOPIAN, COPTIC, ISLAMIC, BIKRAM_SAMBAT, MYANMAR, PERSIAN
     }
 
     public enum DatePickerMode {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DateTimeUtils.java
@@ -9,6 +9,7 @@ import org.joda.time.LocalDateTime;
 import org.joda.time.chrono.CopticChronology;
 import org.joda.time.chrono.EthiopicChronology;
 import org.joda.time.chrono.IslamicChronology;
+import org.joda.time.chrono.PersianChronologyKhayyamBorkowski;
 import org.odk.collect.android.R;
 import org.odk.collect.android.logic.DatePickerDetails;
 
@@ -75,6 +76,10 @@ public class DateTimeUtils {
                         customDate.getMonthOfYear(), customDate.getDayOfMonth(), customDate.getHourOfDay(),
                         customDate.getMinuteOfHour(), customDate.getSecondOfMinute());
                 monthArray = MyanmarDateUtils.getMyanmarMonthsArray(myanmarDate.getYearInt());
+                break;
+            case PERSIAN:
+                customDate = new DateTime(date).withChronology(PersianChronologyKhayyamBorkowski.getInstance());
+                monthArray = context.getResources().getStringArray(R.array.persian_months);
                 break;
             default:
                 Timber.w("Not supported date type.");
@@ -180,6 +185,9 @@ public class DateTimeUtils {
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
             } else if (appearance.contains(WidgetAppearanceUtils.MYANMAR)) {
                 datePickerType = DatePickerDetails.DatePickerType.MYANMAR;
+                datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
+            } else if (appearance.contains(WidgetAppearanceUtils.PERSIAN)) {
+                datePickerType = DatePickerDetails.DatePickerType.PERSIAN;
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;
             } else if (appearance.contains(WidgetAppearanceUtils.NO_CALENDAR)) {
                 datePickerMode = DatePickerDetails.DatePickerMode.SPINNERS;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WidgetAppearanceUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WidgetAppearanceUtils.java
@@ -36,6 +36,7 @@ public class WidgetAppearanceUtils {
     public static final String ISLAMIC                  = "islamic";
     public static final String BIKRAM_SAMBAT            = "bikram-sambat";
     public static final String MYANMAR                  = "myanmar";
+    public static final String PERSIAN                  = "persian";
     public static final String NO_CALENDAR              = "no-calendar";
     public static final String MONTH_YEAR               = "month-year";
     public static final String YEAR                     = "year";

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -57,6 +57,8 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget, Widg
             dateWidget = new BikramSambatDateWidget(context, prompt);
         } else if (appearance != null && appearance.contains(WidgetAppearanceUtils.MYANMAR)) {
             dateWidget = new MyanmarDateWidget(context, prompt);
+        } else if (appearance != null && appearance.contains(WidgetAppearanceUtils.PERSIAN)) {
+            dateWidget = new PersianDateWidget(context, prompt);
         } else {
             dateWidget = new DateWidget(context, prompt);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/PersianDateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/PersianDateWidget.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.widgets;
+
+import android.content.Context;
+
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.fragments.dialogs.PersianDatePickerDialog;
+
+import static org.odk.collect.android.fragments.dialogs.CustomDatePickerDialog.DATE_PICKER_DIALOG;
+
+public class PersianDateWidget extends AbstractDateWidget {
+
+    public PersianDateWidget(Context context, FormEntryPrompt prompt) {
+        super(context, prompt);
+    }
+
+    protected void showDatePickerDialog() {
+        PersianDatePickerDialog persianDatePickerDialog = PersianDatePickerDialog.newInstance(getFormEntryPrompt().getIndex(), date, datePickerDetails);
+        persianDatePickerDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), DATE_PICKER_DIALOG);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -61,6 +61,8 @@ public class WidgetFactory {
                             questionWidget = new BikramSambatDateWidget(context, fep);
                         } else if (appearance.contains(WidgetAppearanceUtils.MYANMAR)) {
                             questionWidget = new MyanmarDateWidget(context, fep);
+                        } else if (appearance.contains(WidgetAppearanceUtils.PERSIAN)) {
+                            questionWidget = new PersianDateWidget(context, fep);
                         } else {
                             questionWidget = new DateWidget(context, fep);
                         }

--- a/collect_app/src/main/res/values/arrays.xml
+++ b/collect_app/src/main/res/values/arrays.xml
@@ -212,6 +212,20 @@ the specific language governing permissions and limitations under the License. -
         <item>@string/islamic_month_11</item>
         <item>@string/islamic_month_12</item>
     </string-array>
+    <string-array name="persian_months">
+        <item>@string/persian_month_1</item>
+        <item>@string/persian_month_2</item>
+        <item>@string/persian_month_3</item>
+        <item>@string/persian_month_4</item>
+        <item>@string/persian_month_5</item>
+        <item>@string/persian_month_6</item>
+        <item>@string/persian_month_7</item>
+        <item>@string/persian_month_8</item>
+        <item>@string/persian_month_9</item>
+        <item>@string/persian_month_10</item>
+        <item>@string/persian_month_11</item>
+        <item>@string/persian_month_12</item>
+    </string-array>
     <string-array name="periodic_form_updates_check_entry_values">
         <item>@string/never_value</item>
         <item>@string/every_fifteen_minutes_value</item>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -605,9 +605,20 @@
     <string name="islamic_month_8">Sha\'ban</string>
     <string name="islamic_month_9">Ramadan</string>
     <string name="islamic_month_10">Shawwal</string>
-
     <string name="islamic_month_11">Dhu al-Qidah</string>
     <string name="islamic_month_12">Dhu al-Hijjah</string>
+    <string name="persian_month_1">Farvardin</string>
+    <string name="persian_month_2">Ordibehesht</string>
+    <string name="persian_month_3">Khordad</string>
+    <string name="persian_month_4">Tir</string>
+    <string name="persian_month_5">Mordad</string>
+    <string name="persian_month_6">Shahrivar</string>
+    <string name="persian_month_7">Mehr</string>
+    <string name="persian_month_8">Aban</string>
+    <string name="persian_month_9">Azar</string>
+    <string name="persian_month_10">Dey</string>
+    <string name="persian_month_11">Bahman</string>
+    <string name="persian_month_12">Esfand</string>
     <string name="moving_backwards_title">Moving backwards</string>
     <string name="moving_backwards_disabled_title">Moving backwards disabled</string>
     <string name="moving_backwards_disabled_message">Configure the device to prevent users from bypassing this setting?\n\nThe changes are:\n\u2022 Disable Edit Saved Form\n\u2022 Disable Save Form\n\u2022 Disable Go To Prompt\n\u2022 Set Constraint processing to Validate upon forward swipe</string>

--- a/collect_app/src/test/java/org/odk/collect/android/dependencies/PersianCalendarTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/dependencies/PersianCalendarTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.dependencies;
+
+import org.joda.time.DateTime;
+import org.joda.time.chrono.GregorianChronology;
+import org.joda.time.chrono.PersianChronologyKhayyamBorkowski;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Results confirmed with:
+ * http://www.iranchamber.com/calendar/converter/iranian_calendar_converter.php
+ * and
+ * https://calcuworld.com/calendar-calculators/persian-calendar-converter/
+ */
+public class PersianCalendarTest {
+
+    @Test
+    public void convertingGregorianToPersianTest() {
+        DateTime gregorianDateTime = new DateTime().withYear(1905).withMonthOfYear(2).withDayOfMonth(5);
+        assertDate(getPersianDateTime(gregorianDateTime), 1283, 11, 16);
+
+        gregorianDateTime = new DateTime().withYear(1918).withMonthOfYear(12).withDayOfMonth(1);
+        assertDate(getPersianDateTime(gregorianDateTime), 1297, 9, 9);
+
+        gregorianDateTime = new DateTime().withYear(1921).withMonthOfYear(1).withDayOfMonth(31);
+        assertDate(getPersianDateTime(gregorianDateTime), 1299, 11, 11);
+
+        gregorianDateTime = new DateTime().withYear(1935).withMonthOfYear(5).withDayOfMonth(18);
+        assertDate(getPersianDateTime(gregorianDateTime), 1314, 2, 27);
+
+        gregorianDateTime = new DateTime().withYear(1947).withMonthOfYear(9).withDayOfMonth(24);
+        assertDate(getPersianDateTime(gregorianDateTime), 1326, 7, 1);
+
+        gregorianDateTime = new DateTime().withYear(1952).withMonthOfYear(7).withDayOfMonth(17);
+        assertDate(getPersianDateTime(gregorianDateTime), 1331, 4, 26);
+
+        gregorianDateTime = new DateTime().withYear(1968).withMonthOfYear(10).withDayOfMonth(8);
+        assertDate(getPersianDateTime(gregorianDateTime), 1347, 7, 16);
+
+        gregorianDateTime = new DateTime().withYear(1970).withMonthOfYear(4).withDayOfMonth(30);
+        assertDate(getPersianDateTime(gregorianDateTime), 1349, 2, 10);
+
+        gregorianDateTime = new DateTime().withYear(1987).withMonthOfYear(6).withDayOfMonth(8);
+        assertDate(getPersianDateTime(gregorianDateTime), 1366, 3, 18);
+
+        gregorianDateTime = new DateTime().withYear(1991).withMonthOfYear(10).withDayOfMonth(20);
+        assertDate(getPersianDateTime(gregorianDateTime), 1370, 7, 28);
+
+        gregorianDateTime = new DateTime().withYear(2005).withMonthOfYear(11).withDayOfMonth(17);
+        assertDate(getPersianDateTime(gregorianDateTime), 1384, 8, 26);
+
+        gregorianDateTime = new DateTime().withYear(2019).withMonthOfYear(6).withDayOfMonth(5);
+        assertDate(getPersianDateTime(gregorianDateTime), 1398, 3, 15);
+
+        gregorianDateTime = new DateTime().withYear(2023).withMonthOfYear(2).withDayOfMonth(28);
+        assertDate(getPersianDateTime(gregorianDateTime), 1401, 12, 9);
+
+        gregorianDateTime = new DateTime().withYear(2034).withMonthOfYear(4).withDayOfMonth(1);
+        assertDate(getPersianDateTime(gregorianDateTime), 1413, 1, 12);
+
+        gregorianDateTime = new DateTime().withYear(2048).withMonthOfYear(1).withDayOfMonth(2);
+        assertDate(getPersianDateTime(gregorianDateTime), 1426, 10, 12);
+
+        gregorianDateTime = new DateTime().withYear(2056).withMonthOfYear(8).withDayOfMonth(22);
+        assertDate(getPersianDateTime(gregorianDateTime), 1435, 6, 1);
+
+        gregorianDateTime = new DateTime().withYear(2063).withMonthOfYear(10).withDayOfMonth(11);
+        assertDate(getPersianDateTime(gregorianDateTime), 1442, 7, 19);
+
+        gregorianDateTime = new DateTime().withYear(2075).withMonthOfYear(4).withDayOfMonth(18);
+        assertDate(getPersianDateTime(gregorianDateTime), 1454, 1, 29);
+
+        gregorianDateTime = new DateTime().withYear(2080).withMonthOfYear(12).withDayOfMonth(30);
+        assertDate(getPersianDateTime(gregorianDateTime), 1459, 10, 10);
+
+        gregorianDateTime = new DateTime().withYear(2099).withMonthOfYear(7).withDayOfMonth(14);
+        assertDate(getPersianDateTime(gregorianDateTime), 1478, 4, 24);
+    }
+
+    @Test
+    public void convertingPersianToGregorianTest() {
+        DateTime persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1281).withMonthOfYear(3).withDayOfMonth(17);
+        assertDate(getGregorianDateTime(persianDateTime), 1902, 6, 8);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1290).withMonthOfYear(1).withDayOfMonth(30);
+        assertDate(getGregorianDateTime(persianDateTime), 1911, 4, 20);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1307).withMonthOfYear(10).withDayOfMonth(1);
+        assertDate(getGregorianDateTime(persianDateTime), 1928, 12, 22);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1314).withMonthOfYear(7).withDayOfMonth(14);
+        assertDate(getGregorianDateTime(persianDateTime), 1935, 10, 7);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1326).withMonthOfYear(11).withDayOfMonth(21);
+        assertDate(getGregorianDateTime(persianDateTime), 1948, 2, 11);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1339).withMonthOfYear(3).withDayOfMonth(28);
+        assertDate(getGregorianDateTime(persianDateTime), 1960, 6, 18);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1348).withMonthOfYear(5).withDayOfMonth(9);
+        assertDate(getGregorianDateTime(persianDateTime), 1969, 7, 31);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1352).withMonthOfYear(8).withDayOfMonth(5);
+        assertDate(getGregorianDateTime(persianDateTime), 1973, 10, 27);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1367).withMonthOfYear(12).withDayOfMonth(15);
+        assertDate(getGregorianDateTime(persianDateTime), 1989, 3, 6);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1375).withMonthOfYear(2).withDayOfMonth(20);
+        assertDate(getGregorianDateTime(persianDateTime), 1996, 5, 9);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1381).withMonthOfYear(6).withDayOfMonth(11);
+        assertDate(getGregorianDateTime(persianDateTime), 2002, 9, 2);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1395).withMonthOfYear(9).withDayOfMonth(29);
+        assertDate(getGregorianDateTime(persianDateTime), 2016, 12, 19);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1400).withMonthOfYear(5).withDayOfMonth(10);
+        assertDate(getGregorianDateTime(persianDateTime), 2021, 8, 1);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1417).withMonthOfYear(10).withDayOfMonth(12);
+        assertDate(getGregorianDateTime(persianDateTime), 2039, 1, 2);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1424).withMonthOfYear(8).withDayOfMonth(20);
+        assertDate(getGregorianDateTime(persianDateTime), 2045, 11, 10);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1439).withMonthOfYear(11).withDayOfMonth(5);
+        assertDate(getGregorianDateTime(persianDateTime), 2061, 1, 24);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1443).withMonthOfYear(12).withDayOfMonth(17);
+        assertDate(getGregorianDateTime(persianDateTime), 2065, 3, 7);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1452).withMonthOfYear(3).withDayOfMonth(4);
+        assertDate(getGregorianDateTime(persianDateTime), 2073, 5, 24);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1467).withMonthOfYear(9).withDayOfMonth(22);
+        assertDate(getGregorianDateTime(persianDateTime), 2088, 12, 12);
+
+        persianDateTime = new DateTime(PersianChronologyKhayyamBorkowski.getInstance()).withYear(1474).withMonthOfYear(6).withDayOfMonth(12);
+        assertDate(getGregorianDateTime(persianDateTime), 2095, 9, 2);
+    }
+
+    private void assertDate(DateTime dateTime, int expectedYear, int expectedMonth, int expectedDay) {
+        assertEquals(expectedYear, dateTime.getYear());
+        assertEquals(expectedMonth, dateTime.getMonthOfYear());
+        assertEquals(expectedDay, dateTime.getDayOfMonth());
+    }
+
+    private DateTime getPersianDateTime(DateTime gregorianDateTime) {
+        return new DateTime(gregorianDateTime).withChronology(PersianChronologyKhayyamBorkowski.getInstance());
+    }
+
+    private DateTime getGregorianDateTime(DateTime persianDateTime) {
+        return new DateTime(persianDateTime).withChronology(GregorianChronology.getInstance());
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -35,21 +35,27 @@ public class DateTimeUtilsTest {
     private DatePickerDetails gregorianSpinners;
     private DatePickerDetails gregorianMonthYear;
     private DatePickerDetails gregorianYear;
+
     private DatePickerDetails ethiopian;
     private DatePickerDetails ethiopianMonthYear;
     private DatePickerDetails ethiopianYear;
+
     private DatePickerDetails coptic;
     private DatePickerDetails copticMonthYear;
     private DatePickerDetails copticYear;
+
     private DatePickerDetails islamic;
     private DatePickerDetails islamicMonthYear;
     private DatePickerDetails islamicYear;
+
     private DatePickerDetails bikramSambat;
     private DatePickerDetails bikramSambatMonthYear;
     private DatePickerDetails bikramSambatYear;
+
     private DatePickerDetails myanmar;
     private DatePickerDetails myanmarMonthYear;
     private DatePickerDetails myanmarYear;
+
     private DatePickerDetails persian;
     private DatePickerDetails persianMonthYear;
     private DatePickerDetails persianYear;
@@ -60,21 +66,27 @@ public class DateTimeUtilsTest {
         gregorianSpinners = new DatePickerDetails(DatePickerDetails.DatePickerType.GREGORIAN, DatePickerDetails.DatePickerMode.SPINNERS);
         gregorianMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.GREGORIAN, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         gregorianYear = new DatePickerDetails(DatePickerDetails.DatePickerType.GREGORIAN, DatePickerDetails.DatePickerMode.YEAR);
+
         ethiopian = new DatePickerDetails(DatePickerDetails.DatePickerType.ETHIOPIAN, DatePickerDetails.DatePickerMode.SPINNERS);
         ethiopianMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ETHIOPIAN, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         ethiopianYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ETHIOPIAN, DatePickerDetails.DatePickerMode.YEAR);
+
         coptic = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.SPINNERS);
         copticMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         copticYear = new DatePickerDetails(DatePickerDetails.DatePickerType.COPTIC, DatePickerDetails.DatePickerMode.YEAR);
+
         islamic = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.SPINNERS);
         islamicMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         islamicYear = new DatePickerDetails(DatePickerDetails.DatePickerType.ISLAMIC, DatePickerDetails.DatePickerMode.YEAR);
+
         bikramSambat = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.SPINNERS);
         bikramSambatMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         bikramSambatYear = new DatePickerDetails(DatePickerDetails.DatePickerType.BIKRAM_SAMBAT, DatePickerDetails.DatePickerMode.YEAR);
+
         myanmar = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.SPINNERS);
         myanmarMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         myanmarYear = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.YEAR);
+
         persian = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.SPINNERS);
         persianMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         persianYear = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.YEAR);

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -50,6 +50,9 @@ public class DateTimeUtilsTest {
     private DatePickerDetails myanmar;
     private DatePickerDetails myanmarMonthYear;
     private DatePickerDetails myanmarYear;
+    private DatePickerDetails persian;
+    private DatePickerDetails persianMonthYear;
+    private DatePickerDetails persianYear;
 
     @Before
     public void setUp() {
@@ -72,6 +75,9 @@ public class DateTimeUtilsTest {
         myanmar = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.SPINNERS);
         myanmarMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.MONTH_YEAR);
         myanmarYear = new DatePickerDetails(DatePickerDetails.DatePickerType.MYANMAR, DatePickerDetails.DatePickerMode.YEAR);
+        persian = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.SPINNERS);
+        persianMonthYear = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.MONTH_YEAR);
+        persianYear = new DatePickerDetails(DatePickerDetails.DatePickerType.PERSIAN, DatePickerDetails.DatePickerMode.YEAR);
     }
 
     @Test
@@ -159,5 +165,16 @@ public class DateTimeUtilsTest {
         assertEquals(myanmarYear, DateTimeUtils.getDatePickerDetails(appearance));
         appearance = "year myanmar";
         assertEquals(myanmarYear, DateTimeUtils.getDatePickerDetails(appearance));
+
+        appearance = "persian";
+        assertEquals(persian, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "Persian month-year";
+        assertEquals(persianMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "month-year persian";
+        assertEquals(persianMonthYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "Persian year";
+        assertEquals(persianYear, DateTimeUtils.getDatePickerDetails(appearance));
+        appearance = "year persian";
+        assertEquals(persianYear, DateTimeUtils.getDatePickerDetails(appearance));
     }
 }


### PR DESCRIPTION
Closes #3084 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue and added automated tests.
Results were confirmed using two online converters:
http://www.iranchamber.com/calendar/converter/iranian_calendar_converter.php
https://calcuworld.com/calendar-calculators/persian-calendar-converter/

#### Why is this the best possible solution? Were any other approaches considered?
I analyzed other libs we could and shared my thoughts in the issue. Initially, I didn't want to use a lib created by one person by all the others were too big so I decided to try this one despite the fact it's not something actively maintained.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Changes implemented here are not risky or related to other functionalities so testing the new calendar would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
[PersianForm.xml.txt](https://github.com/opendatakit/collect/files/3256953/PersianForm.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Yes, I'll create an issue.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)