### PR TITLE
Fixed logging to server

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -56,7 +56,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
         return client;
     }
 
-    private boolean credentialsHaveChanged(@Nullable HttpCredentialsInterface credentials) {
+    public boolean credentialsHaveChanged(@Nullable HttpCredentialsInterface credentials) {
         return lastCredentials != null && !lastCredentials.equals(credentials)
                 || lastCredentials == null && credentials != null;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/http/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -57,7 +57,8 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
     }
 
     private boolean credentialsHaveChanged(@Nullable HttpCredentialsInterface credentials) {
-        return lastCredentials != null && !lastCredentials.equals(credentials);
+        return lastCredentials != null && !lastCredentials.equals(credentials)
+                || lastCredentials == null && credentials != null;
     }
 
     @NonNull

--- a/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/OkHttpOpenRosaServerClientProviderTest.java
@@ -1,10 +1,15 @@
 package org.odk.collect.android.http;
 
+import org.junit.Test;
+import org.odk.collect.android.http.openrosa.HttpCredentials;
 import org.odk.collect.android.http.openrosa.okhttp.OkHttpOpenRosaServerClientProvider;
 import org.odk.collect.android.http.openrosa.OpenRosaServerClientProvider;
 
 import okhttp3.OkHttpClient;
 import okhttp3.tls.internal.TlsUtil;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClientProviderTest {
 
@@ -17,5 +22,19 @@ public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClient
                 .build();
         
         return new OkHttpOpenRosaServerClientProvider(baseClient);
+    }
+
+    @Test
+    public void credentialsHaveChangedTest() {
+        OkHttpOpenRosaServerClientProvider clientProvider = (OkHttpOpenRosaServerClientProvider) buildSubject();
+        HttpCredentials newCredentials = new HttpCredentials("Admin", "Admin");
+
+        assertFalse(clientProvider.credentialsHaveChanged(null));
+        assertTrue(clientProvider.credentialsHaveChanged(newCredentials));
+
+        clientProvider.get("https", "Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.093) org.odk.collect.android/v1.23.3-127-g2e2b1ac76", newCredentials);
+
+        assertTrue(clientProvider.credentialsHaveChanged(null));
+        assertFalse(clientProvider.credentialsHaveChanged(newCredentials));
     }
 }


### PR DESCRIPTION
Closes #3465 

#### What has been done to verify that this works as intended?
I reproduced the issue and confirmed the pr fixes it. Additionally I added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
The `credentialsHaveChanged()` method was just broken. If `lastCredentials` was null it returned false not checking the new credentials.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with submission url.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)