### PR TITLE
Make Form subtext translatable

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTest.java
@@ -166,7 +166,6 @@ public class ResetAppStateTest {
         values.put(FormsProviderAPI.FormsColumns.DATE, "1487077903756");
         values.put(FormsProviderAPI.FormsColumns.DISPLAY_NAME, "displayName");
         values.put(FormsProviderAPI.FormsColumns.FORM_FILE_PATH, Collect.FORMS_PATH + "/testFile1.xml");
-        values.put(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT, "Added on Tue, Feb 14, 2017 at 14:21");
         Collect.getInstance().getContentResolver()
                 .insert(FormsProviderAPI.FormsColumns.CONTENT_URI, values);
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -171,7 +171,7 @@ public class FormChooserList extends FormListActivity implements
 
     private void setupAdapter() {
         String[] data = new String[]{
-                FormsColumns.DISPLAY_NAME, FormsColumns.JR_VERSION, FormsColumns.DISPLAY_SUBTEXT
+                FormsColumns.DISPLAY_NAME, FormsColumns.JR_VERSION, "MAX(" + FormsColumns.DATE + ")"
         };
         int[] view = new int[]{
                 R.id.form_title, R.id.form_subtitle, R.id.form_subtitle2

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -39,7 +39,7 @@ import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.PermissionUtils;
-import org.odk.collect.android.utilities.VersionHidingCursorAdapter;
+import org.odk.collect.android.adapters.VersionHidingCursorAdapter;
 
 import timber.log.Timber;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserList.java
@@ -171,7 +171,7 @@ public class FormChooserList extends FormListActivity implements
 
     private void setupAdapter() {
         String[] data = new String[]{
-                FormsColumns.DISPLAY_NAME, FormsColumns.JR_VERSION, "MAX(" + FormsColumns.DATE + ")"
+                FormsColumns.DISPLAY_NAME, FormsColumns.JR_VERSION, FormsColumns.MAX_DATE
         };
         int[] view = new int[]{
                 R.id.form_title, R.id.form_subtitle, R.id.form_subtitle2

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
@@ -46,41 +46,36 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
         this.versionColumnName = versionColumnName;
         ctxt = context;
         originalBinder = getViewBinder();
-        setViewBinder(new ViewBinder() {
-
-            @Override
-            public boolean setViewValue(View view, Cursor cursor,
-                    int columnIndex) {
-                String columnName = cursor.getColumnName(columnIndex);
-                if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals("MAX(" + FormsProviderAPI.FormsColumns.DATE + ")")) {
-                    String subtext = getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
-                    TextView v = (TextView) view;
-                    ((TextView) view).setText(subtext);
+        setViewBinder((view, cursor, columnIndex) -> {
+            String columnName = cursor.getColumnName(columnIndex);
+            if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals("MAX(" + FormsProviderAPI.FormsColumns.DATE + ")")) {
+                String subtext = getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
+                TextView v = (TextView) view;
+                ((TextView) view).setText(subtext);
+                v.setVisibility(View.VISIBLE);
+            } else if (columnName.equals(VersionHidingCursorAdapter.this.versionColumnName)) {
+                String version = cursor.getString(columnIndex);
+                TextView v = (TextView) view;
+                v.setText("");
+                v.setVisibility(View.GONE);
+                if (version != null) {
+                    v.append(String.format(ctxt.getString(R.string.version_number), version));
+                    v.append(" ");
                     v.setVisibility(View.VISIBLE);
-                } else if (columnName.equals(VersionHidingCursorAdapter.this.versionColumnName)) {
-                    String version = cursor.getString(columnIndex);
-                    TextView v = (TextView) view;
-                    v.setText("");
-                    v.setVisibility(View.GONE);
-                    if (version != null) {
-                        v.append(String.format(ctxt.getString(R.string.version_number), version));
-                        v.append(" ");
+                }
+                if (from.length > 3) {
+                    int idColumnIndex = cursor.getColumnIndex(from[3]);
+                    String id = cursor.getString(idColumnIndex);
+                    if (id != null) {
+                        v.append(String.format(ctxt.getString(R.string.id_number), id));
                         v.setVisibility(View.VISIBLE);
                     }
-                    if (from.length > 3) {
-                        int idColumnIndex = cursor.getColumnIndex(from[3]);
-                        String id = cursor.getString(idColumnIndex);
-                        if (id != null) {
-                            v.append(String.format(ctxt.getString(R.string.id_number), id));
-                            v.setVisibility(View.VISIBLE);
-                        }
-                    }
-                } else {
-                    view.setVisibility(View.VISIBLE);
-                    return originalBinder != null && originalBinder.setViewValue(view, cursor, columnIndex);
                 }
-                return true;
+            } else {
+                view.setVisibility(View.VISIBLE);
+                return originalBinder != null && originalBinder.setViewValue(view, cursor, columnIndex);
             }
+            return true;
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
@@ -37,13 +37,11 @@ import timber.log.Timber;
 public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
 
     private final Context ctxt;
-    private final String versionColumnName;
     private final ViewBinder originalBinder;
 
     public VersionHidingCursorAdapter(String versionColumnName, Context context, int layout,
             Cursor c, String[] from, int[] to) {
         super(context, layout, c, from, to);
-        this.versionColumnName = versionColumnName;
         ctxt = context;
         originalBinder = getViewBinder();
         setViewBinder((view, cursor, columnIndex) -> {
@@ -55,7 +53,7 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                     ((TextView) view).setText(subtext);
                     v.setVisibility(View.VISIBLE);
                 }
-            } else if (columnName.equals(VersionHidingCursorAdapter.this.versionColumnName)) {
+            } else if (columnName.equals(versionColumnName)) {
                 String version = cursor.getString(columnIndex);
                 TextView v = (TextView) view;
                 v.setText("");

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
@@ -50,9 +50,11 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
             String columnName = cursor.getColumnName(columnIndex);
             if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals("MAX(" + FormsProviderAPI.FormsColumns.DATE + ")")) {
                 String subtext = getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
-                TextView v = (TextView) view;
-                ((TextView) view).setText(subtext);
-                v.setVisibility(View.VISIBLE);
+                if (!subtext.isEmpty()) {
+                    TextView v = (TextView) view;
+                    ((TextView) view).setText(subtext);
+                    v.setVisibility(View.VISIBLE);
+                }
             } else if (columnName.equals(VersionHidingCursorAdapter.this.versionColumnName)) {
                 String version = cursor.getString(columnIndex);
                 TextView v = (TextView) view;

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
@@ -21,10 +21,13 @@ import android.widget.SimpleCursorAdapter;
 import android.widget.TextView;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.provider.FormsProvider;
 import org.odk.collect.android.provider.FormsProviderAPI;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
+
+import timber.log.Timber;
 
 /**
  * Implementation of cursor adapter that displays the version of a form if a form has a version.
@@ -50,7 +53,7 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                     int columnIndex) {
                 String columnName = cursor.getColumnName(columnIndex);
                 if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals("MAX(" + FormsProviderAPI.FormsColumns.DATE + ")")) {
-                    String subtext = FormsProvider.getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
+                    String subtext = getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
                     TextView v = (TextView) view;
                     ((TextView) view).setText(subtext);
                     v.setVisibility(View.VISIBLE);
@@ -79,6 +82,19 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                 return true;
             }
         });
+    }
+
+    private String getDisplaySubtext(Context context, Date date) {
+        String displaySubtext = "";
+        try {
+            if (context != null) {
+                displaySubtext = new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
+                        Locale.getDefault()).format(date);
+            }
+        } catch (IllegalArgumentException e) {
+            Timber.e(e);
+        }
+        return displaySubtext;
     }
 
 }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package org.odk.collect.android.utilities;
+package org.odk.collect.android.adapters;
 
 import android.content.Context;
 import android.database.Cursor;

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/VersionHidingCursorAdapter.java
@@ -46,7 +46,7 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
         originalBinder = getViewBinder();
         setViewBinder((view, cursor, columnIndex) -> {
             String columnName = cursor.getColumnName(columnIndex);
-            if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals("MAX(" + FormsProviderAPI.FormsColumns.DATE + ")")) {
+            if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals(FormsProviderAPI.FormsColumns.MAX_DATE)) {
                 String subtext = getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
                 if (!subtext.isEmpty()) {
                     TextView v = (TextView) view;

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -243,7 +243,6 @@ public class FormsDao {
                     int formFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH);
                     int submissionUriColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.SUBMISSION_URI);
                     int base64RSAPublicKeyColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY);
-                    int displaySubtextColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT);
                     int md5HashColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.MD5_HASH);
                     int dateColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DATE);
                     int jrCacheFilePathColumnIndex = cursor.getColumnIndex(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH);
@@ -262,7 +261,6 @@ public class FormsDao {
                             .formFilePath(cursor.getString(formFilePathColumnIndex))
                             .submissionUri(cursor.getString(submissionUriColumnIndex))
                             .base64RSAPublicKey(cursor.getString(base64RSAPublicKeyColumnIndex))
-                            .displaySubtext(cursor.getString(displaySubtextColumnIndex))
                             .md5Hash(cursor.getString(md5HashColumnIndex))
                             .date(cursor.getLong(dateColumnIndex))
                             .jrCacheFilePath(cursor.getString(jrCacheFilePathColumnIndex))
@@ -291,7 +289,6 @@ public class FormsDao {
         values.put(FormsProviderAPI.FormsColumns.FORM_FILE_PATH, form.getFormFilePath());
         values.put(FormsProviderAPI.FormsColumns.SUBMISSION_URI, form.getSubmissionUri());
         values.put(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY, form.getBASE64RSAPublicKey());
-        values.put(FormsProviderAPI.FormsColumns.DISPLAY_SUBTEXT, form.getDisplaySubtext());
         values.put(FormsProviderAPI.FormsColumns.MD5_HASH, form.getMD5Hash());
         values.put(FormsProviderAPI.FormsColumns.DATE, form.getDate());
         values.put(FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH, form.getJrCacheFilePath());

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -101,7 +101,7 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
     }
 
     private void setupAdapter() {
-        String[] data = new String[]{FormsColumns.DISPLAY_NAME, FormsColumns.JR_VERSION, FormsColumns.DISPLAY_SUBTEXT,
+        String[] data = new String[]{FormsColumns.DISPLAY_NAME, FormsColumns.JR_VERSION, FormsColumns.DATE,
                                         FormsColumns.JR_FORM_ID};
         int[] view = new int[]{R.id.form_title, R.id.form_subtitle, R.id.form_subtitle2};
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -31,7 +31,7 @@ import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DeleteFormsTask;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.ToastUtils;
-import org.odk.collect.android.utilities.VersionHidingCursorAdapter;
+import org.odk.collect.android.adapters.VersionHidingCursorAdapter;
 
 import timber.log.Timber;
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -111,7 +111,7 @@ public class FormsProvider extends ContentProvider {
                 // Only include the latest form that was downloaded with each form_id
                 case NEWEST_FORMS_BY_FORM_ID:
                     Map<String, String> filteredProjectionMap = new HashMap<>(sFormsProjectionMap);
-                    filteredProjectionMap.put(FormsColumns.DATE, "MAX(" + FormsColumns.DATE + ")");
+                    filteredProjectionMap.put(FormsColumns.DATE, FormsColumns.MAX_DATE);
 
                     qb.setProjectionMap(filteredProjectionMap);
                     groupBy = FormsColumns.JR_FORM_ID;

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -542,6 +542,19 @@ public class FormsProvider extends ContentProvider {
         return displaySubtext;
     }
 
+    public static String getDisplaySubtext(Context context, Date date) {
+        String displaySubtext = "";
+        try {
+            if (context != null) {
+                displaySubtext = new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
+                        Locale.getDefault()).format(date);
+            }
+        } catch (IllegalArgumentException e) {
+            Timber.e(e);
+        }
+        return displaySubtext;
+    }
+
     @NonNull
     private String[] prepareWhereArgs(String[] whereArgs, String formId) {
         String[] newWhereArgs;

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -17,7 +17,6 @@ package org.odk.collect.android.provider;
 import android.content.ContentProvider;
 import android.content.ContentUris;
 import android.content.ContentValues;
-import android.content.Context;
 import android.content.UriMatcher;
 import android.database.Cursor;
 import android.database.SQLException;
@@ -27,7 +26,6 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import android.text.TextUtils;
 
-import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.ItemsetDbAdapter;
 import org.odk.collect.android.database.helpers.FormsDatabaseHelper;
@@ -36,10 +34,7 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import timber.log.Timber;
@@ -512,19 +507,6 @@ public class FormsProvider extends ContentProvider {
         }
 
         return count;
-    }
-
-    public static String getDisplaySubtext(Context context, Date date) {
-        String displaySubtext = "";
-        try {
-            if (context != null) {
-                displaySubtext = new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
-                        Locale.getDefault()).format(date);
-            }
-        } catch (IllegalArgumentException e) {
-            Timber.e(e);
-        }
-        return displaySubtext;
     }
 
     @NonNull

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -188,10 +188,6 @@ public class FormsProvider extends ContentProvider {
                 values.put(FormsColumns.DATE, now);
             }
 
-            if (!values.containsKey(FormsColumns.DISPLAY_SUBTEXT)) {
-                values.put(FormsColumns.DISPLAY_SUBTEXT, getDisplaySubtext());
-            }
-
             if (!values.containsKey(FormsColumns.DISPLAY_NAME)) {
                 values.put(FormsColumns.DISPLAY_NAME, form.getName());
             }
@@ -437,11 +433,6 @@ public class FormsProvider extends ContentProvider {
                         }
                     }
 
-                    // Make sure that the necessary fields are all set
-                    if (values.containsKey(FormsColumns.DATE)) {
-                        values.put(FormsColumns.DISPLAY_SUBTEXT, getDisplaySubtext());
-                    }
-
                     count = db.update(FORMS_TABLE_NAME, values, where, whereArgs);
                     break;
 
@@ -495,11 +486,6 @@ public class FormsProvider extends ContentProvider {
                                                 + ".formdef");
                             }
 
-                            // Make sure that the necessary fields are all set
-                            if (values.containsKey(FormsColumns.DATE)) {
-                                values.put(FormsColumns.DISPLAY_SUBTEXT, getDisplaySubtext());
-                            }
-
                             count = db.update(
                                     FORMS_TABLE_NAME,
                                     values,
@@ -526,20 +512,6 @@ public class FormsProvider extends ContentProvider {
         }
 
         return count;
-    }
-
-    private String getDisplaySubtext() {
-        String displaySubtext = "";
-        try {
-            Context context = getContext();
-            if (context != null) {
-                displaySubtext = new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
-                        Locale.getDefault()).format(new Date());
-            }
-        } catch (IllegalArgumentException e) {
-            Timber.e(e);
-        }
-        return displaySubtext;
     }
 
     public static String getDisplaySubtext(Context context, Date date) {
@@ -580,7 +552,6 @@ public class FormsProvider extends ContentProvider {
         sFormsProjectionMap = new HashMap<>();
         sFormsProjectionMap.put(FormsColumns._ID, FormsColumns._ID);
         sFormsProjectionMap.put(FormsColumns.DISPLAY_NAME, FormsColumns.DISPLAY_NAME);
-        sFormsProjectionMap.put(FormsColumns.DISPLAY_SUBTEXT, FormsColumns.DISPLAY_SUBTEXT);
         sFormsProjectionMap.put(FormsColumns.DESCRIPTION, FormsColumns.DESCRIPTION);
         sFormsProjectionMap.put(FormsColumns.JR_FORM_ID, FormsColumns.JR_FORM_ID);
         sFormsProjectionMap.put(FormsColumns.JR_VERSION, FormsColumns.JR_VERSION);

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -71,6 +71,7 @@ public final class FormsProviderAPI {
         public static final String DISPLAY_SUBTEXT = "displaySubtext"; // not used in the newest database version
         public static final String MD5_HASH = "md5Hash";
         public static final String DATE = "date";
+        public static final String MAX_DATE = "MAX(date)"; // used only to get latest forms for each form_id
         public static final String JRCACHE_FILE_PATH = "jrcacheFilePath";
         public static final String FORM_MEDIA_PATH = "formMediaPath";
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -68,7 +68,7 @@ public final class FormsProviderAPI {
         public static final String AUTO_SEND = "autoSubmit"; // can be null
 
         // these are generated for you (but you can insert something else if you want)
-        public static final String DISPLAY_SUBTEXT = "displaySubtext";
+        public static final String DISPLAY_SUBTEXT = "displaySubtext"; // not used in the newest database version
         public static final String MD5_HASH = "md5Hash";
         public static final String DATE = "date";
         public static final String JRCACHE_FILE_PATH = "jrcacheFilePath";

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/VersionHidingCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/VersionHidingCursorAdapter.java
@@ -21,6 +21,10 @@ import android.widget.SimpleCursorAdapter;
 import android.widget.TextView;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.provider.FormsProvider;
+import org.odk.collect.android.provider.FormsProviderAPI;
+
+import java.util.Date;
 
 /**
  * Implementation of cursor adapter that displays the version of a form if a form has a version.
@@ -45,10 +49,12 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
             public boolean setViewValue(View view, Cursor cursor,
                     int columnIndex) {
                 String columnName = cursor.getColumnName(columnIndex);
-                if (!columnName.equals(VersionHidingCursorAdapter.this.versionColumnName)) {
-                    view.setVisibility(View.VISIBLE);
-                    return originalBinder != null && originalBinder.setViewValue(view, cursor, columnIndex);
-                } else {
+                if (columnName.equals(FormsProviderAPI.FormsColumns.DATE) || columnName.equals("MAX(" + FormsProviderAPI.FormsColumns.DATE + ")")) {
+                    String subtext = FormsProvider.getDisplaySubtext(context, new Date(cursor.getLong(columnIndex)));
+                    TextView v = (TextView) view;
+                    ((TextView) view).setText(subtext);
+                    v.setVisibility(View.VISIBLE);
+                } else if (columnName.equals(VersionHidingCursorAdapter.this.versionColumnName)) {
                     String version = cursor.getString(columnIndex);
                     TextView v = (TextView) view;
                     v.setText("");
@@ -66,6 +72,9 @@ public class VersionHidingCursorAdapter extends SimpleCursorAdapter {
                             v.setVisibility(View.VISIBLE);
                         }
                     }
+                } else {
+                    view.setVisibility(View.VISIBLE);
+                    return originalBinder != null && originalBinder.setViewValue(view, cursor, columnIndex);
                 }
                 return true;
             }


### PR DESCRIPTION
Closes #3026 

#### What has been done to verify that this works as intended?
- tested installing apk with database v7 on v6 and v6 on v7
- tested the content of form subtext

#### Why is this the best possible solution? Were any other approaches considered?
I decided to remove `displaySubtext` which keeps an untranslatable form subtext and use `date` column to create such subtext dynamically (to make it translatable). `date` column stores downloading dates so it's the same value as in `displaySubtext`. There is no need to use the `displaySubtext` column.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I upgraded the forms database version so it's a thing that should be carefully tested, upgrading/downgrading @mmarciniak90 I'm counting on your creativity here.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)