### PR TITLE
Rework home page typography

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -89,8 +89,6 @@ public class MainMenuActivity extends CollectAbstractActivity {
     private Button viewSentFormsButton;
     private Button reviewDataButton;
     private Button getFormsButton;
-    private View reviewSpacer;
-    private View getFormsSpacer;
     private AlertDialog alertDialog;
     private SharedPreferences adminPreferences;
     private int completedCount;
@@ -263,9 +261,6 @@ public class MainMenuActivity extends CollectAbstractActivity {
             }
         }
 
-        reviewSpacer = findViewById(R.id.review_spacer);
-        getFormsSpacer = findViewById(R.id.get_forms_spacer);
-
         adminPreferences = this.getSharedPreferences(
                 AdminPreferencesActivity.ADMIN_PREFERENCES, 0);
 
@@ -334,15 +329,9 @@ public class MainMenuActivity extends CollectAbstractActivity {
             if (reviewDataButton != null) {
                 reviewDataButton.setVisibility(View.GONE);
             }
-            if (reviewSpacer != null) {
-                reviewSpacer.setVisibility(View.GONE);
-            }
         } else {
             if (reviewDataButton != null) {
                 reviewDataButton.setVisibility(View.VISIBLE);
-            }
-            if (reviewSpacer != null) {
-                reviewSpacer.setVisibility(View.VISIBLE);
             }
         }
 
@@ -376,15 +365,9 @@ public class MainMenuActivity extends CollectAbstractActivity {
             if (getFormsButton != null) {
                 getFormsButton.setVisibility(View.GONE);
             }
-            if (getFormsSpacer != null) {
-                getFormsSpacer.setVisibility(View.GONE);
-            }
         } else {
             if (getFormsButton != null) {
                 getFormsButton.setVisibility(View.VISIBLE);
-            }
-            if (getFormsSpacer != null) {
-                getFormsSpacer.setVisibility(View.VISIBLE);
             }
         }
 

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -34,6 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:text="@string/app_name"
+            android:textStyle="bold"
             android:textAlignment="center" />
 
         <TextView

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -30,30 +30,29 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/toolbar"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingTop="@dimen/margin_large">
 
         <TextView
             android:id="@+id/main_menu_header"
             style="@style/TextAppearance.Collect.Headline6"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:paddingTop="6dp"
-            android:paddingBottom="1dp"
+            android:layout_gravity="center"
             android:text="@string/app_name" />
 
         <TextView
             style="@style/TextAppearance.Collect.Subtitle1"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:paddingTop="1dp"
-            android:paddingBottom="10dp"
+            android:layout_gravity="center"
+            android:layout_marginTop="@dimen/margin_medium"
             android:text="@string/main_menu_details" />
 
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/margin_medium"
             android:orientation="vertical">
 
             <LinearLayout

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -33,7 +33,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:text="@string/app_name" />
+            android:text="@string/app_name"
+            android:textAlignment="center" />
 
         <TextView
             style="@style/TextAppearance.Collect.Subtitle1"
@@ -41,7 +42,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginTop="@dimen/margin_medium"
-            android:text="@string/main_menu_details" />
+            android:text="@string/main_menu_details"
+            android:textAlignment="center" />
 
         <ScrollView
             android:layout_width="match_parent"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -53,66 +53,63 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingStart="@dimen/margin_medium"
-                android:paddingEnd="@dimen/margin_medium"
-                android:paddingBottom="@dimen/margin_large">
+                android:padding="@dimen/margin_medium">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:paddingTop="@dimen/margin_medium">
+                    android:orientation="vertical">
 
                     <Button
                         android:id="@+id/enter_data"
+                        style="@style/MainMenuBigButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        style="@style/MainMenuBigButton" />
+                        android:layout_marginTop="@dimen/margin_small" />
 
                     <Button
                         android:id="@+id/review_data"
+                        style="@style/MainMenuBigButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        style="@style/MainMenuBigButton" />
+                        android:layout_marginTop="@dimen/margin_small" />
 
                     <Button
                         android:id="@+id/send_data"
+                        style="@style/MainMenuBigButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        style="@style/MainMenuBigButton" />
+                        android:layout_marginTop="@dimen/margin_small" />
 
                     <Button
                         android:id="@+id/view_sent_forms"
+                        style="@style/MainMenuBigButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:text="@string/view_sent_forms"
-                        style="@style/MainMenuBigButton" />
+                        android:text="@string/view_sent_forms" />
 
                 </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:paddingTop="@dimen/margin_medium">
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:orientation="vertical">
 
                     <Button
                         android:id="@+id/get_forms"
+                        style="@style/MainMenuBigButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        style="@style/MainMenuBigButton" />
+                        android:layout_marginTop="@dimen/margin_small" />
 
                     <Button
                         android:id="@+id/manage_forms"
+                        style="@style/MainMenuBigButton"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        style="@style/MainMenuBigButton" />
+                        android:layout_marginTop="@dimen/margin_small" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -53,10 +53,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingStart="10dp"
-                android:paddingLeft="10dp"
-                android:paddingEnd="10dp"
-                android:paddingRight="10dp">
+                android:padding="@dimen/margin_medium">
 
                 <View
                     android:layout_width="match_parent"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -7,25 +7,24 @@
   OR CONDITIONS OF ANY KIND, either express or implied. See the License for
   the specific language governing permissions and limitations under the License.
 -->
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginBottom="0dp"
     android:layout_marginLeft="0dp"
-    android:layout_marginRight="0dp"
     android:layout_marginTop="0dp"
+    android:layout_marginRight="0dp"
+    android:layout_marginBottom="0dp"
     android:orientation="vertical"
     android:padding="0dp">
 
     <!-- Toolbar -->
-    <include layout="@layout/toolbar"/>
+    <include layout="@layout/toolbar" />
 
     <include
         layout="@layout/toolbar_action_bar_shadow"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar"/>
+        android:layout_below="@id/toolbar" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -35,25 +34,22 @@
 
         <TextView
             android:id="@+id/main_menu_header"
+            style="@style/TextAppearance.Collect.Headline6"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:paddingBottom="1dp"
             android:paddingTop="6dp"
-            android:text="@string/app_name"
-            android:textColor="?primaryTextColor"
-            android:textSize="21sp"
-            android:textStyle="bold"/>
+            android:paddingBottom="1dp"
+            android:text="@string/app_name" />
 
         <TextView
+            style="@style/TextAppearance.Collect.Subtitle1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
-            android:paddingBottom="10dp"
             android:paddingTop="1dp"
-            android:text="@string/main_menu_details"
-            android:textColor="?primaryTextColor"
-            android:textSize="17sp"/>
+            android:paddingBottom="10dp"
+            android:text="@string/main_menu_details" />
 
         <ScrollView
             android:layout_width="match_parent"
@@ -64,14 +60,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingEnd="10dp"
+                android:paddingStart="10dp"
                 android:paddingLeft="10dp"
-                android:paddingRight="10dp"
-                android:paddingStart="10dp">
+                android:paddingEnd="10dp"
+                android:paddingRight="10dp">
 
                 <View
                     android:layout_width="match_parent"
-                    android:layout_height="10dp"/>
+                    android:layout_height="10dp" />
 
                 <Button
                     android:id="@+id/enter_data"
@@ -80,11 +76,11 @@
                     android:padding="20dp"
                     android:textAllCaps="false"
                     android:textSize="21sp"
-                    android:textStyle="normal"/>
+                    android:textStyle="normal" />
 
                 <View
                     android:layout_width="match_parent"
-                    android:layout_height="5dp"/>
+                    android:layout_height="5dp" />
 
                 <Button
                     android:id="@+id/review_data"
@@ -93,12 +89,12 @@
                     android:padding="20dp"
                     android:textAllCaps="false"
                     android:textSize="21sp"
-                    android:textStyle="normal"/>
+                    android:textStyle="normal" />
 
                 <View
                     android:id="@+id/review_spacer"
                     android:layout_width="match_parent"
-                    android:layout_height="5dp"/>
+                    android:layout_height="5dp" />
 
                 <Button
                     android:id="@+id/send_data"
@@ -107,11 +103,11 @@
                     android:padding="20dp"
                     android:textAllCaps="false"
                     android:textSize="21sp"
-                    android:textStyle="normal"/>
+                    android:textStyle="normal" />
 
                 <View
                     android:layout_width="match_parent"
-                    android:layout_height="5dp"/>
+                    android:layout_height="5dp" />
 
                 <Button
                     android:id="@+id/view_sent_forms"
@@ -121,11 +117,11 @@
                     android:text="@string/view_sent_forms"
                     android:textAllCaps="false"
                     android:textSize="21sp"
-                    android:textStyle="normal"/>
+                    android:textStyle="normal" />
 
                 <View
                     android:layout_width="match_parent"
-                    android:layout_height="20dp"/>
+                    android:layout_height="20dp" />
 
                 <Button
                     android:id="@+id/get_forms"
@@ -134,12 +130,12 @@
                     android:padding="20dp"
                     android:textAllCaps="false"
                     android:textSize="21sp"
-                    android:textStyle="normal"/>
+                    android:textStyle="normal" />
 
                 <View
                     android:id="@+id/get_forms_spacer"
                     android:layout_width="match_parent"
-                    android:layout_height="5dp"/>
+                    android:layout_height="5dp" />
 
                 <Button
                     android:id="@+id/manage_forms"
@@ -148,7 +144,7 @@
                     android:padding="20dp"
                     android:textAllCaps="false"
                     android:textSize="21sp"
-                    android:textStyle="normal"/>
+                    android:textStyle="normal" />
             </LinearLayout>
 
         </ScrollView>

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -29,7 +29,7 @@
 
         <TextView
             android:id="@+id/main_menu_header"
-            style="@style/TextAppearance.Collect.Headline6"
+            style="?attr/textAppearanceHeadline6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -37,7 +37,7 @@
             android:textAlignment="center" />
 
         <TextView
-            style="@style/TextAppearance.Collect.Subtitle1"
+            style="?attr/textAppearanceSubtitle1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -48,7 +48,6 @@
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="@dimen/margin_medium"
             android:orientation="vertical">
 
             <LinearLayout

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -9,13 +9,7 @@
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_marginLeft="0dp"
-    android:layout_marginTop="0dp"
-    android:layout_marginRight="0dp"
-    android:layout_marginBottom="0dp"
-    android:orientation="vertical"
-    android:padding="0dp">
+    android:layout_height="match_parent">
 
     <!-- Toolbar -->
     <include layout="@layout/toolbar" />

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -68,41 +68,29 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:padding="20dp"
-                        android:textAllCaps="false"
-                        android:textSize="21sp"
-                        android:textStyle="normal" />
+                        style="@style/MainMenuBigButton" />
 
                     <Button
                         android:id="@+id/review_data"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:padding="20dp"
-                        android:textAllCaps="false"
-                        android:textSize="21sp"
-                        android:textStyle="normal" />
+                        style="@style/MainMenuBigButton" />
 
                     <Button
                         android:id="@+id/send_data"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:padding="20dp"
-                        android:textAllCaps="false"
-                        android:textSize="21sp"
-                        android:textStyle="normal" />
+                        style="@style/MainMenuBigButton" />
 
                     <Button
                         android:id="@+id/view_sent_forms"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:padding="20dp"
                         android:text="@string/view_sent_forms"
-                        android:textAllCaps="false"
-                        android:textSize="21sp"
-                        android:textStyle="normal" />
+                        style="@style/MainMenuBigButton" />
 
                 </LinearLayout>
 
@@ -117,20 +105,14 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:padding="20dp"
-                        android:textAllCaps="false"
-                        android:textSize="21sp"
-                        android:textStyle="normal" />
+                        style="@style/MainMenuBigButton" />
 
                     <Button
                         android:id="@+id/manage_forms"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:padding="20dp"
-                        android:textAllCaps="false"
-                        android:textSize="21sp"
-                        android:textStyle="normal" />
+                        style="@style/MainMenuBigButton" />
                 </LinearLayout>
             </LinearLayout>
 

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -29,7 +29,7 @@
 
         <TextView
             android:id="@+id/main_menu_header"
-            style="?attr/textAppearanceHeadline6"
+            style="@style/TextAppearance.Collect.Headline6"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -37,7 +37,7 @@
             android:textAlignment="center" />
 
         <TextView
-            style="?attr/textAppearanceSubtitle1"
+            style="@style/TextAppearance.Collect.Subtitle1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -53,88 +53,85 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:padding="@dimen/margin_medium">
+                android:paddingStart="@dimen/margin_medium"
+                android:paddingEnd="@dimen/margin_medium"
+                android:paddingBottom="@dimen/margin_large">
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <Button
-                    android:id="@+id/enter_data"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    android:textAllCaps="false"
-                    android:textSize="21sp"
-                    android:textStyle="normal" />
+                    android:orientation="vertical"
+                    android:paddingTop="@dimen/margin_medium">
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="5dp" />
+                    <Button
+                        android:id="@+id/enter_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:padding="20dp"
+                        android:textAllCaps="false"
+                        android:textSize="21sp"
+                        android:textStyle="normal" />
 
-                <Button
-                    android:id="@+id/review_data"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    android:textAllCaps="false"
-                    android:textSize="21sp"
-                    android:textStyle="normal" />
+                    <Button
+                        android:id="@+id/review_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:padding="20dp"
+                        android:textAllCaps="false"
+                        android:textSize="21sp"
+                        android:textStyle="normal" />
 
-                <View
-                    android:id="@+id/review_spacer"
-                    android:layout_width="match_parent"
-                    android:layout_height="5dp" />
+                    <Button
+                        android:id="@+id/send_data"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:padding="20dp"
+                        android:textAllCaps="false"
+                        android:textSize="21sp"
+                        android:textStyle="normal" />
 
-                <Button
-                    android:id="@+id/send_data"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    android:textAllCaps="false"
-                    android:textSize="21sp"
-                    android:textStyle="normal" />
+                    <Button
+                        android:id="@+id/view_sent_forms"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:padding="20dp"
+                        android:text="@string/view_sent_forms"
+                        android:textAllCaps="false"
+                        android:textSize="21sp"
+                        android:textStyle="normal" />
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="5dp" />
+                </LinearLayout>
 
-                <Button
-                    android:id="@+id/view_sent_forms"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    android:text="@string/view_sent_forms"
-                    android:textAllCaps="false"
-                    android:textSize="21sp"
-                    android:textStyle="normal" />
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="20dp" />
-
-                <Button
-                    android:id="@+id/get_forms"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    android:textAllCaps="false"
-                    android:textSize="21sp"
-                    android:textStyle="normal" />
+                    android:orientation="vertical"
+                    android:paddingTop="@dimen/margin_medium">
 
-                <View
-                    android:id="@+id/get_forms_spacer"
-                    android:layout_width="match_parent"
-                    android:layout_height="5dp" />
+                    <Button
+                        android:id="@+id/get_forms"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:padding="20dp"
+                        android:textAllCaps="false"
+                        android:textSize="21sp"
+                        android:textStyle="normal" />
 
-                <Button
-                    android:id="@+id/manage_forms"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    android:textAllCaps="false"
-                    android:textSize="21sp"
-                    android:textStyle="normal" />
+                    <Button
+                        android:id="@+id/manage_forms"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:padding="20dp"
+                        android:textAllCaps="false"
+                        android:textSize="21sp"
+                        android:textStyle="normal" />
+                </LinearLayout>
             </LinearLayout>
 
         </ScrollView>

--- a/collect_app/src/main/res/values/styles.xml
+++ b/collect_app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="MainMenuBigButton">
+        <item name="android:padding">20dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">21sp</item>
+        <item name="android:textStyle">normal</item>
+    </style>
+</resources>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -11,6 +11,11 @@
     <style name="BaseDarkAppTheme.Collect" parent="BaseDarkAppTheme" />
 
     <style name="BaseDarkAppTheme" parent="Theme.AppCompat.NoActionBar">
+        <!--Material theme attributes-->
+        <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
+        <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
+        <!--/Material theme attributes-->
+
         <item name="primaryTextColor">@color/darkPrimaryTextColor</item>
         <item name="secondaryTextColor">@color/darkSecondaryTextColor</item>
         <item name="android:scrollbarThumbHorizontal">@drawable/thumb</item>
@@ -61,6 +66,11 @@
     <style name="BaseLightAppTheme.Collect" parent="BaseLightAppTheme" />
 
     <style name="BaseLightAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <!--Material theme attributes-->
+        <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
+        <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
+        <!--/Material theme attributes-->
+
         <item name="primaryTextColor">@color/lightPrimaryTextColor</item>
         <item name="secondaryTextColor">@color/lightSecondaryTextColor</item>
         <item name="android:scrollbarThumbHorizontal">@drawable/thumb</item>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="TextAppearance.Collect.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
+
+    </style>
+
+    <style name="TextAppearance.Collect.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
+
+    </style>
+</resources>


### PR DESCRIPTION
This is the first of hopefully many PRs that attempts to rework the typography in Collect to be more consistent. The reasoning behind what we're doing is [here](https://forum.opendatakit.org/t/reworking-collects-typography/20634). I've also, while in the area, tried to clean up the layouts involved by reworking the structure, using standard values and extracting common styles.

Here is before the changes:

![before](https://user-images.githubusercontent.com/556280/60118832-0a393580-9775-11e9-9adb-478ced0247c4.png)

And after:

![after](https://user-images.githubusercontent.com/556280/60118855-1624f780-9775-11e9-9b12-39052d887288.png)


#### What has been done to verify that this works as intended?

Ran tests, played around with effected screen.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I did change the way that spacing between views work so it would be good to try different main menu configurations to check everything still looks correct.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)