### PR TITLE
Increase no-output timeout for Firebase Test Lab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
               --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
               --directories-to-pull /sdcard --timeout 20m
             fi
+          no_output_timeout: 60m
       - run:
           name: Copy integration test results
           command: |


### PR DESCRIPTION
The build is currently broken because the default time a command can run without output on CircleCI is 10m and [the latest instrumentation test run](https://console.firebase.google.com/u/0/project/api-project-322300403941/testlab/histories/bh.f6f8331e5ae6e371/matrices/7661079713399201046) (needs credentials) passed in 10m32sec.

See description of `no_output_timeout` key in CircleCI docs at https://circleci.com/docs/2.0/configuration-reference/#run. I picked 60m because it leaves us room to add more tests while also timing out if something really strange happens.

I think this should just need a check that 60m is reasonable and that I got the syntax/spacing/etc correct.
