### PR TITLE
Rework Settings typography

### DIFF
--- a/collect_app/src/main/res/values/settings_theme.xml
+++ b/collect_app/src/main/res/values/settings_theme.xml
@@ -2,18 +2,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Collect.Settings.Light" parent="Theme.Collect.BaseLight">
-        <item name="android:textColor">?primaryTextColor</item>
+        <item name="android:textAppearance">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
-        <item name="android:textSize">18sp</item>
         <item name="android:listDivider">@null</item>
-        <item name="android:dividerHeight">0dp</item>
     </style>
 
     <style name="Theme.Collect.Settings.Dark" parent="Theme.Collect.BaseDark">
-        <item name="android:textColor">?primaryTextColor</item>
+        <item name="android:textAppearance">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
-        <item name="android:textSize">18sp</item>
         <item name="android:listDivider">@null</item>
-        <item name="android:dividerHeight">0dp</item>
     </style>
 </resources>


### PR DESCRIPTION
This reworks typography for settings of the app. This doesn't change much at all as we use the `PreferencesFragment` to control most of the visual style of settings. All we change here is the default title font size to be inline with the [experiment styleguide](https://github.com/seadowg/collect-design).

The reasoning behind what we're doing is [here](https://forum.opendatakit.org/t/reworking-collects-typography/20634). I've also, while in the area, tried to clean up the layouts involved by reworking the structure, using standard values and extracting common styles.

Here is before the changes:

![Screenshot_1567432367](https://user-images.githubusercontent.com/556280/64119284-5dd98800-cd91-11e9-84b7-baf47f4ef3c5.png)

And after:

![Screenshot_1567432171](https://user-images.githubusercontent.com/556280/64119093-edcb0200-cd90-11e9-9cb6-bac07fbaeed8.png)

#### What has been done to verify that this works as intended?

Ran tests, played around with effected screen.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)