### PR TITLE
Make raster tiles 100% opaque on Mapbox maps.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -65,7 +65,6 @@ import timber.log.Timber;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.rasterOpacity;
 
 public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.MapFragment
     implements MapFragment, OnMapReadyCallback,
@@ -515,6 +514,9 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
             List<MbtilesFile.VectorLayer> layers = mbtiles.getVectorLayers();
             for (MbtilesFile.VectorLayer layer : layers) {
                 // Pick a colour that's a function of the filename and layer name.
+                // The colour will appear essentially random; the only purpose here
+                // is to try to assign different colours to different layers, such
+                // that each individual layer appears in its own consistent colour.
                 int hue = (((id + "." + layer.name).hashCode()) & 0x7fffffff) % 360;
                 addOverlayLayer(new LineLayer(id + "/" + layer.name, id).withProperties(
                     lineColor(Color.HSVToColor(new float[] {hue, 0.7f, 1})),
@@ -525,9 +527,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
         }
         if (mbtiles.getLayerType() == LayerType.RASTER) {
             addOverlaySource(new RasterSource(id, tileSet));
-            addOverlayLayer(new RasterLayer(id + ".raster", id).withProperties(
-                rasterOpacity(0.5f)
-            ));
+            addOverlayLayer(new RasterLayer(id + ".raster", id));
         }
         Timber.i("Added %s as a %s layer at /%s", file, mbtiles.getLayerType(), id);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -467,6 +467,13 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
     }
 
     private Style.Builder getDesiredStyleBuilder() {
+        Drawable pointIcon = ContextCompat.getDrawable(getContext(), R.drawable.ic_map_point);
+        return getBasemapStyleBuilder()
+            .withImage(POINT_ICON_ID, pointIcon)
+            .withTransition(new TransitionOptions(0, 0, false));
+    }
+
+    private Style.Builder getBasemapStyleBuilder() {
         if (BuildConfig.MAPBOX_ACCESS_TOKEN.isEmpty()) {
             // When the MAPBOX_ACCESS_TOKEN is missing, any attempt to load
             // map data from Mapbox will cause the Mapbox SDK to abort with an
@@ -478,10 +485,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
                 .withSource(new RasterSource("[osm]", tiles, 256))
                 .withLayer(new RasterLayer("[osm]", "[osm]"));
         }
-        Drawable pointIcon = ContextCompat.getDrawable(getContext(), R.drawable.ic_map_point);
-        return new Style.Builder().fromUrl(styleUrl)
-            .withImage(POINT_ICON_ID, pointIcon)
-            .withTransition(new TransitionOptions(0, 0, false));
+        return new Style.Builder().fromUrl(styleUrl);
     }
 
     /**


### PR DESCRIPTION
As discussed, this makes raster offline tile layers appear 100% opaque (instead of 50% transparent) on Mapbox maps, for consistency with the rendering of offline tiles on Google and OSMDroid maps.

#### What has been done to verify that this works as intended?

- Built and ran this APK on both Android 6.0.1 and Android 9.0
- Selected the "satellite.mbtiles" raster layer (attached)
- Opened GeoShape with a Google map, a Mapbox map, and the USGS topographic map
    - In each case, I zoomed out until the satellite tiles appeared, and confirmed they were drawn fully opaque.
    - In each case, I used the Layers button to turn the layer on and off and confirmed it still appears properly.

#### Why is this the best possible solution? Were any other approaches considered?

The main reason we decided to do this is that raster layers are drawn fully opaque on Google maps and OSMDroid maps, and we wanted to make this behaviour consistent on Mapbox maps.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The intentional change is that the raster layer is 100% opaque.

However, there is now a different inconsistency.  MBTiles files contain, in their metadata, a minimum and maximum zoom level declaration.  For the low-res satellite.mbtiles file, this range is 0 to 5.

On Google and OSMDroid maps, the raster layer is only drawn at the zoom levels for which it is declared.  On Mapbox maps, the raster layer is always drawn.  So when the map zooms to your current location, on Google and OSMDroid, you will see the basemap, but on Mapbox, the entire screen will be a solid colour (dark green on land, typically).

#### Open questions

Should we implement our own check to make the raster layer disappear when the zoom level is outside of the declared range?
  - Pro: The behaviour will exactly match that in Google and OSMDroid.
  - Con: The sudden appearance/disappearance of the raster layer in Google and OSMDroid is jarring and has confused me in the past.  At the default zoom level after a GPS fix (level 16), the raster layer typically doesn't appear, so I think it's not working, and there's no indication in the UI what the zoom level is or what zoom levels it should be expected to appear at.  It's actually kind of nice to be able to see that the raster layer is there.

In theory, this is a reference layer, so it isn't really supposed to be used for images that are opaque everywhere. But of course this is the only option we are providing right now; we don't offer a way to specify an offline "basemap" in the preferences.

One could imagine a nice compromise behaviour where the opacity is 100% within the declared range (in this case, 0 to 5), and then smoothly falls off to something like 30–40% outside of that range (maybe at zoom level 6 it's 70%, at zoom level 7 it's 40%, that sort of thing).  I'm pretty sure Mapbox can do this nicely if we want it to, though this would be inconsistent with Google and OSMDroid.

#### Do we need any specific form for testing your changes? If so, please attach one.

The regular GPS widgets in the "All widgets" form are sufficient for testing.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Documentation issue: https://github.com/opendatakit/docs/issues/1073

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkCode` and confirmed all checks pass
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally (this started 20 minutes ago and is still running so I'll post this PR for now and update this when it finishes)
- [ ] verified that any code or assets from external sources **(no new code or assets)**
- [ ] verified that any new UI elements use theme colors **(no new UI elements)**