### PR TITLE
Provide user-friendly error message when CSV for search() or external itemsets is not on device

### DIFF
--- a/collect_app/src/androidTest/assets/forms/external_data_questions.xml
+++ b/collect_app/src/androidTest/assets/forms/external_data_questions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<h:html
+    xmlns="http://www.w3.org/2002/xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>externalDataQuestions</h:title>
+        <model>
+            <instance>
+                <externalDataQuestions id="externalDataQuestions">
+                    <q1/>
+                    <q2/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </externalDataQuestions>
+            </instance>
+            <bind nodeset="/externalDataQuestions/q1" type="select1"/>
+            <bind nodeset="/externalDataQuestions/q2" type="string"/>
+            <bind jr:preload="uid" nodeset="/externalDataQuestions/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 appearance="search('fruits')" ref="/externalDataQuestions/q1">
+            <label>Search func</label>
+            <item>
+                <label>name</label>
+                <value>name_key</value>
+            </item>
+        </select1>
+        <input query="instance('counties')/root/item[county= &quot;King&quot;]" ref="/externalDataQuestions/q2">
+            <label>External csv</label>
+        </input>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ExternalDataFileNotFoundTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ExternalDataFileNotFoundTest.java
@@ -1,0 +1,40 @@
+package org.odk.collect.android.formentry;
+
+import android.Manifest;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.espressoutils.pages.FormEntryPage;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.test.FormLoadingUtils;
+
+public class ExternalDataFileNotFoundTest {
+    private static final String EXTERNAL_DATA_QUESTIONS = "external_data_questions.xml";
+
+    @Rule
+    public IntentsTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(EXTERNAL_DATA_QUESTIONS);
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            )
+            .around(new ResetStateRule())
+            .around(new CopyFormRule(EXTERNAL_DATA_QUESTIONS));
+
+    @Test
+    public void questionsThatUseExternalFiles_ShouldDisplayFriendlyMessageWhenFilesAreMissing() {
+        new FormEntryPage("externalDataQuestions", activityTestRule)
+                .checkIsTextDisplayed(activityTestRule.getActivity().getString(R.string.file_missing, "/storage/emulated/0/odk/forms/external_data_questions-media/fruits.csv"))
+                .swipeToNextQuestion()
+                .checkIsTextDisplayed(activityTestRule.getActivity().getString(R.string.file_missing, "/storage/emulated/0/odk/forms/external_data_questions-media/itemsets.csv"));
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
@@ -208,7 +208,10 @@ public final class ExternalDataUtil {
             }
             return returnedChoices;
         } catch (Exception e) {
-            String fileName = xpathfuncexpr.args[0].eval(null, null) + ".csv";
+            String fileName = String.valueOf(xpathfuncexpr.args[0].eval(null, null));
+            if (!fileName.endsWith(".csv")) {
+                fileName = fileName + ".csv";
+            }
             FormController formController = Collect.getInstance().getFormController();
             String filePath = fileName;
             if (formController != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
@@ -33,7 +33,10 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.android.external.handler.ExternalDataHandlerSearch;
+import org.odk.collect.android.logic.FormController;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -156,7 +159,7 @@ public final class ExternalDataUtil {
     }
 
     public static ArrayList<SelectChoice> populateExternalChoices(FormEntryPrompt formEntryPrompt,
-            XPathFuncExpr xpathfuncexpr) {
+            XPathFuncExpr xpathfuncexpr) throws FileNotFoundException {
         try {
             List<SelectChoice> selectChoices = formEntryPrompt.getSelectChoices();
             ArrayList<SelectChoice> returnedChoices = new ArrayList<>();
@@ -205,6 +208,16 @@ public final class ExternalDataUtil {
             }
             return returnedChoices;
         } catch (Exception e) {
+            String fileName = xpathfuncexpr.args[0].eval(null, null) + ".csv";
+            FormController formController = Collect.getInstance().getFormController();
+            String filePath = fileName;
+            if (formController != null) {
+                filePath = Collect.getInstance().getFormController().getMediaFolder() + File.separator + fileName;
+            }
+            if (!new File(filePath).exists()) {
+                throw new FileNotFoundException(filePath);
+            }
+
             throw new ExternalDataException(e.getMessage(), e);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsWidget.java
@@ -17,12 +17,15 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.widget.TextView;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.xpath.expr.XPathFuncExpr;
+import org.odk.collect.android.R;
 import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 
+import java.io.FileNotFoundException;
 import java.util.List;
 
 /**
@@ -43,9 +46,19 @@ public abstract class ItemsWidget extends QuestionWidget {
         // SurveyCTO-added support for dynamic select content (from .csv files)
         XPathFuncExpr xpathFuncExpr = ExternalDataUtil.getSearchXPathExpression(getFormEntryPrompt().getAppearanceHint());
         if (xpathFuncExpr != null) {
-            items = ExternalDataUtil.populateExternalChoices(getFormEntryPrompt(), xpathFuncExpr);
+            try {
+                items = ExternalDataUtil.populateExternalChoices(getFormEntryPrompt(), xpathFuncExpr);
+            } catch (FileNotFoundException e) {
+                addMissingFileMsg(e.getMessage());
+            }
         } else {
             items = getFormEntryPrompt().getSelectChoices();
         }
+    }
+
+    protected void addMissingFileMsg(String filePath) {
+        TextView error = new TextView(getContext());
+        error.setText(getContext().getString(R.string.file_missing, filePath));
+        addAnswerView(error);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsWidget.java
@@ -17,7 +17,6 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
-import android.widget.TextView;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.xpath.expr.XPathFuncExpr;
@@ -26,6 +25,7 @@ import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public abstract class ItemsWidget extends QuestionWidget {
 
-    List<SelectChoice> items;
+    List<SelectChoice> items = new ArrayList<>();
 
     public ItemsWidget(Context context, QuestionDetails prompt) {
         super(context, prompt);
@@ -49,16 +49,10 @@ public abstract class ItemsWidget extends QuestionWidget {
             try {
                 items = ExternalDataUtil.populateExternalChoices(getFormEntryPrompt(), xpathFuncExpr);
             } catch (FileNotFoundException e) {
-                addMissingFileMsg(e.getMessage());
+                showWarning(getContext().getString(R.string.file_missing, e.getMessage()));
             }
         } else {
             items = getFormEntryPrompt().getSelectChoices();
         }
-    }
-
-    protected void addMissingFileMsg(String filePath) {
-        TextView error = new TextView(getContext());
-        error.setText(getContext().getString(R.string.file_missing, filePath));
-        addAnswerView(error);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
@@ -272,7 +272,7 @@ public class ItemsetWidget extends AbstractSelectOneWidget {
                 adapter.close();
             }
         } else {
-            addMissingFileMsg(itemsetFile.getAbsolutePath());
+            showWarning(getContext().getString(R.string.file_missing, itemsetFile.getAbsolutePath()));
         }
         return items;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
@@ -272,9 +272,7 @@ public class ItemsetWidget extends AbstractSelectOneWidget {
                 adapter.close();
             }
         } else {
-            TextView error = new TextView(getContext());
-            error.setText(getContext().getString(R.string.file_missing, itemsetFile.getAbsolutePath()));
-            addAnswerView(error);
+            addMissingFileMsg(itemsetFile.getAbsolutePath());
         }
         return items;
     }


### PR DESCRIPTION
Closes #3235 

#### What has been done to verify that this works as intended?
I tested the attached forms and added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
We already handle such a case in case of external itemsets so I decided to use the same code and display the same message.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change it's just related with two widgets for which I added sample forms below. Testing them would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
[selectOneExternal.zip](https://github.com/opendatakit/collect/files/3851183/selectOneExternal.zip)
[search.zip](https://github.com/opendatakit/collect/files/3851184/search.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)