### PR TITLE
Move the Maps preferences to their own page.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -27,8 +27,6 @@ import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import androidx.annotation.VisibleForTesting;
-
 import org.odk.collect.android.R;
 import org.odk.collect.android.map.GoogleMapFragment;
 import org.odk.collect.android.map.MapFragment;
@@ -46,6 +44,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.VisibleForTesting;
 
 import static org.odk.collect.android.utilities.PermissionUtils.areLocationPermissionsGranted;
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminKeys.java
@@ -150,7 +150,10 @@ public final class AdminKeys {
             KEY_APP_LANGUAGE,
             KEY_CHANGE_FONT_SIZE,
             KEY_NAVIGATION,
-            KEY_SHOW_SPLASH_SCREEN,
+            KEY_SHOW_SPLASH_SCREEN
+    );
+
+    static Collection<String> mapsKeys = Arrays.asList(
             KEY_SHOW_MAP_BASEMAP,
             KEY_SHOW_MAP_SDK
     );

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralPreferencesFragment.java
@@ -19,12 +19,13 @@ package org.odk.collect.android.preferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
-import androidx.annotation.Nullable;
 import android.view.View;
 
 import org.odk.collect.android.R;
 
 import java.util.Collection;
+
+import androidx.annotation.Nullable;
 
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
 
@@ -47,6 +48,7 @@ public class GeneralPreferencesFragment extends BasePreferenceFragment implement
 
         findPreference("protocol").setOnPreferenceClickListener(this);
         findPreference("user_interface").setOnPreferenceClickListener(this);
+        findPreference("maps").setOnPreferenceClickListener(this);
         findPreference("form_management").setOnPreferenceClickListener(this);
         findPreference("user_and_device_identity").setOnPreferenceClickListener(this);
 
@@ -64,18 +66,22 @@ public class GeneralPreferencesFragment extends BasePreferenceFragment implement
     @Override
     public boolean onPreferenceClick(Preference preference) {
         BasePreferenceFragment basePreferenceFragment = null;
+        boolean adminMode = getArguments().getBoolean(INTENT_KEY_ADMIN_MODE, false);
         switch (preference.getKey()) {
             case "protocol":
-                basePreferenceFragment = ServerPreferences.newInstance(getArguments().getBoolean(INTENT_KEY_ADMIN_MODE, false));
+                basePreferenceFragment = ServerPreferences.newInstance(adminMode);
                 break;
             case "user_interface":
-                basePreferenceFragment = UserInterfacePreferences.newInstance(getArguments().getBoolean(INTENT_KEY_ADMIN_MODE, false));
+                basePreferenceFragment = UserInterfacePreferences.newInstance(adminMode);
+                break;
+            case "maps":
+                basePreferenceFragment = MapsPreferences.newInstance(adminMode);
                 break;
             case "form_management":
-                basePreferenceFragment = FormManagementPreferences.newInstance(getArguments().getBoolean(INTENT_KEY_ADMIN_MODE, false));
+                basePreferenceFragment = FormManagementPreferences.newInstance(adminMode);
                 break;
             case "user_and_device_identity":
-                basePreferenceFragment = IdentityPreferences.newInstance(getArguments().getBoolean(INTENT_KEY_ADMIN_MODE, false));
+                basePreferenceFragment = IdentityPreferences.newInstance(adminMode);
                 break;
         }
         if (basePreferenceFragment != null) {
@@ -96,6 +102,10 @@ public class GeneralPreferencesFragment extends BasePreferenceFragment implement
 
         if (!hasAtleastOneSettingEnabled(AdminKeys.userInterfaceKeys)) {
             preferenceScreen.removePreference(findPreference("user_interface"));
+        }
+
+        if (!hasAtleastOneSettingEnabled(AdminKeys.mapsKeys)) {
+            preferenceScreen.removePreference(findPreference("maps"));
         }
 
         if (!hasAtleastOneSettingEnabled(AdminKeys.formManagementKeys)) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Shobhit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.odk.collect.android.preferences;
+
+import android.os.Bundle;
+import android.preference.ListPreference;
+import android.view.View;
+
+import com.google.common.collect.ObjectArrays;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.map.MapboxUtils;
+import org.odk.collect.android.spatial.MapHelper;
+
+import androidx.annotation.Nullable;
+
+import static org.odk.collect.android.preferences.GeneralKeys.GOOGLE_MAPS_BASEMAP_DEFAULT;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_MAP_BASEMAP;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_MAP_SDK;
+import static org.odk.collect.android.preferences.GeneralKeys.MAPBOX_BASEMAP_DEFAULT;
+import static org.odk.collect.android.preferences.GeneralKeys.MAPBOX_BASEMAP_KEY;
+import static org.odk.collect.android.preferences.GeneralKeys.OSM_BASEMAP_KEY;
+import static org.odk.collect.android.preferences.GeneralKeys.OSM_MAPS_BASEMAP_DEFAULT;
+import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
+
+public class MapsPreferences extends BasePreferenceFragment {
+
+    public static MapsPreferences newInstance(boolean adminMode) {
+        Bundle bundle = new Bundle();
+        bundle.putBoolean(INTENT_KEY_ADMIN_MODE, adminMode);
+
+        MapsPreferences prefs = new MapsPreferences();
+        prefs.setArguments(bundle);
+        return prefs;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.maps_preferences);
+        initMapPrefs();
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        toolbar.setTitle(R.string.maps);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        if (toolbar != null) {
+            toolbar.setTitle(R.string.general_preferences);
+        }
+    }
+
+    private void initMapPrefs() {
+        final ListPreference mapSdk = (ListPreference) findPreference(KEY_MAP_SDK);
+        final ListPreference mapBasemap = (ListPreference) findPreference(KEY_MAP_BASEMAP);
+
+        if (mapSdk == null || mapBasemap == null) {
+            return;
+        }
+
+        if (mapSdk.getValue() == null || mapSdk.getEntry() == null) {
+            mapSdk.setValueIndex(0);  // use the first option as the default
+        }
+
+        String[] basemapValues;
+        String[] basemapEntries;
+        if (mapSdk.getValue().equals(OSM_BASEMAP_KEY)) {
+            basemapValues = getResources().getStringArray(R.array.map_osm_basemap_selector_entry_values);
+            basemapEntries = getResources().getStringArray(R.array.map_osm_basemap_selector_entries);
+        } else if (mapSdk.getValue().equals(MAPBOX_BASEMAP_KEY)) {
+            basemapValues = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entry_values);
+            basemapEntries = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entries);
+        } else { // otherwise fall back to Google, the default
+            basemapValues = getResources().getStringArray(R.array.map_google_basemap_selector_entry_values);
+            basemapEntries = getResources().getStringArray(R.array.map_google_basemap_selector_entries);
+        }
+        mapBasemap.setEntryValues(ObjectArrays.concat(basemapValues, MapHelper.getOfflineLayerListWithTags(), String.class));
+        mapBasemap.setEntries(ObjectArrays.concat(basemapEntries, MapHelper.getOfflineLayerListWithTags(), String.class));
+
+        mapSdk.setSummary(mapSdk.getEntry());
+        mapSdk.setOnPreferenceChangeListener((preference, newValue) -> {
+            String value = (String) newValue;
+            String[] values;
+            String[] entries;
+
+            if (value.equals(OSM_BASEMAP_KEY)) {
+                values = getResources().getStringArray(R.array.map_osm_basemap_selector_entry_values);
+                entries = getResources().getStringArray(R.array.map_osm_basemap_selector_entries);
+                mapBasemap.setValue(OSM_MAPS_BASEMAP_DEFAULT);
+            } else if (value.equals(MAPBOX_BASEMAP_KEY)) {
+                if (MapboxUtils.initMapbox() == null) {
+                    // This settings code will be rewritten very soon (planned for r1.23),
+                    // so let's just warn for now instead of trying to disable the option.
+                    MapboxUtils.warnMapboxUnsupported(getActivity());
+                }
+                values = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entry_values);
+                entries = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entries);
+                mapBasemap.setValue(MAPBOX_BASEMAP_DEFAULT);
+            } else {  // GOOGLE_MAPS_BASEMAP_KEY, or default
+                values = getResources().getStringArray(R.array.map_google_basemap_selector_entry_values);
+                entries = getResources().getStringArray(R.array.map_google_basemap_selector_entries);
+                mapBasemap.setValue(GOOGLE_MAPS_BASEMAP_DEFAULT);
+            }
+            mapBasemap.setEntryValues(ObjectArrays.concat(values, MapHelper.getOfflineLayerListWithTags(), String.class));
+            mapBasemap.setEntries(ObjectArrays.concat(entries, MapHelper.getOfflineLayerListWithTags(), String.class));
+            mapBasemap.setSummary(mapBasemap.getEntry());
+
+            mapSdk.setSummary(mapSdk.getEntries()[mapSdk.findIndexOfValue(value)]);
+            return true;
+        });
+
+        CharSequence entry = mapBasemap.getEntry();
+        if (entry != null) {
+            mapBasemap.setSummary(entry);
+        } else {
+            mapBasemap.setSummary(mapBasemap.getEntries()[0]);
+            mapBasemap.setValueIndex(0);
+        }
+
+        mapBasemap.setOnPreferenceChangeListener((preference, newValue) -> {
+            int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+            preference.setSummary(((ListPreference) preference).getEntries()[index]);
+            return true;
+        });
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -24,12 +24,8 @@ import android.preference.PreferenceManager;
 import android.provider.MediaStore;
 import android.view.View;
 
-import com.google.common.collect.ObjectArrays;
-
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
-import org.odk.collect.android.map.MapboxUtils;
-import org.odk.collect.android.spatial.MapHelper;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
 
@@ -40,18 +36,11 @@ import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 import static android.app.Activity.RESULT_CANCELED;
-import static org.odk.collect.android.preferences.GeneralKeys.GOOGLE_MAPS_BASEMAP_DEFAULT;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_APP_LANGUAGE;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_APP_THEME;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_FONT_SIZE;
-import static org.odk.collect.android.preferences.GeneralKeys.KEY_MAP_BASEMAP;
-import static org.odk.collect.android.preferences.GeneralKeys.KEY_MAP_SDK;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_NAVIGATION;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_SPLASH_PATH;
-import static org.odk.collect.android.preferences.GeneralKeys.MAPBOX_BASEMAP_DEFAULT;
-import static org.odk.collect.android.preferences.GeneralKeys.MAPBOX_BASEMAP_KEY;
-import static org.odk.collect.android.preferences.GeneralKeys.OSM_BASEMAP_KEY;
-import static org.odk.collect.android.preferences.GeneralKeys.OSM_MAPS_BASEMAP_DEFAULT;
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
 
 public class UserInterfacePreferences extends BasePreferenceFragment {
@@ -78,7 +67,6 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
         initFontSizePref();
         initLanguagePrefs();
         initSplashPrefs();
-        initMapPrefs();
     }
 
     @Override
@@ -185,80 +173,6 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
             pref.setOnPreferenceClickListener(new SplashClickListener(this, pref));
             pref.setSummary((String) GeneralSharedPreferences.getInstance().get(KEY_SPLASH_PATH));
         }
-    }
-
-    private void initMapPrefs() {
-        final ListPreference mapSdk = (ListPreference) findPreference(KEY_MAP_SDK);
-        final ListPreference mapBasemap = (ListPreference) findPreference(KEY_MAP_BASEMAP);
-
-        if (mapSdk == null || mapBasemap == null) {
-            return;
-        }
-
-        if (mapSdk.getValue() == null || mapSdk.getEntry() == null) {
-            mapSdk.setValueIndex(0);  // use the first option as the default
-        }
-
-        String[] onlineLayerEntryValues;
-        String[] onlineLayerEntries;
-        if (mapSdk.getValue().equals(OSM_BASEMAP_KEY)) {
-            onlineLayerEntryValues = getResources().getStringArray(R.array.map_osm_basemap_selector_entry_values);
-            onlineLayerEntries = getResources().getStringArray(R.array.map_osm_basemap_selector_entries);
-        } else if (mapSdk.getValue().equals(MAPBOX_BASEMAP_KEY)) {
-            onlineLayerEntryValues = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entry_values);
-            onlineLayerEntries = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entries);
-        } else { // otherwise fall back to Google, the default
-            onlineLayerEntryValues = getResources().getStringArray(R.array.map_google_basemap_selector_entry_values);
-            onlineLayerEntries = getResources().getStringArray(R.array.map_google_basemap_selector_entries);
-        }
-        mapBasemap.setEntryValues(ObjectArrays.concat(onlineLayerEntryValues, MapHelper.getOfflineLayerListWithTags(), String.class));
-        mapBasemap.setEntries(ObjectArrays.concat(onlineLayerEntries, MapHelper.getOfflineLayerListWithTags(), String.class));
-
-        mapSdk.setSummary(mapSdk.getEntry());
-        mapSdk.setOnPreferenceChangeListener((preference, newValue) -> {
-            String[] onlineLayerEntryValues1;
-            String[] onlineLayerEntries1;
-            String value = (String) newValue;
-
-            if (value.equals(OSM_BASEMAP_KEY)) {
-                onlineLayerEntryValues1 = getResources().getStringArray(R.array.map_osm_basemap_selector_entry_values);
-                onlineLayerEntries1 = getResources().getStringArray(R.array.map_osm_basemap_selector_entries);
-                mapBasemap.setValue(OSM_MAPS_BASEMAP_DEFAULT);
-            } else if (value.equals(MAPBOX_BASEMAP_KEY)) {
-                if (MapboxUtils.initMapbox() == null) {
-                    // This settings code will be rewritten very soon (planned for r1.23),
-                    // so let's just warn for now instead of trying to disable the option.
-                    MapboxUtils.warnMapboxUnsupported(getActivity());
-                }
-                onlineLayerEntryValues1 = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entry_values);
-                onlineLayerEntries1 = getResources().getStringArray(R.array.map_mapbox_basemap_selector_entries);
-                mapBasemap.setValue(MAPBOX_BASEMAP_DEFAULT);
-            } else {  // GOOGLE_MAPS_BASEMAP_KEY, or default
-                onlineLayerEntryValues1 = getResources().getStringArray(R.array.map_google_basemap_selector_entry_values);
-                onlineLayerEntries1 = getResources().getStringArray(R.array.map_google_basemap_selector_entries);
-                mapBasemap.setValue(GOOGLE_MAPS_BASEMAP_DEFAULT);
-            }
-            mapBasemap.setEntryValues(ObjectArrays.concat(onlineLayerEntryValues1, MapHelper.getOfflineLayerListWithTags(), String.class));
-            mapBasemap.setEntries(ObjectArrays.concat(onlineLayerEntries1, MapHelper.getOfflineLayerListWithTags(), String.class));
-            mapBasemap.setSummary(mapBasemap.getEntry());
-
-            mapSdk.setSummary(mapSdk.getEntries()[mapSdk.findIndexOfValue(value)]);
-            return true;
-        });
-
-        CharSequence entry = mapBasemap.getEntry();
-        if (entry != null) {
-            mapBasemap.setSummary(entry);
-        } else {
-            mapBasemap.setSummary(mapBasemap.getEntries()[0]);
-            mapBasemap.setValueIndex(0);
-        }
-
-        mapBasemap.setOnPreferenceChangeListener((preference, newValue) -> {
-            int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
-            preference.setSummary(((ListPreference) preference).getEntries()[index]);
-            return true;
-        });
     }
 
     @Override

--- a/collect_app/src/main/res/drawable/ic_map.xml
+++ b/collect_app/src/main/res/drawable/ic_map.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?colorAccent"
+        android:pathData="M20.5,3l-0.16,0.03L15,5.1 9,3 3.36,4.9c-0.21,0.07 -0.36,0.25 -0.36,0.48V20.5c0,0.28 0.22,0.5 0.5,0.5l0.16,-0.03L9,18.9l6,2.1 5.64,-1.9c0.21,-0.07 0.36,-0.25 0.36,-0.48V3.5c0,-0.28 -0.22,-0.5 -0.5,-0.5zM15,19l-6,-2.11V5l6,2.11V19z"/>
+</vector>

--- a/collect_app/src/main/res/values-am/strings.xml
+++ b/collect_app/src/main/res/values-am/strings.xml
@@ -208,7 +208,6 @@
   <string name="google_search_browse">ቅጾችን ይፈልጉ፡፡ ወይም ለማሰስ ከታች \"የእኔ Drive\" ን ይምረጡ.</string>
   <string name="about_preferences">ስለ</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">ካርታ</string>
   <string name="streets">መንገዶች</string>
   <string name="terrain">መልከአ ምድር</string>
   <string name="satellite">ሳተላይት</string>

--- a/collect_app/src/main/res/values-ar/strings.xml
+++ b/collect_app/src/main/res/values-ar/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">اترك تعليق في Play Store</string>
   <string name="leave_a_review_msg">رأيك (نأمل إيجابيا) يزيد من رؤية التطبيق في Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">رسم الخريطة</string>
   <string name="map_sdk_selector_title">خدمة الخريطة</string>
   <string name="map_sdk_behavior">الخريطة</string>
   <string name="google_maps_sdk">خريطة جوجل</string>

--- a/collect_app/src/main/res/values-ca/strings.xml
+++ b/collect_app/src/main/res/values-ca/strings.xml
@@ -268,7 +268,6 @@
   <string name="google_play_services_error_occured">No pot accedir a Google Maps. Teniu el servei instal·lat ?</string>
   <string name="about_preferences">Sobre</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Mapejant</string>
   <string name="map_sdk_selector_title">Mapejant SDK</string>
   <string name="map_sdk_behavior">Mapejant SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Nechte recenzi v Play Store</string>
   <string name="leave_a_review_msg">Vaše recenze (snad pozitivní) zvyšuje viditelnost aplikace v Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Mapování</string>
   <string name="map_sdk_selector_title">SDK Mapování</string>
   <string name="map_sdk_behavior">SDK Mapování</string>
   <string name="google_maps_sdk">SDK Google Maps</string>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Geben Sie eine Play Store Bewertung ab</string>
   <string name="leave_a_review_msg">Ihre (hoffentlich positive) Bewertung steigert die Bekanntheit der App im Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Karten</string>
   <string name="map_sdk_selector_title">Karten-SDK</string>
   <string name="map_sdk_behavior">Karten-SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -309,7 +309,6 @@
   <string name="leave_a_review">Ir a Play Store - Comentar y/o Actualizar</string>
   <string name="leave_a_review_msg">Su comentario (ojalá positivo) incrementa la visibilidad de la App en Play Store</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Cartografía</string>
   <string name="map_sdk_selector_title">Cartografía SDK</string>
   <string name="map_sdk_behavior">Cartografía SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-et/strings.xml
+++ b/collect_app/src/main/res/values-et/strings.xml
@@ -267,7 +267,6 @@
   <string name="google_play_services_error_occured">Puudub ligipääs Google Maps-ile. Veenduge, et Google Play teenused on paigaldatud.</string>
   <string name="about_preferences">Teave</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Kaardistus</string>
   <string name="map_sdk_selector_title">Kaardistus SDK</string>
   <string name="map_sdk_behavior">Kaardistus SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Kirjoita Play Store -arvio</string>
   <string name="leave_a_review_msg">Sinun (toivottavasti myönteinen) arviosi lisää sovelluksen näkyvyyttä Play Store -kaupassa.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Kartoitus</string>
   <string name="map_sdk_selector_title">Mapping SDK</string>
   <string name="map_sdk_behavior">Mapping SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Laissez un avis sur Play Store</string>
   <string name="leave_a_review_msg">Votre avis (ce qu\'on espère est positif) augmente la visibilité de l\'application dans le Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Cartographie</string>
   <string name="map_sdk_selector_title">Moteur cartographique - SDK</string>
   <string name="map_sdk_behavior">Moteur cartographique - SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-hi/strings.xml
+++ b/collect_app/src/main/res/values-hi/strings.xml
@@ -280,7 +280,6 @@
   <string name="google_play_services_error_occured">गूगल मानचित्र तक पहुंचने में असमर्थ क्या गूगल प्ले सर्विस इनस्टॉल है?</string>
   <string name="about_preferences">बारे में </string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">मानचित्रण</string>
   <string name="map_sdk_selector_title">मानचित्रण SDK</string>
   <string name="map_sdk_behavior">मानचित्रण SDK</string>
   <string name="google_maps_sdk">गूगल मैप SDK</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -305,7 +305,6 @@
   <string name="leave_a_review">Berikan ulasan di Play Store</string>
   <string name="leave_a_review_msg">Ulasan anda (semoga positif) dapat mempromosikan aplikasi ODK di Play Store</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Pemetaan</string>
   <string name="map_sdk_selector_title">SDK Pemetaan</string>
   <string name="map_sdk_behavior">Pemetaan SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-it/strings.xml
+++ b/collect_app/src/main/res/values-it/strings.xml
@@ -306,7 +306,6 @@
   <string name="leave_a_review">Lascia un commento su Play Store</string>
   <string name="leave_a_review_msg">Il tuo commento (speriamo positivo) aumenta la visibilità dell\'applicazione su Play Store</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Mappatura</string>
   <string name="map_sdk_selector_title">Mappatura SDK</string>
   <string name="map_sdk_behavior">Mappatura SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Play ストアにレビューを残す</string>
   <string name="leave_a_review_msg">あなたの (肯定的な) レビューが Play ストアでアプリの認知度を向上させてくれます</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">マッピング</string>
   <string name="map_sdk_selector_title">マッピング SDK</string>
   <string name="map_sdk_behavior">マッピング SDK</string>
   <string name="google_maps_sdk">Google マップ SDK</string>

--- a/collect_app/src/main/res/values-km/strings.xml
+++ b/collect_app/src/main/res/values-km/strings.xml
@@ -295,7 +295,6 @@
   <string name="leave_a_review">ទុកមតិនៅក្នុងហាង Play</string>
   <string name="leave_a_review_msg">ការ​ផ្តល់​មតិ​ (សង្ឃឹមថាជាវិជ្ជមាន) របស់​អ្នក​បង្កើន​ភាព​មើល​ឃើញ​នៃ​កម្មវិធី​នៅ​ក្នុង Play Store ។</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">ដៅផែនទី</string>
   <string name="map_sdk_selector_title">ផែនទី SDK</string>
   <string name="map_sdk_behavior">ផែនទី SDK</string>
   <string name="google_maps_sdk">ផែនទី Google SDK</string>

--- a/collect_app/src/main/res/values-mr/strings.xml
+++ b/collect_app/src/main/res/values-mr/strings.xml
@@ -275,7 +275,6 @@
   <string name="google_play_services_error_occured">गूगल नकाशे मध्ये प्रवेश करण्यात अक्षम. गूगल प्ले सेवा स्थापित केली आहे का?</string>
   <string name="about_preferences">विषयी</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">मॅपिंग</string>
   <string name="map_sdk_selector_title">मॅपिंग एसडीके</string>
   <string name="map_sdk_behavior">मॅपिंग एसडीके</string>
   <string name="google_maps_sdk">गूगल नकाशे एसडीके</string>

--- a/collect_app/src/main/res/values-ne-rNP/strings.xml
+++ b/collect_app/src/main/res/values-ne-rNP/strings.xml
@@ -295,7 +295,6 @@
   <string name="tell_your_friends_msg">के तपाईँका सहकर्मीहरू अझै कागजमा डाटा संकलन गर्दै हुनुहुन्छ? तिनीहरुसँग ODK Collect शेयर गर्नुहोस् ।</string>
   <string name="leave_a_review">हामीलाई  प्ले स्टोर आफ्नो मा समीक्षा छोड्नुहोस् ।</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">नक्शाकंन</string>
   <string name="map_sdk_selector_title">SDK नक्शाकंन गर्न</string>
   <string name="map_sdk_behavior">SDK नक्शाकंन गर्न</string>
   <string name="google_maps_sdk">गुगल म्याप्स् SDK</string>

--- a/collect_app/src/main/res/values-pl/strings.xml
+++ b/collect_app/src/main/res/values-pl/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Zostaw swoją opinię na Play Store</string>
   <string name="leave_a_review_msg">Twoja (mamy nadzieję pozytywna) recenzja przyczyni się do zwiększenia widoczności Aplikacji w Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Mapowanie</string>
   <string name="map_sdk_selector_title">SDK Mapowania</string>
   <string name="map_sdk_behavior">SDK Mapowania</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-pt/strings.xml
+++ b/collect_app/src/main/res/values-pt/strings.xml
@@ -295,7 +295,6 @@ Escolher Imagem</string>
   <string name="leave_a_review">Deixe um opinião sua na Play Store</string>
   <string name="leave_a_review_msg">A sua opinião (possivelmente positiva) aumenta a visibilidade da App na Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Cartografia</string>
   <string name="map_sdk_selector_title">Cartografia SDK</string>
   <string name="map_sdk_behavior">Cartografia SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-ru/strings.xml
+++ b/collect_app/src/main/res/values-ru/strings.xml
@@ -301,7 +301,6 @@
   <string name="leave_a_review">Оставить отзыв в Play Store</string>
   <string name="leave_a_review_msg">Ваш отзыв (надеемся, положительный) делает приложение более заметным в Play Store</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">КАРТЫ</string>
   <string name="map_sdk_selector_title">Источник карт</string>
   <string name="map_sdk_behavior">Источник карт</string>
   <string name="google_maps_sdk">Google</string>

--- a/collect_app/src/main/res/values-sr/strings.xml
+++ b/collect_app/src/main/res/values-sr/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Napiši Play Store recenziju</string>
   <string name="leave_a_review_msg">Vaša (nadamo se pozitivna) recenzija povećava vidljivost aplikacije u Play Storu.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Mapiranje</string>
   <string name="map_sdk_selector_title">Mapiranje SDK</string>
   <string name="map_sdk_behavior">Mapiranje SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-sv-rSE/strings.xml
+++ b/collect_app/src/main/res/values-sv-rSE/strings.xml
@@ -297,7 +297,6 @@ Dela ODK Collect med dem.</string>
   <string name="leave_a_review">Lämna ett omdöme på Play Store</string>
   <string name="leave_a_review_msg">Din (förhoppningsvis positiva) recension ökar synligheten av Appen i Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Kartor</string>
   <string name="map_sdk_selector_title">SDK för kartor</string>
   <string name="map_sdk_behavior">SDK för kartor</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-sw/strings.xml
+++ b/collect_app/src/main/res/values-sw/strings.xml
@@ -301,7 +301,6 @@
   <string name="leave_a_review">Acha tathmini katika Play Store</string>
   <string name="leave_a_review_msg">Tathmini yako (tunatumaini itakuwa chanya) inaongeza nafasi ya programu hii kuonekana Pay Store</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Kuchora ramani</string>
   <string name="map_sdk_selector_title">Ramani SDK</string>
   <string name="map_sdk_behavior">Ramani SDK</string>
   <string name="google_maps_sdk">Ramani za Google SDK</string>

--- a/collect_app/src/main/res/values-th-rTH/strings.xml
+++ b/collect_app/src/main/res/values-th-rTH/strings.xml
@@ -259,7 +259,6 @@
 </string>
   <string name="about_preferences">เกี่ยวกับ</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">ทำแผนที่</string>
   <string name="map_sdk_selector_title">Mapping SDK</string>
   <string name="map_sdk_behavior">Mapping SDK</string>
   <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values-uk/strings.xml
+++ b/collect_app/src/main/res/values-uk/strings.xml
@@ -307,7 +307,6 @@
   <string name="leave_a_review">Залишити відгук в Play Store</string>
   <string name="leave_a_review_msg">Ваш (сподіваємось позитивний) відгук покращить помітність програми в Play Store.</string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">Мапування</string>
   <string name="map_sdk_selector_title">SDK для мапування</string>
   <string name="map_sdk_behavior">SDK для мапування</string>
   <string name="google_maps_sdk">Google Карти SDK</string>

--- a/collect_app/src/main/res/values-ur/strings.xml
+++ b/collect_app/src/main/res/values-ur/strings.xml
@@ -301,7 +301,6 @@
   <string name="leave_a_review">پلے اسٹور پر رائے دیجیے</string>
   <string name="leave_a_review_msg">آپ ( امید ہے مثبت) کی رائے سے پلے اسٹورمیں اپپ کی نمائش میں اضافہ ہوتا ہے </string>
   <!--Geo string added in feature-geofeatures branch-->
-  <string name="map_preferences">میپنگ</string>
   <string name="map_sdk_selector_title"> ایس ڈی کے میپنگ</string>
   <string name="map_sdk_behavior"> ایس ڈی کے میپنگ</string>
   <string name="google_maps_sdk">گوگل میپس ایس ڈی کے </string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -314,7 +314,6 @@
     <!-- Geo string added in feature-geofeatures branch-->
 
     <string name="maps">Maps</string>
-    <string name="map_preferences">Mapping</string>
     <string name="map_sdk_selector_title">Mapping SDK</string>
     <string name="map_sdk_behavior">Mapping SDK</string>
     <string name="google_maps_sdk">Google Maps SDK</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -312,6 +312,8 @@
     <string name="leave_a_review">Leave a Play Store review</string>
     <string name="leave_a_review_msg">Your (hopefully positive) review increases the visibility of the App in the Play Store.</string>
     <!-- Geo string added in feature-geofeatures branch-->
+
+    <string name="maps">Maps</string>
     <string name="map_preferences">Mapping</string>
     <string name="map_sdk_selector_title">Mapping SDK</string>
     <string name="map_sdk_behavior">Mapping SDK</string>

--- a/collect_app/src/main/res/xml/general_preferences.xml
+++ b/collect_app/src/main/res/xml/general_preferences.xml
@@ -19,6 +19,10 @@ limitations under the License.
         android:key="user_interface"
         android:title="@string/client" />
     <Preference
+        android:icon="@drawable/ic_map"
+        android:key="maps"
+        android:title="@string/maps" />
+    <Preference
         android:icon="@drawable/ic_assignment"
         android:key="form_management"
         android:title="@string/form_management_preferences" />

--- a/collect_app/src/main/res/xml/maps_preferences.xml
+++ b/collect_app/src/main/res/xml/maps_preferences.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <ListPreference
+        android:dialogTitle="@string/map_sdk_selector_title"
+        android:entries="@array/map_sdk_selector_entries"
+        android:entryValues="@array/map_sdk_selector_entry_values"
+        android:key="map_sdk_behavior"
+        android:title="@string/map_sdk_behavior" />
+    <ListPreference
+        android:dialogTitle="@string/map_basemap_selector_title"
+        android:entries="@array/map_mapbox_basemap_selector_entries"
+        android:entryValues="@array/map_mapbox_basemap_selector_entry_values"
+        android:key="map_basemap_behavior"
+        android:title="@string/map_basemap_behavior_title" />
+</PreferenceScreen>

--- a/collect_app/src/main/res/xml/user_interface_preferences.xml
+++ b/collect_app/src/main/res/xml/user_interface_preferences.xml
@@ -32,7 +32,6 @@
         android:key="splashPath"
         android:layout="?android:attr/preferenceLayoutChild"
         android:title="@string/splash_path" />
-
     <PreferenceCategory
         android:key="@string/map_preferences"
         android:title="@string/map_preferences">

--- a/collect_app/src/main/res/xml/user_interface_preferences.xml
+++ b/collect_app/src/main/res/xml/user_interface_preferences.xml
@@ -32,20 +32,4 @@
         android:key="splashPath"
         android:layout="?android:attr/preferenceLayoutChild"
         android:title="@string/splash_path" />
-    <PreferenceCategory
-        android:key="@string/map_preferences"
-        android:title="@string/map_preferences">
-        <ListPreference
-            android:dialogTitle="@string/map_sdk_selector_title"
-            android:entries="@array/map_sdk_selector_entries"
-            android:entryValues="@array/map_sdk_selector_entry_values"
-            android:key="map_sdk_behavior"
-            android:title="@string/map_sdk_behavior" />
-        <ListPreference
-            android:dialogTitle="@string/map_basemap_selector_title"
-            android:entries="@array/map_google_basemap_selector_entries"
-            android:entryValues="@array/map_google_basemap_selector_entry_values"
-            android:key="map_basemap_behavior"
-            android:title="@string/map_basemap_behavior_title" />
-    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Issues: makes progress on #3129 (but does not close)
Scope: User Interface preferences, Maps preferences (new)
Requested reviewers: @ln

#### User-visible changes

Currently, the preference settings for maps (the SDK and the basemap type) are on the "User Interface" preferences page.  This moves them to a new page, the "Maps" page.

#### Verification performed

I uninstalled ODK Collect and did a fresh install, then went to the "Maps" settings page and confirmed that "Google Maps SDK" is still the default.

I used the new "Maps" settings page to change the map SDK to OpenStreetMap, launched a widget and confirmed that I got the OSMdroid map, changed it to Mapbox, launched again and confirmed that I got the Mapbox map, and changed it back to Google and confirmed that I got the Google map.