### PR TITLE
Ensure OpenRosa requests use correct auth schemes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -277,13 +277,13 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
         }
 
         Credentials cred = new Credentials(credentials.getUsername(), credentials.getPassword());
-        DispatchingAuthenticator.Builder daBuilder = new DispatchingAuthenticator.Builder();
 
+        DispatchingAuthenticator.Builder daBuilder = new DispatchingAuthenticator.Builder();
+        daBuilder.with("digest", new DigestAuthenticator(cred));
         if (scheme.equalsIgnoreCase("https")) {
             daBuilder.with("basic", new BasicAuthenticator(cred));
         }
 
-        daBuilder.with("digest", new DigestAuthenticator(cred));
         DispatchingAuthenticator authenticator = daBuilder.build();
 
         initializeHttpClient(); // Need to initalise the http client again to get rid of the cached credentials

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -276,9 +276,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
             return;
         }
 
-        final Map<String, CachingAuthenticator> authCache = new ConcurrentHashMap<>();
         Credentials cred = new Credentials(credentials.getUsername(), credentials.getPassword());
-
         DispatchingAuthenticator.Builder daBuilder = new DispatchingAuthenticator.Builder();
 
         if (scheme.equalsIgnoreCase("https")) {
@@ -286,11 +284,11 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
         }
 
         daBuilder.with("digest", new DigestAuthenticator(cred));
-
         DispatchingAuthenticator authenticator = daBuilder.build();
 
         initializeHttpClient(); // Need to initalise the http client again to get rid of the cached credentials
 
+        final Map<String, CachingAuthenticator> authCache = new ConcurrentHashMap<>();
         httpClient = httpClient.newBuilder().authenticator(new CachingAuthenticatorDecorator(authenticator, authCache))
                 .addInterceptor(new AuthenticationCacheInterceptor(authCache)).build();
 

--- a/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaGetRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaGetRequestTest.java
@@ -23,6 +23,7 @@ import okio.Buffer;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public abstract class OpenRosaGetRequestTest {
@@ -99,7 +100,7 @@ public abstract class OpenRosaGetRequestTest {
     }
 
     @Test
-    public void withCredentials_whenHttp_doesNotRetryWithCredentials() throws Exception {
+    public void withCredentials_whenBasicChallengeReceived_whenHttp_doesNotRetryWithCredentials() throws Exception {
         mockWebServer.enqueue(new MockResponse()
                 .setResponseCode(401)
                 .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
@@ -112,7 +113,7 @@ public abstract class OpenRosaGetRequestTest {
     }
 
     @Test
-    public void withCredentials_whenHttps_retriesWithCredentials() throws Exception {
+    public void withCredentials_whenBasicChallengeReceived_whenHttps_retriesWithCredentials() throws Exception {
         startHttpsMockWebServer();
 
         httpsMockWebServer.enqueue(new MockResponse()
@@ -129,6 +130,62 @@ public abstract class OpenRosaGetRequestTest {
         assertThat(request.getHeader("Authorization"), equalTo("Basic dXNlcjpwYXNz"));
     }
 
+    @Test
+    public void withCredentials_whenDigestChallengeReceived_retriesWithCredentials() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
+                .setBody("Please authenticate."));
+        mockWebServer.enqueue(new MockResponse());
+
+        subject.executeGetRequest(mockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(2));
+        mockWebServer.takeRequest();
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
+    }
+
+    @Test
+    public void withCredentials_whenHttps_onceBasicChallenged_proactivelySendsCredentials() throws Exception {
+        startHttpsMockWebServer();
+
+        httpsMockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
+                .setBody("Please authenticate."));
+        httpsMockWebServer.enqueue(new MockResponse());
+        httpsMockWebServer.enqueue(new MockResponse());
+
+        subject.executeGetRequest(httpsMockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
+        subject.executeGetRequest(httpsMockWebServer.url("/different").uri(), null, new HttpCredentials("user", "pass"));
+
+        assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
+        httpsMockWebServer.takeRequest();
+        httpsMockWebServer.takeRequest();
+        RecordedRequest request = httpsMockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), equalTo("Basic dXNlcjpwYXNz"));
+    }
+
+    @Test
+    public void withCredentials_onceDigestChallenged_proactivelySendsCredentials() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
+                .setBody("Please authenticate."));
+        mockWebServer.enqueue(new MockResponse());
+        mockWebServer.enqueue(new MockResponse());
+
+        subject.executeGetRequest(mockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
+        subject.executeGetRequest(mockWebServer.url("/different").uri(), null, new HttpCredentials("user", "pass"));
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(3));
+        mockWebServer.takeRequest();
+        mockWebServer.takeRequest();
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
+    }
+    
     @Test
     public void whenLastRequestSetCookies_nextRequestDoesNotSendThem() throws Exception {
         mockWebServer.enqueue(new MockResponse()


### PR DESCRIPTION
Closes #3287.

Added tests based on the docs [here](https://docs.opendatakit.org/openrosa-authentication/) around proactively sending credentials. At first it seemed like nothing was wrong but then I discovered that we ran into a problem only when using HTTPS (because `Basic` auth isn't enabled over HTTP).

It seems the key to problem here is that `BasicAuthenticator` was being added before `DigestAuthenticator` to our list of `CachingAuthenticator`s. This meant that when we made a request our setup would try and proactively send credentials and use the first `Authenticator` that was able to build an authenticated request. This would result in it always sending a `Basic` attempt as `BasicAuthenticator` can always build a header - it just needs the credentials. It's not a problem the other way round as `DigestAuthenticator` is unable to build a header without having previously authenticated a request - it needs realm, nonce etc. 🙄

Aggregate didn't seem to have a problem with `Basic` being sent before `Digest` as it would just return a `Digest` challenge. I don't think the behavior was actually "incorrect" but it would create a bunch more network chatter and went against what you'd expect from the docs which had led to problems for a 3rd party server.

#### What has been done to verify that this works as intended?

The key was writing and green-ing `withCredentials_onceDigestChallenged_whenHttps_proactivelySendsCredentials` as this was the only failing test added and also matched the behaviour seen in #3287. I was also able to reproduce and verify using the Android Studio Network profiler.

#### Why is this the best possible solution? Were any other approaches considered?

For now I think this is good but I'd like to follow up with work to extract some of the authentication logic (at least the tests) so the code around that is easier to read and debug. It'd also be nice to not have to duplicate authentication tests between all the different HTTP verbs (right now only GET checks this case but we know the authentication is the same for all verbs).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should only have a positive effect of reducing the number of network requests made to carry out unnecessary authentication but it would be good to test this against known Open Rosa servers with Digest and Basic auth.

For testing it would be good to do the same pass as we carried out on #3163.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)