### PR TITLE
Fixed Memory leak in MainMenuActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -264,47 +264,6 @@ public class MainMenuActivity extends CollectAbstractActivity {
         adminPreferences = this.getSharedPreferences(
                 AdminPreferencesActivity.ADMIN_PREFERENCES, 0);
 
-        InstancesDao instancesDao = new InstancesDao();
-
-        // count for finalized instances
-        try {
-            finalizedCursor = instancesDao.getFinalizedInstancesCursor();
-        } catch (Exception e) {
-            createErrorDialog(e.getMessage(), EXIT);
-            return;
-        }
-
-        if (finalizedCursor != null) {
-            startManagingCursor(finalizedCursor);
-        }
-        completedCount = finalizedCursor != null ? finalizedCursor.getCount() : 0;
-
-        // count for saved instances
-        try {
-            savedCursor = instancesDao.getUnsentInstancesCursor();
-        } catch (Exception e) {
-            createErrorDialog(e.getMessage(), EXIT);
-            return;
-        }
-
-        if (savedCursor != null) {
-            startManagingCursor(savedCursor);
-        }
-        savedCount = savedCursor != null ? savedCursor.getCount() : 0;
-
-        //count for view sent form
-        try {
-            viewSentCursor = instancesDao.getSentInstancesCursor();
-        } catch (Exception e) {
-            createErrorDialog(e.getMessage(), EXIT);
-            return;
-        }
-        if (viewSentCursor != null) {
-            startManagingCursor(viewSentCursor);
-        }
-        viewSentCount = viewSentCursor != null ? viewSentCursor.getCount() : 0;
-
-        updateButtons();
         setupGoogleAnalytics();
     }
 
@@ -320,6 +279,8 @@ public class MainMenuActivity extends CollectAbstractActivity {
         SharedPreferences sharedPreferences = this.getSharedPreferences(
                 AdminPreferencesActivity.ADMIN_PREFERENCES, 0);
 
+        countSavedForms();
+        updateButtons();
         getContentResolver().registerContentObserver(InstanceColumns.CONTENT_URI, true,
                 contentObserver);
 
@@ -423,6 +384,48 @@ public class MainMenuActivity extends CollectAbstractActivity {
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void countSavedForms() {
+        InstancesDao instancesDao = new InstancesDao();
+
+        // count for finalized instances
+        try {
+            finalizedCursor = instancesDao.getFinalizedInstancesCursor();
+        } catch (Exception e) {
+            createErrorDialog(e.getMessage(), EXIT);
+            return;
+        }
+
+        if (finalizedCursor != null) {
+            startManagingCursor(finalizedCursor);
+        }
+        completedCount = finalizedCursor != null ? finalizedCursor.getCount() : 0;
+
+        // count for saved instances
+        try {
+            savedCursor = instancesDao.getUnsentInstancesCursor();
+        } catch (Exception e) {
+            createErrorDialog(e.getMessage(), EXIT);
+            return;
+        }
+
+        if (savedCursor != null) {
+            startManagingCursor(savedCursor);
+        }
+        savedCount = savedCursor != null ? savedCursor.getCount() : 0;
+
+        //count for view sent form
+        try {
+            viewSentCursor = instancesDao.getSentInstancesCursor();
+        } catch (Exception e) {
+            createErrorDialog(e.getMessage(), EXIT);
+            return;
+        }
+        if (viewSentCursor != null) {
+            startManagingCursor(viewSentCursor);
+        }
+        viewSentCount = viewSentCursor != null ? viewSentCursor.getCount() : 0;
     }
 
     private void createErrorDialog(String errorMsg, final boolean shouldExit) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -278,9 +278,6 @@ public class MainMenuActivity extends CollectAbstractActivity {
             startManagingCursor(finalizedCursor);
         }
         completedCount = finalizedCursor != null ? finalizedCursor.getCount() : 0;
-        getContentResolver().registerContentObserver(InstanceColumns.CONTENT_URI, true,
-                contentObserver);
-        // finalizedCursor.registerContentObserver(contentObserver);
 
         // count for saved instances
         try {
@@ -322,6 +319,9 @@ public class MainMenuActivity extends CollectAbstractActivity {
         super.onResume();
         SharedPreferences sharedPreferences = this.getSharedPreferences(
                 AdminPreferencesActivity.ADMIN_PREFERENCES, 0);
+
+        getContentResolver().registerContentObserver(InstanceColumns.CONTENT_URI, true,
+                contentObserver);
 
         boolean edit = sharedPreferences.getBoolean(
                 AdminKeys.KEY_EDIT_SAVED, true);
@@ -394,6 +394,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         if (alertDialog != null && alertDialog.isShowing()) {
             alertDialog.dismiss();
         }
+        getContentResolver().unregisterContentObserver(contentObserver);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -276,16 +276,24 @@ public class MainMenuActivity extends CollectAbstractActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        SharedPreferences sharedPreferences = this.getSharedPreferences(
-                AdminPreferencesActivity.ADMIN_PREFERENCES, 0);
 
         countSavedForms();
         updateButtons();
         getContentResolver().registerContentObserver(InstanceColumns.CONTENT_URI, true,
                 contentObserver);
 
-        boolean edit = sharedPreferences.getBoolean(
-                AdminKeys.KEY_EDIT_SAVED, true);
+        setButtonsVisibility();
+
+        ((Collect) getApplication())
+                .getDefaultTracker()
+                .enableAutoActivityTracking(true);
+    }
+
+    private void setButtonsVisibility() {
+        SharedPreferences sharedPreferences = this.getSharedPreferences(
+                AdminPreferencesActivity.ADMIN_PREFERENCES, 0);
+
+        boolean edit = sharedPreferences.getBoolean(AdminKeys.KEY_EDIT_SAVED, true);
         if (!edit) {
             if (reviewDataButton != null) {
                 reviewDataButton.setVisibility(View.GONE);
@@ -296,8 +304,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             }
         }
 
-        boolean send = sharedPreferences.getBoolean(
-                AdminKeys.KEY_SEND_FINALIZED, true);
+        boolean send = sharedPreferences.getBoolean(AdminKeys.KEY_SEND_FINALIZED, true);
         if (!send) {
             if (sendDataButton != null) {
                 sendDataButton.setVisibility(View.GONE);
@@ -308,8 +315,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             }
         }
 
-        boolean viewSent = sharedPreferences.getBoolean(
-                AdminKeys.KEY_VIEW_SENT, true);
+        boolean viewSent = sharedPreferences.getBoolean(AdminKeys.KEY_VIEW_SENT, true);
         if (!viewSent) {
             if (viewSentFormsButton != null) {
                 viewSentFormsButton.setVisibility(View.GONE);
@@ -320,8 +326,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             }
         }
 
-        boolean getBlank = sharedPreferences.getBoolean(
-                AdminKeys.KEY_GET_BLANK, true);
+        boolean getBlank = sharedPreferences.getBoolean(AdminKeys.KEY_GET_BLANK, true);
         if (!getBlank) {
             if (getFormsButton != null) {
                 getFormsButton.setVisibility(View.GONE);
@@ -332,8 +337,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
             }
         }
 
-        boolean deleteSaved = sharedPreferences.getBoolean(
-                AdminKeys.KEY_DELETE_SAVED, true);
+        boolean deleteSaved = sharedPreferences.getBoolean(AdminKeys.KEY_DELETE_SAVED, true);
         if (!deleteSaved) {
             if (manageFilesButton != null) {
                 manageFilesButton.setVisibility(View.GONE);
@@ -343,10 +347,6 @@ public class MainMenuActivity extends CollectAbstractActivity {
                 manageFilesButton.setVisibility(View.VISIBLE);
             }
         }
-
-        ((Collect) getApplication())
-                .getDefaultTracker()
-                .enableAutoActivityTracking(true);
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainActivityTest.java
@@ -120,7 +120,7 @@ public class MainActivityTest {
 
         assertNotNull(reviewDataButton);
         assertEquals(View.VISIBLE, reviewDataButton.getVisibility());
-        assertEquals(mainMenuActivity.getString(R.string.review_data_button), reviewDataButton.getText());
+        assertEquals(mainMenuActivity.getString(R.string.review_data), reviewDataButton.getText());
 
         reviewDataButton.performClick();
         ShadowActivity shadowActivity = shadowOf(mainMenuActivity);
@@ -139,7 +139,7 @@ public class MainActivityTest {
 
         assertNotNull(sendDataButton);
         assertEquals(View.VISIBLE, sendDataButton.getVisibility());
-        assertEquals(mainMenuActivity.getString(R.string.send_data_button), sendDataButton.getText());
+        assertEquals(mainMenuActivity.getString(R.string.send_data), sendDataButton.getText());
 
         sendDataButton.performClick();
         ShadowActivity shadowActivity = shadowOf(mainMenuActivity);


### PR DESCRIPTION
Closes #2716 

#### What has been done to verify that this works as intended?
I tested the functionality of counting saved forms manually, additionally, I confirmed that there are no more reports about the leak.

#### Why is this the best possible solution? Were any other approaches considered?
We just needed to unregister the observer and there is no other solution to fix the leak.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Besides fixing the leak the changes are related to counting saved forms (numbers that we display in buttons in the main menu), so this functionality should be tested.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)