### PR TITLE
Fix various memory leaks in Geo activities by detaching listeners and using WeakReferences.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -24,7 +24,6 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.provider.Settings;
-import androidx.annotation.NonNull;
 import android.text.format.DateUtils;
 import android.view.Window;
 
@@ -41,6 +40,7 @@ import java.text.DecimalFormat;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.PermissionUtils.areLocationPermissionsGranted;
@@ -192,7 +192,11 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
 
     @Override
     public void onClientStop() {
-
+        locationClient.stopLocationUpdates();
+        LocationManager locationManager = (LocationManager) getSystemService(LOCATION_SERVICE);
+        if (locationManager != null) {
+            locationManager.removeGpsStatusListener(this);
+        }
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -50,6 +50,7 @@ import org.odk.collect.android.geo.MbtilesFile.MbtilesException;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,8 +71,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
 
 public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.MapFragment
     implements MapFragment, OnMapReadyCallback,
-    MapboxMap.OnMapClickListener, MapboxMap.OnMapLongClickListener,
-    LocationEngineCallback<LocationEngineResult> {
+    MapboxMap.OnMapClickListener, MapboxMap.OnMapLongClickListener {
 
     private static final String POINT_ICON_ID = "point-icon-id";
     private static final long LOCATION_INTERVAL_MILLIS = 1000;
@@ -106,6 +106,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
     private File referenceLayerFile;
     private final List<Layer> overlayLayers = new ArrayList<>();
     private final List<Source> overlaySources = new ArrayList<>();
+    private final LocationCallback locationCallback = new LocationCallback(this);
     private static String lastLocationProvider;
 
     private TileHttpServer tileServer;
@@ -388,24 +389,36 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
         return lastLocationFix;
     }
 
-    @Override public void onSuccess(LocationEngineResult result) {
-        Location location = result.getLastLocation();
-        lastLocationFix = fromLocation(location);
-        lastLocationProvider = location != null ? location.getProvider() : null;
-        Timber.i("Received LocationEngineResult: %s", lastLocationFix);
-        if (locationComponent != null) {
-            locationComponent.forceLocationUpdate(location);
-        }
-        for (ReadyListener listener : gpsLocationReadyListeners) {
-            listener.onReady(this);
-        }
-        gpsLocationReadyListeners.clear();
-        if (gpsLocationListener != null) {
-            gpsLocationListener.onPoint(lastLocationFix);
-        }
-    }
+    // See https://docs.mapbox.com/android/core/overview/#requesting-location-updates
+    protected static class LocationCallback implements LocationEngineCallback<LocationEngineResult> {
+        private final WeakReference<MapboxMapFragment> mapRef;
 
-    @Override public void onFailure(@NonNull Exception exception) { }
+        public LocationCallback(MapboxMapFragment map) {
+            mapRef = new WeakReference<>(map);
+        }
+
+        @Override public void onSuccess(LocationEngineResult result) {
+            MapboxMapFragment map = mapRef.get();
+            if (map != null) {
+                Location location = result.getLastLocation();
+                map.lastLocationFix = fromLocation(location);
+                lastLocationProvider = location != null ? location.getProvider() : null;
+                Timber.i("Received location update: %s (%s)", map.lastLocationFix, lastLocationProvider);
+                if (map.locationComponent != null) {
+                    map.locationComponent.forceLocationUpdate(location);
+                }
+                for (ReadyListener listener : map.gpsLocationReadyListeners) {
+                    listener.onReady(map);
+                }
+                map.gpsLocationReadyListeners.clear();
+                if (map.gpsLocationListener != null) {
+                    map.gpsLocationListener.onPoint(map.lastLocationFix);
+                }
+            }
+        }
+
+        @Override public void onFailure(@NonNull Exception exception) { }
+    }
 
     private static @NonNull MapPoint fromLatLng(@NonNull LatLng latLng) {
         return new MapPoint(latLng.getLatitude(), latLng.getLongitude());
@@ -680,11 +693,11 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
             LocationEngine engine = locationComponent.getLocationEngine();
             if (enable) {
                 Timber.i("Requesting location updates from %s (to %s)", engine, this);
-                engine.requestLocationUpdates(LOCATION_REQUEST, this, null);
-                engine.getLastLocation(this);
+                engine.requestLocationUpdates(LOCATION_REQUEST, locationCallback, null);
+                engine.getLastLocation(locationCallback);
             } else {
                 Timber.i("Stopping location updates from %s (to %s)", engine, this);
-                engine.removeLocationUpdates(this);
+                engine.removeLocationUpdates(locationCallback);
             }
             Timber.i("setLocationComponentEnabled to %s (for %s)", enable, locationComponent);
             locationComponent.setLocationComponentEnabled(enable);

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -131,6 +131,11 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
         super.onStop();
     }
 
+    @Override public void onDestroy() {
+        clearFeatures();  // prevent a memory leak due to refs held by markers
+        super.onDestroy();
+    }
+
     @Override public void applyConfig(Bundle config) {
         webMapService = (WebMapService) config.getSerializable(KEY_WEB_MAP_SERVICE);
         String path = config.getString(KEY_REFERENCE_LAYER);

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/AndroidLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/AndroidLocationClient.java
@@ -5,11 +5,11 @@ import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.google.android.gms.location.LocationListener;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 /**
@@ -25,9 +25,6 @@ import timber.log.Timber;
 class AndroidLocationClient
         extends BaseLocationClient
         implements android.location.LocationListener {
-
-    @Nullable
-    private LocationClientListener locationClientListener;
 
     @Nullable
     private LocationListener locationListener;
@@ -59,16 +56,16 @@ class AndroidLocationClient
     @Override
     public void start() {
         if (getProvider() == null) {
-            if (locationClientListener != null) {
-                locationClientListener.onClientStartFailure();
+            if (getListener() != null) {
+                getListener().onClientStartFailure();
             }
 
             return;
         }
 
         isConnected = true;
-        if (locationClientListener != null) {
-            locationClientListener.onClientStart();
+        if (getListener() != null) {
+            getListener().onClientStart();
         }
     }
 
@@ -78,8 +75,8 @@ class AndroidLocationClient
         stopLocationUpdates();
         isConnected = false;
 
-        if (locationClientListener != null) {
-            locationClientListener.onClientStop();
+        if (getListener() != null) {
+            getListener().onClientStop();
         }
     }
 
@@ -106,11 +103,6 @@ class AndroidLocationClient
 
         getLocationManager().removeUpdates(this);
         this.locationListener = null;
-    }
-
-    @Override
-    public void setListener(@Nullable LocationClientListener locationClientListener) {
-        this.locationClientListener = locationClientListener;
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/BaseLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/BaseLocationClient.java
@@ -1,10 +1,12 @@
 package org.odk.collect.android.location.client;
 
 import android.location.LocationManager;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import java.util.List;
 
 /**
  * An abstract base LocationClient class that provides some shared functionality for determining
@@ -14,6 +16,9 @@ abstract class BaseLocationClient implements LocationClient {
 
     @NonNull
     private final LocationManager locationManager;
+
+    @Nullable
+    private WeakReference<LocationClientListener> listenerRef;
 
     @NonNull
     private Priority priority = Priority.PRIORITY_HIGH_ACCURACY;
@@ -103,5 +108,14 @@ abstract class BaseLocationClient implements LocationClient {
     @NonNull
     LocationManager getLocationManager() {
         return locationManager;
+    }
+
+    @Override
+    public void setListener(@Nullable LocationClientListener locationClientListener) {
+        listenerRef = new WeakReference<>(locationClientListener);
+    }
+
+    protected LocationClientListener getListener() {
+        return listenerRef != null ? listenerRef.get() : null;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleLocationClient.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -17,6 +15,8 @@ import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 /**
@@ -48,9 +48,6 @@ public class GoogleLocationClient
 
     @NonNull
     private final GoogleApiClient googleApiClient;
-
-    @Nullable
-    private LocationClientListener locationClientListener;
 
     @Nullable
     private LocationListener locationListener;
@@ -132,11 +129,6 @@ public class GoogleLocationClient
     }
 
     @Override
-    public void setListener(@Nullable LocationClientListener locationClientListener) {
-        this.locationClientListener = locationClientListener;
-    }
-
-    @Override
     @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public Location getLastLocation() {
         // We need to block if the Client isn't already connected:
@@ -189,15 +181,15 @@ public class GoogleLocationClient
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
-        if (locationClientListener != null) {
-            locationClientListener.onClientStart();
+        if (getListener() != null) {
+            getListener().onClientStart();
         }
     }
 
     @Override
     public void onConnectionSuspended(int cause) {
-        if (locationClientListener != null) {
-            locationClientListener.onClientStop();
+        if (getListener() != null) {
+            getListener().onClientStop();
         }
     }
 
@@ -205,8 +197,8 @@ public class GoogleLocationClient
 
     @Override
     public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
-        if (locationClientListener != null) {
-            locationClientListener.onClientStartFailure();
+        if (getListener() != null) {
+            getListener().onClientStartFailure();
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/LocationClient.java
@@ -1,11 +1,12 @@
 package org.odk.collect.android.location.client;
 
 import android.location.Location;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.google.android.gms.location.LocationListener;
 import com.google.android.gms.location.LocationRequest;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * An interface for classes that allow monitoring and retrieving the User's Location.
@@ -45,7 +46,8 @@ public interface LocationClient {
 
     /**
      * Sets the {@link LocationClientListener} which will receive status updates
-     * for the LocationClient.
+     * for the LocationClient.  The LocationClient should hold only a WeakReference
+     * to the listener so that it does not cause a memory leak.
      *
      * @param locationClientListener The new {@link LocationClientListener}.
      */

--- a/collect_app/src/test/java/org/odk/collect/android/location/client/FakeLocationClient.java
+++ b/collect_app/src/test/java/org/odk/collect/android/location/client/FakeLocationClient.java
@@ -4,10 +4,14 @@ import android.location.Location;
 
 import com.google.android.gms.location.LocationListener;
 
+import java.lang.ref.WeakReference;
+
+import androidx.annotation.Nullable;
+
 public class FakeLocationClient implements LocationClient {
     private boolean failOnStart;
     private boolean failOnRequest;
-    private LocationClientListener clientListener;
+    private WeakReference<LocationClientListener> listenerRef;
     private LocationListener locationListener;
     private boolean running;
     private boolean locationAvailable = true;
@@ -43,11 +47,11 @@ public class FakeLocationClient implements LocationClient {
 
     public void start() {
         running = true;
-        if (clientListener != null) {
+        if (getListener() != null) {
             if (failOnStart) {
-                clientListener.onClientStartFailure();
+                getListener().onClientStartFailure();
             } else {
-                clientListener.onClientStart();
+                getListener().onClientStart();
             }
         }
     }
@@ -55,8 +59,8 @@ public class FakeLocationClient implements LocationClient {
     public void stop() {
         running = false;
         stopLocationUpdates();
-        if (clientListener != null) {
-            clientListener.onClientStop();
+        if (getListener() != null) {
+            getListener().onClientStop();
         }
     }
 
@@ -76,8 +80,13 @@ public class FakeLocationClient implements LocationClient {
         this.locationListener = null;
     }
 
-    public void setListener(LocationClientListener clientListener) {
-        this.clientListener = clientListener;
+    @Override
+    public void setListener(@Nullable LocationClientListener locationClientListener) {
+        this.listenerRef = new WeakReference<>(locationClientListener);
+    }
+
+    protected LocationClientListener getListener() {
+        return listenerRef != null ? listenerRef.get() : null;
     }
 
     public Location getLastLocation() {


### PR DESCRIPTION
Closes #3441.  Closes #3446.

Sorry @grzesiek2010, I hope this doesn't collide with your work!  The LeakCanary notifications were just bothering me too much and I figured it wouldn't be too hard to fix.

#### What has been done to verify that this works as intended?

I ran the app without this change and LeakCanary showed memory leaks of various kinds shown in #3441 and #3446 (lingering references from the LocationClient and LocationEngine, lingering references from the LocationManager to a listener, and lingering references from map markers).  In each case, I only needed to open the GeoPointActivity, GeoPointMapActivity, or GeoPolyActivity and close it three times, and a leak would occur.  I changed the Maps settings in order to test all three map implementations (GoogleMapFragment, MapboxMapFragment, and OsmDroidMapFragment) and the leaks in GeoPointMapActivity and GeoPolyActivity would occur for all three.

I ran the app again with this change, and again tested GeoPointActivity.  I opened and closed the activity at least 10 times.  I also tested GeoPointMapActivity and GeoPolyActivity, opening and closing the activity at least 10 times, for all three map implementations, and no memory leaks have been reported by LeakCanary.

#### Why is this the best possible solution? Were any other approaches considered?

- For MapboxMapFragment, the WeakReference solution is recommended in the Mapbox documentation: https://docs.mapbox.com/android/core/overview/#requesting-location-updates

- The pattern of the memory leak looked identical in GoogleMapFragment, except involving LocationClientListener instead of Mapbox's LocationEngineCallback.  Both GoogleMapFragment and OsmDroidMapFragment use the LocationClientListener in the same way, so I implemented the same solution for those two classes as well.

- Rather than setting up the WeakReference in the MapFragment, I decided to make it the responsibility of the LocationClient implementations to hold only a WeakReference.  This is a little nicer because there is less code to change and because it is clear from looking at the members of the LocationClient that it cannot hold a strong reference to the listener in question.

- Separately, there was another leak due to a reference held by the Android LocationManager.  I fixed this with a call to removeGpsStatusListener.

- There was another leak due to map markers holding references to the OsmDroid map.  I fixed this by clearing the markers when the OsmDroid map is destroyed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change has no impact on the user experience.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form with geo questions will do.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)