### PR TITLE
Extract authentication and common headers from OkHttpConnection

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/ServerNameIndicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/ServerNameIndicationTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.http.HttpGetResult;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
 import java.io.BufferedReader;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/CollectServerClientTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/CollectServerClientTest.java
@@ -1,12 +1,9 @@
 package org.odk.collect.android.utilities;
 
-import android.webkit.MimeTypeMap;
-
 import org.junit.Before;
 import org.junit.Test;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.http.CollectServerClient;
-import org.odk.collect.android.http.CollectThenSystemContentTypeMapper;
-import org.odk.collect.android.http.okhttp.OkHttpConnection;
 import org.odk.collect.android.test.MockedServerTest;
 
 import okhttp3.mockwebserver.MockResponse;
@@ -25,7 +22,7 @@ public class CollectServerClientTest extends MockedServerTest {
     public void setUp() throws Exception {
         // server hangs without a response queued:
         server.enqueue(new MockResponse());
-        collectServerClient = new CollectServerClient(new OkHttpConnection(null, new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())), new WebCredentialsUtils());
+        collectServerClient = new CollectServerClient(Collect.getInstance().getComponent().openRosaHttpInterface(), new WebCredentialsUtils());
     }
 
         @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/CollectServerClientTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/CollectServerClientTest.java
@@ -6,7 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.http.CollectThenSystemContentTypeMapper;
-import org.odk.collect.android.http.OkHttpConnection;
+import org.odk.collect.android.http.okhttp.OkHttpConnection;
 import org.odk.collect.android.test.MockedServerTest;
 
 import okhttp3.mockwebserver.MockResponse;

--- a/collect_app/src/main/java/org/odk/collect/android/http/CollectServerClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/CollectServerClient.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 
 import org.kxml2.io.KXmlParser;
 import org.kxml2.kdom.Document;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.utilities.DocumentFetchResult;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.xmlpull.v1.XmlPullParser;

--- a/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
@@ -4,6 +4,7 @@ import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
 
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.utilities.FileUtils;
 
 public class CollectThenSystemContentTypeMapper implements OpenRosaHttpInterface.FileToContentTypeMapper {

--- a/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/OkHttpConnection.java
@@ -56,19 +56,19 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
     /**
      * Shared client object used for all HTTP requests. Credentials are set on a per-request basis.
      */
-    private static OkHttpClient httpClient;
+    private OkHttpClient httpClient;
 
     /**
      * The credentials used for the last request. When a new request is made, this is used to see
      * whether the {@link #httpClient} credentials need to be changed.
      */
-    private static HttpCredentialsInterface lastRequestCredentials;
+    private HttpCredentialsInterface lastRequestCredentials;
 
     /**
      * The scheme used for the last request. When a new request is made, this is used to see
      * whether the {@link #httpClient} credentials need to be changed.
      */
-    private static String lastRequestScheme = "";
+    private String lastRequestScheme = "";
 
     private MultipartBody multipartBody;
 

--- a/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
@@ -18,6 +18,7 @@ import org.odk.collect.android.utilities.Clock;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -90,14 +91,14 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
             return client.newCall(request.newBuilder()
                     .addHeader(USER_AGENT_HEADER, userAgent)
                     .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
-                    .addHeader(DATE_HEADER, getHeaderDate())
+                    .addHeader(DATE_HEADER, getHeaderDate(clock.getCurrentTime()))
                     .build()).execute();
         }
 
-        private String getHeaderDate() {
+        private static String getHeaderDate(Date currentTime) {
             SimpleDateFormat dateFormatGmt = new SimpleDateFormat("E, dd MMM yyyy hh:mm:ss zz", Locale.US);
             dateFormatGmt.setTimeZone(TimeZone.getTimeZone("GMT"));
-            return dateFormatGmt.format(clock.getCurrentTime());
+            return dateFormatGmt.format(currentTime);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
@@ -87,15 +87,11 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
 
         @Override
         public Response makeRequest(Request request) throws IOException {
-            return client.newCall(addHeaders(request)).execute();
-        }
-
-        private Request addHeaders(Request request) {
-            return request.newBuilder()
+            return client.newCall(request.newBuilder()
                     .addHeader(USER_AGENT_HEADER, userAgent)
                     .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
                     .addHeader(DATE_HEADER, getHeaderDate())
-                    .build();
+                    .build()).execute();
         }
 
         private String getHeaderDate() {

--- a/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
@@ -14,10 +14,10 @@ import com.burgstaller.okhttp.digest.DigestAuthenticator;
 import org.odk.collect.android.http.HttpCredentialsInterface;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClient;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
+import org.odk.collect.android.utilities.Clock;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -39,9 +39,11 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
     private static final String DATE_HEADER = "Date";
 
     private final OkHttpClient.Builder baseClient;
+    private final Clock clock;
 
-    public OkHttpOpenRosaServerClientFactory(@NonNull OkHttpClient.Builder baseClient) {
+    public OkHttpOpenRosaServerClientFactory(@NonNull OkHttpClient.Builder baseClient, Clock clock) {
         this.baseClient = baseClient;
+        this.clock = clock;
     }
 
     @Override
@@ -68,17 +70,19 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
                     .addInterceptor(new AuthenticationCacheInterceptor(authCache)).build();
         }
 
-        return new OkHttpOpenRosaServerClient(builder.build(), userAgent);
+        return new OkHttpOpenRosaServerClient(builder.build(), userAgent, clock);
     }
 
     private static class OkHttpOpenRosaServerClient implements OpenRosaServerClient {
 
         private final OkHttpClient client;
         private final String userAgent;
+        private final Clock clock;
 
-        OkHttpOpenRosaServerClient(OkHttpClient client, String userAgent) {
+        OkHttpOpenRosaServerClient(OkHttpClient client, String userAgent, Clock clock) {
             this.client = client;
             this.userAgent = userAgent;
+            this.clock = clock;
         }
 
         @Override
@@ -97,7 +101,7 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
         private String getHeaderDate() {
             SimpleDateFormat dateFormatGmt = new SimpleDateFormat("E, dd MMM yyyy hh:mm:ss zz", Locale.US);
             dateFormatGmt.setTimeZone(TimeZone.getTimeZone("GMT"));
-            return dateFormatGmt.format(new Date());
+            return dateFormatGmt.format(clock.getCurrentTime());
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
@@ -1,0 +1,103 @@
+package org.odk.collect.android.http.okhttp;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.burgstaller.okhttp.AuthenticationCacheInterceptor;
+import com.burgstaller.okhttp.CachingAuthenticatorDecorator;
+import com.burgstaller.okhttp.DispatchingAuthenticator;
+import com.burgstaller.okhttp.basic.BasicAuthenticator;
+import com.burgstaller.okhttp.digest.CachingAuthenticator;
+import com.burgstaller.okhttp.digest.Credentials;
+import com.burgstaller.okhttp.digest.DigestAuthenticator;
+
+import org.odk.collect.android.http.HttpCredentialsInterface;
+import org.odk.collect.android.http.openrosa.OpenRosaServerClient;
+import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFactory {
+
+    private static final int CONNECTION_TIMEOUT = 30000;
+    private static final int WRITE_CONNECTION_TIMEOUT = 60000; // it can take up to 27 seconds to spin up an Aggregate
+    private static final int READ_CONNECTION_TIMEOUT = 60000; // it can take up to 27 seconds to spin up an Aggregate
+    private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final String OPEN_ROSA_VERSION_HEADER = "X-OpenRosa-Version";
+    private static final String OPEN_ROSA_VERSION = "1.0";
+    private static final String DATE_HEADER = "Date";
+
+    private final OkHttpClient.Builder baseClient;
+
+    public OkHttpOpenRosaServerClientFactory(@NonNull OkHttpClient.Builder baseClient) {
+        this.baseClient = baseClient;
+    }
+
+    @Override
+    public OpenRosaServerClient create(String scheme, String userAgent, @Nullable HttpCredentialsInterface credentials) {
+        OkHttpClient.Builder builder = baseClient
+                .connectTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .writeTimeout(WRITE_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .readTimeout(READ_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
+                .followRedirects(true);
+
+        if (credentials != null) {
+            Credentials cred = new Credentials(credentials.getUsername(), credentials.getPassword());
+
+            DispatchingAuthenticator.Builder daBuilder = new DispatchingAuthenticator.Builder();
+            daBuilder.with("digest", new DigestAuthenticator(cred));
+            if (scheme.equalsIgnoreCase("https")) {
+                daBuilder.with("basic", new BasicAuthenticator(cred));
+            }
+
+            DispatchingAuthenticator authenticator = daBuilder.build();
+
+            final Map<String, CachingAuthenticator> authCache = new ConcurrentHashMap<>();
+            builder.authenticator(new CachingAuthenticatorDecorator(authenticator, authCache))
+                    .addInterceptor(new AuthenticationCacheInterceptor(authCache)).build();
+        }
+
+        return new OkHttpOpenRosaServerClient(builder.build(), userAgent);
+    }
+
+    private static class OkHttpOpenRosaServerClient implements OpenRosaServerClient {
+
+        private final OkHttpClient client;
+        private final String userAgent;
+
+        OkHttpOpenRosaServerClient(OkHttpClient client, String userAgent) {
+            this.client = client;
+            this.userAgent = userAgent;
+        }
+
+        @Override
+        public Response makeRequest(Request request) throws IOException {
+            return client.newCall(addHeaders(request)).execute();
+        }
+
+        private Request addHeaders(Request request) {
+            return request.newBuilder()
+                    .addHeader(USER_AGENT_HEADER, userAgent)
+                    .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
+                    .addHeader(DATE_HEADER, getHeaderDate())
+                    .build();
+        }
+
+        private String getHeaderDate() {
+            SimpleDateFormat dateFormatGmt = new SimpleDateFormat("E, dd MMM yyyy hh:mm:ss zz", Locale.US);
+            dateFormatGmt.setTimeZone(TimeZone.getTimeZone("GMT"));
+            return dateFormatGmt.format(new Date());
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaHttpInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaHttpInterface.java
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-package org.odk.collect.android.http;
+package org.odk.collect.android.http.openrosa;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import org.odk.collect.android.http.HttpCredentialsInterface;
+import org.odk.collect.android.http.HttpGetResult;
+import org.odk.collect.android.http.HttpHeadResult;
+import org.odk.collect.android.http.HttpPostResult;
 
 import java.io.File;
 import java.io.IOException;

--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClient.java
@@ -1,0 +1,11 @@
+package org.odk.collect.android.http.openrosa;
+
+import java.io.IOException;
+
+import okhttp3.Request;
+import okhttp3.Response;
+
+public interface OpenRosaServerClient {
+
+    Response makeRequest(Request request) throws IOException;
+}

--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClientFactory.java
@@ -6,5 +6,5 @@ import org.odk.collect.android.http.HttpCredentialsInterface;
 
 public interface OpenRosaServerClientFactory {
 
-    OpenRosaServerClient create(String schema, @Nullable HttpCredentialsInterface credentialsInterface);
+    OpenRosaServerClient create(String schema, String userAgent, @Nullable HttpCredentialsInterface credentialsInterface);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClientFactory.java
@@ -1,0 +1,10 @@
+package org.odk.collect.android.http.openrosa;
+
+import androidx.annotation.Nullable;
+
+import org.odk.collect.android.http.HttpCredentialsInterface;
+
+public interface OpenRosaServerClientFactory {
+
+    OpenRosaServerClient create(String schema, @Nullable HttpCredentialsInterface credentialsInterface);
+}

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -13,7 +13,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.fragments.DataManagerList;
 import org.odk.collect.android.http.CollectServerClient;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.ServerPreferencesFragment;
 import org.odk.collect.android.tasks.InstanceServerUploaderTask;

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -70,6 +70,7 @@ public class AppDependencyModule {
     }
 
     @Provides
+    @Singleton
     OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap) {
         return new OkHttpConnection(null, new CollectThenSystemContentTypeMapper(mimeTypeMap));
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -22,6 +22,8 @@ import org.odk.collect.android.utilities.DownloadFormListUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
+import java.util.Date;
+
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -75,7 +77,7 @@ public class AppDependencyModule {
     @Singleton
     OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap) {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
                 new CollectThenSystemContentTypeMapper(mimeTypeMap)
         );
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -13,8 +13,9 @@ import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.http.CollectThenSystemContentTypeMapper;
-import org.odk.collect.android.http.OkHttpConnection;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
+import org.odk.collect.android.http.okhttp.OkHttpConnection;
+import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.tasks.sms.SmsSubmissionManager;
 import org.odk.collect.android.tasks.sms.contracts.SmsSubmissionManagerContract;
 import org.odk.collect.android.utilities.DownloadFormListUtils;
@@ -25,6 +26,7 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import okhttp3.OkHttpClient;
 
 /**
  * Add dependency providers here (annotated with @Provides)
@@ -72,11 +74,14 @@ public class AppDependencyModule {
     @Provides
     @Singleton
     OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap) {
-        return new OkHttpConnection(null, new CollectThenSystemContentTypeMapper(mimeTypeMap));
+        return new OkHttpConnection(
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
+                new CollectThenSystemContentTypeMapper(mimeTypeMap)
+        );
     }
 
     @Provides
-    public CollectServerClient provideCollectServerClient(OpenRosaHttpInterface httpInterface, WebCredentialsUtils webCredentialsUtils) {
+    CollectServerClient provideCollectServerClient(OpenRosaHttpInterface httpInterface, WebCredentialsUtils webCredentialsUtils) {
         return new CollectServerClient(httpInterface, webCredentialsUtils);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploaderTask.java
@@ -17,7 +17,7 @@ package org.odk.collect.android.tasks;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dto.Instance;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.upload.InstanceServerUploader;
 import org.odk.collect.android.upload.UploadAuthRequestedException;

--- a/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
@@ -37,7 +37,7 @@ import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.dto.Form;
 import org.odk.collect.android.dto.Instance;
 import org.odk.collect.android.http.CollectThenSystemContentTypeMapper;
-import org.odk.collect.android.http.OkHttpConnection;
+import org.odk.collect.android.http.okhttp.OkHttpConnection;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;

--- a/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
@@ -23,7 +23,6 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Environment;
-import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
 import androidx.work.Worker;
@@ -36,8 +35,7 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.dto.Form;
 import org.odk.collect.android.dto.Instance;
-import org.odk.collect.android.http.CollectThenSystemContentTypeMapper;
-import org.odk.collect.android.http.okhttp.OkHttpConnection;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
@@ -126,7 +124,8 @@ public class AutoSendWorker extends Worker {
                 return Result.FAILURE;
             }
         } else {
-            uploader = new InstanceServerUploader(new OkHttpConnection(null, new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())),
+            OpenRosaHttpInterface httpInterface = Collect.getInstance().getComponent().openRosaHttpInterface();
+            uploader = new InstanceServerUploader(httpInterface,
                     new WebCredentialsUtils(), new HashMap<>());
             deviceId = new PropertyManager(Collect.getInstance().getApplicationContext())
                     .getSingularProperty(PropertyManager.withUri(PropertyManager.PROPMGR_DEVICE_ID));

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -24,7 +24,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dto.Instance;
 import org.odk.collect.android.http.HttpHeadResult;
 import org.odk.collect.android.http.HttpPostResult;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.utilities.ResponseMessageParser;
 import org.odk.collect.android.utilities.WebCredentialsUtils;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Clock.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Clock.java
@@ -1,0 +1,8 @@
+package org.odk.collect.android.utilities;
+
+import java.util.Date;
+
+public interface Clock {
+
+    Date getCurrentTime();
+}

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionGetRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionGetRequestTest.java
@@ -3,24 +3,21 @@ package org.odk.collect.android.http;
 import android.webkit.MimeTypeMap;
 
 import org.junit.runner.RunWith;
+import org.odk.collect.android.http.okhttp.OkHttpConnection;
+import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
 import okhttp3.OkHttpClient;
-import okhttp3.tls.internal.TlsUtil;
 
 @RunWith(RobolectricTestRunner.class)
 public class OkHttpConnectionGetRequestTest extends OpenRosaGetRequestTest {
 
     @Override
     protected OpenRosaHttpInterface buildSubject() {
-        return new OkHttpConnection(new OkHttpClient.Builder()
-                .sslSocketFactory(TlsUtil.localhost().sslSocketFactory(), TlsUtil.localhost().trustManager()),
+        return new OkHttpConnection(
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())
         );
-    }
-
-    @Override
-    protected Boolean useRealHttps() {
-        return true;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionGetRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionGetRequestTest.java
@@ -8,6 +8,8 @@ import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Date;
+
 import okhttp3.OkHttpClient;
 
 @RunWith(RobolectricTestRunner.class)
@@ -16,7 +18,7 @@ public class OkHttpConnectionGetRequestTest extends OpenRosaGetRequestTest {
     @Override
     protected OpenRosaHttpInterface buildSubject() {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
                 new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionHeadRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionHeadRequestTest.java
@@ -8,6 +8,8 @@ import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Date;
+
 import okhttp3.OkHttpClient;
 
 @RunWith(RobolectricTestRunner.class)
@@ -16,7 +18,7 @@ public class OkHttpConnectionHeadRequestTest extends OpenRosaHeadRequestTest {
     @Override
     protected OpenRosaHttpInterface buildSubject() {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
                 new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionHeadRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionHeadRequestTest.java
@@ -3,24 +3,21 @@ package org.odk.collect.android.http;
 import android.webkit.MimeTypeMap;
 
 import org.junit.runner.RunWith;
+import org.odk.collect.android.http.okhttp.OkHttpConnection;
+import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
 import okhttp3.OkHttpClient;
-import okhttp3.tls.internal.TlsUtil;
 
 @RunWith(RobolectricTestRunner.class)
 public class OkHttpConnectionHeadRequestTest extends OpenRosaHeadRequestTest {
 
     @Override
     protected OpenRosaHttpInterface buildSubject() {
-        return new OkHttpConnection(new OkHttpClient.Builder()
-                .sslSocketFactory(TlsUtil.localhost().sslSocketFactory(), TlsUtil.localhost().trustManager()),
+        return new OkHttpConnection(
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())
         );
-    }
-
-    @Override
-    protected Boolean useRealHttps() {
-        return true;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionPostRequest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionPostRequest.java
@@ -1,24 +1,21 @@
 package org.odk.collect.android.http;
 
 import org.junit.runner.RunWith;
+import org.odk.collect.android.http.okhttp.OkHttpConnection;
+import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
 import okhttp3.OkHttpClient;
-import okhttp3.tls.internal.TlsUtil;
 
 @RunWith(RobolectricTestRunner.class)
 public class OkHttpConnectionPostRequest extends OpenRosaPostRequestTest {
 
     @Override
     protected OpenRosaHttpInterface buildSubject(OpenRosaHttpInterface.FileToContentTypeMapper mapper) {
-        return new OkHttpConnection(new OkHttpClient.Builder()
-                .sslSocketFactory(TlsUtil.localhost().sslSocketFactory(), TlsUtil.localhost().trustManager()),
+        return new OkHttpConnection(
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 mapper
         );
-    }
-
-    @Override
-    protected Boolean useRealHttps() {
-        return true;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionPostRequest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionPostRequest.java
@@ -6,6 +6,8 @@ import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Date;
+
 import okhttp3.OkHttpClient;
 
 @RunWith(RobolectricTestRunner.class)
@@ -14,7 +16,7 @@ public class OkHttpConnectionPostRequest extends OpenRosaPostRequestTest {
     @Override
     protected OpenRosaHttpInterface buildSubject(OpenRosaHttpInterface.FileToContentTypeMapper mapper) {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
                 mapper
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientFactoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientFactoryTest.java
@@ -2,17 +2,21 @@ package org.odk.collect.android.http;
 
 import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
+import org.odk.collect.android.utilities.Clock;
 
 import okhttp3.OkHttpClient;
 import okhttp3.tls.internal.TlsUtil;
 
 public class OkHttpOpenRosaServerClientFactoryTest extends OpenRosaServerClientFactoryTest {
+
     @Override
-    protected OpenRosaServerClientFactory buildSubject() {
-        return new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()
+    protected OpenRosaServerClientFactory buildSubject(Clock clock) {
+        OkHttpClient.Builder baseClient = new OkHttpClient.Builder()
                 .sslSocketFactory(
                         TlsUtil.localhost().sslSocketFactory(),
-                        TlsUtil.localhost().trustManager()));
+                        TlsUtil.localhost().trustManager());
+        
+        return new OkHttpOpenRosaServerClientFactory(baseClient, clock);
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientFactoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientFactoryTest.java
@@ -1,0 +1,22 @@
+package org.odk.collect.android.http;
+
+import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
+import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
+
+import okhttp3.OkHttpClient;
+import okhttp3.tls.internal.TlsUtil;
+
+public class OkHttpOpenRosaServerClientFactoryTest extends OpenRosaServerClientFactoryTest {
+    @Override
+    protected OpenRosaServerClientFactory buildSubject() {
+        return new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()
+                .sslSocketFactory(
+                        TlsUtil.localhost().sslSocketFactory(),
+                        TlsUtil.localhost().trustManager()));
+    }
+
+    @Override
+    protected Boolean useRealHttps() {
+        return true;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaGetRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaGetRequestTest.java
@@ -5,6 +5,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.BuildConfig;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.ByteArrayInputStream;
@@ -17,23 +18,18 @@ import java.util.zip.GZIPOutputStream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
-import okhttp3.tls.internal.TlsUtil;
 import okio.Buffer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public abstract class OpenRosaGetRequestTest {
 
     protected abstract OpenRosaHttpInterface buildSubject();
 
-    protected abstract Boolean useRealHttps();
-
     private final MockWebServer mockWebServer = new MockWebServer();
-    private MockWebServer httpsMockWebServer;
     private OpenRosaHttpInterface subject;
 
     @Before
@@ -45,11 +41,6 @@ public abstract class OpenRosaGetRequestTest {
     @After
     public void teardown() throws Exception {
         mockWebServer.shutdown();
-
-        if (httpsMockWebServer != null) {
-            httpsMockWebServer.shutdown();
-            httpsMockWebServer = null;
-        }
     }
 
     @Test
@@ -77,152 +68,6 @@ public abstract class OpenRosaGetRequestTest {
                 "null %s/%s",
                 BuildConfig.APPLICATION_ID,
                 BuildConfig.VERSION_NAME)));
-    }
-
-    @Test
-    public void sendsOpenRosaHeaders() throws Exception {
-        mockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(mockWebServer.url("").uri(), null, null);
-
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertThat(request.getHeader("X-OpenRosa-Version"), equalTo("1.0"));
-    }
-
-    @Test
-    public void sendsAcceptsGzipHeader() throws Exception {
-        mockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(mockWebServer.url("").uri(), null, null);
-
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertThat(request.getHeader("Accept-Encoding"), equalTo("gzip"));
-    }
-
-    @Test
-    public void withCredentials_whenBasicChallengeReceived_doesNotRetryWithCredentials() throws Exception {
-        mockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-                .setBody("Please authenticate."));
-        mockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(mockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(mockWebServer.getRequestCount(), equalTo(1));
-    }
-
-    @Test
-    public void withCredentials_whenBasicChallengeReceived_whenHttps_retriesWithCredentials() throws Exception {
-        startHttpsMockWebServer();
-
-        httpsMockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-                .setBody("Please authenticate."));
-        httpsMockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(httpsMockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(httpsMockWebServer.getRequestCount(), equalTo(2));
-        httpsMockWebServer.takeRequest();
-        RecordedRequest request = httpsMockWebServer.takeRequest();
-        assertThat(request.getHeader("Authorization"), equalTo("Basic dXNlcjpwYXNz"));
-    }
-
-    @Test
-    public void withCredentials_whenDigestChallengeReceived_retriesWithCredentials() throws Exception {
-        mockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
-                .setBody("Please authenticate."));
-        mockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(mockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(mockWebServer.getRequestCount(), equalTo(2));
-        mockWebServer.takeRequest();
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
-    }
-
-    @Test
-    public void withCredentials_whenDigestChallengeReceived_whenHttps_retriesWithCredentials() throws Exception {
-        startHttpsMockWebServer();
-
-        httpsMockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
-                .setBody("Please authenticate."));
-        httpsMockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(httpsMockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(httpsMockWebServer.getRequestCount(), equalTo(2));
-        httpsMockWebServer.takeRequest();
-        RecordedRequest request = httpsMockWebServer.takeRequest();
-        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
-    }
-
-    @Test
-    public void withCredentials_onceBasicChallenged_whenHttps_proactivelySendsCredentials() throws Exception {
-        startHttpsMockWebServer();
-
-        httpsMockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
-                .setBody("Please authenticate."));
-        httpsMockWebServer.enqueue(new MockResponse());
-        httpsMockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(httpsMockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-        subject.executeGetRequest(httpsMockWebServer.url("/different").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
-        httpsMockWebServer.takeRequest();
-        httpsMockWebServer.takeRequest();
-        RecordedRequest request = httpsMockWebServer.takeRequest();
-        assertThat(request.getHeader("Authorization"), equalTo("Basic dXNlcjpwYXNz"));
-    }
-
-    @Test
-    public void withCredentials_onceDigestChallenged_proactivelySendsCredentials() throws Exception {
-        mockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
-                .setBody("Please authenticate."));
-        mockWebServer.enqueue(new MockResponse());
-        mockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(mockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-        subject.executeGetRequest(mockWebServer.url("/different").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(mockWebServer.getRequestCount(), equalTo(3));
-        mockWebServer.takeRequest();
-        mockWebServer.takeRequest();
-        RecordedRequest request = mockWebServer.takeRequest();
-        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
-    }
-
-    @Test
-    public void withCredentials_onceDigestChallenged_whenHttps_proactivelySendsCredentials() throws Exception {
-        startHttpsMockWebServer();
-
-        httpsMockWebServer.enqueue(new MockResponse()
-                .setResponseCode(401)
-                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
-                .setBody("Please authenticate."));
-        httpsMockWebServer.enqueue(new MockResponse());
-        httpsMockWebServer.enqueue(new MockResponse());
-
-        subject.executeGetRequest(httpsMockWebServer.url("").uri(), null, new HttpCredentials("user", "pass"));
-        subject.executeGetRequest(httpsMockWebServer.url("/different").uri(), null, new HttpCredentials("user", "pass"));
-
-        assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
-        httpsMockWebServer.takeRequest();
-        httpsMockWebServer.takeRequest();
-        RecordedRequest request = httpsMockWebServer.takeRequest();
-        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
     }
 
     @Test
@@ -324,16 +169,6 @@ public abstract class OpenRosaGetRequestTest {
         HttpGetResult result2 = subject.executeGetRequest(mockWebServer.url("").uri(), null, null);
         assertThat(result2.getInputStream(), nullValue());
         assertThat(result2.getStatusCode(), equalTo(304));
-    }
-
-    private void startHttpsMockWebServer() throws IOException {
-        httpsMockWebServer = new MockWebServer();
-
-        if (useRealHttps()) {
-            httpsMockWebServer.useHttps(TlsUtil.localhost().sslSocketFactory(), false);
-        }
-
-        httpsMockWebServer.start(8443);
     }
 
     private static byte[] gzip(String data) throws IOException {

--- a/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaServerClientFactoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaServerClientFactoryTest.java
@@ -1,0 +1,211 @@
+package org.odk.collect.android.http;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.odk.collect.android.http.openrosa.OpenRosaServerClient;
+import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
+
+import java.io.IOException;
+
+import okhttp3.Request;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.tls.internal.TlsUtil;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+public abstract class OpenRosaServerClientFactoryTest {
+
+    protected abstract OpenRosaServerClientFactory buildSubject();
+
+    protected abstract Boolean useRealHttps();
+
+    private final MockWebServer mockWebServer = new MockWebServer();
+    private MockWebServer httpsMockWebServer;
+    private OpenRosaServerClientFactory subject;
+
+    @Before
+    public void setup() throws Exception {
+        mockWebServer.start();
+        subject = buildSubject();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        mockWebServer.shutdown();
+
+        if (httpsMockWebServer != null) {
+            httpsMockWebServer.shutdown();
+            httpsMockWebServer = null;
+        }
+    }
+
+    @Test
+    public void sendsOpenRosaHeaders() throws Exception {
+        mockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("http", "Android", null);
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat(request.getHeader("X-OpenRosa-Version"), equalTo("1.0"));
+    }
+
+    @Test
+    public void sendsAcceptsGzipHeader() throws Exception {
+        mockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("http", "Android", null);
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat(request.getHeader("Accept-Encoding"), equalTo("gzip"));
+    }
+    
+    @Test
+    public void withCredentials_whenBasicChallengeReceived_doesNotRetryWithCredentials() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
+                .setBody("Please authenticate."));
+        mockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("http", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(1));
+    }
+
+    @Test
+    public void withCredentials_whenBasicChallengeReceived_whenHttps_retriesWithCredentials() throws Exception {
+        startHttpsMockWebServer();
+
+        httpsMockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
+                .setBody("Please authenticate."));
+        httpsMockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
+
+        assertThat(httpsMockWebServer.getRequestCount(), equalTo(2));
+        httpsMockWebServer.takeRequest();
+        RecordedRequest request = httpsMockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), equalTo("Basic dXNlcjpwYXNz"));
+    }
+
+    @Test
+    public void withCredentials_whenDigestChallengeReceived_retriesWithCredentials() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
+                .setBody("Please authenticate."));
+        mockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("http", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(2));
+        mockWebServer.takeRequest();
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
+    }
+
+    @Test
+    public void withCredentials_whenDigestChallengeReceived_whenHttps_retriesWithCredentials() throws Exception {
+        startHttpsMockWebServer();
+
+        httpsMockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
+                .setBody("Please authenticate."));
+        httpsMockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
+
+        assertThat(httpsMockWebServer.getRequestCount(), equalTo(2));
+        httpsMockWebServer.takeRequest();
+        RecordedRequest request = httpsMockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
+    }
+
+    @Test
+    public void withCredentials_onceBasicChallenged_whenHttps_proactivelySendsCredentials() throws Exception {
+        startHttpsMockWebServer();
+
+        httpsMockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Basic realm=\"protected area\"")
+                .setBody("Please authenticate."));
+        httpsMockWebServer.enqueue(new MockResponse());
+        httpsMockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("/different")).build());
+
+        assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
+        httpsMockWebServer.takeRequest();
+        httpsMockWebServer.takeRequest();
+        RecordedRequest request = httpsMockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), equalTo("Basic dXNlcjpwYXNz"));
+    }
+
+    @Test
+    public void withCredentials_onceDigestChallenged_proactivelySendsCredentials() throws Exception {
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
+                .setBody("Please authenticate."));
+        mockWebServer.enqueue(new MockResponse());
+        mockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("http", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("/different")).build());
+
+        assertThat(mockWebServer.getRequestCount(), equalTo(3));
+        mockWebServer.takeRequest();
+        mockWebServer.takeRequest();
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
+    }
+
+    @Test
+    public void withCredentials_onceDigestChallenged_whenHttps_proactivelySendsCredentials() throws Exception {
+        startHttpsMockWebServer();
+
+        httpsMockWebServer.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate: Digest realm=\"ODK Aggregate\", qop=\"auth\", nonce=\"MTU2NTA4MjEzODI4OTpmMjc4MDM5N2YxZTJiNDRiNjNiYTBiMThiOWQ4ZTlkMg==\"")
+                .setBody("Please authenticate."));
+        httpsMockWebServer.enqueue(new MockResponse());
+        httpsMockWebServer.enqueue(new MockResponse());
+
+        OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("/different")).build());
+
+        assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
+        httpsMockWebServer.takeRequest();
+        httpsMockWebServer.takeRequest();
+        RecordedRequest request = httpsMockWebServer.takeRequest();
+        assertThat(request.getHeader("Authorization"), startsWith("Digest"));
+    }
+
+    private void startHttpsMockWebServer() throws IOException {
+        httpsMockWebServer = new MockWebServer();
+
+        if (useRealHttps()) {
+            httpsMockWebServer.useHttps(TlsUtil.localhost().sslSocketFactory(), false);
+        }
+
+        httpsMockWebServer.start(8443);
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/http/stub/StubOpenRosaHttpInterface.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/stub/StubOpenRosaHttpInterface.java
@@ -7,7 +7,7 @@ import org.odk.collect.android.http.HttpCredentialsInterface;
 import org.odk.collect.android.http.HttpGetResult;
 import org.odk.collect.android.http.HttpHeadResult;
 import org.odk.collect.android.http.HttpPostResult;
-import org.odk.collect.android.http.OpenRosaHttpInterface;
+import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;


### PR DESCRIPTION
This is a follow up to #3289 and is based on the [post mortem of the issue](https://gist.github.com/seadowg/925999bd28504fc97efa918b0a5d85d9).

The two key changes here are:

1. Remove static state from `OkHttpConnection` and have it be an `@Singleton` instead. This keeps the state that needs to persist between instances of `CollectServerClient` but stops tests being affected by the static variables and also should make the class slightly easier to reason about.

2. Extract the authentication and common header logic out of `OkHttpConnection` and into `OkHttpOpenRosaServerClientFactory`. This also means our tests for that behaviour move to that object (which don't need Robolectric). I've kept these tests in a contact style so we don't lose the ability to switch HTTP clients in the future.

#### What has been done to verify that this works as intended?

Ran tests locally and played around with the app. Also had a check with the Network Profiler to make sure we weren't generating any extra/unexpected traffic.

#### Why is this the best possible solution? Were any other approaches considered?

We're still not in the best possible world as it's still unclear where the boundaries sit between `CollectServerClient` and `OpenRosaHttpInterface` but I think this is a step in the right direction as we know have a class that is responsible for communicating with an Open Rosa server that sits outside of the Android/Collect world.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There shouldn't be any change in behaviour. Is still think it would be good to run the QA checks we did for #3289 as we don't yet have E2E tests that actually hit a server.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)