### PR TITLE
Use CopyFormRule chained with GrantPermissionRule in all Espresso tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
@@ -1,23 +1,25 @@
 package org.odk.collect.android;
 
-import androidx.test.rule.ActivityTestRule;
+import android.Manifest;
 import android.text.TextUtils;
 
-import org.javarosa.form.api.FormEntryPrompt;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
 
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GuidanceHint;
-import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.test.FormLoadingUtils;
-
-import java.io.IOException;
 
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
@@ -34,19 +36,21 @@ import static org.hamcrest.CoreMatchers.not;
 public class GuidanceHintFormTest {
     private static final String GUIDANCE_SAMPLE_FORM = "guidance_hint_form.xml";
 
-    @Rule
-    public ActivityTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(GUIDANCE_SAMPLE_FORM);
-
-    //region Test prep.
-    @BeforeClass
-    public static void copyFormToSdCard() throws IOException {
-        FormLoadingUtils.copyFormToSdCard(GUIDANCE_SAMPLE_FORM);
-    }
-
     @BeforeClass
     public static void beforeAll() {
         Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
     }
+
+    @Rule
+    public ActivityTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(GUIDANCE_SAMPLE_FORM);
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ))
+            .around(new CopyFormRule(GUIDANCE_SAMPLE_FORM));
 
     @Before
     public void resetPreferences() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/IntentGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/IntentGroupTest.java
@@ -21,18 +21,18 @@ import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Intent;
 
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
-import org.odk.collect.android.test.FormLoadingUtils;
-
-import java.io.IOException;
-import java.util.Random;
-
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.test.FormLoadingUtils;
+
+import java.util.Random;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -55,12 +55,12 @@ public class IntentGroupTest {
     public ActivityTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(INTENT_GROUP_FORM);
 
     @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-    @BeforeClass
-    public static void copyFormToSdCard() throws IOException {
-        FormLoadingUtils.copyFormToSdCard(INTENT_GROUP_FORM);
-    }
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ))
+            .around(new CopyFormRule(INTENT_GROUP_FORM));
 
     // Verifies that a value given to the label text with form buttonText is used as the button text.
     @Test


### PR DESCRIPTION
This should prevent any "permission denied" error when running Espresso tests due to the `@BeforeClass` running before the permission rule.

#### What has been done to verify that this works as intended?

Ran tests locally.

#### Why is this the best possible solution? Were any other approaches considered?

We could actually use the new `@Rule` ordering in JUnit but this would mean upgrading. Probably a  switch in the future but I think the `RuleChain` is a pretty solution for now.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)