### PR TITLE
Catch exceptions and errors thrown by createFormDefFromCacheOrXml()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -148,6 +148,9 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         } catch (StackOverflowError e) {
             Timber.e(e);
             errorMsg = Collect.getInstance().getString(R.string.too_complex_form);
+        } catch (Exception | Error e) {
+            Timber.w(e);
+            errorMsg = e.getMessage();
         }
 
         if (errorMsg != null || formDef == null) {


### PR DESCRIPTION
Closes #https://github.com/opendatakit/javarosa/issues/500
Closes #3398 
Closes #3383 

#### What has been done to verify that this works as intended?
I tested the form mentioned in the issue.

#### Why is this the best possible solution? Were any other approaches considered?
As I said [share](https://github.com/opendatakit/javarosa/issues/500#issuecomment-542865722) I don't think we need to provide backward compatibility for `setlocation`. Catching the exception and displaying an appropriate message would be enough. The problem is not only with `setlocation` action but every unsupported action would cause a crash so catching an exception is the best option that fixes all cases.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change is not risky, it's just a catch clause. Testing the mentioned forms would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms mentioned in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)