### PR TITLE
Avoid crash on Android 4 by getting a vector icon from the local context instead of the application context.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -45,7 +45,6 @@ import com.mapbox.mapboxsdk.utils.ColorUtils;
 
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.geo.MbtilesFile.LayerType;
 import org.odk.collect.android.geo.MbtilesFile.MbtilesException;
 
@@ -473,8 +472,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
                 .withSource(new RasterSource("[osm]", tiles, 256))
                 .withLayer(new RasterLayer("[osm]", "[osm]"));
         }
-        Context context = Collect.getInstance().getApplicationContext();
-        Drawable pointIcon = ContextCompat.getDrawable(context, R.drawable.ic_map_point);
+        Drawable pointIcon = ContextCompat.getDrawable(getContext(), R.drawable.ic_map_point);
         return new Style.Builder().fromUrl(styleUrl)
             .withImage(POINT_ICON_ID, pointIcon)
             .withTransition(new TransitionOptions(0, 0, false));


### PR DESCRIPTION
Issues: Closes #3246.
Scope: MapboxMapFragment
Requested reviewers: @lognaturel 

#### User-visible changes

A crash when opening a Mapbox map on Android 4.x is avoided.

#### Internal changes

I was able to replicate and confirm this crash in an Android 4.x emulator.  I was puzzled by this, and don't understand why it's happening.

First, I tried switching to `VectorDrawableCompat.create()` as recommended by [this Stack Overflow post](https://stackoverflow.com/questions/48285547/resourcesnotfoundexception-for-xml-vector-drawable-on-api-19).  This did avoid the crash.

But then I went looking and found that there are many places where we call `ContextCompat.getDrawable` to get a vector icon (e.g. `FileArrayAdapter`, `FormHierarchyActivity`), and when I exercised those code paths in my Android 4.4 emulator, they did not crash.  There is even a similar call in `OsmDroidMapFragment` and it does not crash.

Upon closer inspection I found that these other calls did not use `getApplicationContext()`, but instead got a context from a local Activity or View.  So I tried switching `MapboxMapFragment` to also use the fragment's context instead of the application context, and that seems to work.

I don't understand why it works, though.