### PR TITLE
Remove unused MediaPlayer instances

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1250,7 +1250,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         odkViewLifecycle.destroy();
 
         if (odkView != null) {
-            odkView.releaseWidgetResources();
             odkView = null;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -618,15 +618,6 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
     }
 
     /**
-     * Releases widget resources, such as {@link android.media.MediaPlayer}s
-     */
-    public void releaseWidgetResources() {
-        for (QuestionWidget w : widgets) {
-            w.release();
-        }
-    }
-
-    /**
      * Highlights the question at the given {@link FormIndex} in red for 2.5 seconds, scrolls the
      * view to display that question at the top and gives it focus.
      */
@@ -687,7 +678,6 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
             view.removeViewAt(indexAccountingForDividers - 1);
         }
 
-        widgets.get(index).release();
         widgets.remove(index);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -20,7 +20,6 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.media.MediaPlayer;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -91,7 +90,6 @@ public abstract class QuestionWidget
     private final FormEntryPrompt formEntryPrompt;
     private final AudioVideoImageTextLabel audioVideoImageTextLabel;
     private final QuestionDetails questionDetails;
-    private MediaPlayer player;
     private final TextView helpTextView;
     private final TextView guidanceTextView;
     private final View helpTextLayout;
@@ -127,8 +125,6 @@ public abstract class QuestionWidget
             state = ((FormEntryActivity) context).getState();
             permissionUtils = new PermissionUtils();
         }
-
-        player = new MediaPlayer();
 
         questionFontSize = Collect.getQuestionFontsize();
 
@@ -227,16 +223,6 @@ public abstract class QuestionWidget
         guidanceTextView.setTextColor(themeUtils.getPrimaryTextColor());
         guidanceTextView.setMovementMethod(LinkMovementMethod.getInstance());
         return guidanceTextView;
-    }
-
-    /**
-     * Releases resources held by this widget
-     */
-    public void release() {
-        if (player != null) {
-            player.release();
-            player = null;
-        }
     }
 
     //source::https://stackoverflow.com/questions/18996183/identifying-rtl-language-in-android/23203698#23203698
@@ -502,21 +488,6 @@ public abstract class QuestionWidget
         warningText.setText(warningBody);
     }
 
-    @Override
-    protected void onWindowVisibilityChanged(int visibility) {
-        if (visibility == INVISIBLE || visibility == GONE) {
-            stopAudio();
-        }
-    }
-
-    public void stopAudio() {
-        if (player != null && player.isPlaying()) {
-            Timber.i("stopAudio " + player);
-            player.stop();
-            player.reset();
-        }
-    }
-
     protected Button getSimpleButton(String text, @IdRes final int withId) {
         final Button button = new Button(getContext());
 
@@ -732,10 +703,6 @@ public abstract class QuestionWidget
 
     public AudioVideoImageTextLabel getAudioVideoImageTextLabel() {
         return audioVideoImageTextLabel;
-    }
-
-    public MediaPlayer getPlayer() {
-        return player;
     }
 
     public AudioHelper getAudioHelper() {


### PR DESCRIPTION
This just removes unused instances of `MediaPlayer` and they're related code in `ODKView` and `QuestionWidget`. These were being used for audio playback that is now covered by `AudioPlayerViewModel`.

#### What has been done to verify that this works as intended?

Ran tests locally and quick play with the app.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to check with our Birds media form but this feels fairly low risk.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)