### PR TITLE
Fixed NPE while opening MapsPreferences from GeoPointActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CollectAbstractActivity.java
@@ -87,7 +87,9 @@ public abstract class CollectAbstractActivity extends AppCompatActivity {
 
     public void initToolbar(CharSequence title) {
         Toolbar toolbar = findViewById(R.id.toolbar);
-        toolbar.setTitle(title);
-        setSupportActionBar(toolbar);
+        if (toolbar != null) {
+            toolbar.setTitle(title);
+            setSupportActionBar(toolbar);
+        }
     }
 }


### PR DESCRIPTION
Closes #3442 

#### What has been done to verify that this works as intended?
I confirmed that the crash described in the issue is no longer visible would be enough.

#### Why is this the best possible solution? Were any other approaches considered?
We just need a null check here so there is no other option. We display MapsPreferences clicking on the layers icon but it's a dialog so there is no toolbar like in case when we display the same fragment from settings. So the problem was we tried to call `setTitle()` on a `toolbar` which was null.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not risky at all because I just added a null check. Confirming that the crash described in the issue is no longer visible would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `GeoPointWidget` like `AllWidgets` form for example.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)