### PR TITLE
Increase margin used by RatingWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RatingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RatingWidget.java
@@ -63,7 +63,10 @@ public class RatingWidget extends QuestionWidget {
         gridLayout.setColumnCount(columns);
         gridLayout.setRowCount(rows);
 
-        for (int column = 0, starId = 0; starId < numberOfStars; column++, starId++) {
+        for (int column = 0,
+             starId = 0;
+             starId < numberOfStars;
+             column++, starId++) {
             column = column == columns ? 0 : column;
 
             ImageButton imageButton = createImageButton(context, numberOfStars, starId);


### PR DESCRIPTION
And another step towards #3119 by fixing `selectingARating_ShouldChangeRelevanceOfRelatedField`. This just increases margin (from 20 to 40) that the `RatingWidget` uses to calculate the number of stars it can fit in a row. It looked like (from using the Layout Inspector) that there were two ancestors views with 10dp margins - not just one as the widget was assuming.

#### What has been done to verify that this works as intended?

Checked test locally and on Firebase Test Lab.

#### Why is this the best possible solution? Were any other approaches considered?

This is definitely not the best way to do this. Right know the widget uses the total screen width to calculate the amount of space it has when calculating columns and rows for the stars. It should probably be doing this using it's own width. This would require a rework of the code so that rendering occurred later in the view lifecycle though as the view dimension aren't available at construction.

I think we should go with this for the moment however to get CI green again and I can look at a change next.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I did do a refactor of the rating widget so there is always a risk that introduced something. It does seem like it gets hit by a few different Espresso tests though.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)