### PR TITLE
Added a listener to change text size immediately.Fix #3356

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -92,9 +92,9 @@ android {
         }
     }
 
-    lintOptions {
-        abortOnError false
-    }
+    //lintOptions {
+       // abortOnError false
+    //}
 
     buildTypes {
         // Release build for all forks

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -92,9 +92,6 @@ android {
         }
     }
 
-    //lintOptions {
-       // abortOnError false
-    //}
 
     buildTypes {
         // Release build for all forks

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -92,6 +92,10 @@ android {
         }
     }
 
+    lintOptions {
+        abortOnError false
+    }
+
     buildTypes {
         // Release build for all forks
         release {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -113,6 +113,7 @@ import org.odk.collect.android.listeners.FormLoaderListener;
 import org.odk.collect.android.listeners.FormSavedListener;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.listeners.SavePointListener;
+import org.odk.collect.android.listeners.TextSizeChangeListener;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.location.client.GoogleLocationClient;
 import org.odk.collect.android.logic.AuditEvent;
@@ -125,6 +126,7 @@ import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferencesActivity;
+import org.odk.collect.android.preferences.UserInterfacePreferences;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.FormLoaderTask;
@@ -197,6 +199,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         RankingWidgetDialog.RankingListener,
         SaveFormIndexTask.SaveFormIndexListener, FormLoadingDialogFragment.FormLoadingDialogFragmentListener,
         WidgetValueChangedListener,
+        TextSizeChangeListener,
         ScreenContext,
         AudioControllerView.SwipableParent {
 
@@ -295,6 +298,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         this.doSwipe = doSwipe;
     }
 
+    @Override
+    public void onTextSizeChange() {
+         loadForm();
+    }
+
     enum AnimationType {
         LEFT, RIGHT, FADE
     }
@@ -324,6 +332,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        UserInterfacePreferences.textSizeChangeListener = (TextSizeChangeListener) this;
 
         viewModel = ViewModelProviders.of(this, new FormEntryViewModelFactory()).get(FormEntryViewModel.class);
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -113,7 +113,6 @@ import org.odk.collect.android.listeners.FormLoaderListener;
 import org.odk.collect.android.listeners.FormSavedListener;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.listeners.SavePointListener;
-import org.odk.collect.android.listeners.TextSizeChangeListener;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.location.client.GoogleLocationClient;
 import org.odk.collect.android.logic.AuditEvent;
@@ -126,7 +125,6 @@ import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferencesActivity;
-import org.odk.collect.android.preferences.UserInterfacePreferences;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.FormLoaderTask;
@@ -199,7 +197,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         RankingWidgetDialog.RankingListener,
         SaveFormIndexTask.SaveFormIndexListener, FormLoadingDialogFragment.FormLoadingDialogFragmentListener,
         WidgetValueChangedListener,
-        TextSizeChangeListener,
         ScreenContext,
         AudioControllerView.SwipableParent {
 
@@ -298,11 +295,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         this.doSwipe = doSwipe;
     }
 
-    @Override
-    public void onTextSizeChange() {
-         loadForm();
-    }
-
     enum AnimationType {
         LEFT, RIGHT, FADE
     }
@@ -332,8 +324,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        UserInterfacePreferences.textSizeChangeListener = (TextSizeChangeListener) this;
 
         viewModel = ViewModelProviders.of(this, new FormEntryViewModelFactory()).get(FormEntryViewModel.class);
 
@@ -916,6 +906,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     getCurrentViewIfODKView().setBinaryData(bearing);
                 }
                 break;
+                case RequestCodes.FONT_SIZE_MATCHER:
+                    loadForm();
+                    break;
         }
     }
 
@@ -1030,7 +1023,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 return true;
             case R.id.menu_preferences:
                 Intent pref = new Intent(this, PreferencesActivity.class);
-                startActivity(pref);
+                startActivityForResult(pref, RequestCodes.FONT_SIZE_MATCHER);
                 return true;
             case R.id.track_location:
                 GeneralSharedPreferences.getInstance().save(KEY_BACKGROUND_LOCATION, !GeneralSharedPreferences.getInstance().getBoolean(KEY_BACKGROUND_LOCATION, true));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -906,7 +906,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     getCurrentViewIfODKView().setBinaryData(bearing);
                 }
                 break;
-                case RequestCodes.FONT_SIZE_MATCHER:
+                case RequestCodes.PREFERENCES:
                     loadForm();
                     break;
         }
@@ -1023,7 +1023,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 return true;
             case R.id.menu_preferences:
                 Intent pref = new Intent(this, PreferencesActivity.class);
-                startActivityForResult(pref, RequestCodes.FONT_SIZE_MATCHER);
+                startActivityForResult(pref, RequestCodes.PREFERENCES);
                 return true;
             case R.id.track_location:
                 GeneralSharedPreferences.getInstance().save(KEY_BACKGROUND_LOCATION, !GeneralSharedPreferences.getInstance().getBoolean(KEY_BACKGROUND_LOCATION, true));

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/TextSizeChangeListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/TextSizeChangeListener.java
@@ -1,5 +1,0 @@
-package org.odk.collect.android.listeners;
-
-public interface TextSizeChangeListener {
-     void onTextSizeChange();
-}

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/TextSizeChangeListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/TextSizeChangeListener.java
@@ -1,0 +1,5 @@
+package org.odk.collect.android.listeners;
+
+public interface TextSizeChangeListener {
+     void onTextSizeChange();
+}

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -17,12 +17,14 @@
 package org.odk.collect.android.preferences;
 
 import android.app.Fragment;
+import android.content.Intent;
 import android.os.Bundle;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.OnBackPressedListener;
+import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ThemeUtils;
 
 public class PreferencesActivity extends CollectAbstractActivity {
@@ -62,6 +64,8 @@ public class PreferencesActivity extends CollectAbstractActivity {
         } else {
             super.onBackPressed();
         }
+        Intent intent = new Intent();
+        setResult(ApplicationConstants.RequestCodes.FONT_SIZE_MATCHER, intent);
     }
 
     public void setOnBackPressedListener(OnBackPressedListener onBackPressedListener) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/PreferencesActivity.java
@@ -65,7 +65,7 @@ public class PreferencesActivity extends CollectAbstractActivity {
             super.onBackPressed();
         }
         Intent intent = new Intent();
-        setResult(ApplicationConstants.RequestCodes.FONT_SIZE_MATCHER, intent);
+        setResult(ApplicationConstants.RequestCodes.PREFERENCES, intent);
     }
 
     public void setOnBackPressedListener(OnBackPressedListener onBackPressedListener) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -26,6 +26,7 @@ import android.view.View;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.listeners.TextSizeChangeListener;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
 
@@ -46,6 +47,7 @@ import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY
 public class UserInterfacePreferences extends BasePreferenceFragment {
 
     protected static final int IMAGE_CHOOSER = 0;
+   public static  TextSizeChangeListener textSizeChangeListener;
 
     public static UserInterfacePreferences newInstance(boolean adminMode) {
         Bundle bundle = new Bundle();
@@ -121,6 +123,7 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
             pref.setSummary(pref.getEntry());
             pref.setOnPreferenceChangeListener((preference, newValue) -> {
                 int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+                textSizeChangeListener.onTextSizeChange();
                 CharSequence entry = ((ListPreference) preference).getEntries()[index];
                 preference.setSummary(entry);
                 return true;

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferences.java
@@ -26,7 +26,6 @@ import android.view.View;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
-import org.odk.collect.android.listeners.TextSizeChangeListener;
 import org.odk.collect.android.utilities.LocaleHelper;
 import org.odk.collect.android.utilities.MediaUtils;
 
@@ -47,7 +46,6 @@ import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY
 public class UserInterfacePreferences extends BasePreferenceFragment {
 
     protected static final int IMAGE_CHOOSER = 0;
-   public static  TextSizeChangeListener textSizeChangeListener;
 
     public static UserInterfacePreferences newInstance(boolean adminMode) {
         Bundle bundle = new Bundle();
@@ -123,7 +121,6 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
             pref.setSummary(pref.getEntry());
             pref.setOnPreferenceChangeListener((preference, newValue) -> {
                 int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
-                textSizeChangeListener.onTextSizeChange();
                 CharSequence entry = ((ListPreference) preference).getEntries()[index];
                 preference.setSummary(entry);
                 return true;
@@ -198,6 +195,7 @@ public class UserInterfacePreferences extends BasePreferenceFragment {
                 setSplashPath(sourceMediaPath);
 
                 break;
+
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -96,6 +96,7 @@ public class ApplicationConstants {
         public static final int GEOSHAPE_CAPTURE = 20;
         public static final int GEOTRACE_CAPTURE = 21;
         public static final int ARBITRARY_FILE_CHOOSER = 22;
+        public static final int FONT_SIZE_MATCHER = 23;
 
         public static final int FORMS_UPLOADED_NOTIFICATION = 97;
         public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -96,7 +96,7 @@ public class ApplicationConstants {
         public static final int GEOSHAPE_CAPTURE = 20;
         public static final int GEOTRACE_CAPTURE = 21;
         public static final int ARBITRARY_FILE_CHOOSER = 22;
-        public static final int FONT_SIZE_MATCHER = 23;
+        public static final int PREFERENCES = 23;
 
         public static final int FORMS_UPLOADED_NOTIFICATION = 97;
         public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;


### PR DESCRIPTION
Closes #3356

#### What has been done to verify that this works as intended?
I had implemented an interface listener to update the form text size immediately.
#### Why is this the best possible solution? Were any other approaches considered?
I considered this approach because we have to reload the form after changing preferences.
