### PR TITLE
Add convenience methods to get content URIs for form and instance items.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcuts.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcuts.java
@@ -22,13 +22,14 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
-import androidx.appcompat.app.AppCompatActivity;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 
 import java.util.ArrayList;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Allows the user to create desktop shortcuts to any form currently avaiable to Collect
@@ -71,12 +72,8 @@ public class AndroidShortcuts extends AppCompatActivity {
             if (c.getCount() > 0) {
                 c.moveToPosition(-1);
                 while (c.moveToNext()) {
-                    String formName = c.getString(c.getColumnIndex(FormsColumns.DISPLAY_NAME));
-                    names.add(formName);
-                    Uri uri =
-                            Uri.withAppendedPath(FormsColumns.CONTENT_URI,
-                                    c.getString(c.getColumnIndex(FormsColumns._ID)));
-                    commands.add(uri);
+                    names.add(c.getString(c.getColumnIndex(FormsColumns.DISPLAY_NAME)));
+                    commands.add(FormsColumns.getItemUri(c));
                 }
             }
         } finally {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormChooserListActivity.java
@@ -15,32 +15,31 @@
 package org.odk.collect.android.activities;
 
 import android.app.AlertDialog;
-import android.content.ContentUris;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
 import android.view.View;
 import android.widget.AdapterView;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.adapters.VersionHidingCursorAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.listeners.DiskSyncListener;
 import org.odk.collect.android.listeners.PermissionListener;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.PermissionUtils;
-import org.odk.collect.android.adapters.VersionHidingCursorAdapter;
 
+import androidx.annotation.NonNull;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.Loader;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
@@ -122,8 +121,7 @@ public class FormChooserListActivity extends FormListActivity implements
         if (Collect.allowClick(getClass().getName())) {
             // get uri to form
             long idFormsTable = listView.getAdapter().getItemId(position);
-            Uri formUri = ContentUris.withAppendedId(FormsColumns.CONTENT_URI, idFormsTable);
-
+            Uri formUri = FormsColumns.getItemUri(idFormsTable);
             String action = getIntent().getAction();
             if (Intent.ACTION_PICK.equals(action)) {
                 // caller is waiting on a picked form
@@ -134,7 +132,7 @@ public class FormChooserListActivity extends FormListActivity implements
                 intent.putExtra(ApplicationConstants.BundleKeys.FORM_MODE, ApplicationConstants.FormModes.EDIT_SAVED);
                 startActivity(intent);
             }
-            
+
             finish();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -15,21 +15,17 @@
 package org.odk.collect.android.activities;
 
 import android.app.AlertDialog;
-import android.content.ContentUris;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.TextView;
-
 import android.widget.Toast;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.application.Collect;
@@ -42,6 +38,9 @@ import org.odk.collect.android.tasks.InstanceSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.PermissionUtils;
 
+import androidx.annotation.NonNull;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.Loader;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
@@ -126,10 +125,7 @@ public class InstanceChooserList extends InstanceListActivity implements
         if (Collect.allowClick(getClass().getName())) {
             if (view.isEnabled()) {
                 Cursor c = (Cursor) listView.getAdapter().getItem(position);
-                Uri instanceUri =
-                        ContentUris.withAppendedId(InstanceColumns.CONTENT_URI,
-                                c.getLong(c.getColumnIndex(InstanceColumns._ID)));
-
+                Uri instanceUri = InstanceColumns.getItemUri(c);
                 String action = getIntent().getAction();
                 if (Intent.ACTION_PICK.equals(action)) {
                     // caller is waiting on a picked form

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
@@ -23,6 +23,7 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 
 import timber.log.Timber;
 
@@ -54,7 +55,7 @@ public final class InstancesDaoHelper {
             try (Cursor c = new InstancesDao().getInstancesCursorForFilePath(path)) {
                 if (c != null && c.getCount() > 0) {
                     c.moveToFirst();
-                    int columnIndex = c.getColumnIndex(InstanceProviderAPI.InstanceColumns.STATUS);
+                    int columnIndex = c.getColumnIndex(InstanceColumns.STATUS);
                     String status = c.getString(columnIndex);
                     if (InstanceProviderAPI.STATUS_COMPLETE.equals(status)) {
                         complete = true;
@@ -73,8 +74,7 @@ public final class InstancesDaoHelper {
                 if (c != null && c.getCount() > 0) {
                     // should only be one...
                     c.moveToFirst();
-                    String id = c.getString(c.getColumnIndex(InstanceProviderAPI.InstanceColumns._ID));
-                    return Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI, id);
+                    return InstanceColumns.getItemUri(c);
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.provider;
 
 import android.content.ContentProvider;
-import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.UriMatcher;
 import android.database.Cursor;
@@ -24,8 +23,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.text.TextUtils;
-
-import androidx.annotation.NonNull;
 
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.ItemsetDbAdapter;
@@ -38,6 +35,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static org.odk.collect.android.database.helpers.FormsDatabaseHelper.FORMS_TABLE_NAME;
@@ -232,8 +230,7 @@ public class FormsProvider extends ContentProvider {
 
             long rowId = db.insert(FORMS_TABLE_NAME, null, values);
             if (rowId > 0) {
-                Uri formUri = ContentUris.withAppendedId(FormsColumns.CONTENT_URI,
-                        rowId);
+                Uri formUri = FormsColumns.getItemUri(rowId);
                 getContext().getContentResolver().notifyChange(formUri, null);
                 getContext().getContentResolver().notifyChange(FormsProviderAPI.FormsColumns.CONTENT_NEWEST_FORMS_BY_FORMID_URI, null);
                 return formUri;

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -16,6 +16,8 @@
 
 package org.odk.collect.android.provider;
 
+import android.content.ContentUris;
+import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
@@ -77,5 +79,13 @@ public final class FormsProviderAPI {
 
         // this is null on create, and can only be set on an update.
         public static final String LANGUAGE = "language";
+
+        public static Uri getItemUri(long id) {
+            return ContentUris.withAppendedId(CONTENT_URI, id);
+        }
+
+        public static Uri getItemUri(Cursor c) {
+            return getItemUri(c.getLong(c.getColumnIndex(_ID)));
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -15,7 +15,6 @@
 package org.odk.collect.android.provider;
 
 import android.content.ContentProvider;
-import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.UriMatcher;
@@ -25,8 +24,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.Uri;
 import android.text.TextUtils;
-
-import androidx.annotation.NonNull;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
@@ -40,6 +37,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static org.odk.collect.android.database.helpers.InstancesDatabaseHelper.INSTANCES_TABLE_NAME;
@@ -54,7 +52,7 @@ public class InstanceProvider extends ContentProvider {
     private static final UriMatcher URI_MATCHER;
 
     private static InstancesDatabaseHelper dbHelper;
-    
+
     private synchronized InstancesDatabaseHelper getDbHelper() {
         // wrapper to test and reset/set the dbHelper based upon the attachment state of the device.
         try {
@@ -170,7 +168,7 @@ public class InstanceProvider extends ContentProvider {
 
             long rowId = instancesDatabaseHelper.getWritableDatabase().insert(INSTANCES_TABLE_NAME, null, values);
             if (rowId > 0) {
-                Uri instanceUri = ContentUris.withAppendedId(InstanceColumns.CONTENT_URI, rowId);
+                Uri instanceUri = InstanceColumns.getItemUri(rowId);
                 getContext().getContentResolver().notifyChange(instanceUri, null);
                 return instanceUri;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
@@ -16,6 +16,8 @@
 
 package org.odk.collect.android.provider;
 
+import android.content.ContentUris;
+import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
@@ -51,5 +53,13 @@ public final class InstanceProviderAPI {
         public static final String CAN_EDIT_WHEN_COMPLETE = "canEditWhenComplete";
         public static final String LAST_STATUS_CHANGE_DATE = "date";
         public static final String DELETED_DATE = "deletedDate";
+
+        public static Uri getItemUri(long id) {
+            return ContentUris.withAppendedId(CONTENT_URI, id);
+        }
+
+        public static Uri getItemUri(Cursor c) {
+            return getItemUri(c.getLong(c.getColumnIndex(_ID)));
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2012 University of Washington
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -52,9 +52,7 @@ public class DeleteFormsTask extends AsyncTask<Long, Void, Integer> {
                 break;
             }
             try {
-                Uri deleteForm =
-                        Uri.withAppendedPath(FormsColumns.CONTENT_URI, param.toString());
-
+                Uri deleteForm = FormsColumns.getItemUri(param);
                 int wasDeleted = cr.delete(deleteForm, null, null);
                 deleted += wasDeleted;
             } catch (Exception ex) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
@@ -53,15 +53,11 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
                 break;
             }
             try {
-                Uri deleteForm =
-                        Uri.withAppendedPath(InstanceColumns.CONTENT_URI, param.toString());
-
+                Uri deleteForm = InstanceColumns.getItemUri(param);
                 int wasDeleted = contentResolver.delete(deleteForm, null, null);
                 deleted += wasDeleted;
-
                 successCount++;
                 publishProgress(successCount, toDeleteCount);
-
             } catch (Exception ex) {
                 Timber.e("Exception during delete of: %s exception: %s", param.toString(), ex.toString());
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -116,9 +116,7 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
                             if (md5Computed == null || md5 == null || !md5Computed.equals(md5)) {
                                 // Probably someone overwrite the file on the sdcard
                                 // So re-parse it and update it's information
-                                String id = cursor.getString(
-                                        cursor.getColumnIndex(FormsColumns._ID));
-                                Uri updateUri = Uri.withAppendedPath(FormsColumns.CONTENT_URI, id);
+                                Uri updateUri = FormsColumns.getItemUri(cursor);
                                 uriToUpdate.add(new UriFile(updateUri, sqlFile));
                             }
                         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/AutoSendWorker.java
@@ -24,10 +24,6 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Environment;
 
-import androidx.annotation.NonNull;
-import androidx.work.Worker;
-import androidx.work.WorkerParameters;
-
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.NotificationActivity;
 import org.odk.collect.android.application.Collect;
@@ -51,6 +47,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
 import timber.log.Timber;
 
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SEND;
@@ -149,7 +148,7 @@ public class AutoSendWorker extends Worker {
                 // communicated to the user. Maybe successful delete should also be communicated?
                 if (InstanceUploader.formShouldBeAutoDeleted(instance.getJrFormId(),
                         (boolean) GeneralSharedPreferences.getInstance().get(GeneralKeys.KEY_DELETE_AFTER_SEND))) {
-                    Uri deleteForm = Uri.withAppendedPath(InstanceColumns.CONTENT_URI, instance.getDatabaseId().toString());
+                    Uri deleteForm = InstanceColumns.getItemUri(instance.getDatabaseId());
                     Collect.getInstance().getContentResolver().delete(deleteForm, null, null);
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
@@ -17,18 +17,20 @@ package org.odk.collect.android.upload;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.dto.Instance;
 import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.utilities.ApplicationConstants;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_DELETE;
 
@@ -63,7 +65,7 @@ public abstract class InstanceUploader {
                 high = instanceDatabaseIds.length;
             }
 
-            StringBuilder selectionBuf = new StringBuilder(InstanceProviderAPI.InstanceColumns._ID + " IN (");
+            StringBuilder selectionBuf = new StringBuilder(InstanceColumns._ID + " IN (");
             String[] selectionArgs = new String[high - low];
             for (int i = 0; i < (high - low); i++) {
                 if (i > 0) {
@@ -86,20 +88,16 @@ public abstract class InstanceUploader {
     }
 
     void saveSuccessStatusToDatabase(Instance instance) {
-        Uri instanceDatabaseUri = Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI,
-                instance.getDatabaseId().toString());
-
+        Uri instanceDatabaseUri = InstanceColumns.getItemUri(instance.getDatabaseId());
         ContentValues contentValues = new ContentValues();
-        contentValues.put(InstanceProviderAPI.InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
+        contentValues.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
         Collect.getInstance().getContentResolver().update(instanceDatabaseUri, contentValues, null, null);
     }
 
     void saveFailedStatusToDatabase(Instance instance) {
-        Uri instanceDatabaseUri = Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI,
-                instance.getDatabaseId().toString());
-
+        Uri instanceDatabaseUri = InstanceColumns.getItemUri(instance.getDatabaseId());
         ContentValues contentValues = new ContentValues();
-        contentValues.put(InstanceProviderAPI.InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMISSION_FAILED);
+        contentValues.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMISSION_FAILED);
         Collect.getInstance().getContentResolver().update(instanceDatabaseUri, contentValues, null, null);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -29,7 +29,7 @@ import org.odk.collect.android.http.CollectServerClient;
 import org.odk.collect.android.listeners.FormDownloaderListener;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.logic.MediaFile;
-import org.odk.collect.android.provider.FormsProviderAPI;
+import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -291,9 +291,8 @@ public class FormDownloader {
                 uri = saveNewForm(formInfo, formFile, mediaPath);
             } else {
                 cursor.moveToFirst();
-                uri = Uri.withAppendedPath(FormsProviderAPI.FormsColumns.CONTENT_URI,
-                        cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns._ID)));
-                mediaPath = cursor.getString(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH));
+                uri = FormsColumns.getItemUri(cursor);
+                mediaPath = cursor.getString(cursor.getColumnIndex(FormsColumns.FORM_MEDIA_PATH));
             }
         }
 
@@ -302,15 +301,15 @@ public class FormDownloader {
 
     private Uri saveNewForm(Map<String, String> formInfo, File formFile, String mediaPath) {
         final ContentValues v = new ContentValues();
-        v.put(FormsProviderAPI.FormsColumns.FORM_FILE_PATH,          formFile.getAbsolutePath());
-        v.put(FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH,         mediaPath);
-        v.put(FormsProviderAPI.FormsColumns.DISPLAY_NAME,            formInfo.get(FileUtils.TITLE));
-        v.put(FormsProviderAPI.FormsColumns.JR_VERSION,              formInfo.get(FileUtils.VERSION));
-        v.put(FormsProviderAPI.FormsColumns.JR_FORM_ID,              formInfo.get(FileUtils.FORMID));
-        v.put(FormsProviderAPI.FormsColumns.SUBMISSION_URI,          formInfo.get(FileUtils.SUBMISSIONURI));
-        v.put(FormsProviderAPI.FormsColumns.BASE64_RSA_PUBLIC_KEY,   formInfo.get(FileUtils.BASE64_RSA_PUBLIC_KEY));
-        v.put(FormsProviderAPI.FormsColumns.AUTO_DELETE,             formInfo.get(FileUtils.AUTO_DELETE));
-        v.put(FormsProviderAPI.FormsColumns.AUTO_SEND,             formInfo.get(FileUtils.AUTO_SEND));
+        v.put(FormsColumns.FORM_FILE_PATH,          formFile.getAbsolutePath());
+        v.put(FormsColumns.FORM_MEDIA_PATH,         mediaPath);
+        v.put(FormsColumns.DISPLAY_NAME,            formInfo.get(FileUtils.TITLE));
+        v.put(FormsColumns.JR_VERSION,              formInfo.get(FileUtils.VERSION));
+        v.put(FormsColumns.JR_FORM_ID,              formInfo.get(FileUtils.FORMID));
+        v.put(FormsColumns.SUBMISSION_URI,          formInfo.get(FileUtils.SUBMISSIONURI));
+        v.put(FormsColumns.BASE64_RSA_PUBLIC_KEY,   formInfo.get(FileUtils.BASE64_RSA_PUBLIC_KEY));
+        v.put(FormsColumns.AUTO_DELETE,             formInfo.get(FileUtils.AUTO_DELETE));
+        v.put(FormsColumns.AUTO_SEND,               formInfo.get(FileUtils.AUTO_SEND));
         return formsDao.saveForm(v);
     }
 
@@ -356,7 +355,7 @@ public class FormDownloader {
                 FileUtils.deleteAndReport(f);
 
                 // set the file returned to the file we already had
-                String existingPath = c.getString(c.getColumnIndex(FormsProviderAPI.FormsColumns.FORM_FILE_PATH));
+                String existingPath = c.getString(c.getColumnIndex(FormsColumns.FORM_FILE_PATH));
                 f = new File(existingPath);
                 Timber.w("Will use %s", existingPath);
             }


### PR DESCRIPTION
There are a variety of ways that these URIs are constructed, some a bit clunky.  This PR provides a `getItemUri` method so there's one concise way to do it.

This is purely code cleanup with no behaviour changes.