### PR TITLE
Disable automatic formatting only for questions that are formatting prone

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -23,6 +23,7 @@ import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
+import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.instance.AbstractTreeElement;
 import org.javarosa.core.model.instance.TreeElement;
@@ -61,10 +62,6 @@ import java.util.regex.Pattern;
 
 import timber.log.Timber;
 
-import static org.javarosa.core.model.Constants.DATATYPE_BARCODE;
-import static org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST;
-import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
-import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
 import static org.odk.collect.android.logic.FormController.INSTANCE_ID;
 
 public class InstanceGoogleSheetsUploader extends InstanceUploader {
@@ -373,9 +370,9 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
     public static String getFormattingResistantAnswer(TreeElement childElement) {
         String answer = childElement.getValue() != null ? childElement.getValue().getDisplayText() : "";
 
-        if (!answer.isEmpty() && (childElement.getDataType() == DATATYPE_TEXT
-                || childElement.getDataType() == DATATYPE_MULTIPLE_ITEMS
-                || childElement.getDataType() == DATATYPE_BARCODE)) {
+        if (!answer.isEmpty() && (childElement.getDataType() == Constants.DATATYPE_TEXT
+                || childElement.getDataType() == Constants.DATATYPE_MULTIPLE_ITEMS
+                || childElement.getDataType() == Constants.DATATYPE_BARCODE)) {
             answer = "'" + answer;
         }
 
@@ -427,7 +424,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
         for (TreeElement child : getChildElements(element, false)) {
             final String elementTitle = getElementTitle(child);
             columnTitles.add(elementTitle);
-            if (newSheet && child.getDataType() == org.javarosa.core.model.Constants.DATATYPE_GEOPOINT) {
+            if (newSheet && child.getDataType() == Constants.DATATYPE_GEOPOINT) {
                 columnTitles.add(elementTitle + ALTITUDE_TITLE_POSTFIX);
                 columnTitles.add(elementTitle + ACCURACY_TITLE_POSTFIX);
             }
@@ -486,25 +483,25 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             TreeElement current = element.getChildAt(i);
             if (includeAllRepeats || !nextInstanceOfTheSameRepeatableGroup(prior, current)) {
                 switch (current.getDataType()) {
-                    case org.javarosa.core.model.Constants.DATATYPE_TEXT:
-                    case org.javarosa.core.model.Constants.DATATYPE_INTEGER:
-                    case org.javarosa.core.model.Constants.DATATYPE_DECIMAL:
-                    case org.javarosa.core.model.Constants.DATATYPE_DATE:
-                    case org.javarosa.core.model.Constants.DATATYPE_TIME:
-                    case org.javarosa.core.model.Constants.DATATYPE_DATE_TIME:
-                    case org.javarosa.core.model.Constants.DATATYPE_CHOICE:
-                    case org.javarosa.core.model.Constants.DATATYPE_CHOICE_LIST:
-                    case org.javarosa.core.model.Constants.DATATYPE_BOOLEAN:
-                    case org.javarosa.core.model.Constants.DATATYPE_GEOPOINT:
-                    case org.javarosa.core.model.Constants.DATATYPE_BARCODE:
-                    case org.javarosa.core.model.Constants.DATATYPE_BINARY:
-                    case org.javarosa.core.model.Constants.DATATYPE_LONG:
-                    case org.javarosa.core.model.Constants.DATATYPE_GEOSHAPE:
-                    case org.javarosa.core.model.Constants.DATATYPE_GEOTRACE:
-                    case org.javarosa.core.model.Constants.DATATYPE_UNSUPPORTED:
+                    case Constants.DATATYPE_TEXT:
+                    case Constants.DATATYPE_INTEGER:
+                    case Constants.DATATYPE_DECIMAL:
+                    case Constants.DATATYPE_DATE:
+                    case Constants.DATATYPE_TIME:
+                    case Constants.DATATYPE_DATE_TIME:
+                    case Constants.DATATYPE_CHOICE:
+                    case Constants.DATATYPE_CHOICE_LIST:
+                    case Constants.DATATYPE_BOOLEAN:
+                    case Constants.DATATYPE_GEOPOINT:
+                    case Constants.DATATYPE_BARCODE:
+                    case Constants.DATATYPE_BINARY:
+                    case Constants.DATATYPE_LONG:
+                    case Constants.DATATYPE_GEOSHAPE:
+                    case Constants.DATATYPE_GEOTRACE:
+                    case Constants.DATATYPE_UNSUPPORTED:
                         elements.add(current);
                         break;
-                    case org.javarosa.core.model.Constants.DATATYPE_NULL:
+                    case Constants.DATATYPE_NULL:
                         if (current.isRepeatable()) { // repeat group
                             elements.add(current);
                         } else if (current.getNumChildren() == 0) { // assume fields that don't have children are string fields

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/InstanceGoogleSheetsUploaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/InstanceGoogleSheetsUploaderTest.java
@@ -1,13 +1,28 @@
 package org.odk.collect.android.utilities;
 
+import static org.javarosa.core.model.Constants.DATATYPE_BARCODE;
+import static org.javarosa.core.model.Constants.DATATYPE_BINARY;
+import static org.javarosa.core.model.Constants.DATATYPE_BOOLEAN;
+import static org.javarosa.core.model.Constants.DATATYPE_CHOICE;
+import static org.javarosa.core.model.Constants.DATATYPE_DATE;
+import static org.javarosa.core.model.Constants.DATATYPE_DATE_TIME;
+import static org.javarosa.core.model.Constants.DATATYPE_DECIMAL;
+import static org.javarosa.core.model.Constants.DATATYPE_GEOPOINT;
+import static org.javarosa.core.model.Constants.DATATYPE_GEOSHAPE;
+import static org.javarosa.core.model.Constants.DATATYPE_GEOTRACE;
+import static org.javarosa.core.model.Constants.DATATYPE_INTEGER;
+import static org.javarosa.core.model.Constants.DATATYPE_LONG;
+import static org.javarosa.core.model.Constants.DATATYPE_MULTIPLE_ITEMS;
+import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
+import static org.javarosa.core.model.Constants.DATATYPE_TIME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.core.model.instance.TreeElement;
 import org.junit.Test;
 import org.odk.collect.android.upload.InstanceGoogleSheetsUploader;
-
-import java.util.HashMap;
 
 public class InstanceGoogleSheetsUploaderTest {
     @Test
@@ -25,36 +40,44 @@ public class InstanceGoogleSheetsUploaderTest {
     }
 
     @Test
-    public void makeAnswersFormattingResistantTests() {
-        HashMap<String, String> answers = new HashMap<>();
-        answers.put("testForm-instanceId", "uuid:748c574c-4aa5-4f80-a628-b96d0f052e92");
-        answers.put("testForm-text", "test string");
-        answers.put("testForm-number", "55");
-        answers.put("testForm-photo", "https://drive.google.com/open?id=1g7bWUq-raEAltOI2NX03jX4Ttt0AdAYA");
-        answers.put("testForm-time", "12:57");
-        answers.put("testForm-newGroup", "=HYPERLINK(\"https://docs.google.com/spreadsheets/d/1PObIXLRDBQjQOnRJLgKQJPOvRpl6cCPRDa99zWFLI60/edit#gid=938236033\", \"data-gr\")");
-        answers.put("testForm-date", "08/08/19");
-        answers.put("testForm-selectOne", "1");
-        answers.put("testForm-selectMultiple", "1, 2, 3");
-        answers.put("testForm-decimal", "7.5");
-        answers.put("testForm-geopoint", "54.38072481,18.6065263");
-        answers.put("testForm-geopoint-altitude", "128");
-        answers.put("testForm-geopoint-accuracy", "24");
+    public void getFormattingResistantAnswerTests() {
+        String originalAnswer = "Test answer";
+        String formattingResistantAnswer = "'" + originalAnswer;
 
-        HashMap<String, String> fixedAnswers = InstanceGoogleSheetsUploader.makeAnswersFormattingResistant(answers);
-        assertEquals(answers.size(), fixedAnswers.size());
-        assertEquals("'uuid:748c574c-4aa5-4f80-a628-b96d0f052e92", fixedAnswers.get("testForm-instanceId"));
-        assertEquals("'test string", fixedAnswers.get("testForm-text"));
-        assertEquals("'55", fixedAnswers.get("testForm-number"));
-        assertEquals("https://drive.google.com/open?id=1g7bWUq-raEAltOI2NX03jX4Ttt0AdAYA", fixedAnswers.get("testForm-photo"));
-        assertEquals("'12:57", fixedAnswers.get("testForm-time"));
-        assertEquals("=HYPERLINK(\"https://docs.google.com/spreadsheets/d/1PObIXLRDBQjQOnRJLgKQJPOvRpl6cCPRDa99zWFLI60/edit#gid=938236033\", \"data-gr\")", fixedAnswers.get("testForm-newGroup"));
-        assertEquals("'08/08/19", fixedAnswers.get("testForm-date"));
-        assertEquals("'1", fixedAnswers.get("testForm-selectOne"));
-        assertEquals("'1, 2, 3", fixedAnswers.get("testForm-selectMultiple"));
-        assertEquals("'7.5", fixedAnswers.get("testForm-decimal"));
-        assertEquals("'54.38072481,18.6065263", fixedAnswers.get("testForm-geopoint"));
-        assertEquals("'128", fixedAnswers.get("testForm-geopoint-altitude"));
-        assertEquals("'24", fixedAnswers.get("testForm-geopoint-accuracy"));
+        TreeElement treeElement = new TreeElement();
+        treeElement.setAnswer(new StringData(originalAnswer));
+
+        treeElement.setDataType(DATATYPE_TEXT);
+        assertEquals(formattingResistantAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_MULTIPLE_ITEMS);
+        assertEquals(formattingResistantAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_BARCODE);
+        assertEquals(formattingResistantAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+
+        treeElement.setDataType(DATATYPE_INTEGER);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_DECIMAL);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_DATE);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_TIME);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_DATE_TIME);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_CHOICE);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_BOOLEAN);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_GEOPOINT);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_BINARY);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_LONG);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_GEOSHAPE);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+        treeElement.setDataType(DATATYPE_GEOTRACE);
+        assertEquals(originalAnswer, InstanceGoogleSheetsUploader.getFormattingResistantAnswer(treeElement));
+
     }
 }


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I added an automated test and tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
Users has complained about the apostrophe in dates and numbers because it made calculating more difficult, so we decided to keep it only in case of questions that are formatting prone like:
```
DATATYPE_TEXT
DATATYPE_MULTIPLE_ITEMS
DATATYPE_BARCODE
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing All widgets form with GS will be enough to confirm that the apostrophe is added only there where it's really needed. It's the only thing that can be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
All widgets form is the best option.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
Yes, I'll file an issue once it's accepted.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)