### PR TITLE
Update all selects depending on a question value when that question value is updated

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -62,6 +62,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.hasFocus;
 import static androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -233,27 +234,25 @@ public class FieldListUpdateTest {
         onView(withText("C1")).check(doesNotExist());
     }
 
-    // TODO: figure out why the third level isn't cleared. Wondering whether there might be an issue
-    // with populateDynamicChoices
-    //    @Test
-    //    public void clearingParentSelect_ShouldUpdateAllDependentLevels() {
-    //        onView(withId(R.id.menu_goto)).perform(click());
-    //        onView(withId(R.id.menu_go_up)).perform(click());
-    //        onView(allOf(withText("Cascading select"), isDisplayed())).perform(click());
-    //        onView(withText(startsWith("Level1"))).perform(click());
-    //
-    //        onView(withText("A")).perform(click());
-    //        onView(withText("A1")).perform(click());
-    //        onView(withText("A1B")).perform(click());
-    //
-    //        onView(withText("A")).perform(longClick());
-    //        onView(withText(R.string.clear_answer)).perform(click());
-    //        onView(withText(R.string.discard_answer)).perform(click());
-    //
-    //        onView(withIndex(withClassName(endsWith("RadioButton")), 0)).check(matches(isNotChecked()));
-    //        onView(withText("A1")).check(doesNotExist());
-    //        onView(withText("A1B")).check(doesNotExist());
-    //    }
+        @Test
+        public void clearingParentSelect_ShouldUpdateAllDependentLevels() {
+            onView(withId(R.id.menu_goto)).perform(click());
+            onView(withId(R.id.menu_go_up)).perform(click());
+            onView(allOf(withText("Cascading select"), isDisplayed())).perform(click());
+            onView(withText(startsWith("Level1"))).perform(click());
+
+            onView(withText("A")).perform(click());
+            onView(withText("A1")).perform(click());
+            onView(withText("A1B")).perform(click());
+
+            onView(withText("A")).perform(longClick());
+            onView(withText(R.string.clear_answer)).perform(click());
+            onView(withText(R.string.discard_answer)).perform(click());
+
+            onView(withIndex(withClassName(endsWith("RadioButton")), 0)).check(matches(isNotChecked()));
+            onView(withText("A1")).check(doesNotExist());
+            onView(withText("A1B")).check(doesNotExist());
+        }
 
     @Test
     public void selectionChangeAtOneCascadeLevelWithMinimalAppearance_ShouldUpdateNextLevels() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2969,15 +2969,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         List<FormEntryPrompt> questionsThatHaveNotChanged = new ArrayList<>();
         for (int i = immutableQuestionsBeforeSave.size() - 1; i >= 0; i--) {
             ImmutableDisplayableQuestion questionBeforeSave = immutableQuestionsBeforeSave.get(i);
-            // We'd like to use questionsAfterSaveByIndex.get but we can't because FormIndex
-            // doesn't implement hashCode and we're not guaranteed the two FormIndexes will be
-            // the same reference
-            FormEntryPrompt questionAtSameFormIndex = null;
-            for (FormIndex index : questionsAfterSaveByIndex.keySet()) {
-                if (questionBeforeSave.getFormIndex().equals(index)) {
-                    questionAtSameFormIndex = questionsAfterSaveByIndex.get(index);
-                }
-            }
+            FormEntryPrompt questionAtSameFormIndex = questionsAfterSaveByIndex.get(questionBeforeSave.getFormIndex());
 
             // Always rebuild questions that use database-driven external data features since they
             // bypass SelectChoices stored in ImmutableDisplayableQuestion


### PR DESCRIPTION
Closes #3208

#### What has been done to verify that this works as intended?
Reenabled and ran https://github.com/opendatakit/collect/blob/e1a726ef6ca5a9c95b4abd3569a04f97e3193c24/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java#L236

#### Why is this the best possible solution? Were any other approaches considered?
Given the partial fix to https://github.com/opendatakit/javarosa/issues/436 introduced at https://github.com/opendatakit/javarosa/pull/437, `populateDynamicChoices` has to be explicitly called for each select in the order that they are connected (which hopefully is always the same order that they are displayed in) so this is the only solution I can think of.

9681647 is not directly related -- it just makes use of the map for quick lookup now that `FormIndex` has a `hashCode` method. This improves performance and simplifies the code. I considered doing it separately but it was really nice to simplify the code here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Field list updates in general are at regression risk. The test coverage is fairly high as far as I know, though, so the risks are mitigated. We know the `hashCode` method didn't work for Android 4.x devices and it's possible this is still a problem.

#### Do we need any specific form for testing your changes? If so, please attach one.
See questions named "Cascading select" and "Cascading select minimal" in https://github.com/opendatakit/collect/blob/e1a726ef6ca5a9c95b4abd3569a04f97e3193c24/collect_app/src/androidTest/assets/fieldlist-updates.xml

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)