### PR TITLE
Disable certain FindBugs warnings

### DIFF
--- a/config/findbugs-filter.xml
+++ b/config/findbugs-filter.xml
@@ -125,6 +125,9 @@
     <Match>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS" />
     </Match>
+    <Match>
+        <Bug pattern="SBSC_USE_STRINGBUFFER_CONCATENATION" />
+    </Match>
 
     <!-- Dodgy code Warnings -->
     <Match>
@@ -162,5 +165,35 @@
     </Match>
     <Match>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC" />
+    </Match>
+    <Match>
+        <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD" />
+    </Match>
+    <Match>
+        <Bug pattern="INT_BAD_REM_BY_1" />
+    </Match>
+    <Match>
+        <Bug pattern="DB_DUPLICATE_SWITCH_CLAUSES" />
+    </Match>
+    <Match>
+        <Bug pattern="INT_BAD_REM_BY_1" />
+    </Match>
+    <Match>
+        <Bug pattern="NS_NON_SHORT_CIRCUIT" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_COMPARISON_OF_NULL_AND_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_COMPARISON_TWO_NULL_VALUES" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE" />
     </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Issues: Closes #2946.
Scope: FindBugs configuration
Requested reviewers: @lognaturel 

#### User-visible changes

This is a developer-facing change only and has no user-visible effect.

The FindBugs warnings disabled in this PR are:
  - The warnings listed in #2946 
  - All the `RCN_REDUNDANT...` warnings, for the same reason as `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` given in #2946 
  - `URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD` and `UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD`.  Rationale: having unused fields shouldn't break the build, as it prevents partial or future-facing work where one might be setting up structures with fields to be used later.
