### PR TITLE
Remove unneeded audio clean up on FormEntryActivity pause

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2138,10 +2138,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 saveAnswersForCurrentScreen(DO_NOT_EVALUATE_CONSTRAINTS);
             }
         }
-        if (getCurrentViewIfODKView() != null) {
-            // stop audio if it's playing
-            getCurrentViewIfODKView().stopAudio();
-        }
 
         super.onPause();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -617,10 +617,6 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
         }
     }
 
-    public void stopAudio() {
-        widgets.get(0).stopAudio();
-    }
-
     /**
      * Releases widget resources, such as {@link android.media.MediaPlayer}s
      */


### PR DESCRIPTION
Closes #3415 

#### What has been done to verify that this works as intended?

Run tests locally and played with backgrounding app during form entry.

#### Why is this the best possible solution? Were any other approaches considered?

The code removed wasn't being used for anything anymore since the rework of the audio features. It would be good to clean up other no longer used audio code (there is an usused instance of `MediaPlayer` in the `ODKView) but I think it's best to make an issue for that when we merge this.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the crash in question. I'm not 100% sure how to reproduce though. Is it possible to create a form without any questions? That would do it I think.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)