### PR TITLE
 Fixed Expression tree is too large error

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/InstanceUploaderUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/InstanceUploaderUtilsTest.java
@@ -1,0 +1,78 @@
+package org.odk.collect.android.utilities;
+
+import android.Manifest;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.dto.Instance;
+import org.odk.collect.android.provider.InstanceProviderAPI;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class InstanceUploaderUtilsTest {
+    private static final int NUMBER_OF_INSTANCES_TO_SEND = 1000;
+
+    private final InstancesDao instancesDao = new InstancesDao();
+
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+    );
+
+    @Test
+    public void getUploadResultMessageTest() {
+        fillTestDatabase();
+        assertEquals(getExpectedResultMsg(), InstanceUploaderUtils.getUploadResultMessage(ApplicationProvider.getApplicationContext(), getTestUploadResult()));
+        instancesDao.deleteInstancesDatabase();
+    }
+
+    @Test
+    public void doesUrlRefersToGoogleSheetsFileTest() {
+        assertTrue(InstanceUploaderUtils.doesUrlRefersToGoogleSheetsFile("https://docs.google.com/spreadsheets/d/169qibpJCWgUy-SRtoyvKd1EKwV1nDfM0/edit#gid=773120038"));
+        assertFalse(InstanceUploaderUtils.doesUrlRefersToGoogleSheetsFile("https://drive.google.com/file/d/169qibpJCWgUy-SRtoyvKd1EKwV1nDfM0/edit#gid=773120038"));
+    }
+
+    private void fillTestDatabase() {
+        for (int i = 1; i <= NUMBER_OF_INSTANCES_TO_SEND; i++) {
+            long time = System.currentTimeMillis();
+            Instance instance = new Instance.Builder()
+                    .displayName("InstanceTest")
+                    .instanceFilePath(Collect.INSTANCES_PATH + "/InstanceTest_" + time + "/InstanceTest_" + time + ".xml")
+                    .jrFormId("instanceTest")
+                    .status(InstanceProviderAPI.STATUS_COMPLETE)
+                    .lastStatusChangeDate(time)
+                    .build();
+            instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(instance));
+        }
+    }
+
+    private Map<String, String> getTestUploadResult() {
+        Map<String, String> result = new HashMap<>();
+        for (int i = 1; i <= NUMBER_OF_INSTANCES_TO_SEND; i++) {
+            result.put(String.valueOf(i), "full submission upload was successful!");
+        }
+        return result;
+    }
+
+    private String getExpectedResultMsg() {
+        StringBuilder expectedResultMsg = new StringBuilder();
+        for (int i = 1; i <= NUMBER_OF_INSTANCES_TO_SEND; i++) {
+            expectedResultMsg.append("InstanceTest - Success\n\n");
+        }
+        return expectedResultMsg.toString().trim();
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/utilities/InstanceUploaderUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/utilities/InstanceUploaderUtilsTest.java
@@ -23,6 +23,10 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class InstanceUploaderUtilsTest {
+    /**
+     * 1000 instances is a big number that would product a very long sql query that would cause
+     * SQLiteException: Expression tree is too large if we didn't split it into parts.
+     */
     private static final int NUMBER_OF_INSTANCES_TO_SEND = 1000;
 
     private final InstancesDao instancesDao = new InstancesDao();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -37,15 +37,12 @@ import com.google.android.gms.auth.GoogleAuthException;
 import com.google.android.gms.auth.UserRecoverableAuthException;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.fragments.dialogs.GoogleSheetsUploaderProgressDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralKeys;
-import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceGoogleSheetsUploaderTask;
-import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ArrayUtils;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
@@ -54,8 +51,6 @@ import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -286,45 +281,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         Timber.i("uploadingComplete: Processing results ( %d ) from upload of %d instances!",
                 result.size(), instancesToSend.length);
 
-        Set<String> keys = result.keySet();
-        Iterator<String> it = keys.iterator();
-
-        StringBuilder message = new StringBuilder();
-        int count = keys.size();
-        while (count > 0) {
-            String[] selectionArgs;
-
-            if (count > ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER) {
-                selectionArgs = new String[ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER];
-            } else {
-                selectionArgs = new String[count];
-            }
-
-            StringBuilder selection = new StringBuilder();
-            selection.append(InstanceColumns._ID + " IN (");
-
-            int i = 0;
-            while (it.hasNext() && i < selectionArgs.length) {
-                selectionArgs[i] = it.next();
-                selection.append('?');
-
-                if (i != selectionArgs.length - 1) {
-                    selection.append(',');
-                }
-                i++;
-            }
-
-            selection.append(')');
-            count -= selectionArgs.length;
-
-            message.append(InstanceUploaderUtils
-                    .getUploadResultMessage(new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs), result));
-        }
-        if (message.length() == 0) {
-            message = new StringBuilder(getString(R.string.no_forms_uploaded));
-        }
-
-        createAlertDialog(message.toString().trim());
+        createAlertDialog(InstanceUploaderUtils.getUploadResultMessage(this, result));
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -22,11 +22,9 @@ import android.os.Bundle;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.fragments.dialogs.SimpleDialog;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.listeners.PermissionListener;
-import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceServerUploaderTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ArrayUtils;
@@ -38,7 +36,6 @@ import org.odk.collect.android.utilities.PermissionUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Set;
 
 import timber.log.Timber;
@@ -249,47 +246,9 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
             // tried to close a dialog not open. don't care.
         }
 
-        Set<String> keys = result.keySet();
-        Iterator<String> it = keys.iterator();
-
-        String message = "";
-        int count = keys.size();
-        while (count > 0) {
-            String[] selectionArgs;
-
-            if (count > ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER) {
-                selectionArgs = new String[ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER];
-            } else {
-                selectionArgs = new String[count];
-            }
-
-            StringBuilder selection = new StringBuilder();
-            selection.append(InstanceColumns._ID + " IN (");
-
-            int i = 0;
-            while (it.hasNext() && i < selectionArgs.length) {
-                selectionArgs[i] = it.next();
-                selection.append('?');
-
-                if (i != selectionArgs.length - 1) {
-                    selection.append(',');
-                }
-                i++;
-            }
-
-            selection.append(')');
-            count -= selectionArgs.length;
-
-            message = InstanceUploaderUtils
-                    .getUploadResultMessage(new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs), result);
-        }
-        if (message.length() == 0) {
-            message = getString(R.string.no_forms_uploaded);
-        }
-
         // If the activity is paused or in the process of pausing, don't show the dialog
         if (!isInstanceStateSaved()) {
-            createUploadInstancesResultDialog(message.trim());
+            createUploadInstancesResultDialog(InstanceUploaderUtils.getUploadResultMessage(this, result));
         } else {
             // Clean up
             finish();

--- a/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
@@ -48,10 +48,8 @@ import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import timber.log.Timber;
 
@@ -167,9 +165,7 @@ public class AutoSendWorker extends Worker {
             }
         }
 
-        String message = formatOverallResultMessage(resultMessagesByInstanceId);
-        showUploadStatusNotification(anyFailure, message);
-
+        showUploadStatusNotification(anyFailure, InstanceUploaderUtils.getUploadResultMessage(getApplicationContext(), resultMessagesByInstanceId));
         return Result.SUCCESS;
     }
 
@@ -260,31 +256,6 @@ public class AutoSendWorker extends Worker {
             }
         }
         return false;
-    }
-
-    private String formatOverallResultMessage(Map<String, String> resultMessagesByInstanceId) {
-        String message = "";
-
-        if (resultMessagesByInstanceId != null) {
-            StringBuilder selection = new StringBuilder();
-            Set<String> keys = resultMessagesByInstanceId.keySet();
-            Iterator<String> it = keys.iterator();
-
-            String[] selectionArgs = new String[keys.size()];
-            int i = 0;
-            while (it.hasNext()) {
-                String id = it.next();
-                selection.append(InstanceColumns._ID + "=?");
-                selectionArgs[i++] = id;
-                if (i != keys.size()) {
-                    selection.append(" or ");
-                }
-            }
-
-            Cursor cursor = new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs);
-            message = InstanceUploaderUtils.getUploadResultMessage(cursor, resultMessagesByInstanceId);
-        }
-        return message;
     }
 
     private void showUploadStatusNotification(boolean anyFailure, String message) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
@@ -36,6 +36,14 @@ public class InstanceUploaderUtils {
     private InstanceUploaderUtils() {
     }
 
+    /**
+     * Returns a formatted message including submission results for all the filled forms accessible
+     * through instancesProcessed in the following structure:
+     *
+     * Form name 1 - result
+     *
+     * Form name 2 - result
+     */
     public static String getUploadResultMessage(Context context, Map<String, String> result) {
         Set<String> keys = result.keySet();
         Iterator<String> it = keys.iterator();
@@ -69,7 +77,7 @@ public class InstanceUploaderUtils {
             count -= selectionArgs.length;
 
             message.append(InstanceUploaderUtils
-                    .getUploadResultMessage(new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs), result));
+                    .getUploadResultMessageForInstances(new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs), result));
         }
 
         if (message.length() == 0) {
@@ -79,16 +87,8 @@ public class InstanceUploaderUtils {
         return message.toString().trim();
     }
 
-    /**
-     * Returns a formatted message including submission results for all the filled forms accessible
-     * through instancesProcessed in the following structure:
-     *
-     * Form name 1 - result
-     *
-     * Form name 2 - result
-     */
-    public static String getUploadResultMessage(Cursor instancesProcessed,
-                                                Map<String, String> resultMessagesByInstanceId) {
+    private static String getUploadResultMessageForInstances(Cursor instancesProcessed,
+                                                             Map<String, String> resultMessagesByInstanceId) {
         StringBuilder queryMessage = new StringBuilder();
         try {
             if (instancesProcessed != null && instancesProcessed.getCount() > 0) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
@@ -24,7 +24,6 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -37,7 +36,7 @@ public class InstanceUploaderUtils {
     private InstanceUploaderUtils() {
     }
 
-    public static String getUploadResultMessage(Context context, HashMap<String, String> result) {
+    public static String getUploadResultMessage(Context context, Map<String, String> result) {
         Set<String> keys = result.keySet();
         Iterator<String> it = keys.iterator();
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
@@ -16,13 +16,18 @@
 
 package org.odk.collect.android.utilities;
 
+import android.content.Context;
 import android.database.Cursor;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 public class InstanceUploaderUtils {
 
@@ -32,6 +37,48 @@ public class InstanceUploaderUtils {
     private InstanceUploaderUtils() {
     }
 
+    public static String getUploadResultMessage(Context context, HashMap<String, String> result) {
+        Set<String> keys = result.keySet();
+        Iterator<String> it = keys.iterator();
+
+        StringBuilder message = new StringBuilder();
+        int count = keys.size();
+        while (count > 0) {
+            String[] selectionArgs;
+
+            if (count > ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER) {
+                selectionArgs = new String[ApplicationConstants.SQLITE_MAX_VARIABLE_NUMBER];
+            } else {
+                selectionArgs = new String[count];
+            }
+
+            StringBuilder selection = new StringBuilder();
+            selection.append(InstanceProviderAPI.InstanceColumns._ID + " IN (");
+
+            int i = 0;
+            while (it.hasNext() && i < selectionArgs.length) {
+                selectionArgs[i] = it.next();
+                selection.append('?');
+
+                if (i != selectionArgs.length - 1) {
+                    selection.append(',');
+                }
+                i++;
+            }
+
+            selection.append(')');
+            count -= selectionArgs.length;
+
+            message.append(InstanceUploaderUtils
+                    .getUploadResultMessage(new InstancesDao().getInstancesCursor(selection.toString(), selectionArgs), result));
+        }
+
+        if (message.length() == 0) {
+            message = new StringBuilder(context.getString(R.string.no_forms_uploaded));
+        }
+
+        return message.toString().trim();
+    }
 
     /**
      * Returns a formatted message including submission results for all the filled forms accessible


### PR DESCRIPTION
Closes #3296 

#### What has been done to verify that this works as intended?
I tested:
1. uploading >1k forms to Google Sheets
2. uploading >1k forms to Aggregate
3. uploading >1k forms using `auto send` option
4. uploading >1k forms to Aggregate with `delete after send` option

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that in some places we didn't handle that case when we have too large expression tree. We did that uploading form to Aggregate but not uploading forms to Google Sheet or using auto-send.
I extracted the code used during uploading to Aggregate and used it in other places.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Cases I described above should be tested. Generally, it's not a very risky pr, changes are only related to creating a result message (after uploading forms) so just that functionality might be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)