### PR TITLE
Rework About screen typography

### DIFF
--- a/collect_app/src/main/res/color/color_on_surface_medium_emphasis.xml
+++ b/collect_app/src/main/res/color/color_on_surface_medium_emphasis.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.6" android:color="?attr/colorOnSurface" />
+</selector>

--- a/collect_app/src/main/res/color/color_on_surface_medium_emphasis.xml
+++ b/collect_app/src/main/res/color/color_on_surface_medium_emphasis.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Provides a medium emphasis version of the `colorOnSurface` Material Theming attribute (found
+here: https://material.io/develop/android/theming/typography/). Material Themes suggest using
+different emphasis/transparency values on text but Android doesn't have a way to set this on a
+`TextView` itself.
+-->
+
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:alpha="0.6" android:color="?attr/colorOnSurface" />
 </selector>

--- a/collect_app/src/main/res/layout/about_item_layout.xml
+++ b/collect_app/src/main/res/layout/about_item_layout.xml
@@ -21,15 +21,17 @@ limitations under the License.
 
     <ImageView
         android:id="@+id/imageView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentTop="true"
         tools:src="@drawable/ic_website" />
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_large"
-        android:layout_marginLeft="@dimen/margin_large"
+        android:layout_alignTop="@id/imageView"
+        android:layout_marginStart="@dimen/margin_extra_extra_large"
+        android:layout_marginLeft="@dimen/margin_extra_extra_large"
         android:layout_toEndOf="@id/imageView"
         android:layout_toRightOf="@id/imageView"
         android:orientation="vertical">
@@ -47,6 +49,7 @@ limitations under the License.
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_small"
+            android:textColor="?attr/colorOnSurfaceMediumEmphasis"
             tools:text="@string/odk_website_summary" />
 
     </LinearLayout>

--- a/collect_app/src/main/res/layout/about_item_layout.xml
+++ b/collect_app/src/main/res/layout/about_item_layout.xml
@@ -49,7 +49,7 @@ limitations under the License.
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_small"
-            android:textColor="?attr/colorOnSurfaceMediumEmphasis"
+            android:textColor="@color/color_on_surface_medium_emphasis"
             tools:text="@string/odk_website_summary" />
 
     </LinearLayout>

--- a/collect_app/src/main/res/layout/about_item_layout.xml
+++ b/collect_app/src/main/res/layout/about_item_layout.xml
@@ -36,17 +36,17 @@ limitations under the License.
 
         <TextView
             android:id="@+id/title"
-            style="?attr/textAppearanceSubtitle1"
+            style="@style/TextAppearance.Collect.Subtitle1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="@string/odk_website" />
 
         <TextView
             android:id="@+id/summary"
-            style="?attr/textAppearanceBody2"
+            style="@style/TextAppearance.Collect.Body2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
+            android:layout_marginTop="@dimen/margin_small"
             tools:text="@string/odk_website_summary" />
 
     </LinearLayout>

--- a/collect_app/src/main/res/layout/about_item_layout.xml
+++ b/collect_app/src/main/res/layout/about_item_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2018 Shobhit Agarwal
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright 2018 Shobhit Agarwal
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,37 +17,37 @@ limitations under the License.
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:padding="@dimen/padding_medium">
+    android:padding="@dimen/margin_large">
 
     <ImageView
         android:id="@+id/imageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_medium"
-        android:layout_marginLeft="@dimen/margin_medium"
-        android:layout_marginRight="@dimen/margin_medium"
-        android:layout_marginStart="@dimen/margin_medium"
-        android:layout_marginTop="@dimen/margin_small"
         tools:src="@drawable/ic_website" />
 
-    <TextView
-        android:id="@+id/title"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginLeft="@dimen/margin_large"
         android:layout_toEndOf="@id/imageView"
         android:layout_toRightOf="@id/imageView"
-        android:textColor="?primaryTextColor"
-        android:textSize="@dimen/text_size_medium"
-        tools:text="@string/odk_website" />
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/summary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/title"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:layout_toEndOf="@id/imageView"
-        android:layout_toRightOf="@id/imageView"
-        android:textSize="@dimen/text_size_small"
-        tools:text="@string/odk_website_summary" />
+        <TextView
+            android:id="@+id/title"
+            style="?attr/textAppearanceSubtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="@string/odk_website" />
+
+        <TextView
+            android:id="@+id/summary"
+            style="?attr/textAppearanceBody2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_medium"
+            tools:text="@string/odk_website_summary" />
+
+    </LinearLayout>
 </RelativeLayout>

--- a/collect_app/src/main/res/layout/toolbar_without_progressbar.xml
+++ b/collect_app/src/main/res/layout/toolbar_without_progressbar.xml
@@ -7,8 +7,5 @@
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
     android:minHeight="?attr/actionBarSize"
-    app:contentInsetEnd="0dp"
-    app:contentInsetStart="0dp"
-    app:contentInsetStartWithNavigation="0dp"
     app:navigationIcon="@drawable/notes"
     app:theme="@style/ThemeOverlay.AppCompat.ActionBar" />

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -9,5 +9,6 @@
         <attr name="rankItemColor" format="color" />
         <attr name="dividerCompat" format="reference" />
         <attr name="spinnerItemBackgroundColor" format="color" />
+        <attr name="colorOnSurfaceMediumEmphasis" format="color" />
     </declare-styleable>
 </resources>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -12,6 +12,8 @@
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
+
+        <item name="colorOnSurface">#DEFFFFFF</item>
         <!--/Material theme attributes-->
 
         <item name="primaryTextColor">#deffffff</item>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -10,6 +10,7 @@
     <style name="Theme.Collect.BaseDark" parent="Theme.AppCompat.NoActionBar">
         <!--Material theme attributes-->
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
+        <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
         <!--/Material theme attributes-->
 

--- a/collect_app/src/main/res/values/dimens.xml
+++ b/collect_app/src/main/res/values/dimens.xml
@@ -11,6 +11,7 @@
     <dimen name="margin_medium">8dp</dimen>
     <dimen name="margin_large">16dp</dimen>
     <dimen name="margin_extra_large">24dp</dimen>
+    <dimen name="margin_extra_extra_large">32dp</dimen>
 
     <!-- fontSize -->
     <dimen name="text_size_extra_small">12sp</dimen>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -10,6 +10,7 @@
     <style name="Theme.Collect.BaseLight" parent="Theme.AppCompat.Light.NoActionBar">
         <!--Material theme attributes-->
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
+        <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
         <!--/Material theme attributes-->
 

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -12,6 +12,8 @@
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
+
+        <item name="colorOnSurface">#DE000000</item>
         <!--/Material theme attributes-->
 
         <item name="primaryTextColor">#de000000</item>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <style name="TextAppearance.Collect.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
 
     </style>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <style name="TextAppearance.Collect.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
 
     </style>
 
     <style name="TextAppearance.Collect.Subtitle1" parent="TextAppearance.MaterialComponents.Subtitle1">
+
+    </style>
+
+    <style name="TextAppearance.Collect.Body2" parent="TextAppearance.MaterialComponents.Body2">
 
     </style>
 </resources>


### PR DESCRIPTION
This is blocked by #3217.

Here I used the Material Guidelines [Lists spec](https://material.io/design/components/lists.html#specs) as a jumping off point for the text scales.

The reasoning behind what we're doing is [here](https://forum.opendatakit.org/t/reworking-collects-typography/20634). I've also, while in the area, tried to clean up the layouts involved by reworking the structure, using standard values and extracting common styles.

Here is before the changes:

![Screenshot_1562848230](https://user-images.githubusercontent.com/556280/61056801-e8ce7f80-a3eb-11e9-94a8-c24ebcecc5f0.png)

And after:

![Screenshot_1562853002](https://user-images.githubusercontent.com/556280/61056815-eec46080-a3eb-11e9-9bf4-9af6625cb0ff.png)

#### What has been done to verify that this works as intended?

Ran tests, played around with effected screen.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)