### PR TITLE
Add note to README about Apply Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ When cloning the project from Android Studio, click "No" when prompted to open t
 
 #### Execution failed for task ':collect_app:transformClassesWithInstantRunForDebug'.
 
-We have seen this problem happen in both IntelliJ IDEA and Android Studio, and believe it to be due to a bug in the IDE, which we can't fix.  As a workaround, turning off [Instant Run](https://developer.android.com/studio/run/#set-up-ir) will usually avoid this problem.  We haven't yet found a way to use Instant Run with this project.
+We have seen this problem happen in both IntelliJ IDEA and Android Studio, and believe it to be due to a bug in the IDE, which we can't fix.  As a workaround, turning off [Instant Run](https://developer.android.com/studio/run/#set-up-ir) will usually avoid this problem.  We haven't yet found a way to use Instant Run with this project but this will most likely be fixed in Android Studio 3.5 with the new [Apply Changes](https://medium.com/androiddevelopers/android-studio-project-marble-apply-changes-e3048662e8cd) feature.
 
 #### Moving to the main view if user minimizes the app
 If you build the app on your own using Android Studio `(Build -> Build APK)` and then install it (from an `.apk` file), you might notice this strange behaviour thoroughly described: [#1280](https://github.com/opendatakit/collect/issues/1280) and [#1142](https://github.com/opendatakit/collect/issues/1142).


### PR DESCRIPTION
I did some looking into whether we could enable Instant Run for Collect but ended up punting as I realized that the new Apply Changes feature in Android Studio 3.5 is replacing Instant Run anyway.

#### What has been done to verify that this works as intended?

I setup the project with Android Studio 3.5 to verify Apply Changes worked for Collect.

#### Why is this the best possible solution? Were any other approaches considered?

I think fixing the build so it works with Instant Run would be a waste of time as will most likely have Android Studio 3.5 released pretty soon (it's in beta at the moment). Seemed better just to update the docs and move on!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)