### PR TITLE
Allow using cleartext traffic on Android 9+

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -86,7 +86,8 @@ the specific language governing permissions and limitations under the License.
         android:installLocation="auto"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:usesCleartextTraffic="true">
 
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION
Closes #3380 

#### What has been done to verify that this works as intended?
I tested the mentioned scenario and confirmed the problem is fixed.

#### Why is this the best possible solution? Were any other approaches considered?
It's the only solution. [Starting with Android 9 (API level 28), cleartext support is disabled by default](https://stackoverflow.com/a/50834600/5479029).

More info:
https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted
https://medium.com/@son.rommer/fix-cleartext-traffic-error-in-android-9-pie-2f4e9e2235e6


According to analytics, we collect a lot of our users use http so we can't just disable it:
![image](https://user-images.githubusercontent.com/3276264/66461117-9c412180-ea78-11e9-8f69-884573f92805.png)


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the mentioned scenario on androi 9 would be enough it's not a risky change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)