### PR TITLE
Convert simple progress dialog to dialog fragment in GoogleSheetsUploaderActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/GoogleSheetsUploaderProgressDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/GoogleSheetsUploaderProgressDialog.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.odk.collect.android.fragments.dialogs;
+
+import android.app.Dialog;
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
+
+import org.odk.collect.android.R;
+
+import timber.log.Timber;
+
+public class GoogleSheetsUploaderProgressDialog extends DialogFragment {
+    public static final String GOOGLE_SHEETS_UPLOADER_PROGRESS_DIALOG_TAG = "googleSheetsUploaderProgressDialogTag";
+    private static final String MESSAGE = "message";
+
+    private OnSendingFormsCanceledListener onSendingFormsCanceled;
+
+    public interface OnSendingFormsCanceledListener {
+        void onSendingFormsCanceled();
+    }
+
+    private ProgressDialog dialog;
+
+    public static GoogleSheetsUploaderProgressDialog newInstance(String message) {
+        Bundle bundle = new Bundle();
+        bundle.putString(MESSAGE, message);
+
+        GoogleSheetsUploaderProgressDialog dialogFragment = new GoogleSheetsUploaderProgressDialog();
+        dialogFragment.setArguments(bundle);
+        return dialogFragment;
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        try {
+            onSendingFormsCanceled = (OnSendingFormsCanceledListener) getActivity();
+        } catch (ClassCastException e) {
+            Timber.w(e);
+        }
+    }
+
+    /*
+    We keep this just in case to avoid problems if someone tries to show a dialog after
+    the activity’s state have been saved. Basically it shouldn't take place since we should control
+    the activity state if we want to show a dialog (especially after long tasks).
+     */
+    @Override
+    public void show(@NonNull FragmentManager manager, String tag) {
+        try {
+            manager
+                    .beginTransaction()
+                    .add(this, tag)
+                    .commit();
+        } catch (IllegalStateException e) {
+            Timber.w(e);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreateDialog(savedInstanceState);
+
+        setRetainInstance(true);
+        setCancelable(false);
+
+        dialog = new ProgressDialog(getActivity(), getTheme());
+        dialog.setTitle(getString(R.string.uploading_data));
+        dialog.setMessage(getString(R.string.please_wait));
+        dialog.setCancelable(false);
+        dialog.setIndeterminate(true);
+        dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        dialog.setButton(getString(R.string.cancel), (dialog1, which) -> onSendingFormsCanceled.onSendingFormsCanceled());
+        return dialog;
+    }
+
+    @Override
+    public void onDestroyView() {
+        Dialog dialog = getDialog();
+        if (dialog != null && getRetainInstance()) {
+            dialog.setDismissMessage(null);
+        }
+        super.onDestroyView();
+    }
+
+    public void setMessage(String alertMsg) {
+        dialog.setMessage(alertMsg);
+    }
+}


### PR DESCRIPTION
Closes #3145 

#### What has been done to verify that this works as intended?
I wasn't able to reproduce the issue so I just tested the new implementation of the dialog in order to confirm that it works as before.

#### Why is this the best possible solution? Were any other approaches considered?
I refactored the progress dialog displayed during sending forms to Google Sheets, now it uses `DialogFragment` and dismissing it is safe.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The progress dialog displayed during sending forms to Google Sheets has been refactored so it should be tested to confirm that it works with no regression. No difference should be visible and the pr is not related to anything else. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)