### PR TITLE
Use positive button ID to click on date picker rather than text

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -346,7 +346,7 @@ public class FieldListUpdateTest {
         onView(withText("Target12")).check(doesNotExist());
 
         onView(withText(R.string.select_date)).perform(click());
-        onView(withText(R.string.ok)).perform(click());
+        onView(withId(android.R.id.button1)).perform(click());
 
         onView(withText("Target12")).check(matches(isDisplayed()));
     }


### PR DESCRIPTION
Should close #3119. This should prevent issues where the text changes based on API level - "Ok" rather than "OK" for example. 

#### What has been done to verify that this works as intended?

Ran test on CI and locally.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)