### PR TITLE
Rework Toolbar/Appbar typography

### DIFF
--- a/collect_app/src/main/res/layout/toolbar_without_progressbar.xml
+++ b/collect_app/src/main/res/layout/toolbar_without_progressbar.xml
@@ -2,6 +2,7 @@
 <androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
+    style="@style/Widget.Collect.Toolbar"
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/colorPrimary"

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -111,4 +111,8 @@
     <style name="SearchViewTheme.Light" parent="Widget.AppCompat.Light.SearchView">
         <item name="searchHintIcon">@null</item>
     </style>
+
+    <style name="Widget.Collect.Toolbar" parent="Widget.AppCompat.Toolbar">
+        <item name="titleTextAppearance">@style/TextAppearance.Collect.Headline6</item>
+    </style>
 </resources>


### PR DESCRIPTION
The only change here is making the Toolbar title use the `Headline6` style to follow the [Material Guidelines](https://material.io/design/components/app-bars-top.html#theming).

The reasoning behind what we're doing is [here](https://forum.opendatakit.org/t/reworking-collects-typography/20634). I've also, while in the area, tried to clean up the layouts involved by reworking the structure, using standard values and extracting common styles.

Here is before the changes:

![Screenshot_1562577068](https://user-images.githubusercontent.com/556280/60802093-17402680-a170-11e9-95d1-5e67032d465f.png)

And after:

![Screenshot_1562577161](https://user-images.githubusercontent.com/556280/60802106-1c9d7100-a170-11e9-94e3-3801217a8c33.png)


#### What has been done to verify that this works as intended?

Ran tests, played around with effected screen.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)