### PR TITLE
Revert putting choices from a search() result into JavaRosa choices

### DIFF
--- a/collect_app/src/androidTest/assets/forms/external-csv-search-produce.csv
+++ b/collect_app/src/androidTest/assets/forms/external-csv-search-produce.csv
@@ -1,0 +1,7 @@
+name,label
+artichoke,Artichoke
+apple,Apple
+banana,Banana
+blueberry,Blueberry
+cherimoya,Cherimoya
+carrot,Carrot

--- a/collect_app/src/androidTest/assets/forms/external-csv-search.xml
+++ b/collect_app/src/androidTest/assets/forms/external-csv-search.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>external-csv-search</h:title>
+    <model>
+      <instance>
+        <external-csv-search id="external-csv-search">
+          <multi_produce/>
+          <produce_search/>
+          <produce/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </external-csv-search>
+      </instance>
+      <bind nodeset="/external-csv-search/multi_produce" type="select"/>
+      <bind nodeset="/external-csv-search/produce_search" type="string"/>
+      <bind nodeset="/external-csv-search/produce" type="select1"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/external-csv-search/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <select appearance="search('external-csv-search-produce')" ref="/external-csv-search/multi_produce">
+      <label>Multiple produce</label>
+      <item>
+        <label>label</label>
+        <value>name</value>
+      </item>
+    </select>
+    <input ref="/external-csv-search/produce_search">
+      <label>Produce search</label>
+    </input>
+    <select1 appearance="search('external-csv-search-produce', 'contains', 'name',  /external-csv-search/produce_search )" ref="/external-csv-search/produce">
+      <label>Produce</label>
+      <item>
+        <label>label</label>
+        <value>name</value>
+      </item>
+    </select1>
+  </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ExternalCsvSearchTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ExternalCsvSearchTest.java
@@ -1,0 +1,82 @@
+package org.odk.collect.android.formentry;
+
+import android.Manifest;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.test.FormLoadingUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.action.ViewActions.swipeLeft;
+import static androidx.test.espresso.action.ViewActions.swipeRight;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.endsWith;
+
+public class ExternalCsvSearchTest {
+    private static final String EXTERNAL_CSV_SEARCH_FORM = "external-csv-search.xml";
+
+    @Rule
+    public IntentsTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(EXTERNAL_CSV_SEARCH_FORM);
+
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @BeforeClass
+    public static void copyFormToSdCard() throws IOException {
+        FormLoadingUtils.copyFormToSdCard(EXTERNAL_CSV_SEARCH_FORM, "forms",
+                Collections.singletonList("external-csv-search-produce.csv"));
+    }
+
+    @Test
+    public void simpleSearchStatement_ShouldDisplayAllCsvChoices() {
+        onView(withText("Multiple produce")).check(matches(isDisplayed()));
+
+        onView(withText("Artichoke")).check(matches(isDisplayed()));
+        onView(withText("Apple")).check(matches(isDisplayed()));
+        onView(withText("Banana")).check(matches(isDisplayed()));
+        onView(withText("Blueberry")).check(matches(isDisplayed()));
+        onView(withText("Cherimoya")).check(matches(isDisplayed()));
+        onView(withText("Carrot")).check(matches(isDisplayed()));
+    }
+
+    @Test
+    // Regression: https://github.com/opendatakit/collect/issues/3132
+    public void searchStatementWithContainsFilter_ShouldUpdateOnSearchChange() {
+        onView(withText("Multiple produce")).perform(swipeLeft());
+
+        onView(withText("Produce search")).check(matches(isDisplayed()));
+        onView(withClassName(endsWith("EditText"))).perform(replaceText("A"));
+        onView(withText("Produce search")).perform(swipeLeft());
+        onView(withText("Artichoke")).check(matches(isDisplayed()));
+        onView(withText("Apple")).check(matches(isDisplayed()));
+        onView(withText("Banana")).check(matches(isDisplayed()));
+        onView(withText("Blueberry")).check(doesNotExist());
+        onView(withText("Cherimoya")).check(matches(isDisplayed()));
+        onView(withText("Carrot")).check(matches(isDisplayed()));
+
+        onView(withText("Produce")).perform(swipeRight());
+        onView(withClassName(endsWith("EditText"))).perform(replaceText("B"));
+        onView(withText("Produce search")).perform(swipeLeft());
+        onView(withText("Artichoke")).check(doesNotExist());
+        onView(withText("Apple")).check(doesNotExist());
+        onView(withText("Banana")).check(matches(isDisplayed()));
+        onView(withText("Blueberry")).check(matches(isDisplayed()));
+        onView(withText("Cherimoya")).check(doesNotExist());
+        onView(withText("Carrot")).check(doesNotExist());
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.odk.collect.android.formfilling;
+package org.odk.collect.android.formentry;
 
 import android.Manifest;
 import android.app.Activity;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormNavigationButtonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormNavigationButtonTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.odk.collect.android.formfilling;
+package org.odk.collect.android.formentry;
 
 import android.Manifest;
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/IntentGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/IntentGroupTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.odk.collect.android.formfilling;
+package org.odk.collect.android.formentry;
 
 import android.Manifest;
 import android.app.Activity;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -70,7 +70,7 @@ public class FileUtils {
     public static final String AUTO_SEND = "autoSend";
 
     /** Suffix for the form media directory. */
-    private static final String MEDIA_SUFFIX = "-media";
+    public static final String MEDIA_SUFFIX = "-media";
 
     /** Filename of the last-saved instance data. */
     public static final String LAST_SAVED_FILENAME = "last-saved.xml";

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsWidget.java
@@ -18,11 +18,9 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 
-import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.expr.XPathFuncExpr;
-import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.android.external.ExternalDataUtil;
 
 import java.util.List;
@@ -43,28 +41,10 @@ public abstract class ItemsWidget extends QuestionWidget {
     protected void readItems() {
         // SurveyCTO-added support for dynamic select content (from .csv files)
         XPathFuncExpr xpathFuncExpr = ExternalDataUtil.getSearchXPathExpression(getFormEntryPrompt().getAppearanceHint());
-        if (readExternalChoices(xpathFuncExpr)) {
-            try {
-                items = ExternalDataUtil.populateExternalChoices(getFormEntryPrompt(), xpathFuncExpr);
-                addExternalChoices(items);
-            } catch (ExternalDataException e) {
-                items = getFormEntryPrompt().getSelectChoices();
-            }
+        if (xpathFuncExpr != null) {
+            items = ExternalDataUtil.populateExternalChoices(getFormEntryPrompt(), xpathFuncExpr);
         } else {
             items = getFormEntryPrompt().getSelectChoices();
-        }
-    }
-
-    private boolean readExternalChoices(XPathFuncExpr xpathFuncExpr) {
-        return xpathFuncExpr != null && getFormEntryPrompt().getQuestion().getNumChoices() == 1;
-    }
-
-    private void addExternalChoices(List<SelectChoice> choices) {
-        QuestionDef questionDef = getFormEntryPrompt().getQuestion();
-        // The first choice in this case is just for providing headers which we need to read external items
-        questionDef.removeSelectChoice(questionDef.getChoice(0));
-        for (SelectChoice choice : choices) {
-            questionDef.addSelectChoice(choice);
         }
     }
 }


### PR DESCRIPTION
Closes #3132

#### What has been done to verify that this works as intended?
Added a test that fails on master, made the fix and then verified that the test passes.

#### Why is this the best possible solution? Were any other approaches considered?
We could fix #2845 by clearing the choices and re-populating them on every form re-evaluation but I don't think we should spend any more effort on this. `search()` fundamentally exists outside of the form spec so it's expected that typical tools wouldn't work with them. If we have additional cycles for external data, we should spend them on supporting external secondary XML and CSV instances.

I didn't revert the whole PR because I think the refactoring is still valuable.

I did a little cleanup when introducing the new test. I changed the name of the package for tests over specific forms to `formentry`. I also put this new form in a `forms` asset subdirectory.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There are possible regression risks around how `search()` works but I think the two simple tests I've put in place are sufficient to guard against them.

#### Do we need any specific form for testing your changes? If so, please attach one.
https://github.com/opendatakit/collect/compare/master...lognaturel:issue-3132?expand=1#diff-02e431bd1590a9e1aa5d472d5e86ce43 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)