### PR TITLE
Ignore flakey tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
@@ -5,6 +5,7 @@ import android.Manifest;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -21,6 +22,7 @@ import static androidx.test.espresso.Espresso.pressBack;
 
 // Issue number NODK-209
 @RunWith(AndroidJUnit4.class)
+@Ignore("https://github.com/opendatakit/collect/issues/3205")
 public class DrawWidgetTest extends BaseRegressionTest {
 
     @Rule

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
@@ -5,6 +5,7 @@ import android.Manifest;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -21,6 +22,7 @@ import static androidx.test.espresso.Espresso.pressBack;
 
 // Issue number NODK-211
 @RunWith(AndroidJUnit4.class)
+@Ignore("https://github.com/opendatakit/collect/issues/3205")
 public class SignatureWidgetTest extends BaseRegressionTest {
 
     @Rule


### PR DESCRIPTION
This is a temporary measure until we have time to have a look at stabilizing them. This means losing the coverage these tests bring but gives us confidence in our test suite again.

This is temporary relief for #3205.

#### What has been done to verify that this works as intended?

Double checked the tests are actually ignored by running the suite.

#### Why is this the best possible solution? Were any other approaches considered?

We could of course delete the tests but I think it's better to ignore right now so that we can have a look at these tests when someone has time. We have an issue open so I'm confident we can get to it.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)