### PR TITLE
Catch Mapbox error on 64bit devices

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MapboxUtils.java
@@ -28,7 +28,7 @@ public class MapboxUtils {
         // an access token. Configure this token in collect_app/secrets.properties.
         try {
             mapbox = Mapbox.getInstance(Collect.getInstance(), BuildConfig.MAPBOX_ACCESS_TOKEN);
-        } catch (Exception e) {
+        } catch (Exception | Error e) {
             // Initialization failed (usually because the Mapbox native library for
             // the current architecture could not be found or loaded).
             mapbox = null;


### PR DESCRIPTION
Closes #3144 

#### What has been done to verify that this works as intended?
I tested the case described in the issue and confirmed that the app is no longer crashing.

#### Why is this the best possible solution? Were any other approaches considered?
I've just realized that my solution in https://github.com/opendatakit/collect/pull/3146/commits has been changed and now it catches exceptions but both `ExceptionInInitializerError` and `UnsatisfiedLinkError` used before extend `Error`, not `Exception` so it won't be caught.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's safe and can't affect anything apart from fixing the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)