### PR TITLE
DownloadFormListUtils refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Always use [string resources](https://developer.android.com/guide/topics/resourc
 
 As much as possible to facilitate simpler, more modular and more testable components you should follow the Dependency Inversion principle in Collect Code. An example tutorial on this concept can be found [here](https://www.seadowg.com/dip-lesson/).
 
-Because many Android components (Activity and Fragment for instance) don't allow us control over their constructors Collect uses [Dagger](https://google.github.io/dagger/) to 'inject' dependencies. The configuration for Dagger can be found in [AppDepdendencyComponent](collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java).
+Because many Android components (Activity and Fragment for instance) don't allow us control over their constructors Collect uses [Dagger](https://google.github.io/dagger/) to 'inject' dependencies. The configuration for Dagger can be found in [AppDepdendencyComponent](collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java). For any normal objects it is probably best to avoid Dagger and use normal Java constructors.
 
 While it's important to read the Dagger [documentation](https://google.github.io/dagger/users-guide) we've provided some basic instructions on how to use Dagger within Collect below.
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/DownloadFormListTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/DownloadFormListTaskTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.tasks;
 
 import org.junit.Test;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.test.MockedServerTest;
 
@@ -21,7 +22,9 @@ public class DownloadFormListTaskTest extends MockedServerTest {
         willRespondWith(RESPONSE);
 
         // when
-        final Map<String, FormDetails> fetched = new DownloadFormListTask().doInBackground();
+        Collect application = Collect.getInstance();
+        DownloadFormListTask task = new DownloadFormListTask(application.getComponent().downloadFormListUtils());
+        final Map<String, FormDetails> fetched = task.doInBackground();
 
         // then
         RecordedRequest r = nextRequest();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadList.java
@@ -16,7 +16,6 @@ package org.odk.collect.android.activities;
 
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -26,14 +25,16 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.SparseBooleanArray;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.ListView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.FormDownloadListViewModel;
@@ -51,6 +52,7 @@ import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.DownloadFormListUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
@@ -119,6 +121,9 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
 
     @Inject
     WebCredentialsUtils webCredentialsUtils;
+
+    @Inject
+    DownloadFormListUtils downloadFormListUtils;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -319,7 +324,7 @@ public class FormDownloadList extends FormListActivity implements FormListDownlo
                 downloadFormListTask = null;
             }
 
-            downloadFormListTask = new DownloadFormListTask();
+            downloadFormListTask = new DownloadFormListTask(downloadFormListUtils);
             downloadFormListTask.setDownloaderListener(this);
 
             if (viewModel.isDownloadOnlyMode()) {

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -17,6 +17,7 @@ import org.odk.collect.android.http.OpenRosaHttpInterface;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.ServerPreferencesFragment;
 import org.odk.collect.android.tasks.InstanceServerUploaderTask;
+import org.odk.collect.android.tasks.ServerPollingJob;
 import org.odk.collect.android.tasks.sms.SmsNotificationReceiver;
 import org.odk.collect.android.tasks.sms.SmsSender;
 import org.odk.collect.android.tasks.sms.SmsSentBroadcastReceiver;
@@ -93,7 +94,7 @@ public interface AppDependencyComponent {
 
     void inject(FormDownloader formDownloader);
 
-    void inject(DownloadFormListUtils downloadFormListUtils);
+    void inject(ServerPollingJob serverPollingJob);
 
     void inject(AuthDialogUtility authDialogUtility);
 
@@ -112,4 +113,6 @@ public interface AppDependencyComponent {
     RxEventBus rxEventBus();
 
     OpenRosaHttpInterface openRosaHttpInterface();
+
+    DownloadFormListUtils downloadFormListUtils();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -17,6 +17,7 @@ import org.odk.collect.android.http.OkHttpConnection;
 import org.odk.collect.android.http.OpenRosaHttpInterface;
 import org.odk.collect.android.tasks.sms.SmsSubmissionManager;
 import org.odk.collect.android.tasks.sms.contracts.SmsSubmissionManagerContract;
+import org.odk.collect.android.utilities.DownloadFormListUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
@@ -81,6 +82,20 @@ public class AppDependencyModule {
     @Provides
     WebCredentialsUtils provideWebCredentials() {
         return new WebCredentialsUtils();
+    }
+
+    @Provides
+    DownloadFormListUtils provideDownloadFormListUtils(
+            Application application,
+            CollectServerClient collectServerClient,
+            WebCredentialsUtils webCredentialsUtils,
+            FormsDao formsDao) {
+        return new DownloadFormListUtils(
+                application,
+                collectServerClient,
+                webCredentialsUtils,
+                formsDao
+        );
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -33,14 +33,20 @@ import java.util.HashMap;
  */
 public class DownloadFormListTask extends AsyncTask<Void, String, HashMap<String, FormDetails>> {
 
+    private final DownloadFormListUtils downloadFormListUtils;
+
     private FormListDownloaderListener stateListener;
     private String url;
     private String username;
     private String password;
 
+    public DownloadFormListTask(DownloadFormListUtils downloadFormListUtils) {
+        this.downloadFormListUtils = downloadFormListUtils;
+    }
+
     @Override
     protected HashMap<String, FormDetails> doInBackground(Void... values) {
-        return new DownloadFormListUtils().downloadFormList(url, username, password, false);
+        return downloadFormListUtils.downloadFormList(url, username, password, false);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/ServerPollingJob.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/ServerPollingJob.java
@@ -45,6 +45,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import static org.odk.collect.android.activities.FormDownloadList.DISPLAY_ONLY_UPDATED_FORMS;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_AUTOMATIC_UPDATE;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.JR_FORM_ID;
@@ -64,6 +66,13 @@ public class ServerPollingJob extends Job {
 
     public static final String TAG = "serverPollingJob";
 
+    @Inject
+    DownloadFormListUtils downloadFormListUtils;
+
+    public ServerPollingJob() {
+        Collect.getInstance().getComponent().inject(this);
+    }
+
     @Override
     @NonNull
     protected Result onRunJob(@NonNull Params params) {
@@ -71,12 +80,11 @@ public class ServerPollingJob extends Job {
             return Result.FAILURE;
         }
 
-        DownloadFormListUtils downloadFormListTask = new DownloadFormListUtils();
-        HashMap<String, FormDetails> formList = downloadFormListTask.downloadFormList(true);
+        HashMap<String, FormDetails> formList = downloadFormListUtils.downloadFormList(true);
 
         if (!formList.containsKey(DL_ERROR_MSG)) {
             if (formList.containsKey(DL_AUTH_REQUIRED)) {
-                formList = downloadFormListTask.downloadFormList(true);
+                formList = downloadFormListUtils.downloadFormList(true);
 
                 if (formList.containsKey(DL_AUTH_REQUIRED) || formList.containsKey(DL_ERROR_MSG)) {
                     return Result.FAILURE;

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DownloadFormListUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DownloadFormListUtilsTest.java
@@ -3,11 +3,10 @@ package org.odk.collect.android.utilities;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.http.CollectServerClient;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
-import org.odk.collect.android.injection.config.AppDependencyModule;
-import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -22,20 +21,18 @@ public class DownloadFormListUtilsTest {
     @Before
     public void setup() {
         when(client.getXmlDocument(any())).thenReturn(new DocumentFetchResult("blah", 200));
-
-        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
-            @Override
-            public CollectServerClient provideCollectServerClient(OpenRosaHttpInterface httpInterface, WebCredentialsUtils webCredentialsUtils) {
-                return client;
-            }
-        });
     }
 
     @Test
     public void removesTrailingSlashesFromUrl() {
-        DownloadFormListUtils downloadFormListUtils = new DownloadFormListUtils();
-        downloadFormListUtils.downloadFormList("http://blah.com///", "user", "password", false);
+        DownloadFormListUtils downloadFormListUtils = new DownloadFormListUtils(
+                RuntimeEnvironment.application,
+                client,
+                new WebCredentialsUtils(),
+                new FormsDao()
+        );
 
+        downloadFormListUtils.downloadFormList("http://blah.com///", "user", "password", false);
         verify(client).getXmlDocument("http://blah.com/formList");
     }
 }


### PR DESCRIPTION
This was some cleanup I wanted to do after #3163 and is based on earlier discussions around avoiding Dagger (or any magic DI) in non "black box" classes such as Activity or Fragment (#2769).

#### What has been done to verify that this works as intended?

Tests run locally and a quick play with the app to check form downloading seems normal.

#### Why is this the best possible solution? Were any other approaches considered?

Moving away from Dagger in classes like this stops them from being tied to the application's configuration so tightly and lets us test them in isolation (the changes in the tests are good example of this). It also stops us having to understand Dagger when working with objects like this. While it's very useful for Activity etc it's way simpler to just have a constructor.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It shouldn't as it's just a change to how to the object is constructed.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)