### PR TITLE
Add needed READ_PHONE_STATE permission to regression tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/BaseRegressionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/BaseRegressionTest.java
@@ -1,9 +1,6 @@
 package org.odk.collect.android.regression;
 
-import android.Manifest;
-
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.odk.collect.android.activities.MainMenuActivity;
@@ -12,7 +9,4 @@ public class BaseRegressionTest {
 
     @Rule
     public ActivityTestRule<MainMenuActivity> main = new ActivityTestRule<>(MainMenuActivity.class);
-
-    @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
@@ -27,7 +27,8 @@ public class DrawWidgetTest extends BaseRegressionTest {
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml"));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -40,7 +40,8 @@ public class FillBlankFormTest extends BaseRegressionTest {
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml"))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -25,7 +25,8 @@ public class FormValidationTest extends BaseRegressionTest {
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("OnePageFormShort.xml"));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
@@ -26,7 +26,8 @@ public class RequiredQuestionTest extends BaseRegressionTest {
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("requiredJR275.xml"));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
@@ -27,7 +27,8 @@ public class SignatureWidgetTest extends BaseRegressionTest {
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("All_widgets.xml"));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SpinnerWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SpinnerWidgetTest.java
@@ -24,7 +24,8 @@ public class SpinnerWidgetTest extends BaseRegressionTest {
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
             .around(new CopyFormRule("selectOneMinimal.xml"));


### PR DESCRIPTION
These tests were sometimes passing because of test ordering (earlier tests adding permissions). Locally I saw them fail on a fresh device pretty much every time.

#### What has been done to verify that this works as intended?

Ran locally to check tests now pass individually.

#### Why is this the best possible solution? Were any other approaches considered?

We may want to look at have some shared set of permissions that always get asked for to avoid these kinds of problems but right now it is nice to be explicit in tests I think.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)