### PR TITLE
Use high accuracy priority to get points in absence of wifi or cell

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/location/client/MaxAccuracyWithinTimeoutLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/MaxAccuracyWithinTimeoutLocationClient.java
@@ -27,7 +27,7 @@ public class MaxAccuracyWithinTimeoutLocationClient implements LocationClient.Lo
     private Location highestAccuracyReading;
     private final Handler timerHandler;
 
-    private static final LocationClient.Priority DEFAULT_PRIORITY = LocationClient.Priority.PRIORITY_BALANCED_POWER_ACCURACY;
+    private static final LocationClient.Priority DEFAULT_PRIORITY = LocationClient.Priority.PRIORITY_HIGH_ACCURACY;
 
     public MaxAccuracyWithinTimeoutLocationClient(LocationClient locationClient, LocationListener listener) {
         this.locationClient = locationClient;


### PR DESCRIPTION
Closes #3244

#### What has been done to verify that this works as intended?
Went to a large park with clear view of the sky and no wifi. Used a device with no SIM to fill out the `Collect v1.23 Beta: Background Geopoint Test` form from the default server. Did it first from master and then from this branch.

#### Why is this the best possible solution? Were any other approaches considered?
I expected that [PRIORITY_BALANCED_POWER_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.html#PRIORITY_BALANCED_POWER_ACCURACY) would still access GPS when no location was available from other providers but that does not appear to be the case or at least it doesn't attempt it frequently. After re-reading [the description of the accuracy levels](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest), I realized that we really do want the most accurate location available for the background geopoint feature rather than "block level" accuracy. If a form designer is explicitly asking for location in the form, it's not acceptable that it only work reliably in an environment with wifi and cell, especially given our users. The battery-saving measure we have in place is that we only request location for 20 seconds and give up if none is available by then (this might need to be revisited as well or perhaps become configurable).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The GPS will be accessed more frequently to capture location in the background. When that occurs, the user will see the location access icon in the device status bar. This should go away after at most 20 seconds for each background location request (in the case of the beta form, each multiple selection question triggers a location request). This may result in more battery usage if wifi or cell localization is unavailable.

#### Do we need any specific form for testing your changes? If so, please attach one.
`Collect v1.23 Beta: Background Geopoint Test` form from the default server. I'm not entirely sure how to verify this in an urban environment. I don't believe all devices make it possible to entirely turn off cell and wifi localization (that is, even if you're not connected to a wifi network, I believe local networks can be used). I had to get out of any network range to really see the bad performance of master.

Since this now matches the accuracy setting of the audit log and mapping features, perhaps it doesn't need QA?

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Once the pyxform implementation is in, the feature will get full documentation.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)