### PR TITLE
Set User-Agent string for osmdroid

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -29,6 +29,10 @@ import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.multidex.MultiDex;
+
 import com.crashlytics.android.Crashlytics;
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobManagerCreateException;
@@ -68,9 +72,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.Locale;
 
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatDelegate;
-import androidx.multidex.MultiDex;
 import timber.log.Timber;
 
 import static org.odk.collect.android.logic.PropertyManager.PROPMGR_USERNAME;
@@ -208,6 +209,19 @@ public class Collect extends Application {
         return getString(R.string.app_name) + versionName;
     }
 
+    /**
+     * Get a User-Agent string that provides the platform details followed by the application ID
+     * and application version name: {@code Dalvik/<version> (platform info) org.odk.collect.android/v<version>}.
+     *
+     * This deviates from the recommended format as described in https://github.com/opendatakit/collect/issues/3253.
+     */
+    public String getUserAgentString() {
+        return String.format("%s %s/%s",
+                System.getProperty("http.agent"),
+                BuildConfig.APPLICATION_ID,
+                BuildConfig.VERSION_NAME);
+    }
+
     public boolean isNetworkAvailable() {
         ConnectivityManager manager = (ConnectivityManager) getInstance()
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -270,6 +284,8 @@ public class Collect extends Application {
         }
 
         setupLeakCanary();
+
+        org.osmdroid.config.Configuration.getInstance().setUserAgentValue(getUserAgentString());
     }
 
     private void setupDagger() {

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -14,7 +14,6 @@ import com.burgstaller.okhttp.digest.Credentials;
 import com.burgstaller.okhttp.digest.DigestAuthenticator;
 
 import org.apache.commons.io.IOUtils;
-import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.FileUtils;
@@ -304,7 +303,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     private Request buildGetRequest(@NonNull URI uri) throws MalformedURLException {
         return new Request.Builder()
                 .url(uri.toURL())
-                .addHeader(USER_AGENT_HEADER, getUserAgentString())
+                .addHeader(USER_AGENT_HEADER, Collect.getInstance().getUserAgentString())
                 .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
                 .addHeader(DATE_HEADER, getHeaderDate())
                 .get()
@@ -314,7 +313,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     private Request buildHeadRequest(@NonNull URI uri) throws MalformedURLException {
         return new Request.Builder()
                 .url(uri.toURL())
-                .addHeader(USER_AGENT_HEADER, getUserAgentString())
+                .addHeader(USER_AGENT_HEADER, Collect.getInstance().getUserAgentString())
                 .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
                 .addHeader(DATE_HEADER, getHeaderDate())
                 .head()
@@ -324,18 +323,11 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     private Request buildPostRequest(@NonNull URI uri, RequestBody body) throws MalformedURLException {
         return new Request.Builder()
                 .url(uri.toURL())
-                .addHeader(USER_AGENT_HEADER, getUserAgentString())
+                .addHeader(USER_AGENT_HEADER, Collect.getInstance().getUserAgentString())
                 .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
                 .addHeader(DATE_HEADER, getHeaderDate())
                 .post(body)
                 .build();
-    }
-
-    private String getUserAgentString() {
-        return String.format("%s %s/%s",
-                System.getProperty("http.agent"),
-                BuildConfig.APPLICATION_ID,
-                BuildConfig.VERSION_NAME);
     }
 
     private String getHeaderDate() {


### PR DESCRIPTION
Closes #3252
Closes #3248

I have communicated with OSM and they have advised us to change the User-Agent string.

#### What has been done to verify that this works as intended?
Verified that we follow [the osmdroid instructions](https://github.com/osmdroid/osmdroid/wiki/Important-notes-on-using-osmdroid-in-your-app#set-the-http-user-agent-variable).

Used the [network profiler](https://developer.android.com/studio/profile/network-profiler) to look at the request details while loading an osmdroid-rendered map and verified that the User-Agent header is as expected (Dalvik/2.1.0 (Linux; U; Android 5.1.1; SM-T285 Build/LMY47V) org.odk.collect.android/v1.23.0-beta.4-9-g4cb530c69).

#### Why is this the best possible solution? Were any other approaches considered?
I moved the `getUserAgentString` method to the application level so all components that send user agent strings can use a consistent one.

I considered also addressing https://github.com/opendatakit/collect/issues/3253 but since I'm not totally sure it's without risk and it's not really a fix, I figured we can do this for the next release.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It should not affect users.

It does affect tile servers that we pull from, though, because now they'll be seeing a new User-Agent string. In particular, this will bring back access to OpenStreetMap tiles which violates their terms of service. We should wait until we learn more about #3248 before merging.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)