### PR TITLE
Cancel timer when no more needed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -70,6 +70,8 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
 
     private String dialogMessage;
 
+    private Timer timer;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -121,7 +123,8 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
 
         if (locationDialog != null) {
             locationDialog.show();
-            new Timer().schedule(new TimerTask() {
+            timer = new Timer();
+            timer.schedule(new TimerTask() {
                 @Override
                 public void run() {
                     updateDialogMessage();
@@ -145,6 +148,14 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
     protected void onStop() {
         locationClient.stop();
         super.onStop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (timer != null) {
+            timer.cancel();
+        }
+        super.onDestroy();
     }
 
     @Override


### PR DESCRIPTION
Closes #3436 

#### What has been done to verify that this works as intended?
Confirmed that the leak is no more visible.

#### Why is this the best possible solution? Were any other approaches considered?
We should just cancel our timer when we destroy the activity as described here for example: https://android.jlelse.eu/9-ways-to-avoid-memory-leaks-in-android-b6d81648e35e

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
In the dialog which is displayed while recording activities we show time elapsed and this functionality should be tested. It's the only thing that might be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `GeoPointWidget`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)