### PR TITLE
Catch IllegalArgumentException during scanning QR codes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -225,7 +225,7 @@ public class ShowQRCodeFragment extends Fragment {
             } else {
                 try {
                     applySettings(CompressionUtils.decompress(result.getContents()));
-                } catch (IOException | DataFormatException e) {
+                } catch (IOException | DataFormatException | IllegalArgumentException e) {
                     Timber.e(e);
                 }
                 return;
@@ -256,7 +256,7 @@ public class ShowQRCodeFragment extends Fragment {
                 } catch (FormatException | NotFoundException | ChecksumException e) {
                     Timber.i(e);
                     ToastUtils.showLongToast(R.string.qr_code_not_found);
-                } catch (DataFormatException | IOException | OutOfMemoryError e) {
+                } catch (DataFormatException | IOException | OutOfMemoryError | IllegalArgumentException e) {
                     Timber.e(e);
                     ToastUtils.showShortToast(getString(R.string.invalid_qrcode));
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/ShowQRCodeFragment.java
@@ -227,6 +227,7 @@ public class ShowQRCodeFragment extends Fragment {
                     applySettings(CompressionUtils.decompress(result.getContents()));
                 } catch (IOException | DataFormatException | IllegalArgumentException e) {
                     Timber.e(e);
+                    ToastUtils.showShortToast(getString(R.string.invalid_qrcode));
                 }
                 return;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CompressionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CompressionUtils.java
@@ -65,7 +65,7 @@ public class CompressionUtils {
         return base64String;
     }
 
-    public static String decompress(String compressedString) throws IOException, DataFormatException {
+    public static String decompress(String compressedString) throws IOException, DataFormatException, IllegalArgumentException {
         if (compressedString == null || compressedString.length() == 0) {
             return compressedString;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/QRCodeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/QRCodeUtils.java
@@ -62,7 +62,7 @@ public class QRCodeUtils {
     private QRCodeUtils() {
     }
 
-    public static String decodeFromBitmap(Bitmap bitmap) throws DataFormatException, IOException, FormatException, ChecksumException, NotFoundException {
+    public static String decodeFromBitmap(Bitmap bitmap) throws DataFormatException, IOException, FormatException, ChecksumException, NotFoundException, IllegalArgumentException {
         Map<DecodeHintType, Object> tmpHintsMap = new EnumMap<>(DecodeHintType.class);
         tmpHintsMap.put(DecodeHintType.TRY_HARDER, Boolean.TRUE);
         tmpHintsMap.put(DecodeHintType.POSSIBLE_FORMATS, BarcodeFormat.QR_CODE);


### PR DESCRIPTION
Closes #3421 

#### What has been done to verify that this works as intended?
I tested the QR code attached below.

#### Why is this the best possible solution? Were any other approaches considered?
Loos as if sometimes people try to scan random QR codes with invalid chars what then throw exceptions. Catching such an exception is everything we can do.

Besides fixing the issue I also added a missing toast that should be displayed when scanning QR codes fails.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change so testing scanning QR codes would be enough. The QR code I used to reproduce the issue was:
![qrcode](https://user-images.githubusercontent.com/3276264/67751115-cf9c1e00-fa30-11e9-8628-95feb695a9aa.png)

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)