### PR TITLE
Avoid ArrayIndexOutOfBoundsException in initMapPrefs()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -71,11 +71,7 @@ public class MapsPreferences extends BasePreferenceFragment {
         final ListPreference mapSdk = (ListPreference) findPreference(KEY_MAP_SDK);
         final ListPreference mapBasemap = (ListPreference) findPreference(KEY_MAP_BASEMAP);
 
-        if (mapSdk == null || mapBasemap == null
-                || mapSdk.getEntryValues() == null || mapSdk.getEntries() == null
-                || mapSdk.getEntryValues().length == 0 || mapSdk.getEntries().length == 0
-                || mapBasemap.getEntryValues() == null || mapBasemap.getEntries() == null
-                || mapBasemap.getEntryValues().length == 0 || mapBasemap.getEntries().length == 0) {
+        if (failedLoadingMapPrefs(mapSdk, mapBasemap)) {
             return;
         }
 
@@ -143,5 +139,13 @@ public class MapsPreferences extends BasePreferenceFragment {
             preference.setSummary(((ListPreference) preference).getEntries()[index]);
             return true;
         });
+    }
+
+    private boolean failedLoadingMapPrefs(ListPreference mapSdk, ListPreference mapBasemap) {
+        return mapSdk == null || mapBasemap == null
+                || mapSdk.getEntryValues() == null || mapSdk.getEntries() == null
+                || mapSdk.getEntryValues().length == 0 || mapSdk.getEntries().length == 0
+                || mapBasemap.getEntryValues() == null || mapBasemap.getEntries() == null
+                || mapBasemap.getEntryValues().length == 0 || mapBasemap.getEntries().length == 0;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -71,7 +71,11 @@ public class MapsPreferences extends BasePreferenceFragment {
         final ListPreference mapSdk = (ListPreference) findPreference(KEY_MAP_SDK);
         final ListPreference mapBasemap = (ListPreference) findPreference(KEY_MAP_BASEMAP);
 
-        if (mapSdk == null || mapBasemap == null) {
+        if (mapSdk == null || mapBasemap == null
+                || mapSdk.getEntryValues() == null || mapSdk.getEntries() == null
+                || mapSdk.getEntryValues().length == 0 || mapSdk.getEntries().length == 0
+                || mapBasemap.getEntryValues() == null || mapBasemap.getEntries() == null
+                || mapBasemap.getEntryValues().length == 0 || mapBasemap.getEntries().length == 0) {
             return;
         }
 


### PR DESCRIPTION
Closes #3157 

#### What has been done to verify that this works as intended?
I wasn't able to reproduce the issue so not much.

#### Why is this the best possible solution? Were any other approaches considered?
Seems like an android bug that sometimes the list of preferences is empty. Everything we can do is adding more checks as I did.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I doubt we can reproduce the issue but we can try. If it's not possible checking just for regression would be enough. It's not a risky change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)