### PR TITLE
Add support for raster and vector .mbtiles files (Mapbox only)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/map/MbtilesFile.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/MbtilesFile.java
@@ -1,0 +1,131 @@
+package org.odk.collect.android.map;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+public class MbtilesFile implements Closeable, TileHttpServer.TileSource {
+    public enum Type { RASTER, VECTOR }
+
+    protected File file;
+    protected SQLiteDatabase db;
+    protected String format;
+    protected Type type;
+    protected String contentType = "application/octet-stream";
+    protected String contentEncoding = "identity";
+
+    public MbtilesFile(File file) throws SQLiteException, UnsupportedFormatException {
+        this.file = file;
+        db = SQLiteDatabase.openOrCreateDatabase(file, null);
+        format = getMetadata("format").toLowerCase(Locale.US);
+        if (format.equals("pbf") || format.equals("mvt")) {
+            contentType = "application/protobuf";
+            contentEncoding = "gzip";
+            type = Type.VECTOR;
+        } else if (format.equals("jpg") || format.equals("jpeg")) {
+            contentType = "image/jpeg";
+            type = Type.RASTER;
+        } else if (format.equals("png")) {
+            contentType = "image/png";
+            type = Type.RASTER;
+        } else {
+            db.close();
+            throw new UnsupportedFormatException(file, format);
+        }
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void close() {
+        db.close();
+    }
+
+    public @NonNull String getMetadata(String key) {
+        try (Cursor results = db.query("metadata", new String[] {"value"},
+            "name = ?", new String[] {key}, null, null, null, null)) {
+            return results.moveToFirst() ? results.getString(0) : "";
+        }
+    }
+
+    public TileHttpServer.Response getTile(int zoom, int x, int y) {
+        // TMS coordinates are used in .mbtiles files, so Y needs to be flipped.
+        byte[] data = getTileBlob(zoom, x, (1 << zoom) - 1 - y);
+        return data == null ? null :
+            new TileHttpServer.Response(data, contentType, contentEncoding);
+    }
+
+    // PMD complains about returning null for an array return type, but we
+    // really do want to return null when there is no tile available.
+    @SuppressWarnings("PMD.ReturnEmptyArrayRatherThanNull")
+    public byte[] getTileBlob(int zoom, int column, int row) {
+        String selection = String.format(
+            Locale.US,
+            "zoom_level = %d and tile_column = %d and tile_row = %d",
+            zoom, column, row
+        );
+
+        try (Cursor results = db.query("tiles", new String[] {"tile_data"},
+            selection, null, null, null, null)) {
+            if (results.moveToFirst()) {
+                try {
+                    return results.getBlob(0);
+                } catch (IllegalStateException e) {
+                    Timber.w(e, "Could not select tile data at zoom %d, column %d, row %d", zoom, column, row);
+                    // In Android, the SQLite cursor can handle at most 2 MB in one row;
+                    // exceeding 2 MB in an .mbtiles file is rare, but it can happen.
+                    // When an attempt to fetch a large row fails, the database ends up
+                    // in an unusable state, so we need to close it and reopen it.
+                    // See https://stackoverflow.com/questions/20094421/cursor-window-window-is-full
+                    db.close();
+                    db = SQLiteDatabase.openOrCreateDatabase(file, null);
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Returns information about the vector layers available in the tiles. */
+    public List<VectorLayer> getVectorLayers() {
+        List<VectorLayer> layers = new ArrayList<>();
+        JSONArray jsonLayers;
+        try {
+            JSONObject json = new JSONObject(getMetadata("json"));
+            jsonLayers = json.getJSONArray("vector_layers");
+            for (int i = 0; i < jsonLayers.length(); i++) {
+                layers.add(new VectorLayer(jsonLayers.getJSONObject(i)));
+            }
+        } catch (JSONException e) { /* ignore */ }
+        return layers;
+    }
+
+    /** Vector layer metadata.  See https://github.com/mapbox/mbtiles-spec for details. */
+    public static class VectorLayer {
+        public final String name;
+
+        public VectorLayer(JSONObject json) {
+            name = json.optString("id", "");
+        }
+    }
+
+    public class UnsupportedFormatException extends IOException {
+        public UnsupportedFormatException(File file, String format) {
+            super(String.format("Unrecognized .mbtiles format \"%s\" in %s", format, file));
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/map/TileHttpServer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/TileHttpServer.java
@@ -1,0 +1,191 @@
+package org.odk.collect.android.map;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.BindException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import timber.log.Timber;
+
+/** A minimal HTTP server that serves tiles from a set of TileSources. */
+public class TileHttpServer {
+    public static final int PORT_MIN = 8000;
+    public static final int PORT_MAX = 8999;
+
+    final Map<String, TileSource> sources = new HashMap<>();
+    final ServerThread server;
+    final ServerSocket socket;
+
+    public TileHttpServer() throws IOException {
+        socket = createBoundSocket(PORT_MIN, PORT_MAX);
+        if (socket == null) {
+            throw new IOException("Could not find an available port");
+        }
+        server = new ServerThread(socket);
+    }
+
+    public void start() {
+        server.start();
+    }
+
+    /** Finds an available port and binds a ServerSocket to it. */
+    protected static ServerSocket createBoundSocket(int portMin, int portMax) throws IOException {
+        for (int port = portMin; port <= portMax; port++) {
+            try {
+                return new ServerSocket(port);
+            } catch (BindException e) {
+                continue;  // this port is in use; try another one
+            }
+        }
+        Timber.e("No ports available from %d to %d", portMin, portMax);
+        return null;
+    }
+
+    public String getUrlTemplate(String key) {
+        return String.format(
+            Locale.US, "http://localhost:%d/%s/{z}/{x}/{y}", socket.getLocalPort(), key);
+    }
+
+    /**
+     * Adds a TileSource with a given key.  Tiles from this source will be served
+     * under the URL path /{key}/{zoom}/{x}/{y}.  If this TileSource implements
+     * Closeable, it will be closed when this server is finalized with destroy().
+     */
+    public void addSource(String key, TileSource source) {
+        sources.put(key, source);
+    }
+
+    /** Permanently closes all sockets and closeable TileSources. */
+    public void destroy() {
+        try {
+            socket.close();
+        } catch (IOException e) { /* ignore */ }
+        server.interrupt();
+        for (TileSource source : sources.values()) {
+            if (source instanceof Closeable) {
+                try {
+                    ((Closeable) source).close();
+                } catch (IOException e) { /* ignore */ }
+            }
+        }
+    }
+
+    class ServerThread extends Thread {
+        final ServerSocket socket;
+
+        ServerThread(ServerSocket socket) {
+            this.socket = socket;
+        }
+
+        public void run() {
+            try {
+                socket.setReuseAddress(true);
+                Timber.i("Ready for requests on port %d", socket.getLocalPort());
+                while (!isInterrupted()) {
+                    Socket connection = socket.accept();
+                    Timber.i("Accepted a client connection");
+                    new ResponseThread(connection).start();
+                }
+                Timber.i("Server thread interrupted");
+            } catch (IOException e) {
+                Timber.i("Server thread stopped: %s", e.getMessage());
+            }
+        }
+    }
+
+    class ResponseThread extends Thread {
+        final Socket connection;
+
+        ResponseThread(Socket connection) {
+            this.connection = connection;
+        }
+
+        public void run() {
+            try (Socket connection = this.connection) {
+                InputStreamReader reader = new InputStreamReader(connection.getInputStream());
+                String request = new BufferedReader(reader).readLine();
+                Timber.i("Received request: %s", request);
+                if (request == null) {
+                    return;
+                }
+                long start = System.currentTimeMillis();
+                Response response = getResponse(request);
+                if (response == null) {
+                    Timber.i("%s: No tile at these coordinates", request);
+                    return;
+                }
+                sendResponse(connection, response);
+                long finish = System.currentTimeMillis();
+                Timber.i("%s: Served %d bytes in %d ms", request, response.data.length, finish - start);
+            } catch (IOException e) {
+                Timber.e(e, "Unable to read request from socket");
+            }
+        }
+
+        protected Response getResponse(String request) {
+            if (request.startsWith("GET /")) {
+                String path = request.substring(5).split("[. ]", 2)[0];
+                String[] parts = path.split("/");
+                if (parts.length == 4) {
+                    try {
+                        String key = parts[0];
+                        int zoom = Integer.parseInt(parts[1]);
+                        int x = Integer.parseInt(parts[2]);
+                        int y = Integer.parseInt(parts[3]);
+                        TileSource source = sources.get(key);
+                        if (source != null) {
+                            return source.getTile(zoom, x, y);
+                        }
+                    } catch (NumberFormatException e) { /* ignore */ }
+                }
+            }
+            Timber.w("Ignoring request: %s", request);
+            return null;
+        }
+
+        protected void sendResponse(Socket connection, Response response) {
+            String headers = String.format(
+                Locale.US,
+                "HTTP/1.0 200\r\n" +
+                    "Content-Type: %s\r\n" +
+                    "Content-Encoding: %s\r\n" +
+                    "Content-Length: %d\r\n" +
+                    "\r\n",
+                response.contentType,
+                response.contentEncoding,
+                response.data.length
+            );
+
+            try (OutputStream output = connection.getOutputStream()) {
+                output.write(headers.getBytes());
+                output.write(response.data);
+                output.flush();
+            } catch (IOException e) {
+                Timber.e(e, "Unable to write response to socket");
+            }
+        }
+    }
+
+    public static class Response {
+        byte[] data;
+        String contentType;
+        String contentEncoding;
+
+        public Response(byte[] data, String contentType, String contentEncoding) {
+            this.data = data;
+            this.contentType = contentType;
+            this.contentEncoding = contentEncoding;
+        }
+    }
+
+    public interface TileSource {
+        Response getTile(int zoom, int x, int y);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/map/TileHttpServer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/map/TileHttpServer.java
@@ -48,6 +48,10 @@ public class TileHttpServer {
         return null;
     }
 
+    /**
+     * Constructs a URL template for fetching tiles from this server for a given
+     * tileset, with placeholders {z} for zoom level and {x} and {y} for coordinates.
+     */
     public String getUrlTemplate(String key) {
         return String.format(
             Locale.US, "http://localhost:%d/%s/{z}/{x}/{y}", socket.getLocalPort(), key);


### PR DESCRIPTION
Issues: none
Scope: MapboxMapFragment
Requested reviewers: @lognaturel 

#### User-visible changes

If any `.mbtiles` files are placed in the `/sdcard/odk/layers` directory, they will be rendered on top of the Mapbox base map.  Both raster (jpg or png) and vector (pbf) tiles are supported.  The metadata in the `.mbtiles` file determines the zoom levels at which the additional layers will appear.

This functionality is not yet discoverable anywhere in the UI.  It just happens if an `.mbtiles` file is present in the right directory.

A follow-up PR will add the UI for selecting these layers in the settings.

#### Guidance for reviewers

I recommend reviewing these changes all at once; the second commit adds some comments that make it a little easier to understand the changes.

#### Guidance for testers

You can use these files to test this functionality:

- [satellite.zip](https://github.com/opendatakit/collect/files/3301203/satellite.zip) contains low-resolution raster satellite imagery for the whole world.  When this file is present in `/sdcard/odk/layers` and you zoom out, you should see the satellite imagery.

- [reykjavik.zip](https://github.com/opendatakit/collect/files/3301204/reykjavik.zip) contains vector geometry for the city of Reykjavik, Iceland.  When this file is present in `/sdcard/odk/layers` and you zoom all the way in to Reykjavik, the outlines of buildings and roads should appear in purple.  Note that the outlines will not appear until you have zoomed in quite far on Reykjavik.

#### Verification performed

I added the above two files, started GeoPoint with Mapbox selected, and confirmed that both the satellite imagery and the geometry in Reykjavik were showing.