### PR TITLE
Sort the items in the Layer data file dialog.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/CaptionedListPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/CaptionedListPreference.java
@@ -19,6 +19,9 @@ import org.odk.collect.android.utilities.ObjectUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 /** A ListPreference where each item has a caption and the entire dialog also has a caption. */
 public class CaptionedListPreference extends ListPreference {
     private final Context context;
@@ -37,10 +40,19 @@ public class CaptionedListPreference extends ListPreference {
     }
 
     /** Sets the values, labels, and captions for the items in the dialog. */
-    public void setItems(CharSequence[] values, CharSequence[] labels, CharSequence[] captions) {
-        setEntryValues(values != null ? values : new CharSequence[0]);
-        setEntries(labels != null ? labels : values);
-        setCaptions(captions != null ? captions : new CharSequence[values.length]);
+    public void setItems(List<Item> items) {
+        int count = items.size();
+        String[] values = new String[count];
+        String[] labels = new String[count];
+        String[] captions = new String[count];
+        for (int i = 0; i < count; i++) {
+            values[i] = items.get(i).value;
+            labels[i] = items.get(i).label;
+            captions[i] = items.get(i).caption;
+        }
+        setEntryValues(values);
+        setEntries(labels);
+        setCaptions(captions);
     }
 
     /** Sets the list of items to offer as choices in the dialog. */
@@ -132,5 +144,17 @@ public class CaptionedListPreference extends ListPreference {
     /** Opens the dialog programmatically, rather than by a click from the user. */
     public void showDialog() {
         showDialog(null);
+    }
+
+    public static class Item {
+        public final @Nullable String value;
+        public final @NonNull String label;
+        public final @NonNull String caption;
+
+        public Item(@Nullable String value, @Nullable String label, @Nullable String caption) {
+            this.value = value;
+            this.label = label != null ? label : "";
+            this.caption = caption != null ? caption : "";
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -542,9 +542,9 @@ public class FileUtils {
         // '\u0000' and '\u0001' causes paths to sort correctly (assuming the paths
         // don't already contain '\u0000' or '\u0001').  This is a bit of a hack,
         // but it's a lot simpler and faster than comparing components one by one.
-        String aParts = a.replace('/', '\u0000').replace('.', '\u0001');
-        String bParts = b.replace('/', '\u0000').replace('.', '\u0001');
-        return aParts.compareTo(bParts);
+        String sortKeyA = a.replace('/', '\u0000').replace('.', '\u0001');
+        String sortKeyB = b.replace('/', '\u0000').replace('.', '\u0001');
+        return sortKeyA.compareTo(sortKeyB);
     }
 
     public static String getFileExtension(String fileName) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -534,6 +534,19 @@ public class FileUtils {
         }
     }
 
+    /** Sorts file paths as if sorting the path components and extensions lexicographically. */
+    public static int comparePaths(String a, String b) {
+        // Regular string compareTo() is incorrect, because it will sort "/" and "."
+        // after other punctuation (e.g. "foo/bar" will sort AFTER "foo-2/bar" and
+        // "pic.jpg" will sort AFTER "pic-2.jpg").  Replacing these delimiters with
+        // '\u0000' and '\u0001' causes paths to sort correctly (assuming the paths
+        // don't already contain '\u0000' or '\u0001').  This is a bit of a hack,
+        // but it's a lot simpler and faster than comparing components one by one.
+        String aParts = a.replace('/', '\u0000').replace('.', '\u0001');
+        String bParts = b.replace('/', '\u0000').replace('.', '\u0001');
+        return aParts.compareTo(bParts);
+    }
+
     public static String getFileExtension(String fileName) {
         int dotIndex = fileName.lastIndexOf('.');
         if (dotIndex == -1) {


### PR DESCRIPTION
Issues: Closes #3236.
Scope: Maps preferences; "Layers" button dialog
Requested reviewers: @lognaturel 

#### User-visible changes

Items in the "Layer data file" dialog used to appear in essentially random order (an order determined by the filesystem, as returned from `listFiles()`).  With this change, they are sorted:

- First, by title, alphabetically ignoring case;
- If titles are identical ignoring case, then by title respecting case (uppercase first);
- If titles are completely identical, then lexicographically by path.

Paths are sorted (effectively) component-by-component; see the screenshots below and the comments in `FileUtils.sortPaths()` for why.

#### Screenshots

Without this change:

![unsorted-items](https://user-images.githubusercontent.com/236086/61835562-293ced00-ae31-11e9-9297-366456ae80da.png)


Sorted, but only sorting paths as Strings:

![sort-as-strings](https://user-images.githubusercontent.com/236086/61835596-4b366f80-ae31-11e9-810c-84be18d47f44.png)


With this change (sorting paths with the new `FileUtils.sortPaths()`):

![sorted-items](https://user-images.githubusercontent.com/236086/61835565-2c37dd80-ae31-11e9-993b-7d08e0ea48ba.png)
