### PR TITLE
Catch SQLiteExceptions during reading csv files

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/FormNavigationTestCase.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/FormNavigationTestCase.java
@@ -101,7 +101,7 @@ public class FormNavigationTestCase {
         FormLoaderTask formLoaderTask = new FormLoaderTask(formPath(formName), null, null);
         formLoaderTask.setFormLoaderListener(new FormLoaderListener() {
             @Override
-            public void loadingComplete(FormLoaderTask task, FormDef fd) {
+            public void loadingComplete(FormLoaderTask task, FormDef fd, String warningMsg) {
                 try {
                     // For each form, simulate swiping forward through screens until the end of the
                     // form and then swiping back once. Verify the expected indices before and after each swipe.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2182,7 +2182,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 FormController fec = formLoaderTask.getFormController();
                 if (fec != null) {
                     if (!readPhoneStatePermissionRequestNeeded) {
-                        loadingComplete(formLoaderTask, formLoaderTask.getFormDef());
+                        loadingComplete(formLoaderTask, formLoaderTask.getFormDef(), null);
                     }
                 } else {
                     dismissFormLoadingDialogFragment();
@@ -2345,7 +2345,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * - Initializes background location capture (only if the instance being loaded is a new one)
      */
     @Override
-    public void loadingComplete(FormLoaderTask task, FormDef formDef) {
+    public void loadingComplete(FormLoaderTask task, FormDef formDef, String warningMsg) {
         dismissFormLoadingDialogFragment();
 
         final FormController formController = task.getFormController();
@@ -2478,6 +2478,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 activityDisplayed();
 
                 refreshCurrentView();
+
+                if (warningMsg != null) {
+                    ToastUtils.showLongToast(warningMsg);
+                    Timber.w(warningMsg);
+                }
             }
         } else {
             Timber.e("FormController is null");

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/FormLoaderListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/FormLoaderListener.java
@@ -22,7 +22,7 @@ import org.odk.collect.android.tasks.ProgressNotifier;
  * @author Carl Hartung (carlhartung@gmail.com)
  */
 public interface FormLoaderListener extends ProgressNotifier {
-    void loadingComplete(FormLoaderTask task, FormDef fd);
+    void loadingComplete(FormLoaderTask task, FormDef fd, String warningMsg);
 
     void loadingError(String errorMsg);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.tasks;
 
 import android.content.Intent;
 import android.database.Cursor;
+import android.database.SQLException;
 import android.os.AsyncTask;
 
 import org.javarosa.core.model.FormDef;
@@ -70,6 +71,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
 
     private FormLoaderListener stateListener;
     private String errorMsg;
+    private String warningMsg;
     private String instancePath;
     private final String xpath;
     private final String waitingXPath;
@@ -469,7 +471,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
                     if (wrapper == null) {
                         stateListener.loadingError(errorMsg);
                     } else {
-                        stateListener.loadingComplete(this, formDef);
+                        stateListener.loadingComplete(this, formDef, warningMsg);
                     }
                 }
             } catch (Exception e) {
@@ -559,8 +561,8 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
                 ida.addRow(pathHash, columnHeaders, nextLine);
 
             }
-        } catch (IOException e) {
-            Timber.e(e, "Exception thrown while reading csv file");
+        } catch (IOException | SQLException e) {
+            warningMsg = e.getMessage();
         } finally {
             if (withinTransaction) {
                 ida.commit();


### PR DESCRIPTION
Closes #3425 

#### What has been done to verify that this works as intended?
I tested the solution but only hardcoding `throw SQLiteException`.

#### Why is this the best possible solution? Were any other approaches considered?
Catching the exception is the only solution. We can't be sure what characters users put in their csv files, some of them might cause such an exception.

Additionally, I added a warning message which tells users that there was something wrong with their csv file. Unlike `errorMsg`, `warningMsg` cause that only a toast is displayed and a user can continue filling the form.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I wasn't able to reproduce the issue so testing would be difficult. I think testing any form with external itemsets would be enough to confirm there is no regression and that's all. I can also prepare a testing version with hardcoded `throw SQLiteException` if needed.

#### Do we need any specific form for testing your changes? If so, please attach one.
Generally a form with external itemsets but as I said above I wasn't able to reproduce the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)