### PR TITLE
Roll back okhttp updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,5 +49,5 @@ task checkTests(type: GradleBuild) {
 ext {
     leakyCanaryVersion = '1.6.3'
     daggerVersion = '2.24'
-    okhttp3Version = '4.1.1'
+    okhttp3Version = '3.12.5' //newer versions require minSdkVersion >= 21
 }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -229,7 +229,7 @@ dependencies {
     }
 
     implementation "com.squareup.okhttp3:okhttp:${rootProject.okhttp3Version}"
-    implementation 'com.burgstaller:okhttp-digest:2.0'
+    implementation 'com.burgstaller:okhttp-digest:1.18' //newer versions require minSdkVersion >= 21
 
     implementation 'com.github.mohamadian:PersianJodaTime:1.2'
     implementation 'com.github.chanmratekoko:myanmar-calendar:1.0.6.RC3'


### PR DESCRIPTION
Closes #3351 

#### What has been done to verify that this works as intended?
I reproduced the crash and confirmed that this pr fixes it.

#### Why is this the best possible solution? Were any other approaches considered?
We just can't use the newest versions of okhttp because it requires minSdkVersion >= 21 :(

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Confirming that the crash no longer take place on Android 4 would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)