### PR TITLE
Bypass caching of internal secondary instances for performance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.upload;
 
 import android.database.Cursor;
+
 import androidx.annotation.NonNull;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -48,7 +49,6 @@ import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
 import org.odk.collect.android.utilities.gdrive.SheetsHelper;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -292,7 +292,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         String lastSavedSrc = FileUtils.getOrCreateLastSavedSrc(formXml);
 
         try {
-            formDef = XFormUtils.getFormFromInputStream(new FileInputStream(formXml), lastSavedSrc);
+            formDef = XFormUtils.getFormFromFormXml(formFilePath, lastSavedSrc);
             FormLoaderTask.importData(instanceFile, new FormEntryController(new FormEntryModel(formDef)));
         } catch (IOException | RuntimeException e) {
             throw new UploadException(e);


### PR DESCRIPTION
Closes #3271

#### What has been done to verify that this works as intended?
1. Loaded [nigeria_wards_internal.xml.txt](https://github.com/opendatakit/collect/files/3454550/nigeria_wards_internal.xml.txt) in v1.22.0, both right after pushing it to the device (no caching) and after that first load (from cache). Confirmed that both took a long time.
1. **Cleared the form load cache** from Admin Settings > Reset Application... > Form load cache
1. Installed from this branch
1. Loaded [nigeria_wards_internal.xml.txt](https://github.com/opendatakit/collect/files/3454550/nigeria_wards_internal.xml.txt) twice and confirmed that it was much faster both times (both from XML and from cache).

#### Why is this the best possible solution? Were any other approaches considered?
It's the narrowest change to use the new method.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only intended change is that forms with internal secondary instances (basically, selects with choice filters) load much faster.

What's happening behind the scenes is that the caching of those internal secondary instances is skipped. There's a risk of bad behavior when upgrading or downgrading. There's a risk to any form with a select and a choice filter. 

The Google Sheets implementation also uses this code to load a form definition on submission (to figure out the column headers). There's a risk of regression there as well.

Since this is a change to caching, issues would show up on second load or later.

#### Do we need any specific form for testing your changes? If so, please attach one.

[nigeria_wards_internal.xml.txt](https://github.com/opendatakit/collect/files/3454550/nigeria_wards_internal.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)