### PR TITLE
Fixed text color for settings. Fix #3367

### DIFF
--- a/collect_app/src/main/res/values/settings_theme.xml
+++ b/collect_app/src/main/res/values/settings_theme.xml
@@ -2,14 +2,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Collect.Settings.Light" parent="Theme.Collect.BaseLight">
-        <item name="android:textColor">?primaryTextColor</item>
+        <item name="android:textColor">?colorOnSurface</item>
         <item name="android:textAppearance">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:listDivider">@null</item>
     </style>
 
     <style name="Theme.Collect.Settings.Dark" parent="Theme.Collect.BaseDark">
-        <item name="android:textColor">?primaryTextColor</item>
+        <item name="android:textColor">?colorOnSurface</item>
         <item name="android:textAppearance">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:listDivider">@null</item>

--- a/collect_app/src/main/res/values/settings_theme.xml
+++ b/collect_app/src/main/res/values/settings_theme.xml
@@ -2,12 +2,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Collect.Settings.Light" parent="Theme.Collect.BaseLight">
+        <item name="android:textColor">?primaryTextColor</item>
         <item name="android:textAppearance">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:listDivider">@null</item>
     </style>
 
     <style name="Theme.Collect.Settings.Dark" parent="Theme.Collect.BaseDark">
+        <item name="android:textColor">?primaryTextColor</item>
         <item name="android:textAppearance">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:listDivider">@null</item>


### PR DESCRIPTION
Closes #3367 

<img src="https://user-images.githubusercontent.com/55661063/66312276-e783f480-e8ff-11e9-8cf9-a050008e2122.png" width="400" alt="Admin Settings Activity">

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Ran in light and dark mode to check the results.

#### Why is this the best possible solution? Were any other approaches considered?

 ```settings_theme.xml``` file contains the theme options for "Settings" activities and changes such as font settings should be applied in this file. Using this approach solves the issue without modifying other files and creating unwanted dependency.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Increases readability on Settings-related pages by making text darker. There shouldn't be any risks.

#### Do we need any specific form for testing your changes? If so, please attach one.

Not required.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Not required.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)