### PR TITLE
Build a FormDef when doing initial form discovery

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
@@ -64,7 +64,7 @@ public class FormLoadingUtils {
     }
 
     private static void saveFormToDatabase(File outFile) {
-        Map<String, String> formInfo = FileUtils.parseXML(outFile);
+        Map<String, String> formInfo = FileUtils.getMetadataFromFormDefinition(outFile);
         final ContentValues v = new ContentValues();
         v.put(FormsProviderAPI.FormsColumns.FORM_FILE_PATH,          outFile.getAbsolutePath());
         v.put(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH,         FileUtils.constructMediaPath(outFile.getAbsolutePath()));

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -168,7 +168,7 @@ public class FormDownloader {
             try {
                 final long start = System.currentTimeMillis();
                 Timber.w("Parsing document %s", fileResult.file.getAbsolutePath());
-                parsedFields = FileUtils.parseXML(fileResult.file);
+                parsedFields = FileUtils.getMetadataFromFormDefinition(fileResult.file);
                 Timber.i("Parse finished in %.3f seconds.",
                         (System.currentTimeMillis() - start) / 1000F);
             } catch (RuntimeException e) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -41,7 +41,7 @@ public class FileUtilsTest {
     }
 
     @Test public void identifiesFormMetadata_formSimpleForm() throws IOException {
-        String simple_form = "<?xml version=\"1.0\"?>\n" +
+        String simpleForm = "<?xml version=\"1.0\"?>\n" +
                 "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
                 "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +
                 "        xmlns:orx=\"http://openrosa.org/xforms\">\n" +
@@ -62,10 +62,10 @@ public class FileUtilsTest {
         temp.deleteOnExit();
 
         BufferedWriter out = new BufferedWriter(new FileWriter(temp));
-        out.write(simple_form);
+        out.write(simpleForm);
         out.close();
 
-        HashMap<String, String> metadataFromFormDefinition = FileUtils.parseXML(temp);
+        HashMap<String, String> metadataFromFormDefinition = FileUtils.getMetadataFromFormDefinition(temp);
 
         assertThat(metadataFromFormDefinition.get(FileUtils.TITLE), is("My Survey"));
         assertThat(metadataFromFormDefinition.get(FileUtils.FORMID), is("mysurvey"));
@@ -74,7 +74,7 @@ public class FileUtilsTest {
     }
 
     @Test public void identifiesFormMetadata_forFormWithSubmission() throws IOException {
-        String submission_form = "<?xml version=\"1.0\"?>\n" +
+        String submissionForm = "<?xml version=\"1.0\"?>\n" +
                 "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
                 "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +
                 "        xmlns:orx=\"http://openrosa.org/xforms\">\n" +
@@ -101,17 +101,17 @@ public class FileUtilsTest {
         temp.deleteOnExit();
 
         BufferedWriter out = new BufferedWriter(new FileWriter(temp));
-        out.write(submission_form);
+        out.write(submissionForm);
         out.close();
 
-        HashMap<String, String> metadataFromFormDefinition = FileUtils.parseXML(temp);
+        HashMap<String, String> metadataFromFormDefinition = FileUtils.getMetadataFromFormDefinition(temp);
 
         assertThat(metadataFromFormDefinition.get(FileUtils.TITLE), is("My Survey"));
         assertThat(metadataFromFormDefinition.get(FileUtils.FORMID), is("mysurvey"));
         assertThat(metadataFromFormDefinition.get(FileUtils.VERSION), is("2014083101"));
-        assertThat(metadataFromFormDefinition.get(FileUtils.SUBMISSIONURI), is ("foo"));
-        assertThat(metadataFromFormDefinition.get(FileUtils.AUTO_SEND), is ("bar"));
-        assertThat(metadataFromFormDefinition.get(FileUtils.AUTO_DELETE), is ("baz"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.SUBMISSIONURI), is("foo"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.AUTO_SEND), is("bar"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.AUTO_DELETE), is("baz"));
         assertThat(metadataFromFormDefinition.get(FileUtils.BASE64_RSA_PUBLIC_KEY), is("quux"));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -40,7 +40,7 @@ public class FileUtilsTest {
         assertEquals(expected, FileUtils.constructMediaPath("sample-file.docx"));
     }
 
-    @Test public void identifiesFormMetadata_formSimpleForm() throws IOException {
+    @Test public void getMetadataFromFormDefinition_withoutSubmission_returnsMetaDataFields() throws IOException {
         String simpleForm = "<?xml version=\"1.0\"?>\n" +
                 "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
                 "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +
@@ -73,7 +73,7 @@ public class FileUtilsTest {
         assertThat(metadataFromFormDefinition.get(FileUtils.BASE64_RSA_PUBLIC_KEY), is(nullValue()));
     }
 
-    @Test public void identifiesFormMetadata_forFormWithSubmission() throws IOException {
+    @Test public void getMetadataFromFormDefinition_withSubmission_returnsMetaDataFields() throws IOException {
         String submissionForm = "<?xml version=\"1.0\"?>\n" +
                 "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
                 "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -2,17 +2,21 @@ package org.odk.collect.android.utilities;
 
 import org.junit.Test;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.HashMap;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class FileUtilsTest {
     @Test
-    public void md5HashIsCorrect() throws NoSuchAlgorithmException, IOException {
+    public void md5HashIsCorrect() throws IOException {
         String contents = "Hello, world";
         File tempFile = File.createTempFile("hello", "txt");
         tempFile.deleteOnExit();
@@ -34,5 +38,80 @@ public class FileUtilsTest {
         assertEquals(expected, FileUtils.constructMediaPath("sample-file.extension"));
         assertEquals(expected, FileUtils.constructMediaPath("sample-file.123"));
         assertEquals(expected, FileUtils.constructMediaPath("sample-file.docx"));
+    }
+
+    @Test public void identifiesFormMetadata_formSimpleForm() throws IOException {
+        String simple_form = "<?xml version=\"1.0\"?>\n" +
+                "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
+                "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +
+                "        xmlns:orx=\"http://openrosa.org/xforms\">\n" +
+                "    <h:head>\n" +
+                "        <h:title>My Survey</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"mysurvey\">\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+        File temp = File.createTempFile("simple_form", ".xml");
+        temp.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        out.write(simple_form);
+        out.close();
+
+        HashMap<String, String> metadataFromFormDefinition = FileUtils.parseXML(temp);
+
+        assertThat(metadataFromFormDefinition.get(FileUtils.TITLE), is("My Survey"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.FORMID), is("mysurvey"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.VERSION), is(nullValue()));
+        assertThat(metadataFromFormDefinition.get(FileUtils.BASE64_RSA_PUBLIC_KEY), is(nullValue()));
+    }
+
+    @Test public void identifiesFormMetadata_forFormWithSubmission() throws IOException {
+        String submission_form = "<?xml version=\"1.0\"?>\n" +
+                "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
+                "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +
+                "        xmlns:orx=\"http://openrosa.org/xforms\">\n" +
+                "    <h:head>\n" +
+                "        <h:title>My Survey</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"mysurvey\" orx:version=\"2014083101\">\n" +
+                "                    <orx:meta>\n" +
+                "                        <orx:instanceID/>\n" +
+                "                    </orx:meta>\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "            <submission action=\"foo\" orx:auto-send=\"bar\" orx:auto-delete=\"baz\" base64RsaPublicKey=\"quux\" />\n" +
+                "            <bind nodeset=\"/data/orx:meta/orx:instanceID\" preload=\"uid\" type=\"string\"/>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+
+        File temp = File.createTempFile("submission_form", ".xml");
+        temp.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        out.write(submission_form);
+        out.close();
+
+        HashMap<String, String> metadataFromFormDefinition = FileUtils.parseXML(temp);
+
+        assertThat(metadataFromFormDefinition.get(FileUtils.TITLE), is("My Survey"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.FORMID), is("mysurvey"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.VERSION), is("2014083101"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.SUBMISSIONURI), is ("foo"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.AUTO_SEND), is ("bar"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.AUTO_DELETE), is ("baz"));
+        assertThat(metadataFromFormDefinition.get(FileUtils.BASE64_RSA_PUBLIC_KEY), is("quux"));
     }
 }


### PR DESCRIPTION
Closes #3448

#### What has been done to verify that this works as intended?
I added some tests for the method I changed before changing it to ensure that all behavior stayed the same. I also manually verified the change on a real device to get a feel for the performance difference. For a large form like [nigeria_wards_internal.xml.txt](https://github.com/opendatakit/collect/files/3852792/nigeria_wards_internal.xml.txt) it does take noticeably longer on my Galaxy Tab A when directly compared: about 3 seconds with this change vs. 2 without. I think this is ok because it's still not a huge amount of time, it only happens once, and it sets us up to do really nice things like start building the cache file immediately.

#### Why is this the best possible solution? Were any other approaches considered?
There's a lot of potential for refactor, reuse and performance improvement in this general area so I initially was going for a much more invasive change. I decided that I should instead make this as low-risk as possible so it's easy to verify and @zestyping can pick it up for #61 which is what initially prompted the change. We can then come back and make the other changes.

I think it'd be nice to have the version and form id directly from the `FormDef` which would be adding a couple of getters in JavaRosa. It's not essential to do now, though.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should be no visible behavior change. However, there will be a slight performance difference because a full `FormDef` is now being built at form discovery time (from disk or download).

There also used to be a logged warning when `uiVersion` was used which is no longer emitted. This was part of a really old form spec and was logging-only so I don't think it will be missed.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form will do. It would be good to verify one with a submission URI, for example one that goes to Google Sheets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)