### PR TITLE
Use `closeSoftKeyboard` instead of `pressBack` in tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
@@ -89,7 +89,7 @@ public final class FormEntry {
         onView(withId(R.id.questionholder)).perform(swipeLeft());
     }
 
-    public static void ignoreChanges() {
+    public static void checkIgnoreChangesDisplayed() {
         onView(withText(getInstrumentation().getTargetContext().getString(R.string.do_not_save))).perform(click());
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
@@ -89,7 +89,7 @@ public final class FormEntry {
         onView(withId(R.id.questionholder)).perform(swipeLeft());
     }
 
-    public static void checkIgnoreChangesDisplayed() {
+    public static void clickIgnoreChanges() {
         onView(withText(getInstrumentation().getTargetContext().getString(R.string.do_not_save))).perform(click());
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -57,6 +57,6 @@ public class FormValidationTest extends BaseRegressionTest {
         pressBack();
         closeSoftKeyboard();
         pressBack();
-        FormEntry.checkIgnoreChangesDisplayed();
+        FormEntry.clickIgnoreChanges();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
 
+import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.pressBack;
 
 // Issue number NODK-251
@@ -54,8 +55,8 @@ public class FormValidationTest extends BaseRegressionTest {
         FormEntry.checkIsTextDisplayed("YY MM");
         FormEntry.checkIsTextDisplayed("YY");
         pressBack();
+        closeSoftKeyboard();
         pressBack();
-        pressBack();
-        FormEntry.ignoreChanges();
+        FormEntry.checkIgnoreChangesDisplayed();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
@@ -39,7 +39,7 @@ public class RequiredQuestionTest extends BaseRegressionTest {
         FormEntry.checkIsTextDisplayed("* Foo");
         closeSoftKeyboard();
         pressBack();
-        FormEntry.checkIgnoreChangesDisplayed();
+        FormEntry.clickIgnoreChanges();
     }
 
     @Test
@@ -51,6 +51,6 @@ public class RequiredQuestionTest extends BaseRegressionTest {
         FormEntry.checkIsToastWithMessageDisplayes("Custom required message", main);
         closeSoftKeyboard();
         pressBack();
-        FormEntry.checkIgnoreChangesDisplayed();
+        FormEntry.clickIgnoreChanges();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
 
+import static androidx.test.espresso.Espresso.closeSoftKeyboard;
 import static androidx.test.espresso.Espresso.pressBack;
 
 
@@ -36,9 +37,9 @@ public class RequiredQuestionTest extends BaseRegressionTest {
         //TestCase1
         MainMenu.startBlankForm("required");
         FormEntry.checkIsTextDisplayed("* Foo");
+        closeSoftKeyboard();
         pressBack();
-        pressBack();
-        FormEntry.ignoreChanges();
+        FormEntry.checkIgnoreChangesDisplayed();
     }
 
     @Test
@@ -48,8 +49,8 @@ public class RequiredQuestionTest extends BaseRegressionTest {
         MainMenu.startBlankForm("required");
         FormEntry.swipeToNextQuestion();
         FormEntry.checkIsToastWithMessageDisplayes("Custom required message", main);
+        closeSoftKeyboard();
         pressBack();
-        pressBack();
-        FormEntry.ignoreChanges();
+        FormEntry.checkIgnoreChangesDisplayed();
     }
 }


### PR DESCRIPTION
In my experience `pressBack` can be a little less reliable as a method of closing the keyboard in Espresso.

#### What has been done to verify that this works as intended?

Run locally and on test lab to verify failing tests are now passing.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)