### PR TITLE
Enable 64-bit support for Mapbox

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -151,9 +151,8 @@ android {
 
         // To ensure that ODK Collect is installable on all devices, we don't use
         // abiFilters to exclude any ABIs; but to keep the APK slim, we include
-        // the Mapbox native library only for armeabi-v7a (which works on all
-        // ARMv7+ 32-bit and 64-bit devices), and omit it for all the other ABIs.
-        exclude 'lib/arm64-v8a/libmapbox-gl.so'
+        // the Mapbox native library only for 32-bit and 64-bit ARM devices and
+        // omit it for all X86 devices.
         exclude 'lib/x86/libmapbox-gl.so'
         exclude 'lib/x86_64/libmapbox-gl.so'
     }


### PR DESCRIPTION
Closes #2844 

This PR includes the 64-bit Mapbox native code. My expectations are that with this change:
1. Mapbox runs on 32-bit and 64-bit Android devices
1. Mapbox continues to gracefully fail on all x86 devices
1. The Collect APK file size increases because of this native code

Something that caught my eye is that the x86 lib ends in`.so1` instead of `.so`. I have confirmed that the production APK doesn't have any x86 libs, so I think the extension is correct.