### PR TITLE
Downgraded androidx.lifecycle:lifecycle-extensions

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     odkCollectReleaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootProject.leakyCanaryVersion}"
 
     // Android Architecture Components:
-    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0-beta01"
+    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
 
     // Dagger:
     implementation "com.google.dagger:dagger:${rootProject.daggerVersion}"


### PR DESCRIPTION
Closes #3418 

#### What has been done to verify that this works as intended?
I tested the fix using `odkCollectRelease` build.

#### Why is this the best possible solution? Were any other approaches considered?
Seems like a bug in `androidx.lifecycle:lifecycle-extensions:2.2.0-beta01+`. The problem is that [onLoadFinished()](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserListActivity.java#L227) is not called, what interesting it works well in another place FileManagerFragment, the only difference is that there it's used in a Fragment and here it's used in an Activity, so it might be a bug related to activities).

When it comes to loaders they have been deprecated so I filled an issue to replace them https://github.com/opendatakit/collect/issues/3419 I can't be sure but I believe it will allow us to upgrade `androidx.lifecycle:lifecycle-extensions`

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
To test the issue we need a device with Android 10.
Then we need to update [debug build](https://github.com/opendatakit/collect/blob/master/collect_app/build.gradle#L118):
adding:
```
minifyEnabled(true)
proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
```

Please also confirm that problems with `ClassCastExceptions` are not visible again: https://github.com/opendatakit/collect/pull/3395

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)