### PR TITLE
Reset state before copying background location forms

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/backgroundlocation/LocationAuditTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/backgroundlocation/LocationAuditTest.java
@@ -12,6 +12,7 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -34,6 +35,7 @@ public class LocationAuditTest {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     Manifest.permission.ACCESS_FINE_LOCATION)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule(LOCATION_AUDIT_FORM, "forms"));
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/backgroundlocation/SetLocationActionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/backgroundlocation/SetLocationActionTest.java
@@ -15,6 +15,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.test.FormLoadingUtils;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -37,6 +38,7 @@ public class SetLocationActionTest {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     Manifest.permission.ACCESS_FINE_LOCATION)
             )
+            .around(new ResetStateRule())
             .around(new CopyFormRule(SETLOCATION_ACTION_FORM, "forms"));
 
     @Before


### PR DESCRIPTION
Fixes instrumented tests related to background location.

No QA needed, this is test only. I promise that I ran the instrumented tests for real. The four FormsDAO ones are failing but I think it makes sense for @grzesiek2010 to take those on since it requires making decisions on what to actually test.