### PR TITLE
Avoid attempt to get length of null array

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -81,7 +81,7 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
             File instancesPath = new File(Collect.INSTANCES_PATH);
             if (instancesPath.exists() && instancesPath.isDirectory()) {
                 File[] instanceFolders = instancesPath.listFiles();
-                if (instanceFolders.length == 0) {
+                if (instanceFolders == null || instanceFolders.length == 0) {
                     Timber.i("[%d] Empty instance folder. Stopping scan process.", instance);
                     Timber.d(Collect.getInstance().getString(R.string.instance_scan_completed));
                     return currentStatus;


### PR DESCRIPTION
Closes #3170 

#### What has been done to verify that this works as intended?
Nothing, it's just a safe null check.

#### Why is this the best possible solution? Were any other approaches considered?
File.listFiles() method sometimes returns null, we had similar problems in other classes as well. All we can do is checking for nulls and that's what I did.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
it's just a safe null check so it doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)