### PR TITLE
Fix tests failing because of missing directories on device

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.tasks.FormLoaderTask;
+import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
@@ -42,7 +43,7 @@ public class FormLoadingUtils {
     public static final String ALL_WIDGETS_FORM = "all-widgets.xml";
 
     private FormLoadingUtils() {
-        
+
     }
 
     /**
@@ -56,6 +57,14 @@ public class FormLoadingUtils {
             formAssetPath = formAssetPath + File.separator;
         }
 
+        copyForm(formFilename, formAssetPath);
+
+        if (mediaFilenames != null) {
+            copyFormMediaFiles(formFilename, formAssetPath, mediaFilenames);
+        }
+    }
+
+    private static void copyForm(String formFilename, String formAssetPath) throws IOException {
         String pathname = Collect.FORMS_PATH + formFilename;
 
         AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
@@ -65,17 +74,20 @@ public class FormLoadingUtils {
         OutputStream outputStream = new FileOutputStream(outFile);
 
         IOUtils.copy(inputStream, outputStream);
+    }
 
-        if (mediaFilenames != null) {
-            String mediaPathName = Collect.FORMS_PATH + formFilename.replace(".xml", "") + FileUtils.MEDIA_SUFFIX + "/";
+    private static void copyFormMediaFiles(String formFilename, String formAssetPath, List<String> mediaFilenames) throws IOException {
+        String mediaPathName = Collect.FORMS_PATH + formFilename.replace(".xml", "") + FileUtils.MEDIA_SUFFIX + "/";
+        FileUtils.checkMediaPath(new File(mediaPathName));
 
-            for (String mediaFilename: mediaFilenames) {
-                InputStream mediaInputStream = assetManager.open(formAssetPath + mediaFilename);
-                File mediaOutFile = new File(mediaPathName + mediaFilename);
-                OutputStream mediaOutputStream = new FileOutputStream(mediaOutFile);
+        AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
 
-                IOUtils.copy(mediaInputStream, mediaOutputStream);
-            }
+        for (String mediaFilename : mediaFilenames) {
+            InputStream mediaInputStream = assetManager.open(formAssetPath + mediaFilename);
+            File mediaOutFile = new File(mediaPathName + mediaFilename);
+            OutputStream mediaOutputStream = new FileOutputStream(mediaOutFile);
+
+            IOUtils.copy(mediaInputStream, mediaOutputStream);
         }
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
@@ -50,6 +50,8 @@ public class FormLoadingUtils {
      * folder to the SD Card where it will be loaded by {@link FormLoaderTask}.
      */
     public static void copyFormToSdCard(String formFilename, String formAssetPath, List<String> mediaFilenames) throws IOException {
+        Collect.createODKDirs();
+
         if (!formAssetPath.isEmpty() && !formAssetPath.endsWith(File.separator)) {
             formAssetPath = formAssetPath + File.separator;
         }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.IOUtils;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.tasks.FormLoaderTask;
-import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
@@ -40,6 +39,7 @@ import java.util.List;
 import static org.odk.collect.android.activities.FormEntryActivity.EXTRA_TESTING_PATH;
 
 public class FormLoadingUtils {
+
     public static final String ALL_WIDGETS_FORM = "all-widgets.xml";
 
     private FormLoadingUtils() {
@@ -61,33 +61,6 @@ public class FormLoadingUtils {
 
         if (mediaFilenames != null) {
             copyFormMediaFiles(formFilename, formAssetPath, mediaFilenames);
-        }
-    }
-
-    private static void copyForm(String formFilename, String formAssetPath) throws IOException {
-        String pathname = Collect.FORMS_PATH + formFilename;
-
-        AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
-        InputStream inputStream = assetManager.open(formAssetPath + formFilename);
-
-        File outFile = new File(pathname);
-        OutputStream outputStream = new FileOutputStream(outFile);
-
-        IOUtils.copy(inputStream, outputStream);
-    }
-
-    private static void copyFormMediaFiles(String formFilename, String formAssetPath, List<String> mediaFilenames) throws IOException {
-        String mediaPathName = Collect.FORMS_PATH + formFilename.replace(".xml", "") + FileUtils.MEDIA_SUFFIX + "/";
-        FileUtils.checkMediaPath(new File(mediaPathName));
-
-        AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
-
-        for (String mediaFilename : mediaFilenames) {
-            InputStream mediaInputStream = assetManager.open(formAssetPath + mediaFilename);
-            File mediaOutFile = new File(mediaPathName + mediaFilename);
-            OutputStream mediaOutputStream = new FileOutputStream(mediaOutFile);
-
-            IOUtils.copy(mediaInputStream, mediaOutputStream);
         }
     }
 
@@ -123,5 +96,32 @@ public class FormLoadingUtils {
                 super.afterActivityLaunched();
             }
         };
+    }
+
+    private static void copyForm(String formFilename, String formAssetPath) throws IOException {
+        String pathname = Collect.FORMS_PATH + formFilename;
+
+        AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
+        InputStream inputStream = assetManager.open(formAssetPath + formFilename);
+
+        File outFile = new File(pathname);
+        OutputStream outputStream = new FileOutputStream(outFile);
+
+        IOUtils.copy(inputStream, outputStream);
+    }
+
+    private static void copyFormMediaFiles(String formFilename, String formAssetPath, List<String> mediaFilenames) throws IOException {
+        String mediaPathName = Collect.FORMS_PATH + formFilename.replace(".xml", "") + FileUtils.MEDIA_SUFFIX + "/";
+        FileUtils.checkMediaPath(new File(mediaPathName));
+
+        AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
+
+        for (String mediaFilename : mediaFilenames) {
+            InputStream mediaInputStream = assetManager.open(formAssetPath + mediaFilename);
+            File mediaOutFile = new File(mediaPathName + mediaFilename);
+            OutputStream mediaOutputStream = new FileOutputStream(mediaOutFile);
+
+            IOUtils.copy(mediaInputStream, mediaOutputStream);
+        }
     }
 }


### PR DESCRIPTION
Another step towards solving #3119 hopefully. 

This adds code to create standard ODK and form media directories when copying forms onto a device before running an Espresso test. This stops us running into problems if the form copying occurs before something in the app creates this directories.

Interestingly we were getting around this locally as the **second** time a test that failed because of this was run it would often pass due to the directories appearing during the app launch. My theory is that usually on launch either the `InstanceProvider` or `FormProvider` would be the first thing to create the ODK directories (using `Collect.createODKDirs()`). On the first test run it's possible that these run **before** the tests grant storage permissions (ContentProvider creation is basically the only thing that happens before `Application.onCreate`) meaning they would skip directory creation causing form copying to fail. The second time the test runs the ContentProviders would now have storage permissions and so would create the directories before form copying causing everything to work. But yeah, it's just a theory. 

#### What has been done to verify that this works as intended?

Tests failing on CI and locally because of missing directories are now passing locally.

#### Why is this the best possible solution? Were any other approaches considered?

A couple of alternatives:

1. Rework tests to defer form copying until the app has created directories
1. Add directory creation to our Application's `onCreate`

The first seems very tricky due to all the horrible lifecycle involved - you want the files there before the Activity launches but you also need the Activity to have launched to create the directories. The second only really makes sense for test as the app generally creates directories when it needs to **after** asking the user for permission.

It seemed like doing directory creation using the app's own code when copying forms was the way to go for the moment.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)