### PR TITLE
Fixed ClassCastException in FormEntryActivity.java:924

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -920,7 +920,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     public QuestionWidget getWidgetWaitingForBinaryData() {
-        ODKView odkView = (ODKView) currentView;
+        ODKView odkView = getCurrentViewIfODKView();
 
         if (odkView != null) {
             for (QuestionWidget qw : odkView.getWidgets()) {


### PR DESCRIPTION
Closes #3183 

#### What has been done to verify that this works as intended?
I just reviewed my changes, nothing else, since it's a rare case, difficult to reproduce.

#### Why is this the best possible solution? Were any other approaches considered?
We just should use `getCurrentViewIfODKView()` which prevents from ClassCastException.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's safe and can't affect anything else. It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)