### PR TITLE
Rework Form List typography

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/externalintents/FormChooserListTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/externalintents/FormChooserListTest.java
@@ -5,7 +5,7 @@ import androidx.test.rule.ActivityTestRule;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.odk.collect.android.activities.FormChooserList;
+import org.odk.collect.android.activities.FormChooserListActivity;
 
 import java.io.IOException;
 
@@ -16,8 +16,8 @@ import static org.odk.collect.android.externalintents.ExportedActivitiesUtils.te
 public class FormChooserListTest {
 
     @Rule
-    public ActivityTestRule<FormChooserList> formChooserListRule =
-            new ExportedActivityTestRule<>(FormChooserList.class);
+    public ActivityTestRule<FormChooserListActivity> formChooserListRule =
+            new ExportedActivityTestRule<>(FormChooserListActivity.class);
 
     @Test
     public void formChooserListMakesDirsTest() throws IOException {

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -124,7 +124,7 @@ the specific language governing permissions and limitations under the License.
             android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="stateHidden" />
         <activity android:name=".activities.InstanceChooserList" />
-        <activity android:name=".activities.FormChooserList" />
+        <activity android:name=".activities.FormChooserListActivity" />
         <activity android:name=".activities.FormDownloadList" />
         <activity
             android:name=".activities.FileManagerTabs"
@@ -244,7 +244,7 @@ the specific language governing permissions and limitations under the License.
 
         <activity-alias
             android:name=".activities.FormChooserList"
-            android:targetActivity=".activities.FormChooserList">
+            android:targetActivity=".activities.FormChooserListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserListActivity.java
@@ -52,7 +52,7 @@ import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivit
  * @author Yaw Anokwa (yanokwa@gmail.com)
  * @author Carl Hartung (carlhartung@gmail.com)
  */
-public class FormChooserList extends FormListActivity implements
+public class FormChooserListActivity extends FormListActivity implements
         DiskSyncListener, AdapterView.OnItemClickListener, LoaderManager.LoaderCallbacks<Cursor> {
     private static final String FORM_CHOOSER_LIST_SORTING_ORDER = "formChooserListSortingOrder";
 
@@ -82,7 +82,7 @@ public class FormChooserList extends FormListActivity implements
             @Override
             public void denied() {
                 // The activity has to finish because ODK Collect cannot function without these permissions.
-                finishAllActivities(FormChooserList.this);
+                finishAllActivities(FormChooserListActivity.this);
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -124,7 +124,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             public void onClick(View v) {
                 if (Collect.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(),
-                            FormChooserList.class);
+                            FormChooserListActivity.class);
                     startActivity(i);
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/PermissionUtils.java
@@ -20,7 +20,7 @@ import com.karumi.dexter.listener.multi.MultiplePermissionsListener;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CollectAbstractActivity;
-import org.odk.collect.android.activities.FormChooserList;
+import org.odk.collect.android.activities.FormChooserListActivity;
 import org.odk.collect.android.activities.FormDownloadList;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.activities.InstanceChooserList;
@@ -96,7 +96,7 @@ public class PermissionUtils {
         List<Class<?>> activities = new ArrayList<>();
         activities.add(FormEntryActivity.class);
         activities.add(InstanceChooserList.class);
-        activities.add(FormChooserList.class);
+        activities.add(FormChooserListActivity.class);
         activities.add(InstanceUploaderListActivity.class);
         activities.add(SplashScreenActivity.class);
         activities.add(FormDownloadList.class);

--- a/collect_app/src/main/java/org/odk/collect/android/views/TwoItemMultipleChoiceView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/TwoItemMultipleChoiceView.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2009 University of Washington
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -18,11 +18,11 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.CheckBox;
 import android.widget.Checkable;
-import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 
 import org.odk.collect.android.R;
 
-public class TwoItemMultipleChoiceView extends LinearLayout implements Checkable {
+public class TwoItemMultipleChoiceView extends RelativeLayout implements Checkable {
 
     public TwoItemMultipleChoiceView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);

--- a/collect_app/src/main/res/layout/about_item_layout.xml
+++ b/collect_app/src/main/res/layout/about_item_layout.xml
@@ -45,11 +45,10 @@ limitations under the License.
 
         <TextView
             android:id="@+id/summary"
-            style="@style/TextAppearance.Collect.Body2"
+            style="@style/TextAppearance.Collect.Body2.MediumEmphasis"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_small"
-            android:textColor="@color/color_on_surface_medium_emphasis"
             tools:text="@string/odk_website_summary" />
 
     </LinearLayout>

--- a/collect_app/src/main/res/layout/form_chooser_list_item.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item.xml
@@ -1,16 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="56dp"
-        android:padding="16dp">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_large">
 
     <!-- Material Design reference: https://material.io/design/components/lists.html#specs -->
 
-    <include layout="@layout/form_chooser_list_item_icon"/>
+    <FrameLayout
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true">
 
-    <include layout="@layout/form_chooser_list_item_text"/>
+        <include layout="@layout/form_chooser_list_item_icon" />
 
-</LinearLayout>
+    </FrameLayout>
+
+
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@id/imageView"
+        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginLeft="@dimen/margin_large"
+        android:layout_toEndOf="@id/imageView"
+        android:layout_toRightOf="@id/imageView">
+
+        <include layout="@layout/form_chooser_list_item_text" />
+
+    </FrameLayout>
+
+
+</RelativeLayout>

--- a/collect_app/src/main/res/layout/form_chooser_list_item_icon.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_icon.xml
@@ -5,11 +5,9 @@
     <!-- Material Design reference: https://material.io/design/components/lists.html#specs -->
 
     <ImageView
-            android:id="@+id/image"
-            app:srcCompat="@drawable/form_state_blank"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"/>
+        android:id="@+id/image"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        app:srcCompat="@drawable/form_state_blank" />
 
 </merge>

--- a/collect_app/src/main/res/layout/form_chooser_list_item_multiple_choice.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_multiple_choice.xml
@@ -1,41 +1,70 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2009 University of Washington Licensed under the Apache
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2009 University of Washington Licensed under the Apache
 License, Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 OR CONDITIONS OF ANY KIND, either express or implied. See the License for
 the specific language governing permissions and limitations under the License. -->
-<org.odk.collect.android.views.TwoItemMultipleChoiceView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:orientation="horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="56dp"
-        android:padding="16dp">
+<org.odk.collect.android.views.TwoItemMultipleChoiceView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_large">
 
     <!-- Material Design reference: https://material.io/design/components/lists.html#specs -->
 
-    <include layout="@layout/form_chooser_list_item_icon"/>
+    <FrameLayout
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true">
 
-    <include layout="@layout/form_chooser_list_item_text"/>
+        <include layout="@layout/form_chooser_list_item_icon" />
 
-    <CheckBox
+    </FrameLayout>
+
+    <FrameLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@id/imageView"
+        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginLeft="@dimen/margin_large"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_toStartOf="@id/selectView"
+        android:layout_toLeftOf="@id/selectView"
+        android:layout_toEndOf="@id/imageView"
+        android:layout_toRightOf="@id/imageView">
+
+        <include layout="@layout/form_chooser_list_item_text" />
+
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/selectView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true">
+
+        <CheckBox
             android:id="@+id/checkbox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
             android:clickable="false"
-            android:focusable="false"/>
+            android:focusable="false"
+            android:padding="0dp" />
 
-    <ImageView
+        <ImageView
             android:id="@+id/close_box"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_gravity="center_vertical"
-            android:padding="4dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
             android:visibility="gone"
-            app:srcCompat="@drawable/ic_cancel"/>
+            app:srcCompat="@drawable/ic_cancel"
+            tools:visibility="visible" />
+
+    </FrameLayout>
 
 </org.odk.collect.android.views.TwoItemMultipleChoiceView>

--- a/collect_app/src/main/res/layout/form_chooser_list_item_text.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_text.xml
@@ -39,7 +39,7 @@
         android:layout_marginTop="@dimen/margin_small"
         android:text="@string/newer_version_of_a_form_info"
         android:textAppearance="@style/TextAppearance.Collect.Body2"
-        android:textColor="@color/displaySubtextColor"
+        android:textColor="?attr/colorSecondary"
         android:visibility="gone"
         tools:visibility="visible" />
 

--- a/collect_app/src/main/res/layout/form_chooser_list_item_text.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_text.xml
@@ -19,8 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
-        android:textAppearance="@style/TextAppearance.Collect.Body2"
-        android:textColor="@color/color_on_surface_medium_emphasis"
+        android:textAppearance="@style/TextAppearance.Collect.Body2.MediumEmphasis"
         tools:text="Version: 2019051301" />
 
     <TextView
@@ -28,8 +27,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
-        android:textAppearance="@style/TextAppearance.Collect.Body2"
-        android:textColor="@color/color_on_surface_medium_emphasis"
+        android:textAppearance="@style/TextAppearance.Collect.Body2.MediumEmphasis"
         android:visibility="gone"
         tools:text="Added on Thu, Jul 11, 2019 at 15:35"
         tools:visibility="visible" />

--- a/collect_app/src/main/res/layout/form_chooser_list_item_text.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_text.xml
@@ -1,46 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="vertical"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
     <!-- Material Design reference: https://material.io/design/components/lists.html#specs -->
 
     <TextView
-            android:id="@+id/form_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.Collect.ListItemPrimary"/>
+        android:id="@+id/form_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.Collect.Subtitle1"
+        tools:text="All widgets" />
 
     <TextView
-            android:id="@+id/form_subtitle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.Collect.ListItemSecondary"/>
+        android:id="@+id/form_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:textAppearance="@style/TextAppearance.Collect.Body2"
+        android:textColor="@color/color_on_surface_medium_emphasis"
+        tools:text="Version: 2019051301" />
 
     <TextView
-            android:id="@+id/form_subtitle2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/TextAppearance.Collect.ListItemSecondary"
-            android:visibility="gone"/>
+        android:id="@+id/form_subtitle2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:textAppearance="@style/TextAppearance.Collect.Body2"
+        android:textColor="@color/color_on_surface_medium_emphasis"
+        android:visibility="gone"
+        tools:text="Added on Thu, Jul 11, 2019 at 15:35"
+        tools:visibility="visible" />
 
     <TextView
-            android:id="@+id/form_update_alert"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/newer_version_of_a_form_info"
-            android:textAppearance="@style/TextAppearance.Collect.ListItemSecondary"
-            android:textColor="@color/displaySubtextColor"
-            android:visibility="gone"/>
+        android:id="@+id/form_update_alert"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:text="@string/newer_version_of_a_form_info"
+        android:textAppearance="@style/TextAppearance.Collect.Body2"
+        android:textColor="@color/displaySubtextColor"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <org.odk.collect.android.views.ProgressBar
-            android:id="@+id/progress_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:visibility="gone"/>
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -22,7 +22,6 @@ the License.
     <color name="amber_500">#FFC107</color>
 
     <color name="highContrastHighlight">#ff8c00</color>
-    <color name="displaySubtextColor">@color/green_500</color>
 
     <!-- Background colors in the GeoTrace status bar, under white text. -->
     <color name="locationStatusSearching">#333333</color>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -13,6 +13,7 @@
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
 
+        <item name="colorSecondary">#57C4C2</item>
         <item name="colorOnSurface">#DEFFFFFF</item>
         <!--/Material theme attributes-->
 

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -13,6 +13,7 @@
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
 
+        <item name="colorSecondary">#2196F3</item>
         <item name="colorOnSurface">#DE000000</item>
         <!--/Material theme attributes-->
 

--- a/collect_app/src/main/res/values/styles.xml
+++ b/collect_app/src/main/res/values/styles.xml
@@ -62,14 +62,6 @@
         <item name="android:layout_marginBottom">0dp</item>
     </style>
 
-    <style name="TextAppearance.Collect.ListItemPrimary" parent="TextAppearance.MaterialComponents.Body1">
-        <item name="android:textColor">?primaryTextColor</item>
-    </style>
-
-    <style name="TextAppearance.Collect.ListItemSecondary" parent="TextAppearance.MaterialComponents.Body2">
-        <item name="android:textColor">?secondaryTextColor</item>
-    </style>
-
     <style name="Widget.Collect.Toolbar" parent="Widget.AppCompat.Toolbar">
         <item name="titleTextAppearance">@style/TextAppearance.Collect.Headline6</item>
     </style>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -11,4 +11,8 @@
     <style name="TextAppearance.Collect.Body2" parent="TextAppearance.MaterialComponents.Body2">
 
     </style>
+
+    <style name="TextAppearance.Collect.Body2.MediumEmphasis" parent="TextAppearance.MaterialComponents.Body2">
+        <item name="android:textColor">@color/color_on_surface_medium_emphasis</item>
+    </style>
 </resources>

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainActivityTest.java
@@ -107,7 +107,7 @@ public class MainActivityTest {
         ShadowActivity shadowActivity = shadowOf(mainMenuActivity);
         Intent startedIntent = shadowActivity.getNextStartedActivity();
         ShadowIntent shadowIntent = shadowOf(startedIntent);
-        assertEquals(FormChooserList.class.getName(),
+        assertEquals(FormChooserListActivity.class.getName(),
                 shadowIntent.getIntentClass().getName());
     }
 


### PR DESCRIPTION
Blocked by #3207.

This reworks typography for the form lists in the app ("Fill Blank Form", "Get Blank Form" etc).

The reasoning behind what we're doing is [here](https://forum.opendatakit.org/t/reworking-collects-typography/20634). I've also, while in the area, tried to clean up the layouts involved by reworking the structure, using standard values and extracting common styles.

There is also a small color change where the "This is an update..." on a form item now uses the theme's "secondary" (for our light theme that's the blue color used throughout the app) rather than a green color.

Here is before the changes:

![Screenshot_1567001235](https://user-images.githubusercontent.com/556280/63864520-e201c900-c9a7-11e9-8919-b201bc09ea0e.png)

And after:

![Screenshot_1567001057](https://user-images.githubusercontent.com/556280/63864538-eb8b3100-c9a7-11e9-8235-2c49d54e0b23.png)

#### What has been done to verify that this works as intended?

Ran tests, played around with effected screen.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)