### PR TITLE
Fail encrypted form finalization if form does not specify instanceID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,8 @@ icon color | themeUtils.getIconColor() | ?iconColor
 ## Strings
 Always use [string resources](https://developer.android.com/guide/topics/resources/string-resource.html) instead of literal strings. This ensures wording consistency across the project and also enables full translation of the app. Only make changes to the base `res/values/strings.xml` English file and not to the other language files. The translated files are generated from [Transifex](https://www.transifex.com/opendatakit/collect/) where translations can be submitted by the community. Names of software packages or other untranslatable strings should be placed in `res/values/untranslated.xml`.
 
+Strings that represent very rare failure cases or that are meant more for ODK developers to use for troubleshooting rather than directly by users may be written as literal strings. This reduces the burden on translators and makes it easier for developers to troubleshoot edge cases without having to look up translations.
+
 ## Dependency injection
 
 As much as possible to facilitate simpler, more modular and more testable components you should follow the Dependency Inversion principle in Collect Code. An example tutorial on this concept can be found [here](https://www.seadowg.com/dip-lesson/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ icon color | themeUtils.getIconColor() | ?iconColor
 ## Strings
 Always use [string resources](https://developer.android.com/guide/topics/resources/string-resource.html) instead of literal strings. This ensures wording consistency across the project and also enables full translation of the app. Only make changes to the base `res/values/strings.xml` English file and not to the other language files. The translated files are generated from [Transifex](https://www.transifex.com/opendatakit/collect/) where translations can be submitted by the community. Names of software packages or other untranslatable strings should be placed in `res/values/untranslated.xml`.
 
-Strings that represent very rare failure cases or that are meant more for ODK developers to use for troubleshooting rather than directly by users may be written as literal strings. This reduces the burden on translators and makes it easier for developers to troubleshoot edge cases without having to look up translations.
+Strings that represent very rare failure cases or that are meant more for ODK developers to use for troubleshooting rather than directly for users may be written as literal strings. This reduces the burden on translators and makes it easier for developers to troubleshoot edge cases without having to look up translations.
 
 ## Dependency injection
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/EncryptionUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/EncryptionUtilsTest.java
@@ -1,0 +1,18 @@
+package org.odk.collect.android.utilities;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.odk.collect.android.exception.EncryptionException;
+import org.odk.collect.android.logic.FormController;
+
+public class EncryptionUtilsTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test public void missingInstanceID_causesEncryptionException() throws EncryptionException {
+        exceptionRule.expect(EncryptionException.class);
+        exceptionRule.expectMessage("This form does not specify an instanceID. You must specify one to enable encryption.");
+        EncryptionUtils.getEncryptedFormInformation(null, new FormController.InstanceMetadata(null, null, null));
+    }
+}


### PR DESCRIPTION
Closes #3264

Note: this is an unlikely case because all known form builders add an `instanceID`. That's why the error message is not translated. I did move it to the top, though, since it feels like an invariant.

I changed logging from `e` to `d` where the error is caused by the form or device configuration since there's nothing that ODK developers can do about those -- they're not software defects.

#### What has been done to verify that this works as intended?
Filled form from issue, verified that finalization is disabled and that a toast is shown.

#### Why is this the best possible solution? Were any other approaches considered?
This uses the existing infrastructure to stop finalization and present an error to the user. I considered keeping the Timber log but it's not a software error so there's no point in logging it to Crashlytics.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The user will be unable to finalize forms with encryption keys and no instanceIDs. No regression risk that I can think of.

#### Do we need any specific form for testing your changes? If so, please attach one.
[Birds-encrypted.xml.txt](https://github.com/opendatakit/collect/files/3449331/Birds-encrypted.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)