### PR TITLE
Fixed styling in select_one/select_multiple widgets with minimal appearance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SpinnerAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SpinnerAdapter.java
@@ -14,13 +14,13 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.ThemeUtils;
 
-public class SpinnerAdapter extends ArrayAdapter<String> {
+public class SpinnerAdapter extends ArrayAdapter<CharSequence> {
     private final Context context;
-    private final String[] items;
+    private final CharSequence[] items;
     private final ThemeUtils themeUtils;
     private int selectedPosition;
 
-    public SpinnerAdapter(final Context context, final String[] objects) {
+    public SpinnerAdapter(final Context context, final CharSequence[] objects) {
         super(context, android.R.layout.simple_spinner_item, objects);
         this.items = objects;
         this.context = context;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -30,6 +30,7 @@ import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
@@ -77,7 +78,7 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
 
         // Build View
         for (int i = 0; i < items.size(); i++) {
-            answerItems[i] = prompt.getSelectChoiceText(items.get(i));
+            answerItems[i] = FormEntryPromptUtils.getItemText(prompt, items.get(i));
         }
 
         selectionText = getAnswerTextView();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -28,7 +28,6 @@ import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
@@ -51,7 +50,8 @@ import java.util.List;
 public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, MultiChoiceWidget {
 
     // The possible select answers
-    CharSequence[] answerItems;
+    String[] answerItems;
+    CharSequence[] styledAnswerItems;
 
     // The button to push to display the answers to choose from
     Button button;
@@ -70,13 +70,15 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
         super(context, prompt);
 
         selections = new boolean[items.size()];
-        answerItems = new CharSequence[items.size()];
+        answerItems = new String[items.size()];
+        styledAnswerItems = new CharSequence[items.size()];
         alertBuilder = new AlertDialog.Builder(context);
         button = getSimpleButton(context.getString(R.string.select_answer));
 
         // Build View
         for (int i = 0; i < items.size(); i++) {
-            answerItems[i] = FormEntryPromptUtils.getItemText(prompt, items.get(i));
+            answerItems[i] = prompt.getSelectChoiceText(items.get(i));
+            styledAnswerItems[i] = org.odk.collect.android.utilities.TextUtils.textToHtml(answerItems[i]);
         }
 
         selectionText = getAnswerTextView();
@@ -95,7 +97,7 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
                 for (Selection s : ve) {
                     if (value.equals(s.getValue())) {
                         selections[i] = true;
-                        selectedValues.add(answerItems[i].toString());
+                        selectedValues.add(answerItems[i]);
                         break;
                     }
                 }
@@ -163,13 +165,13 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
 
                     for (int i = 0; i < selections.length; i++) {
                         if (selections[i]) {
-                            selectedValues.add(answerItems[i].toString());
+                            selectedValues.add(answerItems[i]);
                         }
                     }
                     showSelectedValues(selectedValues);
                 });
 
-        alertBuilder.setMultiChoiceItems(answerItems, selections,
+        alertBuilder.setMultiChoiceItems(styledAnswerItems, selections,
                 (dialog, which, isChecked) -> {
                     selections[which] = isChecked;
                     widgetValueChanged();
@@ -181,8 +183,9 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
         if (selectedValues.isEmpty()) {
             clearAnswer();
         } else {
-            selectionText.setText(String.format(getContext().getString(R.string.selected_answer),
+            CharSequence answerText = org.odk.collect.android.utilities.TextUtils.textToHtml(String.format(getContext().getString(R.string.selected_answer),
                     TextUtils.join(", ", selectedValues)));
+            selectionText.setText(answerText);
             selectionText.setVisibility(View.VISIBLE);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -17,14 +17,12 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
@@ -85,10 +83,9 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
         selectionText.setVisibility(View.GONE);
 
         // Fill in previous answers
-        List<Selection> ve = new ArrayList<>();
-        if (prompt.getAnswerValue() != null) {
-            ve = (List<Selection>) prompt.getAnswerValue().getValue();
-        }
+        List<Selection> ve = prompt.getAnswerValue() != null
+                ? (List<Selection>) prompt.getAnswerValue().getValue()
+                : new ArrayList<>();
 
         if (ve != null) {
             List<String> selectedValues = new ArrayList<>();
@@ -120,16 +117,10 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
         List<Selection> vc = new ArrayList<>();
         for (int i = 0; i < items.size(); i++) {
             if (selections[i]) {
-                SelectChoice sc = items.get(i);
-                vc.add(new Selection(sc));
+                vc.add(new Selection(items.get(i)));
             }
         }
-        if (vc.isEmpty()) {
-            return null;
-        } else {
-            return new SelectMultiData(vc);
-        }
-
+        return vc.isEmpty() ? null : new SelectMultiData(vc);
     }
 
     @Override
@@ -167,31 +158,23 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
     @Override
     public void onButtonClick(int buttonId) {
         alertBuilder.setTitle(getFormEntryPrompt().getQuestionText()).setPositiveButton(R.string.ok,
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        List<String> selectedValues = new ArrayList<>();
+                (dialog, id) -> {
+                    List<String> selectedValues = new ArrayList<>();
 
-                        for (int i = 0; i < selections.length; i++) {
-                            if (selections[i]) {
-                                selectedValues.add(answerItems[i].toString());
-                            }
+                    for (int i = 0; i < selections.length; i++) {
+                        if (selections[i]) {
+                            selectedValues.add(answerItems[i].toString());
                         }
-                        showSelectedValues(selectedValues);
                     }
+                    showSelectedValues(selectedValues);
                 });
 
         alertBuilder.setMultiChoiceItems(answerItems, selections,
-                new DialogInterface.OnMultiChoiceClickListener() {
-
-                    @Override
-                    public void onClick(DialogInterface dialog, int which,
-                                        boolean isChecked) {
-                        selections[which] = isChecked;
-                        widgetValueChanged();
-                    }
+                (dialog, which, isChecked) -> {
+                    selections[which] = isChecked;
+                    widgetValueChanged();
                 });
-        AlertDialog alert = alertBuilder.create();
-        alert.show();
+        alertBuilder.create().show();
     }
 
     private void showSelectedValues(List<String> selectedValues) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
@@ -28,6 +28,7 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.SpinnerAdapter;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
+import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.views.ScrolledToTopSpinner;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
@@ -149,10 +150,10 @@ public class SpinnerWidget extends ItemsWidget implements MultiChoiceWidget {
         }
     }
 
-    private String[] getChoices(FormEntryPrompt prompt) {
-        String[] choices = new String[items.size() + 1];
+    private CharSequence[] getChoices(FormEntryPrompt prompt) {
+        CharSequence[] choices = new CharSequence[items.size() + 1];
         for (int i = 0; i < items.size(); i++) {
-            choices[i] = prompt.getSelectChoiceText(items.get(i));
+            choices[i] = FormEntryPromptUtils.getItemText(prompt, items.get(i));
         }
         choices[items.size()] = getContext().getString(R.string.select_one);
         return choices;


### PR DESCRIPTION
Closes #3190 

#### What has been done to verify that this works as intended?
I tested the attached for which contains sample for both select_one/select_multiple widgets with minimal appearance.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a fix for those two widgets. There is no other solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The implemented changes are related only to those two widgets (SpinnerWidget and SpinnerMultiplWidget) so testing the attached form should be ok there is no need to test other widgets or other functionalities.

#### Do we need any specific form for testing your changes? If so, please attach one.
[style-example.xml.txt](https://github.com/opendatakit/collect/files/3381862/style-example.xml.txt)
[style-example.xlsx](https://github.com/opendatakit/collect/files/3381863/style-example.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)