### PR TITLE
Reset state before tests that copy forms

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/AllWidgetsFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/AllWidgetsFormTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 import org.odk.collect.android.utilities.ActivityAvailability;
 
@@ -95,6 +96,7 @@ public class AllWidgetsFormTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule(ALL_WIDGETS_FORM));
 
     @Mock

--- a/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/GuidanceHintFormTest.java
@@ -19,6 +19,7 @@ import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GuidanceHint;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import tools.fastlane.screengrab.Screengrab;
@@ -50,6 +51,7 @@ public class GuidanceHintFormTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
             ))
+            .around(new ResetStateRule())
             .around(new CopyFormRule(GUIDANCE_SAMPLE_FORM));
 
     @Before

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ExternalCsvSearchTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ExternalCsvSearchTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import java.util.Collections;
@@ -37,6 +38,7 @@ public class ExternalCsvSearchTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule(EXTERNAL_CSV_SEARCH_FORM, "forms",
                     Collections.singletonList("external-csv-search-produce.csv")));
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -38,6 +38,7 @@ import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GuidanceHint;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import java.io.File;
@@ -83,6 +84,7 @@ public class FieldListUpdateTest {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     Manifest.permission.CAMERA)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule(FIELD_LIST_TEST_FORM));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormNavigationButtonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormNavigationButtonTest.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -72,6 +73,7 @@ public class FormNavigationButtonTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule(ALL_WIDGETS_FORM));
 
     @Before

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/IntentGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/IntentGroupTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import java.util.Random;
@@ -60,6 +61,7 @@ public class IntentGroupTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
             ))
+            .around(new ResetStateRule())
             .around(new CopyFormRule(INTENT_GROUP_FORM));
 
     // Verifies that a value given to the label text with form buttonText is used as the button text.

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/BaseRegressionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/BaseRegressionTest.java
@@ -5,29 +5,14 @@ import android.Manifest;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.odk.collect.android.activities.MainMenuActivity;
-import org.odk.collect.android.utilities.ResetUtility;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class BaseRegressionTest {
 
     @Rule
     public ActivityTestRule<MainMenuActivity> main = new ActivityTestRule<>(MainMenuActivity.class);
+
     @Rule
     public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-    @After
-    public void resetAppState() {
-        List<Integer> resetActions = Arrays.asList(
-                ResetUtility.ResetAction.RESET_PREFERENCES, ResetUtility.ResetAction.RESET_INSTANCES,
-                ResetUtility.ResetAction.RESET_FORMS, ResetUtility.ResetAction.RESET_LAYERS,
-                ResetUtility.ResetAction.RESET_CACHE, ResetUtility.ResetAction.RESET_OSM_DROID
-        );
-
-        new ResetUtility().reset(main.getActivity(), resetActions);
-    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -26,6 +27,7 @@ public class DrawWidgetTest extends BaseRegressionTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml", "regression/"));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -25,6 +26,7 @@ public class FormValidationTest extends BaseRegressionTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("OnePageFormShort.xml", "regression/"));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -26,6 +27,7 @@ public class RequiredQuestionTest extends BaseRegressionTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("requiredJR275.xml", "regression/"));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -26,6 +27,7 @@ public class SignatureWidgetTest extends BaseRegressionTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml", "regression/"));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.espressoutils.Settings;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -28,6 +29,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     Manifest.permission.READ_PHONE_STATE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("Test.xml", "regression/"));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/CascadingSelectWithNumberInHeaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/CascadingSelectWithNumberInHeaderTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.regression.BaseRegressionTest;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import java.util.Collections;
 
@@ -26,6 +27,7 @@ public class CascadingSelectWithNumberInHeaderTest extends BaseRegressionTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("numberInCSV.xml", "regression", Collections.singletonList("itemSets.csv")));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/ExternalSecondaryInstancesTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/ExternalSecondaryInstancesTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.regression.BaseRegressionTest;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 
 import java.util.Collections;
 
@@ -26,6 +27,7 @@ public class ExternalSecondaryInstancesTest extends BaseRegressionTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule("internal_select_10.xml", "regression"))
             .around(new CopyFormRule("external_select_10.xml", "regression", Collections.singletonList("external_data_10.xml")));
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
@@ -1,0 +1,45 @@
+package org.odk.collect.android.support;
+
+import android.content.Context;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.odk.collect.android.utilities.ResetUtility;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ResetStateRule implements TestRule {
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new ResetStateStatement(base);
+    }
+
+    private class ResetStateStatement extends Statement {
+
+        private final Statement base;
+
+        ResetStateStatement(Statement base) {
+            this.base = base;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            List<Integer> resetActions = Arrays.asList(
+                    ResetUtility.ResetAction.RESET_PREFERENCES, ResetUtility.ResetAction.RESET_INSTANCES,
+                    ResetUtility.ResetAction.RESET_FORMS, ResetUtility.ResetAction.RESET_LAYERS,
+                    ResetUtility.ResetAction.RESET_CACHE, ResetUtility.ResetAction.RESET_OSM_DROID
+            );
+
+            Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+            new ResetUtility().reset(targetContext, resetActions);
+
+            base.evaluate();
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a `ResetStateRule` we can use before `CopyFormRule` to prevent problems with forms that are already in the app database (or any other polluting problems).

#### What has been done to verify that this works as intended?

Ran tests locally and on test lab to check that tests failing due to duplicate forms were now passing.

#### Why is this the best possible solution? Were any other approaches considered?

We could just clear out the database before copying any form as part of the `CopyFormRule` but this would be a problem for any test that copies more than one form. Alternatively, we could use an after to reset state after tests that modify it. For me personally I think having clean up before tests works better as it lets a test that needs a "clean" state declare that rather than relying on other tests to clean up after themselves.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)