### PR TITLE
Open SQLite .mbtiles files in read-only mode, and only look at files with an .mbtiles extension.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MbtilesFile.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MbtilesFile.java
@@ -165,13 +165,7 @@ class MbtilesFile implements Closeable, TileSource {
         if (!file.exists() || !file.isFile()) {
             throw new NotFileException(file);
         }
-        // SQLite will create a "-journal" file for every file it touches, whether
-        // or not it's a valid SQLite file; and if invalid, it will also create a
-        // ".corrupt" file.  That means every time we scan some files to see whether
-        // they are valid SQLite databases, SQLite will triple all the invalid files.
-        // After several triplings, this quickly explodes into thousands of useless files.
-        // Thus, we refuse to even attempt to open any "-journal" or ".corrupt" files.
-        if (file.getName().endsWith("-journal") || file.getName().endsWith(".corrupt")) {
+        if (!file.getName().toLowerCase(Locale.US).endsWith(".mbtiles")) {
             throw new UnsupportedFilenameException(file);
         }
         try (SQLiteDatabase db = openSqliteReadOnly(file)) {


### PR DESCRIPTION
Scope: MbtilesFile
Requested reviewers: @lognaturel 

We should probably set the READ_ONLY flag for safety here.  I noticed that it's not only creating the `-journal` and `.corrupt` files but also overwriting the originals!

Even with the READ_ONLY flag set, I'm finding that SQLite is still renaming any file it doesn't recognize to add a `.corrupt` extension to it.  😢 

So I think we have to be conservative and only look at files with a `.mbtiles` extension.  (The old `MapHelper` did the same, so it won't be a regression in functionality.)