### PR TITLE
Display whole labels in select_one minimal widget

### DIFF
--- a/collect_app/src/androidTest/assets/forms/select_minimal.xml
+++ b/collect_app/src/androidTest/assets/forms/select_minimal.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Select minimal</h:title>
+        <model>
+            <instance>
+                <selectMinimal id="selectMinimal">
+                    <selectone />
+                    <selectmulti />
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </selectMinimal>
+            </instance>
+            <bind nodeset="/selectMinimal/selectone" type="select1" />
+            <bind nodeset="/selectMinimal/selectmulti" type="select" />
+            <bind jr:preload="uid" nodeset="/selectMinimal/meta/instanceID" readonly="true()" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <select1 appearance="minimal" ref="/selectMinimal/selectone">
+            <label>Select one</label>
+            <item>
+                <label>Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel</label>
+                <value>a</value>
+            </item>
+            <item>
+                <label>Nam varius, lectus non consectetur tincidunt, augue augue dapibus dolor, nec convallis ligula erat eget</label>
+                <value>b</value>
+            </item>
+        </select1>
+        <select appearance="minimal" ref="/selectMinimal/selectmulti">
+            <label>Select multiple</label>
+            <item>
+                <label>Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel</label>
+                <value>a</value>
+            </item>
+            <item>
+                <label>Nam varius, lectus non consectetur tincidunt, augue augue dapibus dolor, nec convallis ligula erat eget</label>
+                <value>b</value>
+            </item>
+        </select>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/FormEntry.java
@@ -91,6 +91,10 @@ public final class FormEntry {
         onView(withId(R.id.simple_button)).perform(click());
     }
 
+    public static void showSpinnerMultipleDialog() {
+        onView(withText(getInstrumentation().getTargetContext().getString(R.string.select_answer))).perform(click());
+    }
+
     public static void checkIsDisplayedInTextClassAndSwipe(String message) {
         onView(withClassName(endsWith("EditText"))).check(matches(withText(message))).perform(swipeLeft());
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/SelectMinimalTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/SelectMinimalTest.java
@@ -1,0 +1,49 @@
+package org.odk.collect.android.formentry;
+
+import android.Manifest;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.espressoutils.FormEntry;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.test.FormLoadingUtils;
+
+@RunWith(AndroidJUnit4.class)
+public class SelectMinimalTest {
+
+    @Rule
+    public IntentsTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor("select_minimal.xml");
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            )
+            .around(new ResetStateRule())
+            .around(new CopyFormRule("select_minimal.xml"));
+
+    @Test
+    public void longLabelsShouldBeDisplayed() {
+        FormEntry.clickOnText("Select One Answer");
+        FormEntry.checkIsTextDisplayed("Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel");
+        FormEntry.checkIsTextDisplayed("Nam varius, lectus non consectetur tincidunt, augue augue dapibus dolor, nec convallis ligula erat eget");
+        FormEntry.clickOnText("Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel");
+        FormEntry.checkIsTextDisplayed("Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel");
+        FormEntry.swipeToNextQuestion();
+        FormEntry.showSpinnerMultipleDialog();
+        FormEntry.checkIsTextDisplayed("Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel");
+        FormEntry.checkIsTextDisplayed("Nam varius, lectus non consectetur tincidunt, augue augue dapibus dolor, nec convallis ligula erat eget");
+        FormEntry.clickOnText("Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel");
+        FormEntry.clickOk();
+        FormEntry.checkIsTextDisplayed("Selected: Integer a eleifend libero, sit amet tincidunt lacus. Donec orci tellus, facilisis et ultricies vel");
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SpinnerAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SpinnerAdapter.java
@@ -21,7 +21,7 @@ public class SpinnerAdapter extends ArrayAdapter<CharSequence> {
     private int selectedPosition;
 
     public SpinnerAdapter(final Context context, final CharSequence[] objects) {
-        super(context, android.R.layout.simple_spinner_item, objects);
+        super(context, android.R.layout.simple_list_item_1, objects);
         this.items = objects;
         this.context = context;
         themeUtils = new ThemeUtils(context);
@@ -33,7 +33,7 @@ public class SpinnerAdapter extends ArrayAdapter<CharSequence> {
 
         if (convertView == null) {
             LayoutInflater inflater = LayoutInflater.from(context);
-            convertView = inflater.inflate(android.R.layout.simple_spinner_dropdown_item, parent, false);
+            convertView = inflater.inflate(android.R.layout.simple_list_item_1, parent, false);
         }
 
         if (themeUtils.isDarkTheme()) {
@@ -66,7 +66,7 @@ public class SpinnerAdapter extends ArrayAdapter<CharSequence> {
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         if (convertView == null) {
             LayoutInflater inflater = LayoutInflater.from(context);
-            convertView = inflater.inflate(android.R.layout.simple_spinner_item, parent, false);
+            convertView = inflater.inflate(android.R.layout.simple_list_item_1, parent, false);
         }
 
         TextView tv = convertView.findViewById(android.R.id.text1);


### PR DESCRIPTION
Closes #3275 

#### What has been done to verify that this works as intended?
I tested the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
It just displays whole labels:

| Before | After |
| ------------- | ------------- |
| ![Screenshot_1564718855](https://user-images.githubusercontent.com/3276264/62363801-4a33cb00-b520-11e9-9a99-eed9de8e27be.png)  | ![Screenshot_1564719593](https://user-images.githubusercontent.com/3276264/62363792-430cbd00-b520-11e9-8b92-f631755749ba.png) |
|  |  ![Screenshot_1564719599](https://user-images.githubusercontent.com/3276264/62363942-9d0d8280-b520-11e9-86a0-14af20d5464c.png) |

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is just in one class which is used just in select_one minimal question, so it's not risky and we can test just that one widget.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)