### PR TITLE
Avoid starting asynctask responsible for uploading forms to GS twice

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -328,11 +328,13 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
     }
 
     private void authorized() {
-        GoogleSheetsUploaderProgressDialog.newInstance(alertMsg)
-                .show(getSupportFragmentManager(), GOOGLE_SHEETS_UPLOADER_PROGRESS_DIALOG_TAG);
+        if (instanceGoogleSheetsUploaderTask.getStatus() == AsyncTask.Status.PENDING) {
+            GoogleSheetsUploaderProgressDialog.newInstance(alertMsg)
+                    .show(getSupportFragmentManager(), GOOGLE_SHEETS_UPLOADER_PROGRESS_DIALOG_TAG);
 
-        instanceGoogleSheetsUploaderTask.setUploaderListener(this);
-        instanceGoogleSheetsUploaderTask.execute(instancesToSend);
+            instanceGoogleSheetsUploaderTask.setUploaderListener(this);
+            instanceGoogleSheetsUploaderTask.execute(instancesToSend);
+        }
     }
 
     private void dismissProgressDialog() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -122,22 +122,16 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
     }
 
     private void runTask() {
-        instanceGoogleSheetsUploaderTask = (InstanceGoogleSheetsUploaderTask) getLastCustomNonConfigurationInstance();
-        if (instanceGoogleSheetsUploaderTask == null) {
-            instanceGoogleSheetsUploaderTask = new InstanceGoogleSheetsUploaderTask(accountsManager);
+        instanceGoogleSheetsUploaderTask = new InstanceGoogleSheetsUploaderTask(accountsManager);
 
-            // ensure we have a google account selected
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-            String googleUsername = prefs.getString(
-                    GeneralKeys.KEY_SELECTED_GOOGLE_ACCOUNT, null);
-            if (googleUsername == null || googleUsername.equals("")) {
-                showDialog(GOOGLE_USER_DIALOG);
-            } else {
-                new AuthorizationChecker().execute();
-            }
+        // ensure we have a google account selected
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        String googleUsername = prefs.getString(
+                GeneralKeys.KEY_SELECTED_GOOGLE_ACCOUNT, null);
+        if (googleUsername == null || googleUsername.equals("")) {
+            showDialog(GOOGLE_USER_DIALOG);
         } else {
-            // it's not null, so we have a task running
-            // progress dialog is handled by the system
+            new AuthorizationChecker().execute();
         }
     }
 
@@ -239,11 +233,6 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         super.onSaveInstanceState(outState);
         outState.putString(ALERT_MSG, alertMsg);
         outState.putBoolean(ALERT_SHOWING, alertShowing);
-    }
-
-    @Override
-    public Object onRetainCustomNonConfigurationInstance() {
-        return instanceGoogleSheetsUploaderTask;
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -85,9 +85,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         // 1) Google Sheets is selected in preferences
         // 2) A google user is selected
 
-        // default initializers
         alertMsg = getString(R.string.please_wait);
-        alertShowing = false;
 
         setTitle(getString(R.string.send_data));
 
@@ -186,8 +184,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
      *                    activity result.
      */
     @Override
-    protected void onActivityResult(
-            int requestCode, int resultCode, Intent data) {
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
         if (resultCode == RESULT_CANCELED) {
@@ -195,13 +192,11 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
             finish();
         }
 
-        switch (requestCode) {
-            case REQUEST_AUTHORIZATION:
-                dismissProgressDialog();
-                if (resultCode == RESULT_OK) {
-                    getResultsFromApi();
-                }
-                break;
+        if (requestCode == REQUEST_AUTHORIZATION) {
+            dismissProgressDialog();
+            if (resultCode == RESULT_OK) {
+                getResultsFromApi();
+            }
         }
     }
 
@@ -260,7 +255,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         try {
             dismissProgressDialog();
         } catch (Exception e) {
-            // tried to close a dialog not open. don't care.
+            Timber.w(e);
         }
 
         if (result == null) {
@@ -284,20 +279,19 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
 
     @Override
     protected Dialog onCreateDialog(int id) {
-        switch (id) {
-            case GOOGLE_USER_DIALOG:
-                AlertDialog.Builder gudBuilder = new AlertDialog.Builder(this);
+        if (id == GOOGLE_USER_DIALOG) {
+            AlertDialog.Builder gudBuilder = new AlertDialog.Builder(this);
 
-                gudBuilder.setTitle(getString(R.string.no_google_account));
-                gudBuilder.setMessage(getString(R.string.google_set_account));
-                gudBuilder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        finish();
-                    }
-                });
-                gudBuilder.setCancelable(false);
-                return gudBuilder.create();
+            gudBuilder.setTitle(getString(R.string.no_google_account));
+            gudBuilder.setMessage(getString(R.string.google_set_account));
+            gudBuilder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    finish();
+                }
+            });
+            gudBuilder.setCancelable(false);
+            return gudBuilder.create();
         }
         return null;
     }
@@ -307,12 +301,10 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         alertDialog.setTitle(getString(R.string.upload_results));
         alertDialog.setMessage(message);
         DialogInterface.OnClickListener quitListener = (dialog, i) -> {
-            switch (i) {
-                case DialogInterface.BUTTON1: // ok
-                    // always exit this activity since it has no interface
-                    alertShowing = false;
-                    finish();
-                    break;
+            if (i == DialogInterface.BUTTON1) { // ok
+                // always exit this activity since it has no interface
+                alertShowing = false;
+                finish();
             }
         };
         alertDialog.setCancelable(false);


### PR DESCRIPTION
Closes #3466

#### What has been done to verify that this works as intended?
I tested uploading forms to GS.

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue so I'm not sure what is the real cause but at least we can avoid it what I did in the [second commit](https://github.com/opendatakit/collect/commit/90728bf7c1586cfb8d9036147f3021fca1a4730d).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The implemented changes are only related to uploading forms to GS so please just test that functionality.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)