### PR TITLE
Fixed header dates

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -1,7 +1,5 @@
 package org.odk.collect.android.http;
 
-import android.text.format.DateFormat;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -24,8 +22,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -331,9 +329,9 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     }
 
     private String getHeaderDate() {
-        GregorianCalendar g = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-        g.setTime(new Date());
-        return DateFormat.format("E, dd MMM yyyy hh:mm:ss zz", g).toString();
+        SimpleDateFormat dateFormatGmt = new SimpleDateFormat("E, dd MMM yyyy hh:mm:ss zz", Locale.US);
+        dateFormatGmt.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return dateFormatGmt.format(new Date());
     }
 
     /**


### PR DESCRIPTION
Closes #3266 

Nice catch @kkrawczyk123 
Explanation:
The problem is that we attach date headers to request:
[here](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java#L308), [here](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java#L318) and [here](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java#L328)

those dates are generated [here](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java#L333) and they are in the same language that the app is using so if you use Spanish it would be `mié., 31 jul. 2019 08:27:51 GMT` what is not acceptable (the `é` char) and OkHttp throws an exception if we try to add a header with such a string.

#### What has been done to verify that this works as intended?
I tested the mentioned scenario, reproduced the issue and confirmed that the fix works well.

#### Why is this the best possible solution? Were any other approaches considered?
I decided to use dates in English no matter what language is set in the app. It fixes the problem and I don't think that it's needed to have translatable dates in request headers.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't change anything apart from the language used to create dates we add to request headers, so I don't think it requires much testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)