### PR TITLE
Make instance subtext translatable

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -196,10 +196,10 @@ public class InstanceChooserList extends InstanceListActivity implements
 
     private void setupAdapter() {
         String[] data = new String[]{
-                InstanceColumns.DISPLAY_NAME, InstanceColumns.DISPLAY_SUBTEXT, InstanceColumns.DELETED_DATE
+                InstanceColumns.DISPLAY_NAME, InstanceColumns.DELETED_DATE
         };
         int[] view = new int[]{
-                R.id.form_title, R.id.form_subtitle, R.id.form_subtitle2
+                R.id.form_title, R.id.form_subtitle2
         };
 
         boolean shouldCheckDisabled = !editMode;

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import org.odk.collect.android.R;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.provider.FormsProviderAPI;
+import org.odk.collect.android.provider.InstanceProvider;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.text.SimpleDateFormat;
@@ -51,6 +52,8 @@ public class InstanceListCursorAdapter extends SimpleCursorAdapter {
 
         ImageView imageView = view.findViewById(R.id.image);
         setImageFromStatus(imageView);
+
+        setUpSubtext(view);
 
         // Some form lists never contain disabled items; if so, we're done.
         if (!shouldCheckDisabled) {
@@ -132,6 +135,15 @@ public class InstanceListCursorAdapter extends SimpleCursorAdapter {
         formSubtitle.setAlpha(0.38f);
         disabledCause.setAlpha(0.38f);
         imageView.setAlpha(0.38f);
+    }
+
+    private void setUpSubtext(View view) {
+        long lastStatusChangeDate = getCursor().getLong(getCursor().getColumnIndex(InstanceProviderAPI.InstanceColumns.LAST_STATUS_CHANGE_DATE));
+        String status = getCursor().getString(getCursor().getColumnIndex(InstanceProviderAPI.InstanceColumns.STATUS));
+        String subtext = InstanceProvider.getDisplaySubtext(context, status, new Date(lastStatusChangeDate));
+
+        final TextView formSubtitle = view.findViewById(R.id.form_subtitle);
+        formSubtitle.setText(subtext);
     }
 
     private void setImageFromStatus(ImageView imageView) {

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
@@ -78,7 +78,7 @@ public class InstanceListCursorAdapter extends SimpleCursorAdapter {
             }
         }
 
-        Long date = getCursor().getLong(getCursor().getColumnIndex(InstanceProviderAPI.InstanceColumns.DELETED_DATE));
+        long date = getCursor().getLong(getCursor().getColumnIndex(InstanceProviderAPI.InstanceColumns.DELETED_DATE));
 
         if (date != 0 || !formExists || isFormEncrypted) {
             String disabledMessage;

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -16,11 +16,14 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.events.SmsRxEvent;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.provider.InstanceProvider;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.tasks.sms.SmsService;
 import org.odk.collect.android.tasks.sms.contracts.SmsSubmissionManagerContract;
 import org.odk.collect.android.tasks.sms.models.SmsSubmission;
 import org.odk.collect.android.views.ProgressBar;
+
+import java.util.Date;
 
 import javax.inject.Inject;
 
@@ -75,8 +78,11 @@ public class InstanceUploaderAdapter extends CursorAdapter {
     public void bindView(View view, Context context, Cursor cursor) {
         ViewHolder viewHolder = (ViewHolder) view.getTag();
 
+        long lastStatusChangeDate = getCursor().getLong(getCursor().getColumnIndex(InstanceProviderAPI.InstanceColumns.LAST_STATUS_CHANGE_DATE));
+        String status = cursor.getString(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.STATUS));
+
         viewHolder.formTitle.setText(cursor.getString(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_NAME)));
-        viewHolder.formSubtitle.setText(cursor.getString(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_SUBTEXT)));
+        viewHolder.formSubtitle.setText(InstanceProvider.getDisplaySubtext(context, status, new Date(lastStatusChangeDate)));
 
         long instanceId = cursor.getLong(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID));
 
@@ -85,8 +91,6 @@ public class InstanceUploaderAdapter extends CursorAdapter {
         boolean smsTransportEnabled = ((String) GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE)).equalsIgnoreCase(context.getString(R.string.transport_type_value_sms));
 
         boolean isSmsSubmission = model != null && smsTransportEnabled;
-
-        String status = cursor.getString(cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.STATUS));
 
         switch (status) {
             case STATUS_SUBMISSION_FAILED:

--- a/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
@@ -309,7 +309,6 @@ public class InstancesDao {
                     int jrVersionColumnIndex = cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.JR_VERSION);
                     int statusColumnIndex = cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.STATUS);
                     int lastStatusChangeDateColumnIndex = cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.LAST_STATUS_CHANGE_DATE);
-                    int displaySubtextColumnIndex = cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.DISPLAY_SUBTEXT);
                     int deletedDateColumnIndex = cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns.DELETED_DATE);
 
                     int databaseIdIndex = cursor.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID);
@@ -323,7 +322,6 @@ public class InstancesDao {
                             .jrVersion(cursor.getString(jrVersionColumnIndex))
                             .status(cursor.getString(statusColumnIndex))
                             .lastStatusChangeDate(cursor.getLong(lastStatusChangeDateColumnIndex))
-                            .displaySubtext(cursor.getString(displaySubtextColumnIndex))
                             .deletedDate(cursor.getLong(deletedDateColumnIndex))
                             .databaseId(cursor.getLong(databaseIdIndex))
                             .build();
@@ -353,7 +351,6 @@ public class InstancesDao {
         values.put(InstanceProviderAPI.InstanceColumns.JR_VERSION, instance.getJrVersion());
         values.put(InstanceProviderAPI.InstanceColumns.STATUS, instance.getStatus());
         values.put(InstanceProviderAPI.InstanceColumns.LAST_STATUS_CHANGE_DATE, instance.getLastStatusChangeDate());
-        values.put(InstanceProviderAPI.InstanceColumns.DISPLAY_SUBTEXT, instance.getDisplaySubtext());
         values.put(InstanceProviderAPI.InstanceColumns.DELETED_DATE, instance.getDeletedDate());
 
         return values;

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
@@ -134,8 +134,8 @@ public class DataManagerList extends InstanceListFragment
     }
 
     private void setupAdapter() {
-        String[] data = new String[]{InstanceColumns.DISPLAY_NAME, InstanceColumns.DISPLAY_SUBTEXT};
-        int[] view = new int[]{R.id.form_title, R.id.form_subtitle};
+        String[] data = new String[]{InstanceColumns.DISPLAY_NAME};
+        int[] view = new int[]{R.id.form_title};
 
         listAdapter = new InstanceListCursorAdapter(getActivity(),
                 R.layout.form_chooser_list_item_multiple_choice, null, data, view, false);

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.provider;
 import android.content.ContentProvider;
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.Context;
 import android.content.UriMatcher;
 import android.database.Cursor;
 import android.database.SQLException;
@@ -180,25 +181,29 @@ public class InstanceProvider extends ContentProvider {
     }
 
     private String getDisplaySubtext(String state, Date date) {
+        return getDisplaySubtext(getContext(), state, date);
+    }
+
+    public static String getDisplaySubtext(Context context, String state, Date date) {
         try {
             if (state == null) {
-                return new SimpleDateFormat(getContext().getString(R.string.added_on_date_at_time),
+                return new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
                         Locale.getDefault()).format(date);
             } else if (InstanceProviderAPI.STATUS_INCOMPLETE.equalsIgnoreCase(state)) {
-                return new SimpleDateFormat(getContext().getString(R.string.saved_on_date_at_time),
+                return new SimpleDateFormat(context.getString(R.string.saved_on_date_at_time),
                         Locale.getDefault()).format(date);
             } else if (InstanceProviderAPI.STATUS_COMPLETE.equalsIgnoreCase(state)) {
-                return new SimpleDateFormat(getContext().getString(R.string.finalized_on_date_at_time),
+                return new SimpleDateFormat(context.getString(R.string.finalized_on_date_at_time),
                         Locale.getDefault()).format(date);
             } else if (InstanceProviderAPI.STATUS_SUBMITTED.equalsIgnoreCase(state)) {
-                return new SimpleDateFormat(getContext().getString(R.string.sent_on_date_at_time),
+                return new SimpleDateFormat(context.getString(R.string.sent_on_date_at_time),
                         Locale.getDefault()).format(date);
             } else if (InstanceProviderAPI.STATUS_SUBMISSION_FAILED.equalsIgnoreCase(state)) {
                 return new SimpleDateFormat(
-                        getContext().getString(R.string.sending_failed_on_date_at_time),
+                        context.getString(R.string.sending_failed_on_date_at_time),
                         Locale.getDefault()).format(date);
             } else {
-                return new SimpleDateFormat(getContext().getString(R.string.added_on_date_at_time),
+                return new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
                         Locale.getDefault()).format(date);
             }
         } catch (IllegalArgumentException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -353,6 +353,11 @@ public class InstanceProvider extends ContentProvider {
                 values.put(InstanceColumns.LAST_STATUS_CHANGE_DATE, now);
             }
 
+            // Don't update last status change date if an instance is being deleted
+            if (values.containsKey(InstanceColumns.DELETED_DATE)) {
+                values.remove(InstanceColumns.LAST_STATUS_CHANGE_DATE);
+            }
+
             String status;
             switch (URI_MATCHER.match(uri)) {
                 case INSTANCES:

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -159,12 +159,6 @@ public class InstanceProvider extends ContentProvider {
                 values.put(InstanceColumns.LAST_STATUS_CHANGE_DATE, now);
             }
 
-            if (!values.containsKey(InstanceColumns.DISPLAY_SUBTEXT)) {
-                Date today = new Date();
-                String text = getDisplaySubtext(InstanceProviderAPI.STATUS_INCOMPLETE, today);
-                values.put(InstanceColumns.DISPLAY_SUBTEXT, text);
-            }
-
             if (!values.containsKey(InstanceColumns.STATUS)) {
                 values.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_INCOMPLETE);
             }
@@ -178,10 +172,6 @@ public class InstanceProvider extends ContentProvider {
         }
 
         throw new SQLException("Failed to insert row into " + uri);
-    }
-
-    private String getDisplaySubtext(String state, Date date) {
-        return getDisplaySubtext(getContext(), state, date);
     }
 
     public static String getDisplaySubtext(Context context, String state, Date date) {
@@ -358,34 +348,13 @@ public class InstanceProvider extends ContentProvider {
                 values.remove(InstanceColumns.LAST_STATUS_CHANGE_DATE);
             }
 
-            String status;
             switch (URI_MATCHER.match(uri)) {
                 case INSTANCES:
-                    if (values.containsKey(InstanceColumns.STATUS)) {
-                        status = values.getAsString(InstanceColumns.STATUS);
-
-                        if (!values.containsKey(InstanceColumns.DISPLAY_SUBTEXT)) {
-                            Date today = new Date();
-                            String text = getDisplaySubtext(status, today);
-                            values.put(InstanceColumns.DISPLAY_SUBTEXT, text);
-                        }
-                    }
-
                     count = db.update(INSTANCES_TABLE_NAME, values, where, whereArgs);
                     break;
 
                 case INSTANCE_ID:
                     String instanceId = uri.getPathSegments().get(1);
-
-                    if (values.containsKey(InstanceColumns.STATUS)) {
-                        status = values.getAsString(InstanceColumns.STATUS);
-
-                        if (!values.containsKey(InstanceColumns.DISPLAY_SUBTEXT)) {
-                            Date today = new Date();
-                            String text = getDisplaySubtext(status, today);
-                            values.put(InstanceColumns.DISPLAY_SUBTEXT, text);
-                        }
-                    }
 
                     String[] newWhereArgs;
                     if (whereArgs == null || whereArgs.length == 0) {
@@ -433,8 +402,6 @@ public class InstanceProvider extends ContentProvider {
         sInstancesProjectionMap.put(InstanceColumns.STATUS, InstanceColumns.STATUS);
         sInstancesProjectionMap.put(InstanceColumns.LAST_STATUS_CHANGE_DATE,
                 InstanceColumns.LAST_STATUS_CHANGE_DATE);
-        sInstancesProjectionMap.put(InstanceColumns.DISPLAY_SUBTEXT,
-                InstanceColumns.DISPLAY_SUBTEXT);
         sInstancesProjectionMap.put(InstanceColumns.DELETED_DATE, InstanceColumns.DELETED_DATE);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
@@ -19,9 +19,6 @@ package org.odk.collect.android.provider;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
-/**
- * Convenience definitions for NotePadProvider
- */
 public final class InstanceProviderAPI {
     public static final String AUTHORITY = "org.odk.collect.android.provider.odk.instances";
 
@@ -35,9 +32,6 @@ public final class InstanceProviderAPI {
     public static final String STATUS_SUBMITTED = "submitted";
     public static final String STATUS_SUBMISSION_FAILED = "submissionFailed";
 
-    /**
-     * Notes table
-     */
     public static final class InstanceColumns implements BaseColumns {
         // This class cannot be instantiated
         private InstanceColumns() {
@@ -47,25 +41,15 @@ public final class InstanceProviderAPI {
         public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.odk.instance";
         public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.odk.instance";
 
-        // These are the only things needed for an insert
+        // instance column names
         public static final String DISPLAY_NAME = "displayName";
         public static final String SUBMISSION_URI = "submissionUri";
         public static final String INSTANCE_FILE_PATH = "instanceFilePath";
         public static final String JR_FORM_ID = "jrFormId";
         public static final String JR_VERSION = "jrVersion";
-        //public static final String FORM_ID = "formId";
-
-        // these are generated for you (but you can insert something else if you want)
         public static final String STATUS = "status";
         public static final String CAN_EDIT_WHEN_COMPLETE = "canEditWhenComplete";
         public static final String LAST_STATUS_CHANGE_DATE = "date";
         public static final String DELETED_DATE = "deletedDate";
-        //public static final String DISPLAY_SUB_SUBTEXT = "displaySubSubtext";
-
-        //        public static final String DEFAULT_SORT_ORDER = "modified DESC";
-        //        public static final String TITLE = "title";
-        //        public static final String NOTE = "note";
-        //        public static final String CREATED_DATE = "created";
-        //        public static final String MODIFIED_DATE = "modified";
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
@@ -59,7 +59,6 @@ public final class InstanceProviderAPI {
         public static final String STATUS = "status";
         public static final String CAN_EDIT_WHEN_COMPLETE = "canEditWhenComplete";
         public static final String LAST_STATUS_CHANGE_DATE = "date";
-        public static final String DISPLAY_SUBTEXT = "displaySubtext";
         public static final String DELETED_DATE = "deletedDate";
         //public static final String DISPLAY_SUB_SUBTEXT = "displaySubSubtext";
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/sms/SmsService.java
@@ -284,7 +284,7 @@ public class SmsService {
          * so that error message is persisted along with SUBMISSION_STATUS_FAILED
          * */
         if (model.isSubmissionComplete()) {
-            markInstanceAsSubmittedOrDelete(instanceId, model.getCompletion(), model.getLastUpdated(), context);
+            markInstanceAsSubmittedOrDelete(instanceId);
         } else if (resultCode != RESULT_OK && resultCode != RESULT_OK_OTHERS_PENDING) {
             updateInstanceStatusFailedText(instanceId, event);
         }
@@ -315,12 +315,11 @@ public class SmsService {
         rxEventBus.post(new SmsRxEvent(instanceId, RESULT_QUEUED));
     }
 
-    private void markInstanceAsSubmittedOrDelete(String instanceId, SmsProgress progress, Date date, Context context) {
+    private void markInstanceAsSubmittedOrDelete(String instanceId) {
         String where = InstanceProviderAPI.InstanceColumns._ID + "=?";
         String[] whereArgs = {instanceId};
 
         ContentValues contentValues = new ContentValues();
-        contentValues.put(InstanceProviderAPI.InstanceColumns.DISPLAY_SUBTEXT, getDisplaySubtext(RESULT_OK, date, progress, context));
         contentValues.put(InstanceProviderAPI.InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
 
         try (Cursor cursor = instancesDao.getInstancesCursorForId(instanceId)) {
@@ -357,7 +356,6 @@ public class SmsService {
 
         ContentValues contentValues = new ContentValues();
         contentValues.put(InstanceProviderAPI.InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMISSION_FAILED);
-        contentValues.put(InstanceProviderAPI.InstanceColumns.DISPLAY_SUBTEXT, getDisplaySubtext(event.getResultCode(), event.getLastUpdated(), event.getProgress(), context));
 
         instancesDao.updateInstance(contentValues, where, whereArgs);
     }


### PR DESCRIPTION
Closes #1419 

#### What has been done to verify that this works as intended?
- tested installing apk with database v5 on v4 and v4 on v5
- tested the content of instance subtext

#### Why is this the best possible solution? Were any other approaches considered?
I decided to remove `displaySubtext` column which keeps an untranslatable instance subtext and use `date` column to create such subtext dynamically (to make it translatable). `date` column stores last update dates so it's the same value as in `displaySubtext`. There is no need to use the `displaySubtext` column.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I upgraded the instances database version so it's a thing that should be carefully tested, upgrading/downgrading @mmarciniak90 I'm counting on your creativity here like in #3193.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)