### PR TITLE
Catch Mapbox exception on 64bit devices

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
@@ -28,7 +28,7 @@ public class MapboxUtils {
         // an access token. Configure this token in collect_app/secrets.properties.
         try {
             mapbox = Mapbox.getInstance(Collect.getInstance(), BuildConfig.MAPBOX_ACCESS_TOKEN);
-        } catch (ExceptionInInitializerError | UnsatisfiedLinkError e) {
+        } catch (Exception e) {
             // Initialization failed (usually because the Mapbox native library for
             // the current architecture could not be found or loaded).
             mapbox = null;

--- a/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
@@ -28,7 +28,7 @@ public class MapboxUtils {
         // an access token. Configure this token in collect_app/secrets.properties.
         try {
             mapbox = Mapbox.getInstance(Collect.getInstance(), BuildConfig.MAPBOX_ACCESS_TOKEN);
-        } catch (ExceptionInInitializerError e) {
+        } catch (ExceptionInInitializerError | UnsatisfiedLinkError e) {
             // Initialization failed (usually because the Mapbox native library for
             // the current architecture could not be found or loaded).
             mapbox = null;


### PR DESCRIPTION
Closes #3144 

#### What has been done to verify that this works as intended?
I tried to choose Mapbox in `General Settings -> User Interface` and confirmed the app is no longer crashing, instead, a toast is displayed which explains the problem.

#### Why is this the best possible solution? Were any other approaches considered?
We would need to get rid of this line https://github.com/opendatakit/collect/blob/master/collect_app/build.gradle#L156
to allow using mapbox on this particular device but it would make the app much heavier so I think it's not acceptable. That;'s why I decided just to catch the exception.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It just catches an exception to avoid crashing. It's not a risky change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)