### PR TITLE
Check a checkbox programmatically before setting onCheckedChangeListener

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
@@ -78,6 +78,8 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
     CheckBox setUpButton(final int index) {
         AppCompatCheckBox checkBox = new AppCompatCheckBox(widget.getContext());
         adjustButton(checkBox, index);
+        checkCheckBoxIfNeeded(checkBox, index); // perform before setting onCheckedChangeListener to avoid redundant calls of its body
+
         checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (isChecked) {
                 addItem(filteredItems.get(index).selection());
@@ -87,6 +89,10 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
             widget.widgetValueChanged();
         });
 
+        return checkBox;
+    }
+
+    private void checkCheckBoxIfNeeded(CheckBox checkBox, int index) {
         for (Selection selectedItem : selectedItems) {
             // match based on value, not key
             if (filteredItems.get(index).getValue().equals(selectedItem.getValue())) {
@@ -94,8 +100,6 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
                 break;
             }
         }
-
-        return checkBox;
     }
 
     @Override


### PR DESCRIPTION
Closes #3402 

#### What has been done to verify that this works as intended?
I tested the attached form.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that we set [OnCheckedChangeListener](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3402?expand=1#diff-d38f3b3845ce85a71ff2999805e14818L81) and the called [checkBox.setChecked(true);](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3402?expand=1#diff-d38f3b3845ce85a71ff2999805e14818R99) what caused the code in OnCheckedChangeListener was called (OnCheckedChangeListener should be use only if we check a checkbox manually not programmatically). We should set the listener after setting a checkbox state to avoid redundant calls and strange result like the one described on the forum https://forum.opendatakit.org/t/odk-collect-version-1-23-3-multiple-select-from-csv/22828/

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change and testing the attached form to confirm the bug is fixed would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)