### PR TITLE
Fixed navigationButtons_ShouldBeVisibleWhenAreSetInTheMiddleOfForm test

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.espressoutils;
 
+import androidx.test.espresso.Espresso;
 import androidx.test.espresso.matcher.PreferenceMatchers;
 import androidx.test.rule.ActivityTestRule;
 import org.odk.collect.android.R;
@@ -16,7 +17,6 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
-import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
@@ -123,7 +123,7 @@ public final class FormEntry {
     }
 
     public static void clickOptionsIcon() {
-        onView(withContentDescription("More options")).perform(click());
+        Espresso.openContextualActionModeOverflowMenu();
     }
 
     public static void clickGeneralSettings() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
@@ -4,6 +4,7 @@ import androidx.test.espresso.Espresso;
 import androidx.test.espresso.matcher.PreferenceMatchers;
 import androidx.test.rule.ActivityTestRule;
 import org.odk.collect.android.R;
+import org.odk.collect.android.support.ActivityHelpers;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -123,7 +124,7 @@ public final class FormEntry {
     }
 
     public static void clickOptionsIcon() {
-        Espresso.openContextualActionModeOverflowMenu();
+        Espresso.openActionBarOverflowOrOptionsMenu(ActivityHelpers.getActivity());
     }
 
     public static void clickGeneralSettings() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/MainMenu.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/MainMenu.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.espressoutils;
 import androidx.test.espresso.Espresso;
 import org.odk.collect.android.R;
 import org.odk.collect.android.provider.FormsProviderAPI;
+import org.odk.collect.android.support.ActivityHelpers;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -21,7 +22,7 @@ public final class MainMenu {
     }
 
     public static void clickOnMenu() {
-        Espresso.openContextualActionModeOverflowMenu();
+        Espresso.openActionBarOverflowOrOptionsMenu(ActivityHelpers.getActivity());
     }
 
     public static void startBlankForm(String text) {


### PR DESCRIPTION
One espresso test is failing https://console.firebase.google.com/project/api-project-322300403941/testlab/histories/bh.f6f8331e5ae6e371/matrices/6777832822726188216

#### What has been done to verify that this works as intended?
I was able to reproduce the issue and confirm that my changes fix it.

#### Why is this the best possible solution? Were any other approaches considered?
`openContextualActionModeOverflowMenu()` method which I used is just a more reliable way to click on `three-dots`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)