### PR TITLE
Don't attempt to write user agent in Robolectric tests

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -284,7 +284,10 @@ public class Collect extends Application {
         }
 
         setupLeakCanary();
+        setupOSMDroid();
+    }
 
+    protected void setupOSMDroid() {
         org.osmdroid.config.Configuration.getInstance().setUserAgentValue(getUserAgentString());
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/TestCollect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/TestCollect.java
@@ -17,4 +17,9 @@ public class TestCollect extends Collect {
         // No leakcanary in unit tests.
         return RefWatcher.DISABLED;
     }
+
+    @Override
+    protected void setupOSMDroid() {
+        // no op for Robolectric
+    }
 }


### PR DESCRIPTION
This was causing a (non fatal) error which made test output confusing.

#### What has been done to verify that this works as intended?

Ran `testDebug` locally to make sure no tests relied on OSMDroid's user agent being configured.

#### Why is this the best possible solution? Were any other approaches considered?

We could pull the OSMDroid stuff and inject a fake/mock in test but more the moment using an override with Robolectric's test application object seems the simplest if we can get away with just not calling the offending method.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)