### PR TITLE
Add screenshot on failure rule to flakey tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
@@ -8,12 +8,14 @@ import androidx.test.runner.AndroidJUnit4;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.ScreenshotOnFailureTestRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -29,6 +31,9 @@ public class DrawWidgetTest extends BaseRegressionTest {
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml", "regression/"));
+
+    @Rule
+    public TestRule screenshotFailRule = new ScreenshotOnFailureTestRule();
 
     @Test
     public void saveIgnoreDialog_ShouldUseBothOptions() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
@@ -8,12 +8,14 @@ import androidx.test.runner.AndroidJUnit4;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.ScreenshotOnFailureTestRule;
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -29,6 +31,9 @@ public class SignatureWidgetTest extends BaseRegressionTest {
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml", "regression/"));
+
+    @Rule
+    public TestRule screenshotFailRule = new ScreenshotOnFailureTestRule();
 
     @Test
     public void saveIgnoreDialog_ShouldUseBothOptions() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ScreenshotOnFailureTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ScreenshotOnFailureTestRule.java
@@ -1,0 +1,23 @@
+package org.odk.collect.android.support;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
+
+public class ScreenshotOnFailureTestRule extends TestWatcher {
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+        super.failed(e, description);
+        takeScreenshot(description);
+    }
+
+    private void takeScreenshot(Description description) {
+        Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
+
+        String filename = description.getTestClass().getSimpleName() + "-" + description.getMethodName();
+        Screengrab.screenshot(filename);
+    }
+}


### PR DESCRIPTION
Work towards #3205. This adds a "screenshot on failure" rule to the two flakey tests classes (`DrawWidgetTest` and `SignatureWidgetTest`) with an aim of helping us understand what's causing the failures.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)