### PR TITLE
Pass activity to general settings Espresso helper

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/MainMenu.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/MainMenu.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.espressoutils;
 
+import android.app.Activity;
+
 import androidx.test.espresso.Espresso;
 import org.odk.collect.android.R;
 import org.odk.collect.android.provider.FormsProviderAPI;
@@ -30,8 +32,8 @@ public final class MainMenu {
         onData(withRowString(FormsProviderAPI.FormsColumns.DISPLAY_NAME, text)).perform(click());
     }
 
-    public static void clickGeneralSettings() {
-        onView(withText(getInstrumentation().getTargetContext().getString(R.string.general_preferences))).perform(click());
+    public static void clickGeneralSettings(Activity activity) {
+        onView(withText(activity.getString(R.string.general_preferences))).perform(click());
     }
 
     public static void clickFillBlankForm() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -158,7 +158,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
 
         //TestCase37
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.clickOnUserInterface();
         Settings.clickOnLanguage();
         Settings.clickOnSelectedLanguage("Deutsch");
@@ -196,7 +196,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
         pressBack();
         pressBack();
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.clickOnUserInterface();
         Settings.clickOnLanguage();
         Settings.clickOnSelectedLanguage("English");

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormManagementTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormManagementTest.java
@@ -42,7 +42,7 @@ public class FormManagementTest extends  BaseRegressionTest {
         FormEntry.swipeToNextQuestion();
         FormEntry.checkIsToastWithMessageDisplayes("Response length must be between 5 and 15", main);
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         Settings.openConstraintProcessing();
         FormEntry.clickOnString(R.string.constraint_behavior_on_finalize);
@@ -57,7 +57,7 @@ public class FormManagementTest extends  BaseRegressionTest {
     public void guidanceForQuestion_ShouldDisplayAlways() {
         //TestCase10
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         Settings.openShowGuidanceForQuestions();
         Settings.clickOnString(R.string.guidance_yes);
@@ -73,7 +73,7 @@ public class FormManagementTest extends  BaseRegressionTest {
     public void guidanceForQuestion_ShouldBeCollapsed() {
         //TestCase11
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         Settings.openShowGuidanceForQuestions();
         Settings.clickOnString(R.string.guidance_yes_collapsed);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
@@ -18,7 +18,7 @@ public class ServerOtherTest extends BaseRegressionTest {
     public void formListPath_ShouldBeUpdated() {
         //TestCase1
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openServerSettings();
         Settings.clickOnServerType();
         FormEntry.clickOnAreaWithIndex("CheckedTextView", 2);
@@ -35,7 +35,7 @@ public class ServerOtherTest extends BaseRegressionTest {
      public void submissionsPath_ShouldBeUpdated() {
          //TestCase2
          MainMenu.clickOnMenu();
-         MainMenu.clickGeneralSettings();
+         MainMenu.clickGeneralSettings(main.getActivity());
          Settings.openServerSettings();
          Settings.clickOnServerType();
          FormEntry.clickOnAreaWithIndex("CheckedTextView", 2);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/TriggerWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/TriggerWidgetTest.java
@@ -34,7 +34,7 @@ public class TriggerWidgetTest extends BaseRegressionTest {
     @Test
     public void guidanceIcons_ShouldBeAlwaysShown() {
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         Settings.openShowGuidanceForQuestions();
         Settings.clickOnString(R.string.guidance_yes);
@@ -50,7 +50,7 @@ public class TriggerWidgetTest extends BaseRegressionTest {
     @Test
     public void guidanceIcons_ShouldBeCollapsed() {
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         Settings.openShowGuidanceForQuestions();
         Settings.clickOnString(R.string.guidance_yes_collapsed);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
@@ -36,7 +36,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
     public void setEmail_ShouldRequireAtSign() {
         //TestCase1
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataEmail();
@@ -66,7 +66,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
 
         //TestCase3
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataUsername();
@@ -85,7 +85,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
 
         //TestCase4
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataUsername();
@@ -95,7 +95,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         pressBack();
         pressBack();
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openServerSettings();
         Settings.clickOnServerType();
         Settings.clickOnString(R.string.server_platform_odk_aggregate);
@@ -114,7 +114,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
 
         //TestCase5
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.clickUserAndDeviceIdentity();
         Settings.clickFormMetadata();
         Settings.clickMetadataUsername();
@@ -124,7 +124,7 @@ public class UserAndDeviceIdentityTest extends BaseRegressionTest {
         pressBack();
         pressBack();
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openServerSettings();
         Settings.clickOnServerType();
         Settings.clickOnString(R.string.server_platform_odk_aggregate);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserSettingsTest.java
@@ -36,7 +36,7 @@ public class UserSettingsTest extends BaseRegressionTest {
         pressBack();
         pressBack();
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.checkIfStringDoesNotExist(R.string.server);
         Settings.checkIfStringDoesNotExist(R.string.client);
         Settings.checkIfStringDoesNotExist(R.string.maps);
@@ -66,7 +66,7 @@ public class UserSettingsTest extends BaseRegressionTest {
         pressBack();
         pressBack();
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         Settings.checkIfStringDoesNotExist(R.string.guidance_hint_title);
         pressBack();
@@ -78,7 +78,7 @@ public class UserSettingsTest extends BaseRegressionTest {
         pressBack();
         pressBack();
         MainMenu.clickOnMenu();
-        MainMenu.clickGeneralSettings();
+        MainMenu.clickGeneralSettings(main.getActivity());
         Settings.openFormManagement();
         FormEntry.checkIsStringDisplayed(R.string.guidance_hint_title);
         pressBack();


### PR DESCRIPTION
Fixes broken tests in `FillBlankFormTest` that were failing due to the test loading strings in a different language from the app.

This change lets us use the `Activity` under test as the source of resources so we don't run into problems with locale changes.

#### What has been done to verify that this works as intended?

Run tests locally and on Test Lab.

#### Why is this the best possible solution? Were any other approaches considered?

I didn't feel comfortable changing the way the app switches `Locale` config as the feature does seem to be working. I think after we have this merged it would be good to look at having our Espresso helpers use a page object style pattern so we can pass the `Activity` in at a constructor but that would be quite a large diff so thought it would be best to avoid as a quick fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only changes tests so shouldn't be any regression risks.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)