### PR TITLE
Address systematic test failures

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
@@ -4,11 +4,9 @@ import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.R;
 import org.odk.collect.android.espressoutils.FormEntry;
 import org.odk.collect.android.espressoutils.MainMenu;
 import org.odk.collect.android.espressoutils.Settings;
-
 
 import static androidx.test.espresso.Espresso.pressBack;
 
@@ -26,7 +24,7 @@ public class ServerOtherTest extends BaseRegressionTest {
         FormEntry.clickOnAreaWithIndex("CheckedTextView", 2);
         FormEntry.clickOnAreaWithKey("formlist_url");
         FormEntry.focusOnTextAndTextInput("/formList", "/sialala");
-        FormEntry.clickOnString(R.string.ok);
+        FormEntry.clickOk();
         FormEntry.checkIsTextDisplayed("/formList/sialala");
         pressBack();
         pressBack();
@@ -43,7 +41,7 @@ public class ServerOtherTest extends BaseRegressionTest {
          FormEntry.clickOnAreaWithIndex("CheckedTextView", 2);
          FormEntry.clickOnAreaWithKey("submission_url");
          FormEntry.focusOnTextAndTextInput("/submission", "/blabla");
-         FormEntry.clickOnString(R.string.ok);
+         FormEntry.clickOk();
          FormEntry.checkIsTextDisplayed("/submission/blabla");
          pressBack();
          pressBack();

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/QRCodeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/QRCodeUtilsTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.robolectric.RobolectricTestRunner;
 
@@ -41,6 +42,7 @@ public class QRCodeUtilsTest {
     @Before
     public void setup() {
         GeneralSharedPreferences.getInstance().loadDefaultPreferences();
+        AdminSharedPreferences.getInstance().loadDefaultPreferences();
         savedQrCodeImage.delete();
         md5File.delete();
     }


### PR DESCRIPTION
# Unit tests / commit 1
We're getting [unit test failures on Circle CI](https://6283-40213809-gh.circle-artifacts.com/0/reports/tests/testDebugUnitTest/classes/org.odk.collect.android.utilities.QRCodeUtilsTest.html#generateQRCodeIfNoCacheExists). In the preference QR code tests, the expectation is to have no admin preferences but instead `["maps":false]` is in there. This comes from `PrefMigratorTest`. 

Interestingly, `PrefMigratorTest` was introduced in #3164 and tests did not fail on that PR. The tests have also sometimes passed on master (e.g. [here](https://circleci.com/workflow-run/0ad3e907-a7b7-4c86-abe4-f25b14785cef)).

It may depend on the order the tests are run in. It also seems maybe some versions of Robolectric maintain shared preference state between tests and others don't https://github.com/robolectric/robolectric/issues/3510. 

Since these tests rely on the preferences being empty, clearing them before running the tests seems like the right thing to do.

# Espresso tests / commit 2
`formListPath_ShouldBeUpdated` and `submissionsPath_ShouldBeUpdated` are failing on clicking the "OK" button. This looks like the same issue as https://github.com/opendatakit/collect/pull/3155 CC @mmarciniak90 @kkrawczyk123 