### PR TITLE
Catch IndexOutOfBoundsException in getXPathPath() method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/AuditEvent.java
@@ -26,6 +26,8 @@ import org.odk.collect.android.utilities.TextUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import timber.log.Timber;
+
 public class AuditEvent {
 
     public enum AuditEventType {
@@ -292,11 +294,15 @@ public class AuditEvent {
         FormIndex walker = formIndex;
         int i = 1;
         while (walker != null) {
-            String currentNodeName = formIndex.getReference().getName(i);
-            if (walker.getInstanceIndex() != -1) {
-                currentNodeName = currentNodeName + "[" + (walker.getInstanceIndex() + 1) + "]";
+            try {
+                String currentNodeName = formIndex.getReference().getName(i);
+                if (walker.getInstanceIndex() != -1) {
+                    currentNodeName = currentNodeName + "[" + (walker.getInstanceIndex() + 1) + "]";
+                }
+                nodeNames.add(currentNodeName);
+            } catch (IndexOutOfBoundsException e) {
+                Timber.i(e);
             }
-            nodeNames.add(currentNodeName);
 
             walker = walker.getNextLevel();
             i++;


### PR DESCRIPTION
Closes #3257 

The crash itself is caused by changes implemented in https://github.com/opendatakit/collect/pull/3231 but the problem is rather with the attached forms.
Used `field-list` groups don't contain refs, sample from Audit.xml:
```xml
<group appearance="field-list">
      <label ref="jr:itext('/data/untitled1:label')"/>
      <input ref="/data/untitled1/untitled2">
      </input>
      <input ref="/data/untitled1/untitled3">
      </input>
    </group>
```
but it should be:
```xml
    <group appearance="field-list" ref="/data/untitled1">
      <label ref="jr:itext('/data/untitled1:label')"/>
      <input ref="/data/untitled1/untitled2">
      </input>
      <input ref="/data/untitled1/untitled3">
      </input>
    </group>
```

It didn't cause any crash on v1.22.4 but it produced wrong nodes in audit.csv file:

| event  | node | start | end |
| ------------- | ------------- | ------------- | ------------- |
| form start  |  | 1564403154996 |  |
| group questions  | /data  | 1564403154998 | 1564403156548 |
| end screen  |  | 1564403156557 | 1564403157774  |
| form save  |  | 1564403157774 |  |
| form exit  |  | 1564403157774 |  |
| form finalize  |  | 1564403157774 |  |

but it should be:

| event  | node | start | end |
| ------------- | ------------- | ------------- | ------------- |
| form start  |  | 1564403154996 |  |
| group questions  | /data/untitled1  | 1564403154998 | 1564403156548 |
| end screen  |  | 1564403156557 | 1564403157774  |
| form save  |  | 1564403157774 |  |
| form exit  |  | 1564403157774 |  |
| form finalize  |  | 1564403157774 |  |

I wonder how you created those forms @kkrawczyk123 @mmarciniak90 I tried ODK build and excel and in both cases ref values are there.

#### What has been done to verify that this works as intended?
I tested the attached forms.

#### Why is this the best possible solution? Were any other approaches considered?
Since the problem is rather with forms we can't do much here and I just decided to catch the exception. Catching the exception the output using master branch would be the same as in v1.22.4

| event  | node | start | end |
| ------------- | ------------- | ------------- | ------------- |
| form start  |  | 1564403154996 |  |
| group questions  | /data  | 1564403154998 | 1564403156548 |
| end screen  |  | 1564403156557 | 1564403157774  |
| form save  |  | 1564403157774 |  |
| form exit  |  | 1564403157774 |  |
| form finalize  |  | 1564403157774 |  |

still the wrong node but as I said it's because of the form.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I added just one catch so it's safe and can't cause any other problems.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)