### PR TITLE
Use separate (more meaningful) messages when an audio file is missing/invalid

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioPlayerViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioPlayerViewModel.java
@@ -8,8 +8,10 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Transformations;
 import androidx.lifecycle.ViewModel;
 
+import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.Scheduler;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -105,7 +107,7 @@ class AudioPlayerViewModel extends ViewModel implements MediaPlayer.OnCompletion
                 try {
                     loadNewClip(nextClip.getURI());
                 } catch (IOException ignored) {
-                    error.setValue(new PlaybackFailedException(nextClip.getURI()));
+                    error.setValue(new PlaybackFailedException(nextClip.getURI(), getExceptionMsg(nextClip.getURI())));
                     playNext(playlist);
                     return;
                 }
@@ -121,6 +123,10 @@ class AudioPlayerViewModel extends ViewModel implements MediaPlayer.OnCompletion
 
             schedulePositionUpdates();
         }
+    }
+
+    private int getExceptionMsg(String uri) {
+        return new File(uri).exists() ? R.string.file_invalid : R.string.file_missing;
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/audio/PlaybackFailedException.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/PlaybackFailedException.java
@@ -5,9 +5,11 @@ import androidx.core.util.ObjectsCompat;
 public class PlaybackFailedException extends Exception {
 
     private final String uri;
+    private final int exceptionMsg;
 
-    public PlaybackFailedException(String uri) {
+    public PlaybackFailedException(String uri, int exceptionMsg) {
         this.uri = uri;
+        this.exceptionMsg = exceptionMsg;
     }
 
     public String getURI() {
@@ -36,5 +38,9 @@ public class PlaybackFailedException extends Exception {
         return "PlaybackFailedException{" +
                 "uri='" + uri + '\'' +
                 '}';
+    }
+
+    public int getExceptionMsg() {
+        return exceptionMsg;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -174,7 +174,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
                 final PlaybackFailedException playbackFailedException = (PlaybackFailedException) e;
                 Toast.makeText(
                         getContext(),
-                        getContext().getString(R.string.file_missing, playbackFailedException.getURI()),
+                        getContext().getString(playbackFailedException.getExceptionMsg(), playbackFailedException.getURI()),
                         Toast.LENGTH_SHORT
                 ).show();
 

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioPlayerViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioPlayerViewModelTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.odk.collect.android.R;
 import org.odk.collect.android.support.FakeScheduler;
 import org.odk.collect.android.support.LiveDataTester;
 import org.robolectric.RobolectricTestRunner;
@@ -371,13 +372,27 @@ public class AudioPlayerViewModelTest {
     }
 
     @Test
-    public void getError_whenPlaybackFails_is_PlaybackFailed() throws Exception {
+    public void getError_whenPlaybackFailsBecauseOfMissingFile_is_PlaybackFailed() throws Exception {
         final LiveData<Exception> error = liveDataTester.activate(viewModel.getError());
 
         doThrow(IOException.class).when(mediaPlayer).setDataSource("file://missing.mp3");
         viewModel.play(new Clip("clip1", "file://missing.mp3"));
 
-        assertThat(error.getValue(), equalTo(new PlaybackFailedException("file://missing.mp3")));
+        PlaybackFailedException playbackFailedException = new PlaybackFailedException("file://missing.mp3", R.string.file_missing);
+        assertThat(error.getValue(), equalTo(playbackFailedException));
+        assertThat(R.string.file_missing, equalTo(playbackFailedException.getExceptionMsg()));
+    }
+
+    @Test
+    public void getError_whenPlaybackFailsBecauseOfInvalidFile_is_PlaybackFailed() throws Exception {
+        final LiveData<Exception> error = liveDataTester.activate(viewModel.getError());
+
+        doThrow(IOException.class).when(mediaPlayer).setDataSource("file://invalid.mp3");
+        viewModel.play(new Clip("clip1", "file://invalid.mp3"));
+
+        PlaybackFailedException playbackFailedException = new PlaybackFailedException("file://invalid.mp3", R.string.file_invalid);
+        assertThat(error.getValue(), equalTo(playbackFailedException));
+        assertThat(R.string.file_invalid, equalTo(playbackFailedException.getExceptionMsg()));
     }
 
     @Test


### PR DESCRIPTION
Closes #3374 

#### What has been done to verify that this works as intended?
I tested the attached form.

#### Why is this the best possible solution? Were any other approaches considered?
It's the simplest solution that improves `PlaybackFailedException` setting the message based on the cause.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change, testing the attached form should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)