### PR TITLE
Add dependency upgrade process

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ODK Collect renders forms that are compliant with the [ODK XForms standard](http
 ## Release cycle
 New versions of ODK Collect are generally released on the last Sunday of a month. We freeze commits to the master branch on the preceding Wednesday (except for bug fixes). Releases can be requested by any community member and generally happen every 2 months. [@yanokwa](https://github.com/yanokwa) pushes the releases to the Play Store.
 
+At the beginning of each release cycle, [@grzesiek2010](https://github.com/grzesiek2010) updates all dependencies that have compatible upgrades available and ensures that the build targets the latest SDK.
+
 ## Suggesting new features
 We try to make sure that all issues in the issue tracker are as close to fully specified as possible so that they can be closed by a pull request. Feature suggestions should be described [in the forum Features category](https://forum.opendatakit.org/c/features) and discussed by the broader user community. Once there is a clear way forward, issues should be filed on the relevant repositories. More controversial features will be discussed as part of the Technical Steering Committee's [roadmapping process](https://github.com/opendatakit/governance/tree/master/TSC1#roadmapping).
 


### PR DESCRIPTION
Upgrading dependencies can be time-consuming, especially when it hasn't been done in a while and deprecations have occurred. @grzesiek2010 already generally takes the initiative to do updates (thanks!) so I propose he automatically take that on once master is unfrozen after a release.

Note that I also included "ensures that the build targets the latest SDK." Google is [moving towards requiring a target of the latest SDK](https://developer.android.com/distribute/best-practices/develop/target-sdk) so I think keeping on top of those changes will be helpful.