### PR TITLE
Remove Clock interface

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpConnection.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpConnection.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -75,7 +76,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
                 .get()
                 .build();
 
-        Response response = httpClient.makeRequest(request);
+        Response response = httpClient.makeRequest(request, new Date());
         int statusCode = response.code();
 
         if (statusCode != HttpURLConnection.HTTP_OK) {
@@ -139,7 +140,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
                 .build();
 
         Timber.i("Issuing HEAD request to: %s", uri.toString());
-        Response response = httpClient.makeRequest(request);
+        Response response = httpClient.makeRequest(request, new Date());
         int statusCode = response.code();
 
         Map<String, String> responseHeaders = new HashMap<>();
@@ -225,7 +226,7 @@ public class OkHttpConnection implements OpenRosaHttpInterface {
                 .url(uri.toURL())
                 .post(multipartBody)
                 .build();
-        Response response = httpClient.makeRequest(request);
+        Response response = httpClient.makeRequest(request, new Date());
 
         if (response.code() == 204) {
             throw new Exception();

--- a/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/okhttp/OkHttpOpenRosaServerClientFactory.java
@@ -14,7 +14,6 @@ import com.burgstaller.okhttp.digest.DigestAuthenticator;
 import org.odk.collect.android.http.HttpCredentialsInterface;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClient;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
-import org.odk.collect.android.utilities.Clock;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -40,11 +39,9 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
     private static final String DATE_HEADER = "Date";
 
     private final OkHttpClient.Builder baseClient;
-    private final Clock clock;
 
-    public OkHttpOpenRosaServerClientFactory(@NonNull OkHttpClient.Builder baseClient, Clock clock) {
+    public OkHttpOpenRosaServerClientFactory(@NonNull OkHttpClient.Builder baseClient) {
         this.baseClient = baseClient;
-        this.clock = clock;
     }
 
     @Override
@@ -71,27 +68,25 @@ public class OkHttpOpenRosaServerClientFactory implements OpenRosaServerClientFa
                     .addInterceptor(new AuthenticationCacheInterceptor(authCache)).build();
         }
 
-        return new OkHttpOpenRosaServerClient(builder.build(), userAgent, clock);
+        return new OkHttpOpenRosaServerClient(builder.build(), userAgent);
     }
 
     private static class OkHttpOpenRosaServerClient implements OpenRosaServerClient {
 
         private final OkHttpClient client;
         private final String userAgent;
-        private final Clock clock;
 
-        OkHttpOpenRosaServerClient(OkHttpClient client, String userAgent, Clock clock) {
+        OkHttpOpenRosaServerClient(OkHttpClient client, String userAgent) {
             this.client = client;
             this.userAgent = userAgent;
-            this.clock = clock;
         }
 
         @Override
-        public Response makeRequest(Request request) throws IOException {
+        public Response makeRequest(Request request, Date currentTime) throws IOException {
             return client.newCall(request.newBuilder()
                     .addHeader(USER_AGENT_HEADER, userAgent)
                     .addHeader(OPEN_ROSA_VERSION_HEADER, OPEN_ROSA_VERSION)
-                    .addHeader(DATE_HEADER, getHeaderDate(clock.getCurrentTime()))
+                    .addHeader(DATE_HEADER, getHeaderDate(currentTime))
                     .build()).execute();
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/OpenRosaServerClient.java
@@ -1,11 +1,12 @@
 package org.odk.collect.android.http.openrosa;
 
 import java.io.IOException;
+import java.util.Date;
 
 import okhttp3.Request;
 import okhttp3.Response;
 
 public interface OpenRosaServerClient {
 
-    Response makeRequest(Request request) throws IOException;
+    Response makeRequest(Request request, Date currentTime) throws IOException;
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -22,8 +22,6 @@ import org.odk.collect.android.utilities.DownloadFormListUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
-import java.util.Date;
-
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -77,7 +75,7 @@ public class AppDependencyModule {
     @Singleton
     OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap) {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 new CollectThenSystemContentTypeMapper(mimeTypeMap)
         );
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Clock.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Clock.java
@@ -1,8 +1,0 @@
-package org.odk.collect.android.utilities;
-
-import java.util.Date;
-
-public interface Clock {
-
-    Date getCurrentTime();
-}

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionGetRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionGetRequestTest.java
@@ -8,8 +8,6 @@ import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.Date;
-
 import okhttp3.OkHttpClient;
 
 @RunWith(RobolectricTestRunner.class)
@@ -18,7 +16,7 @@ public class OkHttpConnectionGetRequestTest extends OpenRosaGetRequestTest {
     @Override
     protected OpenRosaHttpInterface buildSubject() {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionHeadRequestTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionHeadRequestTest.java
@@ -8,8 +8,6 @@ import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.Date;
-
 import okhttp3.OkHttpClient;
 
 @RunWith(RobolectricTestRunner.class)
@@ -18,7 +16,7 @@ public class OkHttpConnectionHeadRequestTest extends OpenRosaHeadRequestTest {
     @Override
     protected OpenRosaHttpInterface buildSubject() {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 new CollectThenSystemContentTypeMapper(MimeTypeMap.getSingleton())
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionPostRequest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpConnectionPostRequest.java
@@ -6,8 +6,6 @@ import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.Date;
-
 import okhttp3.OkHttpClient;
 
 @RunWith(RobolectricTestRunner.class)
@@ -16,7 +14,7 @@ public class OkHttpConnectionPostRequest extends OpenRosaPostRequestTest {
     @Override
     protected OpenRosaHttpInterface buildSubject(OpenRosaHttpInterface.FileToContentTypeMapper mapper) {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder(), Date::new),
+                new OkHttpOpenRosaServerClientFactory(new OkHttpClient.Builder()),
                 mapper
         );
     }

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientFactoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientFactoryTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.http;
 
 import org.odk.collect.android.http.okhttp.OkHttpOpenRosaServerClientFactory;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
-import org.odk.collect.android.utilities.Clock;
 
 import okhttp3.OkHttpClient;
 import okhttp3.tls.internal.TlsUtil;
@@ -10,13 +9,13 @@ import okhttp3.tls.internal.TlsUtil;
 public class OkHttpOpenRosaServerClientFactoryTest extends OpenRosaServerClientFactoryTest {
 
     @Override
-    protected OpenRosaServerClientFactory buildSubject(Clock clock) {
+    protected OpenRosaServerClientFactory buildSubject() {
         OkHttpClient.Builder baseClient = new OkHttpClient.Builder()
                 .sslSocketFactory(
                         TlsUtil.localhost().sslSocketFactory(),
                         TlsUtil.localhost().trustManager());
         
-        return new OkHttpOpenRosaServerClientFactory(baseClient, clock);
+        return new OkHttpOpenRosaServerClientFactory(baseClient);
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaServerClientFactoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OpenRosaServerClientFactoryTest.java
@@ -5,7 +5,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClient;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClientFactory;
-import org.odk.collect.android.utilities.Clock;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -22,17 +21,14 @@ import okhttp3.tls.internal.TlsUtil;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public abstract class OpenRosaServerClientFactoryTest {
 
-    protected abstract OpenRosaServerClientFactory buildSubject(Clock clock);
+    protected abstract OpenRosaServerClientFactory buildSubject();
 
     protected abstract Boolean useRealHttps();
 
     private final MockWebServer mockWebServer = new MockWebServer();
-    private final Clock mockClock = mock(Clock.class);
 
     private MockWebServer httpsMockWebServer;
     private OpenRosaServerClientFactory subject;
@@ -40,9 +36,8 @@ public abstract class OpenRosaServerClientFactoryTest {
     @Before
     public void setup() throws Exception {
         mockWebServer.start();
-        when(mockClock.getCurrentTime()).thenReturn(new Date());
 
-        subject = buildSubject(mockClock);
+        subject = buildSubject();
     }
 
     @After
@@ -60,7 +55,7 @@ public abstract class OpenRosaServerClientFactoryTest {
         mockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("http", "Android", null);
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build(), new Date());
 
         RecordedRequest request = mockWebServer.takeRequest();
         assertThat(request.getHeader("X-OpenRosa-Version"), equalTo("1.0"));
@@ -71,10 +66,9 @@ public abstract class OpenRosaServerClientFactoryTest {
         mockWebServer.enqueue(new MockResponse());
 
         Date currentTime = new Date();
-        when(mockClock.getCurrentTime()).thenReturn(currentTime);
 
         OpenRosaServerClient client = subject.create("http", "Android", null);
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build(), currentTime);
 
         RecordedRequest request = mockWebServer.takeRequest();
 
@@ -88,7 +82,7 @@ public abstract class OpenRosaServerClientFactoryTest {
         mockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("http", "Android", null);
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build(), new Date());
 
         RecordedRequest request = mockWebServer.takeRequest();
         assertThat(request.getHeader("Accept-Encoding"), equalTo("gzip"));
@@ -103,7 +97,7 @@ public abstract class OpenRosaServerClientFactoryTest {
         mockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("http", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build(), new Date());
 
         assertThat(mockWebServer.getRequestCount(), equalTo(1));
     }
@@ -119,7 +113,7 @@ public abstract class OpenRosaServerClientFactoryTest {
         httpsMockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build(), new Date());
 
         assertThat(httpsMockWebServer.getRequestCount(), equalTo(2));
         httpsMockWebServer.takeRequest();
@@ -136,7 +130,7 @@ public abstract class OpenRosaServerClientFactoryTest {
         mockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("http", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build(), new Date());
 
         assertThat(mockWebServer.getRequestCount(), equalTo(2));
         mockWebServer.takeRequest();
@@ -155,7 +149,7 @@ public abstract class OpenRosaServerClientFactoryTest {
         httpsMockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build(), new Date());
 
         assertThat(httpsMockWebServer.getRequestCount(), equalTo(2));
         httpsMockWebServer.takeRequest();
@@ -175,8 +169,8 @@ public abstract class OpenRosaServerClientFactoryTest {
         httpsMockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
-        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("/different")).build());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build(), new Date());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("/different")).build(), new Date());
 
         assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
         httpsMockWebServer.takeRequest();
@@ -195,8 +189,8 @@ public abstract class OpenRosaServerClientFactoryTest {
         mockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("http", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build());
-        client.makeRequest(new Request.Builder().url(mockWebServer.url("/different")).build());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("")).build(), new Date());
+        client.makeRequest(new Request.Builder().url(mockWebServer.url("/different")).build(), new Date());
 
         assertThat(mockWebServer.getRequestCount(), equalTo(3));
         mockWebServer.takeRequest();
@@ -217,8 +211,8 @@ public abstract class OpenRosaServerClientFactoryTest {
         httpsMockWebServer.enqueue(new MockResponse());
 
         OpenRosaServerClient client = subject.create("https", "Android", new HttpCredentials("user", "pass"));
-        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build());
-        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("/different")).build());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("")).build(), new Date());
+        client.makeRequest(new Request.Builder().url(httpsMockWebServer.url("/different")).build(), new Date());
 
         assertThat(httpsMockWebServer.getRequestCount(), equalTo(3));
         httpsMockWebServer.takeRequest();


### PR DESCRIPTION
This is a follow up to the discussion in #3302. The idea here is to remove the `Clock` interface introduced as a form of dependency inversion in `OkHttpOpenRosaClientFactory` in favour of passing the current time as a method parameter.

#### What has been done to verify that this works as intended?

Ran tests locally.

#### Why is this the best possible solution? Were any other approaches considered?

This avoids us having to introduce a new interface that would have made more sense in a top level object (like a Fragment or Activity) so I think even though we have more "noise" in our method signature it's preferable.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There shouldn't be any change in behavior.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)