### PR TITLE
Use RecyclerViewActions to fix test not scrolling to correct item

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -343,6 +343,7 @@ dependencies {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
     androidTestImplementation("androidx.test.espresso:espresso-intents:3.2.0-alpha03") {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.google.code.findbugs', module: 'jsr305'

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -23,19 +23,21 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.GrantPermissionRule;
 
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GuidanceHint;
+import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import java.io.File;
@@ -47,9 +49,7 @@ import java.util.UUID;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.longClick;
-import static androidx.test.espresso.action.ViewActions.repeatedlyUntil;
 import static androidx.test.espresso.action.ViewActions.replaceText;
-import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.assertion.PositionAssertions.isCompletelyAbove;
 import static androidx.test.espresso.assertion.PositionAssertions.isCompletelyBelow;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
@@ -72,21 +72,18 @@ import static org.odk.collect.android.test.CustomMatchers.withIndex;
 
 public class FieldListUpdateTest {
     private static final String FIELD_LIST_TEST_FORM = "fieldlist-updates.xml";
-    private static final int MAX_HIERARCHY_SWIPE_ATTEMPTS = 10;
 
     @Rule
     public IntentsTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(FIELD_LIST_TEST_FORM);
 
     @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
-            Manifest.permission.READ_EXTERNAL_STORAGE,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE,
-            Manifest.permission.CAMERA);
-
-    @BeforeClass
-    public static void copyFormToSdCard() throws IOException {
-        FormLoadingUtils.copyFormToSdCard(FIELD_LIST_TEST_FORM);
-    }
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.CAMERA)
+            )
+            .around(new CopyFormRule(FIELD_LIST_TEST_FORM));
 
     @Test
     public void relevanceChangeAtEnd_ShouldToggleLastWidgetVisibility() {
@@ -181,24 +178,25 @@ public class FieldListUpdateTest {
         onView(withText("Please don't use your calculator, !")).check(matches(isDisplayed()));
     }
 
-    /** TODO: calculation doesn't seem to be updated whether or not there's a fieldlist.
-    @Test
-    public void changeInValueUsedInOtherField_ShouldChangeValue() {
-        onView(withId(R.id.menu_goto)).perform(click());
-        onView(withId(R.id.menu_go_up)).perform(click());
-        onView(allOf(withText("Value change"), isDisplayed())).perform(click());
-        onView(withText(startsWith("What is your"))).perform(click());
-
-        String name = UUID.randomUUID().toString();
-
-        onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
-        onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
-        onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(name));
-        onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText(name.length())));
-        onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
-        onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
-    }
-    **/
+    /**
+     * TODO: calculation doesn't seem to be updated whether or not there's a fieldlist.
+     *
+     * @Test public void changeInValueUsedInOtherField_ShouldChangeValue() {
+     * onView(withId(R.id.menu_goto)).perform(click());
+     * onView(withId(R.id.menu_go_up)).perform(click());
+     * onView(allOf(withText("Value change"), isDisplayed())).perform(click());
+     * onView(withText(startsWith("What is your"))).perform(click());
+     * <p>
+     * String name = UUID.randomUUID().toString();
+     * <p>
+     * onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
+     * onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
+     * onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(name));
+     * onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText(name.length())));
+     * onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
+     * onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
+     * }
+     **/
 
     @Test
     public void selectionChangeAtFirstCascadeLevel_ShouldUpdateNextLevels() {
@@ -354,7 +352,7 @@ public class FieldListUpdateTest {
     }
 
     @Test
-    public void selectingARating_ShouldChangeRelevanceOfRelatedField() {
+    public void selectingARating_ShouldChangeRelevanceOfRelatedField() throws Exception {
         jumpToGroupWithText("Rating");
         onView(withText(startsWith("Source13"))).perform(click());
 
@@ -385,8 +383,8 @@ public class FieldListUpdateTest {
     private void jumpToGroupWithText(String text) {
         onView(withId(R.id.menu_goto)).perform(click());
         onView(withId(R.id.menu_go_up)).perform(click());
-        onView(withId(R.id.list)).perform(repeatedlyUntil(swipeUp(),
-                hasDescendant(allOf(isDisplayed(), withText(text))), MAX_HIERARCHY_SWIPE_ATTEMPTS));
+        onView(withId(R.id.list)).perform(RecyclerViewActions.scrollTo(hasDescendant(withText(text))));
+
         onView(allOf(isDisplayed(), withText(text))).perform(click());
     }
 }


### PR DESCRIPTION
More work towards #3119. Fixes `selectionChangeAtOneCascadeLevelWithMinimalAppearance_ShouldUpdateNextLevels`.

Using `RecyclerViewActions` should help with any test like this that needs to scroll to a specific item. The problem that often occurs (and was happening here) is that a view can be "displayed" to Espresso before it's "clickable" to Espresso.

#### What has been done to verify that this works as intended?

Ran tests locally and using Firebase Test Lab to check the test in question was now passing (correctly).

#### Why is this the best possible solution? Were any other approaches considered?

We could also do an additional swipe up to make sure the item we're looking for is on screen but I think using the tools Google gives us (as much as they're great at hiding them) is the right way to go here.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)