### PR TITLE
Don't use null hashes since it causes IllegalArgumentException

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -234,7 +234,10 @@ public class FormDownloader {
             Timber.w("The user cancelled (or an exception happened) the download of a form at the "
                     + "very beginning.");
         } else {
-            formsDao.deleteFormsFromMd5Hash(FileUtils.getMd5Hash(fileResult.file));
+            String md5Hash = FileUtils.getMd5Hash(fileResult.file);
+            if (md5Hash != null) {
+                formsDao.deleteFormsFromMd5Hash(md5Hash);
+            }
             FileUtils.deleteAndReport(fileResult.getFile());
         }
 


### PR DESCRIPTION
Closes #3168 

#### What has been done to verify that this works as intended?
Nothing since I can't reproduce the issue and it's a simple change.

#### Why is this the best possible solution? Were any other approaches considered?
[getMd5Hash()](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java#L96) method sometimes might return null which we can't use as a selection argument., so we need that null check to avoid IllegalArgumentException.

We pass a list of hashes https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3168?expand=1#diff-637786720eef6db92a42ca3287fc68caL196

some of them might be null: 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a null check so it doesn't require testing. It would be even difficult to reproduce since the exception is not common.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)