### PR TITLE
Fix problems with settings dialog in Espresso tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/Settings.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/Settings.java
@@ -8,11 +8,13 @@ import org.odk.collect.android.R;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.CoreMatchers.is;
@@ -61,10 +63,6 @@ public final class Settings {
         onView(withText(getInstrumentation().getTargetContext().getString(R.string.ok))).perform(click());
     }
 
-    public static void putText(String text) {
-        onView(withClassName(endsWith("EditText"))).perform(replaceText(text));
-    }
-
     public static void clickOnString(int value) {
         onView(withText(getInstrumentation().getTargetContext().getString(value))).perform(click());
     }
@@ -75,5 +73,19 @@ public final class Settings {
 
     public static void checkIsTextDisplayed(String text) {
         onView(withText(text)).check(matches(isDisplayed()));
+    }
+
+    public static final class Dialog {
+
+        private Dialog() {
+        }
+
+        public static void putText(String text) {
+            onView(withClassName(endsWith("EditText"))).perform(replaceText(text), closeSoftKeyboard());
+        }
+
+        public static void clickOK() {
+            onView(withId(android.R.id.button1)).perform(click());
+        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
@@ -34,21 +34,18 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
 
     @Test
     public void setEmail_ShouldRequireAtSign() {
-
         //TestCase1
         MainMenu.clickOnMenu();
         MainMenu.clickGeneralSettings();
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataEmail();
-        Settings.putText("aabb");
-        pressBack();
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("aabb");
+        Settings.Dialog.clickOK();
         Settings.checkIsToastWithStringDisplayes(R.string.invalid_email_address, main);
         Settings.clickMetadataEmail();
-        Settings.putText("aa@bb");
-        pressBack();
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("aa@bb");
+        Settings.Dialog.clickOK();
         Settings.checkIsTextDisplayed("aa@bb");
         pressBack();
         pressBack();
@@ -73,8 +70,8 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataUsername();
-        Settings.putText("AAA");
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("AAA");
+        Settings.Dialog.clickOK();
         pressBack();
         pressBack();
         pressBack();
@@ -92,8 +89,8 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataUsername();
-        Settings.putText("");
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("");
+        Settings.Dialog.clickOK();
         pressBack();
         pressBack();
         pressBack();
@@ -103,8 +100,8 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         Settings.clickOnServerType();
         Settings.clickOnString(R.string.server_platform_odk_aggregate);
         Settings.clickAggregateUsername();
-        Settings.putText("BBB");
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("BBB");
+        Settings.Dialog.clickOK();
         pressBack();
         pressBack();
         MainMenu.startBlankForm("Test");
@@ -121,8 +118,8 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataUsername();
-        Settings.putText("CCC");
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("CCC");
+        Settings.Dialog.clickOK();
         pressBack();
         pressBack();
         pressBack();
@@ -132,8 +129,8 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         Settings.clickOnServerType();
         Settings.clickOnString(R.string.server_platform_odk_aggregate);
         Settings.clickAggregateUsername();
-        Settings.putText("DDD");
-        Settings.clickOnString(R.string.ok);
+        Settings.Dialog.putText("DDD");
+        Settings.Dialog.clickOK();
         pressBack();
         pressBack();
         MainMenu.startBlankForm("Test");


### PR DESCRIPTION
Make Espresso tests use more reliable postive button ID for dialog "OK" button and also make sure to close soft keyboard to avoid weird permission errors.

#### What has been done to verify that this works as intended?

Run tests locally and also on test lab to verify broken tests are now fixed.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines) 