### PR TITLE
Show attribution text for OSM, USGS, Stamen, and CARTO maps.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapProvider.java
@@ -44,8 +44,8 @@ public class MapProvider {
     private static final String OSM_COPYRIGHT = "© OpenStreetMap contributors";
     private static final String CARTO_COPYRIGHT = "© CARTO";
     private static final String CARTO_ATTRIBUTION = OSM_COPYRIGHT + ", " + CARTO_COPYRIGHT;
-    private static final String STAMEN_ATTRIBUTION = "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.";
-    private static final String USGS_ATTRIBUTION = "Map services and data available from U.S. Geological Survey, National Geospatial Program.";
+    private static final String STAMEN_ATTRIBUTION = "Map tiles by Stamen Design, under CC BY 3.0.\nData by OpenStreetMap, under ODbL.";
+    private static final String USGS_ATTRIBUTION = "Map services and data available from U.S. Geological Survey,\nNational Geospatial Program.";
 
     // In general, there will only be one MapFragment, and thus one entry, in
     // each of these two Maps at any given time.  Nonetheless, it's a little

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapProvider.java
@@ -42,6 +42,10 @@ public class MapProvider {
     private static final String USGS_URL_BASE =
         "https://basemap.nationalmap.gov/arcgis/rest/services";
     private static final String OSM_COPYRIGHT = "© OpenStreetMap contributors";
+    private static final String CARTO_COPYRIGHT = "© CARTO";
+    private static final String CARTO_ATTRIBUTION = OSM_COPYRIGHT + ", " + CARTO_COPYRIGHT;
+    private static final String STAMEN_ATTRIBUTION = "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.";
+    private static final String USGS_ATTRIBUTION = "Map services and data available from U.S. Geological Survey, National Geospatial Program.";
 
     // In general, there will only be one MapFragment, and thus one entry, in
     // each of these two Maps at any given time.  Nonetheless, it's a little
@@ -98,15 +102,15 @@ public class MapProvider {
                 new OsmDroidMapConfigurator(
                     KEY_USGS_MAP_STYLE, R.string.basemap_source_usgs,
                     new WmsOption("topographic", R.string.topographic, new WebMapService(
-                        R.string.openmap_usgs_topo, 0, 18, 256, "USGS",
+                        R.string.openmap_usgs_topo, 0, 18, 256, USGS_ATTRIBUTION,
                         USGS_URL_BASE + "/USGSTopo/MapServer/tile/{z}/{y}/{x}"
                     )),
                     new WmsOption("hybrid", R.string.hybrid, new WebMapService(
-                        R.string.openmap_usgs_sat, 0, 18, 256, "USGS",
+                        R.string.openmap_usgs_sat, 0, 18, 256, USGS_ATTRIBUTION,
                         USGS_URL_BASE + "/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}"
                     )),
                     new WmsOption("satellite", R.string.satellite, new WebMapService(
-                        R.string.openmap_usgs_img, 0, 18, 256, "USGS",
+                        R.string.openmap_usgs_img, 0, 18, 256, USGS_ATTRIBUTION,
                         USGS_URL_BASE + "/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
                     ))
                 )
@@ -114,7 +118,7 @@ public class MapProvider {
             new SourceOption(BASEMAP_SOURCE_STAMEN, R.string.basemap_source_stamen,
                 new OsmDroidMapConfigurator(
                     new WebMapService(
-                        R.string.openmap_stamen_terrain, 0, 18, 256, OSM_COPYRIGHT,
+                        R.string.openmap_stamen_terrain, 0, 18, 256, STAMEN_ATTRIBUTION,
                         "http://tile.stamen.com/terrain/{z}/{x}/{y}.jpg"
                     )
                 )
@@ -123,11 +127,11 @@ public class MapProvider {
                 new OsmDroidMapConfigurator(
                     KEY_CARTO_MAP_STYLE, R.string.basemap_source_carto,
                     new WmsOption("positron", R.string.carto_map_style_positron, new WebMapService(
-                        R.string.openmap_cartodb_positron, 0, 18, 256, OSM_COPYRIGHT,
+                        R.string.openmap_cartodb_positron, 0, 18, 256, CARTO_ATTRIBUTION,
                         "http://1.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
                     )),
                     new WmsOption("dark_matter", R.string.carto_map_style_dark_matter, new WebMapService(
-                        R.string.openmap_cartodb_darkmatter, 0, 18, 256, OSM_COPYRIGHT,
+                        R.string.openmap_cartodb_darkmatter, 0, 18, 256, CARTO_ATTRIBUTION,
                         "http://1.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
                     ))
                 )

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -639,7 +639,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         public static final int FONT_SIZE = 12;
         public static final int MARGIN_DP = 10;
 
-        private Paint paint;
+        private final Paint paint;
 
         public AttributionOverlay(Context context) {
             super();

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -157,7 +157,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         map.getController().setCenter(toGeoPoint(INITIAL_CENTER));
         map.getController().setZoom((int) INITIAL_ZOOM);
         map.setTilesScaledToDpi(true);
-        map.getOverlays().add(new CopyrightOverlay(getContext()));
+        map.getOverlays().add(new AttributionOverlay(getContext()));
         map.getOverlays().add(new MapEventsOverlay(this));
         loadReferenceOverlay();
         addMapLayoutChangeListener(map);
@@ -634,13 +634,14 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         }
     }
 
-    private static class CopyrightOverlay extends Overlay {
+    /** An overlay that draws an attribution message in the lower-right corner. */
+    private static class AttributionOverlay extends Overlay {
         public static final int FONT_SIZE = 12;
         public static final int MARGIN_DP = 10;
 
         private Paint paint;
 
-        public CopyrightOverlay(Context context) {
+        public AttributionOverlay(Context context) {
             super();
 
             float density = context.getResources().getDisplayMetrics().density;

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -636,19 +636,19 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     /** An overlay that draws an attribution message in the lower-right corner. */
     private static class AttributionOverlay extends Overlay {
-        public static final int FONT_SIZE = 12;
+        public static final int FONT_SIZE_DP = 12;
         public static final int MARGIN_DP = 10;
 
         private final Paint paint;
 
-        public AttributionOverlay(Context context) {
+        AttributionOverlay(Context context) {
             super();
 
-            float density = context.getResources().getDisplayMetrics().density;
             paint = new Paint();
             paint.setAntiAlias(true);
             paint.setColor(new ThemeUtils(context).getPrimaryTextColor());
-            paint.setTextSize(density * FONT_SIZE);
+            paint.setTextSize(FONT_SIZE_DP *
+                context.getResources().getDisplayMetrics().density);
             paint.setTextAlign(Paint.Align.RIGHT);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -37,6 +37,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
 import org.odk.collect.android.utilities.IconUtils;
+import org.odk.collect.android.utilities.ThemeUtils;
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.events.MapEventsReceiver;
 import org.osmdroid.events.MapListener;
@@ -46,6 +47,7 @@ import org.osmdroid.tileprovider.IRegisterReceiver;
 import org.osmdroid.util.BoundingBox;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.MapEventsOverlay;
 import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.Polyline;
@@ -154,6 +156,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         map.getController().setCenter(toGeoPoint(INITIAL_CENTER));
         map.getController().setZoom((int) INITIAL_ZOOM);
         map.setTilesScaledToDpi(true);
+        map.getOverlays().add(createCopyrightOverlay(getContext()));
         map.getOverlays().add(new MapEventsOverlay(this));
         loadReferenceOverlay();
         addMapLayoutChangeListener(map);
@@ -408,6 +411,13 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     private static @NonNull GeoPoint toGeoPoint(@NonNull MapPoint point) {
         return new GeoPoint(point.lat, point.lon, point.alt);
+    }
+
+    private static CopyrightOverlay createCopyrightOverlay(Context context) {
+        CopyrightOverlay overlay = new CopyrightOverlay(context);
+        overlay.setAlignRight(true);
+        overlay.setTextColor(new ThemeUtils(context).getPrimaryTextColor());
+        return overlay;
     }
 
     /** Updates the map to reflect the value of referenceLayerFile. */


### PR DESCRIPTION
Issues: Closes #3251.
Scope: OsmDroidMapFragment
Requested reviewers: @lognaturel 

#### User-visible changes

Attribution text now appears in the bottom-right corner for the OSM, USGS, Stamen, and CARTO maps.  The text is in the primary text colour for the selected theme.

The text is not always readable, depending on the theme and the lightness/darkness of the map tiles.  The text is also temporarily obscured when the zoom buttons appear (eventually the zoom buttons fade away).

The text follows the recommendations in #3251, though it does not provide clickable hyperlinks.

#### Screenshots

![attr-stamen](https://user-images.githubusercontent.com/236086/61988330-ca17dd80-afd4-11e9-9253-94eac9e24906.png)
![attr-usgs-unreadable](https://user-images.githubusercontent.com/236086/61988331-ca17dd80-afd4-11e9-8241-3be775809f0b.png)
![attr-usgs-dark](https://user-images.githubusercontent.com/236086/61988350-0c411f00-afd5-11e9-90e6-70960f3300e7.png)
![attr-carto-positron](https://user-images.githubusercontent.com/236086/61988351-0c411f00-afd5-11e9-95ce-e1a2fb6d4c95.png)
