### PR TITLE
Use TestCollect class just for tests

### DIFF
--- a/collect_app/src/debug/AndroidManifest.xml
+++ b/collect_app/src/debug/AndroidManifest.xml
@@ -8,8 +8,4 @@
     <!-- Allows changing locales -->
     <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" tools:ignore="ProtectedPermissions" />
 
-    <application
-        android:name=".application.TestCollect"
-        tools:replace="android:name" />
-
 </manifest>


### PR DESCRIPTION
Closes #3366 

#### What has been done to verify that this works as intended?
I tested OSM maps.

#### Why is this the best possible solution? Were any other approaches considered?
We just shouldn't override [setupOSMDroid](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/application/TestCollect.java#L22) method for `debug` build variant.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the scenario described in the issue would be enough. It's not a risky change.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with geo widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)