### PR TITLE
Remove sleep from test

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -381,10 +381,9 @@ public class FieldListUpdateTest {
     }
 
     @Test
-    public void search_function_in_field_list() throws InterruptedException {
+    public void searchInFieldList() throws InterruptedException {
         jumpToGroupWithText("Search in field-list");
         onView(withText(startsWith("Source15"))).perform(click());
-        Thread.sleep(1000);
         onView(withText("Select One Answer")).check(matches(isDisplayed())).perform(click());
         onView(withText("Mango")).check(matches(isDisplayed()));
         onView(withText("Oranges")).check(matches(isDisplayed()));


### PR DESCRIPTION
Closes #3203.

It seems the sleep wasn't required for the test to pass.

#### What has been done to verify that this works as intended?

Ran locally (animations on and off) and on test lab without sleep to check test didn't fail erroneously. 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)