### PR TITLE
Bumped targetSdkVersion and compileSdkVersion

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -67,12 +67,12 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(28)
 
     defaultConfig {
         applicationId('org.odk.collect.android')
         minSdkVersion(16)
-        targetSdkVersion(29)
+        targetSdkVersion(28)
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -67,12 +67,12 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 
 android {
-    compileSdkVersion(28)
+    compileSdkVersion(29)
 
     defaultConfig {
         applicationId('org.odk.collect.android')
         minSdkVersion(16)
-        targetSdkVersion(26)
+        targetSdkVersion(29)
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -218,8 +218,7 @@ public class TimeWidget extends QuestionWidget implements ButtonWidget, TimePick
          */
         @SuppressWarnings("deprecation")
         private void fixSpinner(Context context, int hourOfDay, int minute, boolean is24HourView) {
-            // android:timePickerMode spinner and clock began in Lollipop
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
                 try {
                     // Get the theme's android:timePickerMode
                     final int MODE_SPINNER = 2;
@@ -251,13 +250,7 @@ public class TimeWidget extends QuestionWidget implements ButtonWidget, TimePick
                         Object delegate = delegateField.get(timePicker);
 
                         Class<?> spinnerDelegateClass;
-                        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.LOLLIPOP) {
-                            spinnerDelegateClass = Class.forName("android.widget.TimePickerSpinnerDelegate");
-                        } else {
-                            // TimePickerSpinnerDelegate was initially misnamed in API 21!
-                            spinnerDelegateClass = Class.forName("android.widget.TimePickerClockDelegate");
-                        }
-
+                        spinnerDelegateClass = Class.forName("android.widget.TimePickerSpinnerDelegate");
                         // In 7.0 Nougat for some reason the timePickerMode is ignored and the
                         // delegate is TimePickerClockDelegate
                         if (delegate.getClass() != spinnerDelegateClass) {


### PR DESCRIPTION
Closes #3189 

#### What has been done to verify that this works as intended?
I investigated the doc:
https://developer.android.com/about/versions/pie/android-9.0-changes-28
https://developer.android.com/about/versions/pie/android-9.0-changes-all
https://developer.android.com/about/versions/10/behavior-changes-10
https://developer.android.com/about/versions/10/behavior-changes-all

also, I tested the app a bit:
- downloading forms
- uploading forms (aggregate and google sheets)
- filling forms

#### Why is this the best possible solution? Were any other approaches considered?
We just have to update targetSdkVersion to 28 so we decided to update to 29 to test everything just once.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I wasn't able to find anything apart from the issue with TimeWidget but it doesn't mean that it's the only problem. Bugs might be everywhere...

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)