### PR TITLE
Add track-changes-reason support

### DIFF
--- a/collect_app/src/androidTest/assets/forms/no-track-changes-reason.xml
+++ b/collect_app/src/androidTest/assets/forms/no-track-changes-reason.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<h:html xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.w3.org/2002/xforms">
+    <h:head>
+        <h:title>Normal Form</h:title>
+        <model>
+            <instance>
+                <data id="normal-form">
+                    <what_up />
+                    <meta>
+                        <audit />
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/what_up" type="string" />
+            <bind nodeset="/data/meta/instanceID" readonly="true()" type="string"
+                jr:preload="uid" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/what_up">
+            <label>What up?</label>
+        </input>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/assets/forms/track-changes-reason-on-edit.xml
+++ b/collect_app/src/androidTest/assets/forms/track-changes-reason-on-edit.xml
@@ -16,6 +16,7 @@
                 </data>
             </instance>
             <bind nodeset="/data/what_up" type="string" />
+            <bind nodeset="/data/meta/audit" type="binary" odk:track-changes="true" />
             <bind nodeset="/data/meta/audit" type="binary" odk:track-changes-reason="on-form-edit" />
             <bind nodeset="/data/meta/instanceID" readonly="true()" type="string"
                 jr:preload="uid" />

--- a/collect_app/src/androidTest/assets/forms/track-changes-reason-on-edit.xml
+++ b/collect_app/src/androidTest/assets/forms/track-changes-reason-on-edit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<h:html xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.w3.org/2002/xforms">
+    <h:head>
+        <h:title>Track Changes Reason</h:title>
+        <model>
+            <instance>
+                <data id="track-changes-reason">
+                    <what_up />
+                    <meta>
+                        <audit />
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/what_up" type="string" />
+            <bind nodeset="/data/meta/audit" type="binary" odk:track-changes-reason="on-form-edit" />
+            <bind nodeset="/data/meta/instanceID" readonly="true()" type="string"
+                jr:preload="uid" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/what_up">
+            <label>What up?</label>
+        </input>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/assets/forms/track-changes-reason-on-edit.xml
+++ b/collect_app/src/androidTest/assets/forms/track-changes-reason-on-edit.xml
@@ -17,7 +17,7 @@
             </instance>
             <bind nodeset="/data/what_up" type="string" />
             <bind nodeset="/data/meta/audit" type="binary" odk:track-changes="true" />
-            <bind nodeset="/data/meta/audit" type="binary" odk:track-changes-reason="on-form-edit" />
+            <bind nodeset="/data/meta/audit" type="binary" odk:track-changes-reasons="on-form-edit" />
             <bind nodeset="/data/meta/instanceID" readonly="true()" type="string"
                 jr:preload="uid" />
         </model>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
@@ -12,11 +12,11 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 
-class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
+public class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
 
     private final String formName;
 
-    ChangesReasonPromptPage(String formName, ActivityTestRule rule) {
+    public ChangesReasonPromptPage(String formName, ActivityTestRule rule) {
         super(rule);
         this.formName = formName;
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
@@ -5,9 +5,11 @@ import androidx.test.rule.ActivityTestRule;
 import org.odk.collect.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
@@ -26,5 +28,20 @@ public class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
         onView(allOf(withText(formName), isDescendantOfA(withId(R.id.toolbar)))).check(matches(isDisplayed()));
         onView(withText(getTranslatedString(R.string.reason_for_changes))).check(matches(isDisplayed()));
         return this;
+    }
+
+    public ChangesReasonPromptPage enterReason(String reason) {
+        onView(withHint(getTranslatedString(R.string.reason))).perform(replaceText(reason));
+        return this;
+    }
+
+    public MainMenuPage clickSave() {
+        clickOnString(R.string.save);
+        return new MainMenuPage(rule).assertOnPage();
+    }
+
+    public ChangesReasonPromptPage clickSaveWithValidationError() {
+        clickOnString(R.string.save);
+        return this.assertOnPage();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
@@ -5,10 +5,12 @@ import androidx.test.rule.ActivityTestRule;
 import org.odk.collect.android.R;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withHint;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -38,6 +40,11 @@ public class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
     public MainMenuPage clickSave() {
         clickOnString(R.string.save);
         return new MainMenuPage(rule).assertOnPage();
+    }
+
+    public <D extends Page<D>> D pressClose(D destination) {
+        onView(withContentDescription(getTranslatedString(R.string.close))).perform(click());
+        return destination.assertOnPage();
     }
 
     public ChangesReasonPromptPage clickSaveWithValidationError() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/ChangesReasonPromptPage.java
@@ -1,0 +1,30 @@
+package org.odk.collect.android.espressoutils.pages;
+
+import androidx.test.rule.ActivityTestRule;
+
+import org.odk.collect.android.R;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
+
+    private final String formName;
+
+    ChangesReasonPromptPage(String formName, ActivityTestRule rule) {
+        super(rule);
+        this.formName = formName;
+    }
+
+    @Override
+    public ChangesReasonPromptPage assertOnPage() {
+        onView(allOf(withText(formName), isDescendantOfA(withId(R.id.toolbar)))).check(matches(isDisplayed()));
+        onView(withText(getTranslatedString(R.string.reason_for_changes))).check(matches(isDisplayed()));
+        return this;
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/EditSavedFormPage.java
@@ -63,16 +63,16 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
     }
 
     public IdentifyUserPromptPage clickOnFormWithIdentityPrompt(String formName) {
-        clickOnFormButton(formName);
+        scrollToAndClickOnForm(formName);
         return new IdentifyUserPromptPage(formName, rule).assertOnPage();
     }
 
     public FormEntryPage clickOnForm(String formName) {
-        clickOnFormButton(formName);
+        scrollToAndClickOnForm(formName);
         return new FormEntryPage(formName, rule);
     }
 
-    private void clickOnFormButton(String formName) {
+    private void scrollToAndClickOnForm(String formName) {
         onView(withText(formName)).perform(scrollTo(), click());
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/EditSavedFormPage.java
@@ -26,6 +26,7 @@ import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
@@ -56,13 +57,22 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
         return this;
     }
 
-    public OkDialog clickSavedFormWithDialog(String instanceName) {
-        onView(withText(instanceName)).perform(click());
+    public OkDialog clickOnFormWithDialog(String instanceName) {
+        clickOnForm(instanceName);
         return new OkDialog(rule).assertOnPage();
     }
 
     public IdentifyUserPromptPage clickOnFormWithIdentityPrompt(String formName) {
-        onView(withText(formName)).perform(click());
+        clickOnFormButton(formName);
         return new IdentifyUserPromptPage(formName, rule).assertOnPage();
+    }
+
+    public FormEntryPage clickOnForm(String formName) {
+        clickOnFormButton(formName);
+        return new FormEntryPage(formName, rule);
+    }
+
+    private void clickOnFormButton(String formName) {
+        onView(withText(formName)).perform(scrollTo(), click());
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/FormEntryPage.java
@@ -151,7 +151,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage clickJumpStartButton() {
+    public FormEntryPage clickGoToStart() {
         onView(withId(R.id.jumpBeginningButton)).perform(click());
         return this;
     }
@@ -186,4 +186,8 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    public ChangesReasonPromptPage clickSaveAndExitWithChangesReasonPrompt() {
+        onView(withId(R.id.save_exit_button)).perform(click());
+        return new ChangesReasonPromptPage(formName, rule).assertOnPage();
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/FormEntryPage.java
@@ -190,4 +190,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
         onView(withId(R.id.save_exit_button)).perform(click());
         return new ChangesReasonPromptPage(formName, rule).assertOnPage();
     }
+
+    public ChangesReasonPromptPage clickSaveWithChangesReasonPrompt() {
+        onView(withId(R.id.menu_save)).perform(click());
+        return new ChangesReasonPromptPage(formName, rule).assertOnPage();
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/Page.java
@@ -1,10 +1,15 @@
 package org.odk.collect.android.espressoutils.pages;
 
+import android.app.Activity;
+
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.core.internal.deps.guava.collect.Iterables;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
 
 import org.odk.collect.android.support.actions.RotateAction;
 
@@ -25,6 +30,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.StringContains.containsString;
@@ -72,7 +78,7 @@ abstract class Page<T extends Page<T>> {
         return (T) this;
     }
 
-    public T checkIsTranslationDisplayed(String...  text) {
+    public T checkIsTranslationDisplayed(String... text) {
         for (String s : text) {
             try {
                 onView(withText(s)).check(matches(isDisplayed()));
@@ -104,7 +110,7 @@ abstract class Page<T extends Page<T>> {
 
     public T checkIsToastWithMessageDisplayed(String message) {
         onView(withText(message))
-                .inRoot(withDecorView(not(is(rule.getActivity().getWindow().getDecorView()))))
+                .inRoot(withDecorView(not(is(getCurrentActivity().getWindow().getDecorView()))))
                 .check(matches(isDisplayed()));
 
         return (T) this;
@@ -141,7 +147,7 @@ abstract class Page<T extends Page<T>> {
     }
 
     String getTranslatedString(Integer id) {
-        return rule.getActivity().getString(id);
+        return getCurrentActivity().getString(id);
     }
 
     public T clickOnAreaWithIndex(String clazz, int index) {
@@ -179,7 +185,7 @@ abstract class Page<T extends Page<T>> {
         return (T) this;
     }
 
-    public  <D extends Page<D>> D rotateToLandscape(D destination) {
+    public <D extends Page<D>> D rotateToLandscape(D destination) {
         onView(isRoot()).perform(rotateToLandscape());
         waitForRotationToEnd();
 
@@ -198,6 +204,18 @@ abstract class Page<T extends Page<T>> {
         }
 
         return (T) this;
+    }
+
+    private static Activity getCurrentActivity() {
+        getInstrumentation().waitForIdleSync();
+
+        final Activity[] activity = new Activity[1];
+        getInstrumentation().runOnMainSync(() -> {
+            java.util.Collection<Activity> activities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED);
+            activity[0] = Iterables.getOnlyElement(activities);
+        });
+
+        return activity[0];
     }
 }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/SaveOrIgnoreDialog.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/SaveOrIgnoreDialog.java
@@ -24,11 +24,11 @@ public class SaveOrIgnoreDialog<D extends Page<D>> extends Page<SaveOrIgnoreDial
 
     public D clickSaveChanges() {
         clickOnString(R.string.keep_changes);
-        return destination;
+        return destination.assertOnPage();
     }
 
     public D clickIgnoreChanges() {
         clickOnString(R.string.do_not_save);
-        return destination;
+        return destination.assertOnPage();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/EncryptedFormTest.java
@@ -55,7 +55,7 @@ public class EncryptedFormTest {
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok)
                 .clickEditSavedForm()
                 .checkInstanceState("encrypted", InstanceProviderAPI.STATUS_COMPLETE)
-                .clickSavedFormWithDialog("encrypted")
+                .clickOnFormWithDialog("encrypted")
                 .checkMessage(R.string.cannot_edit_completed_form);
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormHierarchyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormHierarchyTest.java
@@ -85,7 +85,7 @@ public class FormHierarchyTest extends BaseRegressionTest {
                 .atPositionOnView(1, R.id.primary_text))
                 .check(matches(withText("Guest details > 2")));
 
-        page.clickJumpStartButton()
+        page.clickGoToStart()
                 .inputText("1")
                 .clickGoToArrow()
                 .clickOnText("Guest details");

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormNavigationButtonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FormNavigationButtonTest.java
@@ -102,7 +102,7 @@ public class FormNavigationButtonTest {
     }
 
     @Test
-    public void onlyNextButton_ShouldShowOnFirstScreen() {
+    public void onFirstScreen_onlyShowsNextButton() {
         GeneralSharedPreferences.getInstance().save(GeneralKeys.KEY_NAVIGATION, GeneralKeys.NAVIGATION_BUTTONS);
         AdminSharedPreferences.getInstance().save(AdminKeys.KEY_MOVING_BACKWARDS, true);
         activityTestRule.getActivity().runOnUiThread(() -> activityTestRule.getActivity().recreate());

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -174,6 +174,20 @@ public class TrackChangesReasonTest {
     }
 
     @Test
+    public void openingFormToEdit_andChangingValue_andClickingSave_promptsForReason() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .clickSaveWithChangesReasonPrompt();
+    }
+
+    @Test
     public void whenFormDoesNotHaveTrackChangesReason_openingToEdit_andChangingAValue_andClickingSaveAndExit_returnsToMainMenu() {
         new MainMenuPage(rule)
                 .startBlankForm("Normal Form")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -68,6 +68,22 @@ public class TrackChangesReasonTest {
     }
 
     @Test
+    public void openingAFormToEdit_andChangingAValue_andPressingBack_andIgnoringChanges_returnsToMainMenu() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .closeSoftKeyboard()
+                .pressBack(new SaveOrIgnoreDialog<>("Track Changes Reason", new MainMenuPage(rule), rule))
+                .clickIgnoreChanges();
+    }
+
+    @Test
     public void whenFormDoesNotHaveTrackChangesReason_openingToEdit_andChangingAValue_andClickingSaveAndExit_returnsToMainMenu() {
         new MainMenuPage(rule)
                 .startBlankForm("Normal Form")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -159,6 +159,21 @@ public class TrackChangesReasonTest {
     }
 
     @Test
+    public void openingAFormToEdit_andNotChangingAValue_andClickingSaveAndExit_returnsToMainMenu() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .closeSoftKeyboard()
+                .swipeToNextQuestion()
+                .clickSaveAndExit();
+    }
+
+    @Test
     public void whenFormDoesNotHaveTrackChangesReason_openingToEdit_andChangingAValue_andClickingSaveAndExit_returnsToMainMenu() {
         new MainMenuPage(rule)
                 .startBlankForm("Normal Form")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -91,7 +91,7 @@ public class TrackChangesReasonTest {
     }
 
     @Test
-    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andCross_returnsToForm() {
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andClickingCross_returnsToForm() {
         new MainMenuPage(rule)
                 .startBlankForm("Track Changes Reason")
                 .inputText("Nothing much...")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -10,8 +10,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
 import org.odk.collect.android.espressoutils.pages.ChangesReasonPromptPage;
+import org.odk.collect.android.espressoutils.pages.FormEntryPage;
 import org.odk.collect.android.espressoutils.pages.MainMenuPage;
 import org.odk.collect.android.espressoutils.pages.SaveOrIgnoreDialog;
 import org.odk.collect.android.support.CopyFormRule;
@@ -68,6 +70,42 @@ public class TrackChangesReasonTest {
                 .clickSaveAndExitWithChangesReasonPrompt()
                 .enterReason(" ")
                 .clickSaveWithValidationError();
+    }
+
+    @Test
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andPressingBack_returnsToForm() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .swipeToNextQuestion()
+                .clickSaveAndExitWithChangesReasonPrompt()
+                .closeSoftKeyboard()
+                .pressBack(new FormEntryPage("Track Changes Reason", rule))
+                .checkIsStringDisplayed(R.string.save_form_as);
+    }
+
+    @Test
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andCross_returnsToForm() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .swipeToNextQuestion()
+                .clickSaveAndExitWithChangesReasonPrompt()
+                .closeSoftKeyboard()
+                .pressClose(new FormEntryPage("Track Changes Reason", rule))
+                .checkIsStringDisplayed(R.string.save_form_as);
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -109,6 +109,24 @@ public class TrackChangesReasonTest {
     }
 
     @Test
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andRotating_remainsOnPrompt() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .swipeToNextQuestion()
+                .clickSaveAndExitWithChangesReasonPrompt()
+                .enterReason("Something")
+                .rotateToLandscape(new ChangesReasonPromptPage("Track Changes Reason", rule))
+                .checkIsTextDisplayed("Something");
+    }
+
+    @Test
     public void openingAFormToEdit_andChangingAValue_andPressingBack_andClickingSaveChanges_promptsForReason() {
         new MainMenuPage(rule)
                 .startBlankForm("Track Changes Reason")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -11,7 +11,9 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.espressoutils.pages.ChangesReasonPromptPage;
 import org.odk.collect.android.espressoutils.pages.MainMenuPage;
+import org.odk.collect.android.espressoutils.pages.SaveOrIgnoreDialog;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
 
@@ -47,6 +49,22 @@ public class TrackChangesReasonTest {
                 .inputText("Nothing much!")
                 .swipeToNextQuestion()
                 .clickSaveAndExitWithChangesReasonPrompt();
+    }
+
+    @Test
+    public void openingAFormToEdit_andChangingAValue_andPressingBack_andClickingSaveChanges_promptsForReason() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .closeSoftKeyboard()
+                .pressBack(new SaveOrIgnoreDialog<>("Track Changes Reason", new ChangesReasonPromptPage("Track Changes Reason", rule), rule))
+                .clickSaveChanges();
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -37,7 +37,7 @@ public class TrackChangesReasonTest {
             .around(new CopyFormRule(NO_TRACK_CHANGES_REASON_FORM));
 
     @Test
-    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_promptsForReason() {
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andEnteringReason_andClickingSave_returnsToMainMenu() {
         new MainMenuPage(rule)
                 .startBlankForm("Track Changes Reason")
                 .inputText("Nothing much...")
@@ -48,7 +48,26 @@ public class TrackChangesReasonTest {
                 .clickGoToStart()
                 .inputText("Nothing much!")
                 .swipeToNextQuestion()
-                .clickSaveAndExitWithChangesReasonPrompt();
+                .clickSaveAndExitWithChangesReasonPrompt()
+                .enterReason("Needed to be more exciting and less mysterious")
+                .clickSave();
+    }
+
+    @Test
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andEnteringBlankReason_andClickingSave_remainsOnPrompt() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .swipeToNextQuestion()
+                .clickSaveAndExitWithChangesReasonPrompt()
+                .enterReason(" ")
+                .clickSaveWithValidationError();
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -1,0 +1,66 @@
+package org.odk.collect.android.formentry.audit;
+
+import android.Manifest;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.espressoutils.pages.MainMenuPage;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+
+@RunWith(AndroidJUnit4.class)
+public class TrackChangesReasonTest {
+
+    private static final String TRACK_CHANGES_REASON_ON_EDIT_FORM = "track-changes-reason-on-edit.xml";
+    private static final String NO_TRACK_CHANGES_REASON_FORM = "no-track-changes-reason.xml";
+
+    @Rule
+    public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ))
+            .around(new ResetStateRule())
+            .around(new CopyFormRule(TRACK_CHANGES_REASON_ON_EDIT_FORM))
+            .around(new CopyFormRule(NO_TRACK_CHANGES_REASON_FORM));
+
+    @Test
+    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_promptsForReason() {
+        new MainMenuPage(rule)
+                .startBlankForm("Track Changes Reason")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Track Changes Reason")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .swipeToNextQuestion()
+                .clickSaveAndExitWithChangesReasonPrompt();
+    }
+
+    @Test
+    public void whenFormDoesNotHaveTrackChangesReason_openingToEdit_andChangingAValue_andClickingSaveAndExit_returnsToMainMenu() {
+        new MainMenuPage(rule)
+                .startBlankForm("Normal Form")
+                .inputText("Nothing much...")
+                .swipeToNextQuestion()
+                .clickSaveAndExit()
+                .clickEditSavedForm()
+                .clickOnForm("Normal Form")
+                .clickGoToStart()
+                .inputText("Nothing much!")
+                .swipeToNextQuestion()
+                .clickSaveAndExit();
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -418,6 +418,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         });
 
         changesReasonPromptViewModel = ViewModelProviders.of(this).get(ChangesReasonPromptViewModel.class);
+
         changesReasonPromptViewModel.requiresReasonToContinue().observe(this, requiresReason -> {
             if (requiresReason) {
                 FragmentManager fragmentManager = getSupportFragmentManager();
@@ -483,6 +484,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         } else if (data == null) {
             if (!newForm) {
                 if (getFormController(true) != null) {
+                    FormController formController = getFormController();
+                    identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                    changesReasonPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
                     refreshCurrentView();
                 } else {
                     Timber.w("Reloading form and restoring state.");

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1202,7 +1202,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         if (event != FormEntryController.EVENT_QUESTION) {
             formController.getAuditEventLogger().logEvent(AuditEvent.getAuditEventTypeFromFecType(event),
-                    formController.getFormIndex(), true, null, System.currentTimeMillis());
+                    formController.getFormIndex(), true, null, System.currentTimeMillis(), null);
         }
 
         switch (event) {
@@ -1218,7 +1218,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     FormEntryPrompt[] prompts = formController.getQuestionPrompts();
                     for (FormEntryPrompt question : prompts) {
                         String answer = question.getAnswerValue() != null ? question.getAnswerValue().getDisplayText() : null;
-                        formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.QUESTION, question.getIndex(), true, answer, System.currentTimeMillis());
+                        formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.QUESTION, question.getIndex(), true, answer, System.currentTimeMillis(), null);
                     }
                     FormEntryCaption[] groups = formController
                             .getGroupsForCurrentIndex();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -424,10 +424,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         changesReasonPromptViewModel.requiresReasonToContinue().observe(this, requiresReason -> {
             if (requiresReason) {
-                ChangesReasonPromptDialogFragment.show(
+                new ChangesReasonPromptDialogFragment().show(
                         getFormController().getFormTitle(),
-                        getSupportFragmentManager(),
-                        changesReasonViewModelFactory
+                        getSupportFragmentManager()
                 );
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1924,7 +1924,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 IconMenuItem item = (IconMenuItem) adapter.getItem(position);
                 if (item.getTextResId() == R.string.keep_changes) {
-                    saveDataToDisk(EXIT, InstancesDaoHelper.isInstanceComplete(false), null);
+                    changesReasonPromptViewModel.savingForm();
+                    changesReasonPromptViewModel.requiresReasonToContinue().observe(FormEntryActivity.this, requiresReason -> {
+                        if (!requiresReason) {
+                            saveDataToDisk(EXIT, InstancesDaoHelper.isInstanceComplete(false), null);
+                        }
+                    });
                 } else {
                     // close all open databases of external data.
                     ExternalDataManager manager = Collect.getInstance().getExternalDataManager();
@@ -2450,11 +2455,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     runOnUiThread(() -> ToastUtils.showLongToast(R.string.savepoint_used));
                 }
 
-                identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
                 changesReasonPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
 
                 if (formController.getInstanceFile() == null) {
                     createInstanceDirectory(formController);
+                    identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
                     identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                         if (!requiresIdentity) {
                             formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_START, true, System.currentTimeMillis());
@@ -2469,6 +2474,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             // we've just loaded a saved form, so start in the hierarchy view
                             String formMode = reqIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
                             if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
+                                identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
                                 identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                                     if (!requiresIdentity) {
                                         if (!allowMovingBackwards) {
@@ -2499,6 +2505,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                                 finish();
                             }
                     } else {
+                        identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
                         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                             if (!requiresIdentity) {
                                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_RESUME, true, System.currentTimeMillis());

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -430,9 +430,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 );
             }
         });
-        changesReasonPromptViewModel.saveRequests().observe(this, saveDetails -> {
-            if (saveDetails != null) {
-                save(saveDetails.first, saveDetails.second);
+        changesReasonPromptViewModel.saveRequests().observe(this, saveRequest -> {
+            if (saveRequest != null) {
+                save(saveRequest.isComplete(), saveRequest.getUpdatedSaveName(), saveRequest.isExitAfter());
             }
         });
     }
@@ -1881,24 +1881,14 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         }
 
-        if (exit) {
-            getFormController().getAuditEventLogger().exitView();
-            changesReasonPromptViewModel.saveForm(complete, updatedSaveName);
-        } else {
-            saveToDiskTask = new SaveToDiskTask(getIntent().getData(), false, complete,
-                    updatedSaveName);
-            saveToDiskTask.setFormSavedListener(this);
-            autoSaved = true;
-            showDialog(SAVING_DIALOG);
-            // show dialog before we execute...
-            saveToDiskTask.execute();
-        }
+        getFormController().getAuditEventLogger().exitView();
+        changesReasonPromptViewModel.saveForm(complete, updatedSaveName, exit);
 
         return true;
     }
 
-    private void save(boolean complete, String updatedSaveName) {
-        saveToDiskTask = new SaveToDiskTask(getIntent().getData(), true, complete,
+    private void save(boolean complete, String updatedSaveName, boolean exitAfter) {
+        saveToDiskTask = new SaveToDiskTask(getIntent().getData(), exitAfter, complete,
                 updatedSaveName);
         saveToDiskTask.setFormSavedListener(this);
         autoSaved = true;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -430,6 +430,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 );
             }
         });
+        changesReasonPromptViewModel.saveRequests().observe(this, saveDetails -> {
+            if (saveDetails != null) {
+                save(saveDetails.first, saveDetails.second);
+            }
+        });
     }
 
     private void setupFields(Bundle savedInstanceState) {
@@ -1878,18 +1883,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         if (exit) {
             getFormController().getAuditEventLogger().exitView();
-            changesReasonPromptViewModel.savingForm();
-            changesReasonPromptViewModel.readyToSave().observe(this, readyToSave -> {
-                if (readyToSave) {
-                    saveToDiskTask = new SaveToDiskTask(getIntent().getData(), true, complete,
-                            updatedSaveName);
-                    saveToDiskTask.setFormSavedListener(this);
-                    autoSaved = true;
-                    showDialog(SAVING_DIALOG);
-                    // show dialog before we execute...
-                    saveToDiskTask.execute();
-                }
-            });
+            changesReasonPromptViewModel.saveForm(complete, updatedSaveName);
         } else {
             saveToDiskTask = new SaveToDiskTask(getIntent().getData(), false, complete,
                     updatedSaveName);
@@ -1901,6 +1895,16 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
 
         return true;
+    }
+
+    private void save(boolean complete, String updatedSaveName) {
+        saveToDiskTask = new SaveToDiskTask(getIntent().getData(), true, complete,
+                updatedSaveName);
+        saveToDiskTask.setFormSavedListener(this);
+        autoSaved = true;
+        showDialog(SAVING_DIALOG);
+        // show dialog before we execute...
+        saveToDiskTask.execute();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1879,8 +1879,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         if (exit) {
             getFormController().getAuditEventLogger().exitView();
             changesReasonPromptViewModel.savingForm();
-            changesReasonPromptViewModel.requiresReasonToContinue().observe(this, requiresReason -> {
-                if (!requiresReason) {
+            changesReasonPromptViewModel.readyToSave().observe(this, readyToSave -> {
+                if (readyToSave) {
                     saveToDiskTask = new SaveToDiskTask(getIntent().getData(), true, complete,
                             updatedSaveName);
                     saveToDiskTask.setFormSavedListener(this);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -417,13 +417,18 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         });
 
-        changesReasonPromptViewModel = ViewModelProviders.of(this).get(ChangesReasonPromptViewModel.class);
+        ChangesReasonPromptViewModel.Factory changesReasonViewModelFactory = new ChangesReasonPromptViewModel.Factory();
+        changesReasonPromptViewModel = ViewModelProviders
+                .of(this, changesReasonViewModelFactory)
+                .get(ChangesReasonPromptViewModel.class);
 
         changesReasonPromptViewModel.requiresReasonToContinue().observe(this, requiresReason -> {
             if (requiresReason) {
-                FragmentManager fragmentManager = getSupportFragmentManager();
-                ChangesReasonPromptDialogFragment dialog = ChangesReasonPromptDialogFragment.create(getFormController().getFormTitle());
-                dialog.show(fragmentManager.beginTransaction(), ChangesReasonPromptDialogFragment.TAG);
+                ChangesReasonPromptDialogFragment.show(
+                        getFormController().getFormTitle(),
+                        getSupportFragmentManager(),
+                        changesReasonViewModelFactory
+                );
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialog.java
@@ -23,12 +23,9 @@ public class QuitFormDialog {
     }
 
     public static AlertDialog show(Context context, FormController formController, Listener listener) {
-        String title;
-        {
-            title = (formController == null) ? null : formController.getFormTitle();
-            if (title == null) {
-                title = context.getString(R.string.no_form_loaded);
-            }
+        String title = (formController == null) ? null : formController.getFormTitle();
+        if (title == null) {
+            title = context.getString(R.string.no_form_loaded);
         }
 
         List<IconMenuItem> items;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialog.java
@@ -1,0 +1,72 @@
+package org.odk.collect.android.formentry;
+
+import android.content.Context;
+import android.widget.ListView;
+
+import androidx.appcompat.app.AlertDialog;
+
+import com.google.common.collect.ImmutableList;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.adapters.IconMenuListAdapter;
+import org.odk.collect.android.adapters.model.IconMenuItem;
+import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.preferences.AdminKeys;
+import org.odk.collect.android.preferences.AdminSharedPreferences;
+import org.odk.collect.android.utilities.DialogUtils;
+
+import java.util.List;
+
+public class QuitFormDialog {
+
+    private QuitFormDialog() {
+    }
+
+    public static AlertDialog show(Context context, FormController formController, Listener listener) {
+        String title;
+        {
+            title = (formController == null) ? null : formController.getFormTitle();
+            if (title == null) {
+                title = context.getString(R.string.no_form_loaded);
+            }
+        }
+
+        List<IconMenuItem> items;
+        if ((boolean) AdminSharedPreferences.getInstance().get(AdminKeys.KEY_SAVE_MID)) {
+            items = ImmutableList.of(new IconMenuItem(R.drawable.ic_save, R.string.keep_changes),
+                    new IconMenuItem(R.drawable.ic_delete, R.string.do_not_save));
+        } else {
+            items = ImmutableList.of(new IconMenuItem(R.drawable.ic_delete, R.string.do_not_save));
+        }
+
+        ListView listView = DialogUtils.createActionListView(context);
+
+        final IconMenuListAdapter adapter = new IconMenuListAdapter(context, items);
+        listView.setAdapter(adapter);
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            IconMenuItem item = (IconMenuItem) adapter.getItem(position);
+            if (item.getTextResId() == R.string.keep_changes) {
+                listener.onSaveChangedClicked();
+            } else {
+                listener.onIgnoreChangesClicked();
+            }
+        });
+
+        AlertDialog alertDialog = new AlertDialog.Builder(context)
+                .setTitle(
+                        context.getString(R.string.quit_application, title))
+                .setPositiveButton(context.getString(R.string.do_not_exit), (dialog, id) -> {
+                    dialog.cancel();
+                })
+                .setView(listView)
+                .create();
+        alertDialog.show();
+        return alertDialog;
+    }
+
+    public interface Listener {
+        void onSaveChangedClicked();
+
+        void onIgnoreChangesClicked();
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriter.java
@@ -14,18 +14,20 @@ public class AsyncTaskAuditEventWriter implements AuditEventLogger.AuditEventWri
     private final boolean isLocationEnabled;
     private final boolean isTrackingChangesEnabled;
     private final boolean isUserRequired;
+    private final boolean isTrackChangesReasonEnabled;
 
-    public AsyncTaskAuditEventWriter(@NonNull File file, boolean isLocationEnabled, boolean isTrackingChangesEnabled, boolean isUserRequired) {
+    public AsyncTaskAuditEventWriter(@NonNull File file, boolean isLocationEnabled, boolean isTrackingChangesEnabled, boolean isUserRequired, boolean isTrackChangesReasonEnabled) {
         this.file = file;
         this.isLocationEnabled = isLocationEnabled;
         this.isTrackingChangesEnabled = isTrackingChangesEnabled;
         this.isUserRequired = isUserRequired;
+        this.isTrackChangesReasonEnabled = isTrackChangesReasonEnabled;
     }
 
     @Override
     public void writeEvents(List<AuditEvent> auditEvents) {
         AuditEvent[] auditEventArray = auditEvents.toArray(new AuditEvent[0]);
-        saveTask = new AuditEventSaveTask(file, isLocationEnabled, isTrackingChangesEnabled, isUserRequired).execute(auditEventArray);
+        saveTask = new AuditEventSaveTask(file, isLocationEnabled, isTrackingChangesEnabled, isUserRequired, isTrackChangesReasonEnabled).execute(auditEventArray);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditConfig.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditConfig.java
@@ -112,4 +112,47 @@ public class AuditConfig {
     public boolean isTrackChangesReasonEnabled() {
         return isTrackChangesReasonEnabled;
     }
+
+    public static class Builder {
+        private String mode;
+        private String locationMinInterval;
+        private String locationMaxAge;
+        private boolean isTrackingChangesEnabled;
+        private boolean isIdentifyUserEnabled;
+        private boolean isTrackChangesReasonEnabled;
+
+        public Builder setMode(String mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder setLocationMinInterval(String locationMinInterval) {
+            this.locationMinInterval = locationMinInterval;
+            return this;
+        }
+
+        public Builder setLocationMaxAge(String locationMaxAge) {
+            this.locationMaxAge = locationMaxAge;
+            return this;
+        }
+
+        public Builder setIsTrackingChangesEnabled(boolean isTrackingChangesEnabled) {
+            this.isTrackingChangesEnabled = isTrackingChangesEnabled;
+            return this;
+        }
+
+        public Builder setIsIdentifyUserEnabled(boolean isIdentifyUserEnabled) {
+            this.isIdentifyUserEnabled = isIdentifyUserEnabled;
+            return this;
+        }
+
+        public Builder setIsTrackChangesReasonEnabled(boolean isTrackChangesReasonEnabled) {
+            this.isTrackChangesReasonEnabled = isTrackChangesReasonEnabled;
+            return this;
+        }
+
+        public AuditConfig createAuditConfig() {
+            return new AuditConfig(mode, locationMinInterval, locationMaxAge, isTrackingChangesEnabled, isIdentifyUserEnabled, isTrackChangesReasonEnabled);
+        }
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditConfig.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditConfig.java
@@ -52,13 +52,15 @@ public class AuditConfig {
     private final boolean isTrackingChangesEnabled;
 
     private final boolean isIdentifyUserEnabled;
+    private final boolean isTrackChangesReasonEnabled;
 
-    public AuditConfig(String mode, String locationMinInterval, String locationMaxAge, boolean isTrackingChangesEnabled, boolean isIdentifyUserEnabled) {
+    public AuditConfig(String mode, String locationMinInterval, String locationMaxAge, boolean isTrackingChangesEnabled, boolean isIdentifyUserEnabled, boolean isTrackChangesReasonEnabled) {
         this.locationPriority = mode != null ? getMode(mode) : null;
         this.locationMinInterval = locationMinInterval != null ? Long.parseLong(locationMinInterval) * 1000 : null;
         this.locationMaxAge = locationMaxAge != null ? Long.parseLong(locationMaxAge) * 1000 : null;
         this.isTrackingChangesEnabled = isTrackingChangesEnabled;
         this.isIdentifyUserEnabled = isIdentifyUserEnabled;
+        this.isTrackChangesReasonEnabled = isTrackChangesReasonEnabled;
     }
 
     private LocationClient.Priority getMode(@NonNull String mode) {
@@ -105,5 +107,9 @@ public class AuditConfig {
 
     public boolean isIdentifyUserEnabled() {
         return isIdentifyUserEnabled;
+    }
+
+    public boolean isTrackChangesReasonEnabled() {
+        return isTrackChangesReasonEnabled;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
@@ -262,7 +262,13 @@ public class AuditEvent {
         }
 
         if (isTrackingChangesReasonEnabled) {
-            string += String.format(",%s", changeReason != null ? changeReason : "");
+            if (changeReason != null && (changeReason.contains(",") || changeReason.contains("\n"))) {
+                string += String.format(",%s", getEscapedValueForCsv(changeReason));
+            } else if (changeReason != null) {
+                string += String.format(",%s", changeReason);
+            } else {
+                string += ",";
+            }
         }
 
         return string;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
@@ -213,14 +213,14 @@ public class AuditEvent {
         this.user = user;
     }
 
-    public void recordValueChange(String newValue) {
+    public boolean recordValueChange(String newValue) {
         this.newValue = newValue != null ? newValue : "";
 
         // Clear values if they are equal
         if (this.oldValue.equals(this.newValue)) {
             this.oldValue = "";
             this.newValue = "";
-            return;
+            return false;
         }
 
         if (oldValue.contains(",") || oldValue.contains("\n")) {
@@ -230,6 +230,8 @@ public class AuditEvent {
         if (this.newValue.contains(",") || this.newValue.contains("\n")) {
             this.newValue = getEscapedValueForCsv(this.newValue);
         }
+
+        return true;
     }
 
     public String getChangeReason() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
@@ -64,6 +64,8 @@ public class AuditEvent {
         // Delete a repeat group
         DELETE_REPEAT("delete repeat"),
 
+        CHANGE_REASON("change reason"),
+
         // Google Play Services are not available
         GOOGLE_PLAY_SERVICES_NOT_AVAILABLE("google play services not available", true, false, true),
         // Location permissions are granted
@@ -130,6 +132,8 @@ public class AuditEvent {
     @NonNull
     private String oldValue;
     private String user;
+    private final String changeReason;
+    private final boolean isTrackingChangesReasonEnabled;
     @NonNull
     private String newValue = "";
     private long end;
@@ -142,15 +146,15 @@ public class AuditEvent {
      * Create a new event
      */
     public AuditEvent(long start, AuditEventType auditEventType) {
-        this(start, auditEventType, false, false, null, null, null);
+        this(start, auditEventType, false, false, null, null, null, null, false);
     }
 
     public AuditEvent(long start, AuditEventType auditEventType, boolean isTrackingLocationsEnabled, boolean isTrackingChangesEnabled) {
-        this(start, auditEventType, isTrackingLocationsEnabled, isTrackingChangesEnabled, null, null, null);
+        this(start, auditEventType, isTrackingLocationsEnabled, isTrackingChangesEnabled, null, null, null, null, false);
     }
 
     public AuditEvent(long start, AuditEventType auditEventType, boolean isTrackingLocationsEnabled,
-                      boolean isTrackingChangesEnabled, FormIndex formIndex, String oldValue, String user) {
+                      boolean isTrackingChangesEnabled, FormIndex formIndex, String oldValue, String user, String changeReason, boolean isTrackingChangesReasonEnabled) {
         this.start = start;
         this.auditEventType = auditEventType;
         this.isTrackingLocationsEnabled = isTrackingLocationsEnabled;
@@ -158,6 +162,8 @@ public class AuditEvent {
         this.formIndex = formIndex;
         this.oldValue = oldValue == null ? "" : oldValue;
         this.user = user;
+        this.changeReason = changeReason;
+        this.isTrackingChangesReasonEnabled = isTrackingChangesReasonEnabled;
     }
 
     /**
@@ -226,6 +232,10 @@ public class AuditEvent {
         }
     }
 
+    public String getChangeReason() {
+        return changeReason;
+    }
+
     /*
      * convert the event into a record to write to the CSV file
      */
@@ -249,6 +259,10 @@ public class AuditEvent {
             } else {
                 string += String.format(",%s", user);
             }
+        }
+
+        if (isTrackingChangesReasonEnabled) {
+            string += String.format(",%s", changeReason != null ? changeReason : "");
         }
 
         return string;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventCSVLine.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventCSVLine.java
@@ -1,0 +1,100 @@
+package org.odk.collect.android.formentry.audit;
+
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.instance.TreeReference;
+import org.odk.collect.android.utilities.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.CSVUtils.getEscapedValueForCsv;
+
+public class AuditEventCSVLine {
+
+    private AuditEventCSVLine() {
+
+    }
+
+    public static String toCSVLine(AuditEvent auditEvent, boolean isTrackingLocationsEnabled, boolean isTrackingChangesEnabled, boolean isTrackingChangesReasonEnabled) {
+        FormIndex formIndex = auditEvent.getFormIndex();
+        AuditEvent.AuditEventType auditEventType = auditEvent.getAuditEventType();
+        long start = auditEvent.getStart();
+        long end = auditEvent.getEnd();
+        String latitude = auditEvent.getLatitude();
+        String longitude = auditEvent.getLongitude();
+        String accuracy = auditEvent.getAccuracy();
+        String oldValue = auditEvent.getOldValue();
+        String newValue = auditEvent.getNewValue();
+        String user = auditEvent.getUser();
+        String changeReason = auditEvent.getChangeReason();
+
+        String node = formIndex == null || formIndex.getReference() == null ? "" : getXPathPath(formIndex);
+
+        String string = String.format("%s,%s,%s,%s", auditEventType.getValue(), node, start, end != 0 ? end : "");
+
+        if (isTrackingLocationsEnabled) {
+            string += String.format(",%s,%s,%s", latitude, longitude, accuracy);
+        }
+
+        if (isTrackingChangesEnabled) {
+            string += String.format(",%s,%s", oldValue, newValue);
+        }
+
+        if (user != null) {
+            if (user.contains(",") || user.contains("\n")) {
+                string += String.format(",%s", getEscapedValueForCsv(user));
+            } else {
+                string += String.format(",%s", user);
+            }
+        }
+
+        if (isTrackingChangesReasonEnabled) {
+            if (changeReason != null && (changeReason.contains(",") || changeReason.contains("\n"))) {
+                string += String.format(",%s", getEscapedValueForCsv(changeReason));
+            } else if (changeReason != null) {
+                string += String.format(",%s", changeReason);
+            } else {
+                string += ",";
+            }
+        }
+
+        return string;
+    }
+
+    /**
+     * Get the XPath path of the node at a particular {@link FormIndex}.
+     * <p>
+     * Differs from {@link TreeReference#toString()} in that position predicates are only
+     * included for repeats. For example, given a group named {@code my-group} that contains a
+     * repeat named {@code my-repeat} which in turn contains a question named {@code my-question},
+     * {@link TreeReference#toString()} would return paths that look like
+     * {@code /my-group[1]/my-repeat[3]/my-question[1]}. In contrast, this method would return
+     * {@code /my-group/my-repeat[3]/my-question}.
+     * <p>
+     * TODO: consider moving to {@link FormIndex}
+     */
+    private static String getXPathPath(FormIndex formIndex) {
+        List<String> nodeNames = new ArrayList<>();
+        nodeNames.add(formIndex.getReference().getName(0));
+
+        FormIndex walker = formIndex;
+        int i = 1;
+        while (walker != null) {
+            try {
+                String currentNodeName = formIndex.getReference().getName(i);
+                if (walker.getInstanceIndex() != -1) {
+                    currentNodeName = currentNodeName + "[" + (walker.getInstanceIndex() + 1) + "]";
+                }
+                nodeNames.add(currentNodeName);
+            } catch (IndexOutOfBoundsException e) {
+                Timber.i(e);
+            }
+
+            walker = walker.getNextLevel();
+            i++;
+        }
+        return "/" + StringUtils.join("/", nodeNames);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -39,6 +39,7 @@ public class AuditEventLogger {
     private final AuditConfig auditConfig;
     private final FormController formController;
     private String user;
+    private boolean changesMade;
 
     public AuditEventLogger(AuditConfig auditConfig, AuditEventWriter writer, FormController formController) {
         this.auditConfig = auditConfig;
@@ -84,7 +85,7 @@ public class AuditEventLogger {
          * Close any existing interval events if the view is being exited
          */
         if (eventType == AuditEvent.AuditEventType.FORM_EXIT) {
-            manageSavedEvents();
+            finalizeEvents();
         }
 
         auditEvents.add(newAuditEvent);
@@ -107,7 +108,11 @@ public class AuditEventLogger {
 
     private void addNewValueToQuestionAuditEvent(AuditEvent aev, FormController formController) {
         IAnswerData answerData = formController.getQuestionPrompt(aev.getFormIndex()).getAnswerValue();
-        aev.recordValueChange(answerData != null ? answerData.getDisplayText() : null);
+        boolean valueChanged = aev.recordValueChange(answerData != null ? answerData.getDisplayText() : null);
+
+        if (valueChanged) {
+            this.changesMade = true;
+        }
     }
 
     // If location provider are enabled/disabled it sometimes fires the BroadcastReceiver multiple
@@ -140,13 +145,13 @@ public class AuditEventLogger {
      */
     public void exitView() {
         if (isAuditEnabled()) {
-            manageSavedEvents();
+            finalizeEvents();
             writeEvents();
         }
     }
 
     // Filter all events and set final parameters of interval events
-    private void manageSavedEvents() {
+    private void finalizeEvents() {
         // Calculate the time and add the event to the auditEvents array
         long end = getEventTime();
         ArrayList<AuditEvent> filteredAuditEvents = new ArrayList<>();
@@ -281,6 +286,10 @@ public class AuditEventLogger {
 
     public boolean isChangeReasonRequired() {
         return auditConfig != null && auditConfig.isTrackChangesReasonEnabled();
+    }
+
+    public boolean isChangesMade() {
+        return changesMade;
     }
 
     public interface AuditEventWriter {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -65,13 +65,11 @@ public class AuditEventLogger {
         AuditEvent newAuditEvent = new AuditEvent(
                 getEventTime(),
                 eventType,
-                auditConfig.isLocationEnabled(),
-                auditConfig.isTrackingChangesEnabled(),
                 formIndex,
                 questionAnswer,
                 user,
-                changeReason,
-                true);
+                changeReason
+        );
 
         if (isDuplicatedIntervalEvent(newAuditEvent)) {
             return;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -278,6 +278,10 @@ public class AuditEventLogger {
         return user;
     }
 
+    public boolean isChangeReasonRequired() {
+        return auditConfig != null && auditConfig.isTrackChangesReasonEnabled();
+    }
+
     public interface AuditEventWriter {
 
         void writeEvents(List<AuditEvent> auditEvents);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -40,6 +40,7 @@ public class AuditEventLogger {
     private final FormController formController;
     private String user;
     private boolean changesMade;
+    private boolean editing;
 
     public AuditEventLogger(AuditConfig auditConfig, AuditEventWriter writer, FormController formController) {
         this.auditConfig = auditConfig;
@@ -288,6 +289,14 @@ public class AuditEventLogger {
 
     public boolean isChangesMade() {
         return changesMade;
+    }
+
+    public void setEditing(boolean editing) {
+        this.editing = editing;
+    }
+
+    public boolean isEditing() {
+        return editing;
     }
 
     public interface AuditEventWriter {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -47,14 +47,14 @@ public class AuditEventLogger {
     }
 
     public void logEvent(AuditEvent.AuditEventType eventType, boolean writeImmediatelyToDisk, long currentTime) {
-        logEvent(eventType, null, writeImmediatelyToDisk, null, currentTime);
+        logEvent(eventType, null, writeImmediatelyToDisk, null, currentTime, null);
     }
 
     /*
      * Log a new event
      */
     public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
-                         boolean writeImmediatelyToDisk, String questionAnswer, long currentTime) {
+                         boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
         if (!isAuditEnabled() || shouldBeIgnored(eventType)) {
             return;
         }
@@ -68,8 +68,9 @@ public class AuditEventLogger {
                 auditConfig.isTrackingChangesEnabled(),
                 formIndex,
                 questionAnswer,
-                user
-        );
+                user,
+                changeReason,
+                false);
 
         if (isDuplicatedIntervalEvent(newAuditEvent)) {
             return;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -71,7 +71,7 @@ public class AuditEventLogger {
                 questionAnswer,
                 user,
                 changeReason,
-                false);
+                true);
 
         if (isDuplicatedIntervalEvent(newAuditEvent)) {
             return;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventSaveTask.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 
 import timber.log.Timber;
 
+import static org.odk.collect.android.formentry.audit.AuditEventCSVLine.toCSVLine;
+
 /**
  * Background task for appending events to the event log
  */
@@ -52,8 +54,9 @@ public class AuditEventSaveTask extends AsyncTask<AuditEvent, Void, Void> {
             }
             if (params.length > 0) {
                 for (AuditEvent aev : params) {
-                    fw.write(aev.toString() + "\n");
-                    Timber.i("Log audit event: %s", aev.toString());
+                    String csvLine = toCSVLine(aev, isLocationEnabled, isTrackingChangesEnabled, isTrackChangesReasonEnabled);
+                    fw.write(csvLine + "\n");
+                    Timber.i("Log audit event: %s", csvLine);
                 }
             }
         } catch (IOException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventSaveTask.java
@@ -22,17 +22,20 @@ public class AuditEventSaveTask extends AsyncTask<AuditEvent, Void, Void> {
     private final boolean isLocationEnabled;
     private final boolean isTrackingChangesEnabled;
     private final boolean isUserRequired;
+    private final boolean isTrackChangesReasonEnabled;
 
     private static final String DEFAULT_COLUMNS = "event,node,start,end";
     private static final String LOCATION_COORDINATES_COLUMNS = ",latitude,longitude,accuracy";
     private static final String ANSWER_VALUES_COLUMNS = ",old-value,new-value";
     private static final String USER_COLUMNS = ",user";
+    private static final String CHANGE_REASON_COLUMNS = ",change-reason";
 
-    public AuditEventSaveTask(@NonNull File file, boolean isLocationEnabled, boolean isTrackingChangesEnabled, boolean isUserRequired) {
+    public AuditEventSaveTask(@NonNull File file, boolean isLocationEnabled, boolean isTrackingChangesEnabled, boolean isUserRequired, boolean isTrackChangesReasonEnabled) {
         this.file = file;
         this.isLocationEnabled = isLocationEnabled;
         this.isTrackingChangesEnabled = isTrackingChangesEnabled;
         this.isUserRequired = isUserRequired;
+        this.isTrackChangesReasonEnabled = isTrackChangesReasonEnabled;
     }
 
     @Override
@@ -124,6 +127,9 @@ public class AuditEventSaveTask extends AsyncTask<AuditEvent, Void, Void> {
         }
         if (isUserRequired) {
             header += USER_COLUMNS;
+        }
+        if (isTrackChangesReasonEnabled) {
+            header += CHANGE_REASON_COLUMNS;
         }
         return header;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -67,7 +67,7 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
         });
 
         toolbar.setOnMenuItemClickListener(item -> {
-            viewModel.save(System.currentTimeMillis());
+            viewModel.saveReason(System.currentTimeMillis());
             return true;
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -12,6 +12,7 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
@@ -23,8 +24,18 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
     private static final String ARG_FORM_NAME = "ArgFormName";
     private ChangesReasonPromptViewModel viewModel;
 
-    public static ChangesReasonPromptDialogFragment create(String formName) {
+    private ChangesReasonPromptViewModel.Factory viewModelFactory = new ChangesReasonPromptViewModel.Factory();
+
+    public static void show(String formName, FragmentManager fragmentManager, ChangesReasonPromptViewModel.Factory viewModelFactory) {
+        if (fragmentManager.findFragmentByTag(TAG) == null) {
+            ChangesReasonPromptDialogFragment dialog = create(formName, viewModelFactory);
+            dialog.show(fragmentManager.beginTransaction(), TAG);
+        }
+    }
+
+    private static ChangesReasonPromptDialogFragment create(String formName, ChangesReasonPromptViewModel.Factory viewModelFactory) {
         ChangesReasonPromptDialogFragment dialog = new ChangesReasonPromptDialogFragment();
+        dialog.viewModelFactory = viewModelFactory;
 
         Bundle bundle = new Bundle();
         bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
@@ -78,7 +89,7 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
-        viewModel = ViewModelProviders.of(requireActivity()).get(ChangesReasonPromptViewModel.class);
+        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory).get(ChangesReasonPromptViewModel.class);
         viewModel.requiresReasonToContinue().observe(this, requiresIdentity -> {
             if (!requiresIdentity) {
                 dismiss();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -82,8 +82,8 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
         super.onAttach(context);
 
         viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory).get(ChangesReasonPromptViewModel.class);
-        viewModel.requiresReasonToContinue().observe(this, requiresIdentity -> {
-            if (!requiresIdentity) {
+        viewModel.requiresReasonToContinue().observe(this, requiresReason -> {
+            if (!requiresReason) {
                 dismiss();
             }
         });
@@ -91,11 +91,11 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
 
     @Override
     protected void onBackPressed() {
-        dismiss();
+        viewModel.promptDismissed();
     }
 
     @Override
     protected void onCloseClicked() {
-        dismiss();
+        viewModel.promptDismissed();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -1,0 +1,40 @@
+package org.odk.collect.android.formentry.audit;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
+
+public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogFragment {
+
+    public static final String TAG = "ChangesReasonPromptDialogFragment";
+    private static final String ARG_FORM_NAME = "ArgFormName";
+
+    public static ChangesReasonPromptDialogFragment create(String formName) {
+        ChangesReasonPromptDialogFragment dialog = new ChangesReasonPromptDialogFragment();
+
+        Bundle bundle = new Bundle();
+        bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
+        dialog.setArguments(bundle);
+
+        return dialog;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.changes_reason_dialog, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        getToolbar().setTitle(getArguments().getString(ARG_FORM_NAME));
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -66,6 +66,8 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
             }
         });
 
+        reasonField.requestFocus();
+
         toolbar.setOnMenuItemClickListener(item -> {
             viewModel.saveReason(System.currentTimeMillis());
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -64,4 +64,14 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
             }
         });
     }
+
+    @Override
+    protected void onBackPressed() {
+        dismiss();
+    }
+
+    @Override
+    protected void onCloseClicked() {
+        dismiss();
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -2,6 +2,8 @@ package org.odk.collect.android.formentry.audit;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -45,9 +47,26 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
         toolbar.setTitle(getArguments().getString(ARG_FORM_NAME));
         toolbar.inflateMenu(R.menu.changes_reason_dialog);
 
+        EditText reasonField = view.findViewById(R.id.reason);
+        reasonField.setText(viewModel.getReason());
+        reasonField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+                viewModel.setReason(editable.toString());
+            }
+        });
+
         toolbar.setOnMenuItemClickListener(item -> {
-            String reason = view.<EditText>findViewById(R.id.reason).getText().toString();
-            viewModel.setReason(reason);
             viewModel.save(System.currentTimeMillis());
             return true;
         });

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -1,12 +1,16 @@
 package org.odk.collect.android.formentry.audit;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
@@ -15,6 +19,7 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
 
     public static final String TAG = "ChangesReasonPromptDialogFragment";
     private static final String ARG_FORM_NAME = "ArgFormName";
+    private ChangesReasonPromptViewModel viewModel;
 
     public static ChangesReasonPromptDialogFragment create(String formName) {
         ChangesReasonPromptDialogFragment dialog = new ChangesReasonPromptDialogFragment();
@@ -35,6 +40,28 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        getToolbar().setTitle(getArguments().getString(ARG_FORM_NAME));
+
+        Toolbar toolbar = getToolbar();
+        toolbar.setTitle(getArguments().getString(ARG_FORM_NAME));
+        toolbar.inflateMenu(R.menu.changes_reason_dialog);
+
+        toolbar.setOnMenuItemClickListener(item -> {
+            String reason = view.<EditText>findViewById(R.id.reason).getText().toString();
+            viewModel.setReason(reason);
+            viewModel.save(System.currentTimeMillis());
+            return true;
+        });
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        viewModel = ViewModelProviders.of(requireActivity()).get(ChangesReasonPromptViewModel.class);
+        viewModel.requiresReasonToContinue().observe(this, requiresIdentity -> {
+            if (!requiresIdentity) {
+                dismiss();
+            }
+        });
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
@@ -24,24 +25,15 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
     private static final String ARG_FORM_NAME = "ArgFormName";
     private ChangesReasonPromptViewModel viewModel;
 
-    private ChangesReasonPromptViewModel.Factory viewModelFactory = new ChangesReasonPromptViewModel.Factory();
+    public ViewModelProvider.Factory viewModelFactory = new ChangesReasonPromptViewModel.Factory();
 
-    public static void show(String formName, FragmentManager fragmentManager, ChangesReasonPromptViewModel.Factory viewModelFactory) {
+    public void show(String formName, FragmentManager fragmentManager) {
         if (fragmentManager.findFragmentByTag(TAG) == null) {
-            ChangesReasonPromptDialogFragment dialog = create(formName, viewModelFactory);
-            dialog.show(fragmentManager.beginTransaction(), TAG);
+            Bundle bundle = new Bundle();
+            bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
+            setArguments(bundle);
+            show(fragmentManager.beginTransaction(), TAG);
         }
-    }
-
-    private static ChangesReasonPromptDialogFragment create(String formName, ChangesReasonPromptViewModel.Factory viewModelFactory) {
-        ChangesReasonPromptDialogFragment dialog = new ChangesReasonPromptDialogFragment();
-        dialog.viewModelFactory = viewModelFactory;
-
-        Bundle bundle = new Bundle();
-        bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
-        dialog.setArguments(bundle);
-
-        return dialog;
     }
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -34,7 +34,7 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         return reason;
     }
 
-    public void save(Long currentTime) {
+    public void saveReason(Long currentTime) {
         if (reason != null && !isBlank(reason)) {
             this.auditEventLogger.logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, currentTime, reason);
             requiresReasonToContinue.setValue(false);
@@ -43,9 +43,10 @@ public class ChangesReasonPromptViewModel extends ViewModel {
 
     private void updateRequiresReasonToContinue() {
         requiresReasonToContinue.setValue(
-                auditEventLogger != null
+                editingForm
+                        && auditEventLogger != null
                         && auditEventLogger.isChangeReasonRequired()
-                        && editingForm
+                        && auditEventLogger.isChangesMade()
         );
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -63,5 +63,4 @@ public class ChangesReasonPromptViewModel extends ViewModel {
             return (T) new ChangesReasonPromptViewModel();
         }
     }
-
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -4,11 +4,14 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
+import static org.odk.collect.android.utilities.StringUtils.isBlank;
+
 public class ChangesReasonPromptViewModel extends ViewModel {
 
     private final MutableLiveData<Boolean> requiresReasonToContinue = new MutableLiveData<>(false);
     private boolean editingForm;
     private AuditEventLogger auditEventLogger;
+    private String reason;
 
     public LiveData<Boolean> requiresReasonToContinue() {
         return requiresReasonToContinue;
@@ -21,6 +24,17 @@ public class ChangesReasonPromptViewModel extends ViewModel {
 
     public void savingForm() {
         updateRequiresReasonToContinue();
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public void save(Long currentTime) {
+        if (reason != null && !isBlank(reason)) {
+            this.auditEventLogger.logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, currentTime, reason);
+            requiresReasonToContinue.setValue(false);
+        }
     }
 
     private void updateRequiresReasonToContinue() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.formentry.audit;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -11,26 +12,29 @@ import static org.odk.collect.android.utilities.StringUtils.isBlank;
 public class ChangesReasonPromptViewModel extends ViewModel {
 
     private final MutableLiveData<Boolean> requiresReasonToContinue = new MutableLiveData<>(false);
-    private final MutableLiveData<Boolean> readyToSave = new MutableLiveData<>(false);
+    private final MutableLiveData<Pair<Boolean, String>> saveRequests = new MutableLiveData<>(null);
 
     private AuditEventLogger auditEventLogger;
     private String reason;
+    private Pair<Boolean, String> saveDetails;
 
     public LiveData<Boolean> requiresReasonToContinue() {
         return requiresReasonToContinue;
     }
 
-    public LiveData<Boolean> readyToSave() {
-        return readyToSave;
+    public LiveData<Pair<Boolean, String>> saveRequests() {
+        return saveRequests;
     }
 
     public void setAuditEventLogger(AuditEventLogger auditEventLogger) {
         this.auditEventLogger = auditEventLogger;
     }
 
-    public void savingForm() {
+    public void saveForm(boolean complete, String updatedSaveName) {
+        saveDetails = new Pair<>(complete, updatedSaveName);
+
         if (!requiresReasonToSave()) {
-            readyToSave.setValue(true);
+            saveRequests.setValue(saveDetails);
         } else {
             requiresReasonToContinue.setValue(true);
         }
@@ -52,7 +56,7 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         if (reason != null && !isBlank(reason)) {
             this.auditEventLogger.logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, currentTime, reason);
             requiresReasonToContinue.setValue(false);
-            readyToSave.setValue(true);
+            saveRequests.setValue(saveDetails);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -1,0 +1,37 @@
+package org.odk.collect.android.formentry.audit;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class ChangesReasonPromptViewModel extends ViewModel {
+
+    private final MutableLiveData<Boolean> requiresReasonToContinue = new MutableLiveData<>(false);
+    private boolean editingForm;
+    private AuditEventLogger auditEventLogger;
+
+    public LiveData<Boolean> requiresReasonToContinue() {
+        return requiresReasonToContinue;
+    }
+
+    public void setAuditEventLogger(AuditEventLogger auditEventLogger) {
+        this.auditEventLogger = auditEventLogger;
+        updateRequiresReasonToContinue();
+    }
+
+    public void savingForm() {
+        updateRequiresReasonToContinue();
+    }
+
+    private void updateRequiresReasonToContinue() {
+        requiresReasonToContinue.setValue(
+                auditEventLogger != null
+                        && auditEventLogger.isChangeReasonRequired()
+                        && editingForm
+        );
+    }
+
+    public void editingForm() {
+        editingForm = true;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -30,6 +30,10 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         this.reason = reason;
     }
 
+    public String getReason() {
+        return reason;
+    }
+
     public void save(Long currentTime) {
         if (reason != null && !isBlank(reason)) {
             this.auditEventLogger.logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, currentTime, reason);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -9,7 +9,6 @@ import static org.odk.collect.android.utilities.StringUtils.isBlank;
 public class ChangesReasonPromptViewModel extends ViewModel {
 
     private final MutableLiveData<Boolean> requiresReasonToContinue = new MutableLiveData<>(false);
-    private boolean editingForm;
     private AuditEventLogger auditEventLogger;
     private String reason;
 
@@ -27,7 +26,7 @@ public class ChangesReasonPromptViewModel extends ViewModel {
     }
 
     public void editingForm() {
-        editingForm = true;
+        auditEventLogger.setEditing(true);
     }
 
     public void setReason(String reason) {
@@ -47,8 +46,8 @@ public class ChangesReasonPromptViewModel extends ViewModel {
 
     private void updateRequiresReasonToContinue() {
         requiresReasonToContinue.setValue(
-                editingForm
-                        && auditEventLogger != null
+                auditEventLogger != null
+                        && auditEventLogger.isEditing()
                         && auditEventLogger.isChangeReasonRequired()
                         && auditEventLogger.isChangesMade()
         );

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -26,12 +26,12 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         updateRequiresReasonToContinue();
     }
 
-    public void setReason(String reason) {
-        this.reason = reason;
+    public void editingForm() {
+        editingForm = true;
     }
 
-    public String getReason() {
-        return reason;
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 
     public void saveReason(Long currentTime) {
@@ -41,6 +41,10 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         }
     }
 
+    public String getReason() {
+        return reason;
+    }
+
     private void updateRequiresReasonToContinue() {
         requiresReasonToContinue.setValue(
                 editingForm
@@ -48,9 +52,5 @@ public class ChangesReasonPromptViewModel extends ViewModel {
                         && auditEventLogger.isChangeReasonRequired()
                         && auditEventLogger.isChangesMade()
         );
-    }
-
-    public void editingForm() {
-        editingForm = true;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -1,8 +1,10 @@
 package org.odk.collect.android.formentry.audit;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 
 import static org.odk.collect.android.utilities.StringUtils.isBlank;
 
@@ -52,4 +54,14 @@ public class ChangesReasonPromptViewModel extends ViewModel {
                         && auditEventLogger.isChangesMade()
         );
     }
+
+    public static class Factory implements ViewModelProvider.Factory {
+
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            return (T) new ChangesReasonPromptViewModel();
+        }
+    }
+
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
@@ -76,7 +76,7 @@ public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFr
         super.onAttach(context);
 
         viewModel = ViewModelProviders.of(requireActivity()).get(IdentityPromptViewModel.class);
-        viewModel.requiresIdentity().observe(this, requiresIdentity -> {
+        viewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
             if (!requiresIdentity) {
                 dismiss();
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
@@ -1,27 +1,21 @@
 package org.odk.collect.android.formentry.audit;
 
-import android.app.Dialog;
 import android.content.Context;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.WindowManager;
 import android.widget.EditText;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 
-public class IdentifyUserPromptDialogFragment extends DialogFragment {
+public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFragment {
 
     public static final String TAG = "IdentifyUserPromptDialogFragment";
     private static final String ARG_FORM_NAME = "ArgFormName";
@@ -47,16 +41,7 @@ public class IdentifyUserPromptDialogFragment extends DialogFragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        Toolbar toolbar = view.findViewById(R.id.toolbar);
-        toolbar.setTitle(getArguments().getString(ARG_FORM_NAME));
-        toolbar.setNavigationOnClickListener(v -> {
-            dismiss();
-            viewModel.promptDismissed();
-        });
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
-            view.findViewById(R.id.action_bar_shadow).setVisibility(View.VISIBLE);
-        }
+        getToolbar().setTitle(getArguments().getString(ARG_FORM_NAME));
 
         EditText identityField = view.findViewById(R.id.identity);
         identityField.setText(viewModel.getUser());
@@ -99,34 +84,14 @@ public class IdentifyUserPromptDialogFragment extends DialogFragment {
     }
 
     @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setStyle(DialogFragment.STYLE_NORMAL, R.style.Theme_Collect_Dialog_FullScreen);
+    protected void onCloseClicked() {
+        dismiss();
+        viewModel.promptDismissed();
     }
 
     @Override
-    public void onStart() {
-        super.onStart();
-
-        Dialog dialog = getDialog();
-        if (dialog != null) {
-            int width = ViewGroup.LayoutParams.MATCH_PARENT;
-            int height = ViewGroup.LayoutParams.MATCH_PARENT;
-            dialog.getWindow().setLayout(width, height);
-
-            // Make sure soft keyboard shows for focused field - annoyingly needed
-            dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
-
-            setCancelable(false);
-            dialog.setOnKeyListener((dialogInterface, keyCode, event) -> {
-                if (keyCode == KeyEvent.KEYCODE_BACK) {
-                    dialogInterface.dismiss();
-                    viewModel.promptDismissed();
-                    return true;
-                } else {
-                    return false;
-                }
-            });
-        }
+    protected void onBackPressed() {
+        dismiss();
+        viewModel.promptDismissed();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
@@ -20,7 +20,7 @@ public class IdentityPromptViewModel extends ViewModel {
         updateRequiresIdentity();
     }
 
-    public LiveData<Boolean> requiresIdentity() {
+    public LiveData<Boolean> requiresIdentityToContinue() {
         return requiresIdentity;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -1287,8 +1287,9 @@ public class FormController {
                 String locationMaxAge = auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "location-max-age");
                 boolean isTrackingChangesEnabled = Boolean.parseBoolean(auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "track-changes"));
                 boolean isIdentifyUserEnabled = Boolean.parseBoolean(auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "identify-user"));
+                String trackChangesReason = auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "track-changes-reason");
 
-                auditConfig = new AuditConfig(locationPriority, locationMinInterval, locationMaxAge, isTrackingChangesEnabled, isIdentifyUserEnabled);
+                auditConfig = new AuditConfig(locationPriority, locationMinInterval, locationMaxAge, isTrackingChangesEnabled, isIdentifyUserEnabled, trackChangesReason != null && trackChangesReason.equals("on-form-edit"));
 
                 IAnswerData answerData = new StringData();
                 answerData.setValue(AUDIT_FILE_NAME);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -415,7 +415,7 @@ public class FormController {
     /**
      * Returns true if the question at the given FormIndex uses the search() appearance/function
      * of "fast itemset" feature.
-     *
+     * <p>
      * Precondition: there is a question at the given FormIndex.
      */
     public boolean usesDatabaseExternalDataFeature(@NonNull FormIndex index) {
@@ -757,7 +757,7 @@ public class FormController {
     /**
      * Returns true if the group has an XML `ref` attribute,
      * i.e. it's a "logical group".
-     *
+     * <p>
      * TODO: Improve this nasty way to recreate what XFormParser#parseGroup does for nodes without a `ref`.
      */
     private boolean isLogicalGroup(FormIndex groupIndex) {
@@ -904,12 +904,12 @@ public class FormController {
      * Returns an array of question prompts corresponding to the current {@link FormIndex}. These
      * are the prompts that should be displayed to the user and don't include any non-relevant
      * questions.
-     *
+     * <p>
      * The array has a single element if there is a question at this {@link FormIndex} or multiple
      * elements if there is a group.
      *
      * @throws RuntimeException if there is a group at this {@link FormIndex} and it contains
-     * elements that are not questions or regular (non-repeat) groups.
+     *                          elements that are not questions or regular (non-repeat) groups.
      */
     public FormEntryPrompt[] getQuestionPrompts() throws RuntimeException {
         // For questions, there is only one.
@@ -1289,7 +1289,14 @@ public class FormController {
                 boolean isIdentifyUserEnabled = Boolean.parseBoolean(auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "identify-user"));
                 String trackChangesReason = auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "track-changes-reasons");
 
-                auditConfig = new AuditConfig(locationPriority, locationMinInterval, locationMaxAge, isTrackingChangesEnabled, isIdentifyUserEnabled, trackChangesReason != null && trackChangesReason.equals("on-form-edit"));
+                auditConfig = new AuditConfig.Builder()
+                        .setMode(locationPriority)
+                        .setLocationMinInterval(locationMinInterval)
+                        .setLocationMaxAge(locationMaxAge)
+                        .setIsTrackingChangesEnabled(isTrackingChangesEnabled)
+                        .setIsIdentifyUserEnabled(isIdentifyUserEnabled)
+                        .setIsTrackChangesReasonEnabled(trackChangesReason != null && trackChangesReason.equals("on-form-edit"))
+                        .createAuditConfig();
 
                 IAnswerData answerData = new StringData();
                 answerData.setValue(AUDIT_FILE_NAME);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -196,7 +196,7 @@ public class FormController {
             AuditConfig auditConfig = getSubmissionMetadata().auditConfig;
 
             if (auditConfig != null) {
-                setAuditEventLogger(new AuditEventLogger(auditConfig, new AsyncTaskAuditEventWriter(new File(instanceFile.getParentFile().getPath() + File.separator + AUDIT_FILE_NAME), auditConfig.isLocationEnabled(), auditConfig.isTrackingChangesEnabled(), auditConfig.isIdentifyUserEnabled()), this));
+                setAuditEventLogger(new AuditEventLogger(auditConfig, new AsyncTaskAuditEventWriter(new File(instanceFile.getParentFile().getPath() + File.separator + AUDIT_FILE_NAME), auditConfig.isLocationEnabled(), auditConfig.isTrackingChangesEnabled(), auditConfig.isIdentifyUserEnabled(), false), this));
             } else {
                 setAuditEventLogger(new AuditEventLogger(null, null, this));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -196,7 +196,7 @@ public class FormController {
             AuditConfig auditConfig = getSubmissionMetadata().auditConfig;
 
             if (auditConfig != null) {
-                setAuditEventLogger(new AuditEventLogger(auditConfig, new AsyncTaskAuditEventWriter(new File(instanceFile.getParentFile().getPath() + File.separator + AUDIT_FILE_NAME), auditConfig.isLocationEnabled(), auditConfig.isTrackingChangesEnabled(), auditConfig.isIdentifyUserEnabled(), false), this));
+                setAuditEventLogger(new AuditEventLogger(auditConfig, new AsyncTaskAuditEventWriter(new File(instanceFile.getParentFile().getPath() + File.separator + AUDIT_FILE_NAME), auditConfig.isLocationEnabled(), auditConfig.isTrackingChangesEnabled(), auditConfig.isIdentifyUserEnabled(), auditConfig.isTrackChangesReasonEnabled()), this));
             } else {
                 setAuditEventLogger(new AuditEventLogger(null, null, this));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -1287,7 +1287,7 @@ public class FormController {
                 String locationMaxAge = auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "location-max-age");
                 boolean isTrackingChangesEnabled = Boolean.parseBoolean(auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "track-changes"));
                 boolean isIdentifyUserEnabled = Boolean.parseBoolean(auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "identify-user"));
-                String trackChangesReason = auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "track-changes-reason");
+                String trackChangesReason = auditElement.getBindAttributeValue(XML_OPENDATAKIT_NAMESPACE, "track-changes-reasons");
 
                 auditConfig = new AuditConfig(locationPriority, locationMinInterval, locationMaxAge, isTrackingChangesEnabled, isIdentifyUserEnabled, trackChangesReason != null && trackChangesReason.equals("on-form-edit"));
 

--- a/collect_app/src/main/java/org/odk/collect/android/material/MaterialFullScreenDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/material/MaterialFullScreenDialogFragment.java
@@ -19,7 +19,7 @@ import org.odk.collect.android.R;
  * (https://material.io/components/dialogs/#full-screen-dialog) as no implementation currently
  * exists in the Material Components framework
  */
-public class MaterialFullScreenDialogFragment extends DialogFragment {
+public abstract class MaterialFullScreenDialogFragment extends DialogFragment {
 
     private Toolbar toolbar;
 
@@ -68,13 +68,9 @@ public class MaterialFullScreenDialogFragment extends DialogFragment {
         }
     }
 
-    protected void onCloseClicked() {
+    protected abstract void onCloseClicked();
 
-    }
-
-    protected void onBackPressed() {
-
-    }
+    protected abstract void onBackPressed();
 
     protected Toolbar getToolbar() {
         return toolbar;

--- a/collect_app/src/main/java/org/odk/collect/android/material/MaterialFullScreenDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/material/MaterialFullScreenDialogFragment.java
@@ -63,7 +63,7 @@ public abstract class MaterialFullScreenDialogFragment extends DialogFragment {
             onCloseClicked();
         });
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             view.findViewById(R.id.action_bar_shadow).setVisibility(View.VISIBLE);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/material/MaterialFullScreenDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/material/MaterialFullScreenDialogFragment.java
@@ -1,0 +1,82 @@
+package org.odk.collect.android.material;
+
+import android.app.Dialog;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.DialogFragment;
+
+import org.odk.collect.android.R;
+
+/**
+ * Provides an implementation of Material's "Full Screen Dialog"
+ * (https://material.io/components/dialogs/#full-screen-dialog) as no implementation currently
+ * exists in the Material Components framework
+ */
+public class MaterialFullScreenDialogFragment extends DialogFragment {
+
+    private Toolbar toolbar;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setStyle(DialogFragment.STYLE_NORMAL, R.style.Theme_Collect_Dialog_FullScreen);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        Dialog dialog = getDialog();
+        if (dialog != null) {
+            int width = ViewGroup.LayoutParams.MATCH_PARENT;
+            int height = ViewGroup.LayoutParams.MATCH_PARENT;
+            dialog.getWindow().setLayout(width, height);
+
+            // Make sure soft keyboard shows for focused field - annoyingly needed
+            dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+
+            setCancelable(false);
+            dialog.setOnKeyListener((dialogInterface, keyCode, event) -> {
+                if (keyCode == KeyEvent.KEYCODE_BACK) {
+                    onBackPressed();
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+        }
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        toolbar = view.findViewById(R.id.toolbar);
+        toolbar.setNavigationOnClickListener(v -> {
+            onCloseClicked();
+        });
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
+            view.findViewById(R.id.action_bar_shadow).setVisibility(View.VISIBLE);
+        }
+    }
+
+    protected void onCloseClicked() {
+
+    }
+
+    protected void onBackPressed() {
+
+    }
+
+    protected Toolbar getToolbar() {
+        return toolbar;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CSVUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CSVUtils.java
@@ -1,0 +1,19 @@
+package org.odk.collect.android.utilities;
+
+public class CSVUtils {
+
+    private CSVUtils() {
+
+    }
+
+    /**
+     * Escapes quotes and then wraps in quotes for output to CSV.
+     */
+    public static String getEscapedValueForCsv(String value) {
+        if (value.contains("\"")) {
+            value = value.replaceAll("\"", "\"\"");
+        }
+
+        return "\"" + value + "\"";
+    }
+}

--- a/collect_app/src/main/res/drawable/ic_chat_bubble_black_24dp.xml
+++ b/collect_app/src/main/res/drawable/ic_chat_bubble_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,2H4c-1.1,0 -2,0.9 -2,2v18l4,-4h14c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/collect_app/src/main/res/layout/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/layout/changes_reason_dialog.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
+    android:orientation="vertical">
+
+    <include layout="@layout/material_full_screen_dialog_toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:tint="?colorOnSurface"
+                    app:srcCompat="@drawable/ic_person_black_24dp" />
+
+                <TextView
+                    style="@style/TextAppearance.Collect.Headline6"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/reason_for_changes" />
+
+                <TextView
+                    style="@style/TextAppearance.Collect.Body2"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    android:text="@string/enter_identity_description" />
+
+            </LinearLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox"
+                android:layout_width="280dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:theme="@style/Theme.Collect.MaterialComponents.Polyfill">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/identity"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/identity"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:saveEnabled="false"
+                    android:lines="1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/collect_app/src/main/res/layout/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/layout/changes_reason_dialog.xml
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:padding="@dimen/margin_extra_large">
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -31,21 +31,22 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:tint="?colorOnSurface"
-                    app:srcCompat="@drawable/ic_person_black_24dp" />
+                    app:srcCompat="@drawable/ic_chat_bubble_black_24dp" />
 
                 <TextView
                     style="@style/TextAppearance.Collect.Headline6"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
+                    android:layout_marginTop="@dimen/margin_standard"
                     android:text="@string/reason_for_changes" />
 
                 <TextView
-                    style="@style/TextAppearance.Collect.Body2"
+                    style="@style/TextAppearance.Collect.Body1"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp"
-                    android:text="@string/enter_identity_description" />
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:text="@string/reason_for_changes_description"
+                    android:textAlignment="center" />
 
             </LinearLayout>
 
@@ -61,8 +62,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/reason"
-                    android:imeOptions="actionDone"
-                    android:inputType="text" />
+                    android:inputType="textMultiLine" />
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/collect_app/src/main/res/layout/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/layout/changes_reason_dialog.xml
@@ -57,14 +57,12 @@
                 android:theme="@style/Theme.Collect.MaterialComponents.Polyfill">
 
                 <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/identity"
+                    android:id="@+id/reason"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="@string/identity"
+                    android:hint="@string/reason"
                     android:imeOptions="actionDone"
-                    android:inputType="text"
-                    android:saveEnabled="false"
-                    android:lines="1" />
+                    android:inputType="text" />
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/collect_app/src/main/res/layout/identify_user_dialog.xml
+++ b/collect_app/src/main/res/layout/identify_user_dialog.xml
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:padding="@dimen/margin_extra_large">
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -37,14 +37,14 @@
                     style="@style/TextAppearance.Collect.Headline6"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
+                    android:layout_marginTop="@dimen/margin_standard"
                     android:text="@string/enter_identity" />
 
                 <TextView
-                    style="@style/TextAppearance.Collect.Body2"
+                    style="@style/TextAppearance.Collect.Body1"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp"
+                    android:layout_marginTop="@dimen/margin_small"
                     android:text="@string/enter_identity_description" />
 
             </LinearLayout>
@@ -63,8 +63,8 @@
                     android:hint="@string/identity"
                     android:imeOptions="actionDone"
                     android:inputType="text"
-                    android:saveEnabled="false"
-                    android:lines="1" />
+                    android:lines="1"
+                    android:saveEnabled="false" />
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/collect_app/src/main/res/layout/identify_user_dialog.xml
+++ b/collect_app/src/main/res/layout/identify_user_dialog.xml
@@ -7,26 +7,7 @@
     android:background="?attr/colorSurface"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:navigationContentDescription="@string/close"
-            app:navigationIcon="@drawable/ic_close_black_24dp"
-            tools:title="Form Name" />
-
-        <include
-            android:id="@+id/action_bar_shadow"
-            layout="@layout/toolbar_action_bar_shadow"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone" />
-
-    </com.google.android.material.appbar.AppBarLayout>
+    <include layout="@layout/material_full_screen_dialog_toolbar" />
 
     <ScrollView
         android:layout_width="match_parent"

--- a/collect_app/src/main/res/layout/material_full_screen_dialog_toolbar.xml
+++ b/collect_app/src/main/res/layout/material_full_screen_dialog_toolbar.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.appbar.AppBarLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:navigationContentDescription="@string/close"
+        app:navigationIcon="@drawable/ic_close_black_24dp"
+        tools:title="Title" />
+
+    <include
+        android:id="@+id/action_bar_shadow"
+        layout="@layout/toolbar_action_bar_shadow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+
+</com.google.android.material.appbar.AppBarLayout>

--- a/collect_app/src/main/res/menu/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/menu/changes_reason_dialog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:title="@string/save"
+        app:showAsAction="always" />
+</menu>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -723,4 +723,5 @@
     <string name="reason_for_changes">Reason for changes</string>
     <string name="reason">Reason</string>
     <string name="save">Save</string>
+    <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -721,4 +721,6 @@
     <string name="enter_identity_description">This form requires you to identify yourself</string>
     <string name="close">Close</string>
     <string name="reason_for_changes">Reason for changes</string>
+    <string name="reason">Reason</string>
+    <string name="save">Save</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -720,4 +720,5 @@
     <string name="identity">Identity</string>
     <string name="enter_identity_description">This form requires you to identify yourself</string>
     <string name="close">Close</string>
+    <string name="reason_for_changes">Reason for changes</string>
 </resources>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -8,6 +8,10 @@
 
     </style>
 
+    <style name="TextAppearance.Collect.Body1" parent="TextAppearance.MaterialComponents.Body1">
+
+    </style>
+
     <style name="TextAppearance.Collect.Body2" parent="TextAppearance.MaterialComponents.Body2">
 
     </style>

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriterTest.java
@@ -125,8 +125,8 @@ public class AsyncTaskAuditEventWriterTest {
     public void saveAuditWithChangeReason() throws Exception {
         AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, false, true);
         writer.writeEvents(asList(
-                new AuditEvent(1548108900606L, FORM_RESUME, false, false, null, null, null, null, true),
-                new AuditEvent(1548108900606L, CHANGE_REASON, false, false, null, null, null, "A good reason", true)
+                new AuditEvent(1548108900606L, FORM_RESUME, null, null, null, null),
+                new AuditEvent(1548108900606L, CHANGE_REASON, null, null, null, "A good reason")
         ));
 
         String auditContent = FileUtils.readFileToString(auditFile);
@@ -140,8 +140,8 @@ public class AsyncTaskAuditEventWriterTest {
     public void whenChangeReasonHasCommaOrQuotes_escapesThem() throws Exception {
         AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, false, true);
         writer.writeEvents(asList(
-                new AuditEvent(1548108900606L, FORM_RESUME, false, false, null, null, null, null, true),
-                new AuditEvent(1548108900606L, CHANGE_REASON, false, false, null, null, null, "A \"good\", reason", true)
+                new AuditEvent(1548108900606L, FORM_RESUME, null, null, null, null),
+                new AuditEvent(1548108900606L, CHANGE_REASON, null, null, null, "A \"good\", reason")
         ));
 
         String auditContent = FileUtils.readFileToString(auditFile);
@@ -322,22 +322,22 @@ public class AsyncTaskAuditEventWriterTest {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
         auditEvents.add(new AuditEvent(1548106927319L, FORM_START));
-        event = new AuditEvent(1548106927323L, QUESTION, false, false, getTestFormIndex("/data/q1"), "", null, null, false);
+        event = new AuditEvent(1548106927323L, QUESTION, getTestFormIndex("/data/q1"), "", null, null);
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[1]"), "", null, null, false);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[1]"), "", null, null);
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106931612L, QUESTION, false, false, getTestFormIndex("/data/g1[1]/q2"), "", null, null, false);
+        event = new AuditEvent(1548106931612L, QUESTION, getTestFormIndex("/data/g1[1]/q2"), "", null, null);
         event.setEnd(1548106937122L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[2]"), "", null, null, false);
+        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[2]"), "", null, null);
         event.setEnd(1548106938276L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106938277L, QUESTION, false, false, getTestFormIndex("/data/g1[2]/q2"), "", null, null, false);
+        event = new AuditEvent(1548106938277L, QUESTION, getTestFormIndex("/data/g1[2]/q2"), "", null, null);
         event.setEnd(1548106948127L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[3]"), "", null, null, false);
+        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[3]"), "", null, null);
         event.setEnd(1548106949446L);
         auditEvents.add(event);
         event = new AuditEvent(1548106949448L, END_OF_FORM);
@@ -352,33 +352,33 @@ public class AsyncTaskAuditEventWriterTest {
     private ArrayList<AuditEvent> getMoreSampleAuditEventsWithLocations() {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
-        event = new AuditEvent(1548108900606L, FORM_RESUME, true, false);
+        event = new AuditEvent(1548108900606L, FORM_RESUME);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108906276L, HIERARCHY, true, false);
+        event = new AuditEvent(1548108906276L, HIERARCHY);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548108908206L);
         auditEvents.add(event);
-        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, false);
+        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, false);
+        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, false);
+        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(1548108908285L, END_OF_FORM, true, false);
+        event = new AuditEvent(1548108908285L, END_OF_FORM);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548108909730L);
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_SAVE, true, false);
+        event = new AuditEvent(1548108909730L, FORM_SAVE);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_EXIT, true, false);
+        event = new AuditEvent(1548108909730L, FORM_EXIT);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909731L, FORM_FINALIZE, true, false);
+        event = new AuditEvent(1548108909731L, FORM_FINALIZE);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;
@@ -387,32 +387,32 @@ public class AsyncTaskAuditEventWriterTest {
     private ArrayList<AuditEvent> getMoreSampleAuditEventsWithLocationsAndTrackingChanges() {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
-        event = new AuditEvent(1548108900606L, FORM_RESUME, true, true);
+        event = new AuditEvent(1548108900606L, FORM_RESUME);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108900700L, QUESTION, true, true, null, "Old value", null, null, false);
-        event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
-        event.recordValueChange("New value");
-        auditEvents.add(event);
-        event = new AuditEvent(1548108903100L, QUESTION, true, true, null, "Old value, with comma", null, null, false);
+        event = new AuditEvent(1548108900700L, QUESTION, null, "Old value", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value");
         auditEvents.add(event);
-        event = new AuditEvent(1548108903101L, QUESTION, true, true, null, "Old value \n with linebreak", null, null, false);
+        event = new AuditEvent(1548108903100L, QUESTION, null, "Old value, with comma", null, null);
+        event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
+        event.recordValueChange("New value");
+        auditEvents.add(event);
+        event = new AuditEvent(1548108903101L, QUESTION, null, "Old value \n with linebreak", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value \n with linebreak and \"quotes\"");
         auditEvents.add(event);
-        event = new AuditEvent(1548108904200L, QUESTION, true, true, null, "Old value", null, null, false);
+        event = new AuditEvent(1548108904200L, QUESTION, null, "Old value", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value, with comma");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_SAVE, true, true);
+        event = new AuditEvent(1548108909730L, FORM_SAVE);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909730L, FORM_EXIT, true, true);
+        event = new AuditEvent(1548108909730L, FORM_EXIT);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108909731L, FORM_FINALIZE, true, true);
+        event = new AuditEvent(1548108909731L, FORM_FINALIZE);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;
@@ -421,53 +421,53 @@ public class AsyncTaskAuditEventWriterTest {
     private ArrayList<AuditEvent> getSampleAuditEventsWithLocations() {
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
         AuditEvent event;
-        event = new AuditEvent(1548106927319L, FORM_START, true, false);
+        event = new AuditEvent(1548106927319L, FORM_START);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, false);
+        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, false);
+        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, false);
+        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(1548106927323L, QUESTION, true, false, getTestFormIndex("/data/q1"), "", null, null, false);
+        event = new AuditEvent(1548106927323L, QUESTION, getTestFormIndex("/data/q1"), "", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[1]"), "", null, null, false);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[1]"), "", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106931612L, QUESTION, true, false, getTestFormIndex("/data/g1[1]/q2"), "", null, null, false);
+        event = new AuditEvent(1548106931612L, QUESTION, getTestFormIndex("/data/g1[1]/q2"), "", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106937122L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[2]"), "", null, null, false);
+        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[2]"), "", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106938276L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106938277L, QUESTION, true, false, getTestFormIndex("/data/g1[2]/q2"), "", null, null, false);
+        event = new AuditEvent(1548106938277L, QUESTION, getTestFormIndex("/data/g1[2]/q2"), "", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106948127L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[3]"), "", null, null, false);
+        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[3]"), "", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106949446L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106949448L, END_OF_FORM, true, false);
+        event = new AuditEvent(1548106949448L, END_OF_FORM);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106953601L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106953600L, FORM_SAVE, true, false);
+        event = new AuditEvent(1548106953600L, FORM_SAVE);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_EXIT, true, false);
+        event = new AuditEvent(1548106953601L, FORM_EXIT);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, false);
+        event = new AuditEvent(1548106953601L, FORM_FINALIZE);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;
@@ -476,38 +476,38 @@ public class AsyncTaskAuditEventWriterTest {
     private ArrayList<AuditEvent> getSampleAuditEventsWithLocationsAndTrackingChanges() {
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
         AuditEvent event;
-        event = new AuditEvent(1548106927319L, FORM_START, true, true);
+        event = new AuditEvent(1548106927319L, FORM_START);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED, true, true);
+        event = new AuditEvent(548108908250L, LOCATION_TRACKING_ENABLED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED, true, true);
+        event = new AuditEvent(548108908255L, LOCATION_PERMISSIONS_GRANTED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, true);
+        event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(1548106927323L, QUESTION, true, true, getTestFormIndex("/data/q1"), "Old value", null, null, false);
+        event = new AuditEvent(1548106927323L, QUESTION, getTestFormIndex("/data/q1"), "Old value", null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New Value");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, true, getTestFormIndex("/data/g1[1]"), null, null, null, false);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, getTestFormIndex("/data/g1[1]"), null, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106949448L, END_OF_FORM, true, true, null, null, null, null, false);
+        event = new AuditEvent(1548106949448L, END_OF_FORM, null, null, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106953601L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106953600L, FORM_SAVE, true, true, null, null, null, null, false);
+        event = new AuditEvent(1548106953600L, FORM_SAVE, null, null, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_EXIT, true, true, null, null, null, null, false);
+        event = new AuditEvent(1548106953601L, FORM_EXIT, null, null, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, true, null, null, null, null, false);
+        event = new AuditEvent(1548106953601L, FORM_FINALIZE, null, null, null, null);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriterTest.java
@@ -29,7 +29,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.CHANGE_REASON;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.END_OF_FORM;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_EXIT;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_FINALIZE;
@@ -55,7 +57,7 @@ public class AsyncTaskAuditEventWriterTest {
 
     @Test
     public void saveAuditWithLocation() throws Exception {
-        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, true, false, false);
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, true, false, false, false);
         writer.writeEvents(getSampleAuditEventsWithLocations());
 
         String expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -79,7 +81,7 @@ public class AsyncTaskAuditEventWriterTest {
 
     @Test
     public void saveAuditWithLocationAndTrackingChanges() throws Exception {
-        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, true, true, false);
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, true, true, false, false);
         writer.writeEvents(getSampleAuditEventsWithLocationsAndTrackingChanges());
 
         String expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -99,7 +101,7 @@ public class AsyncTaskAuditEventWriterTest {
 
     @Test
     public void saveAuditWithUser() throws Exception {
-        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, true);
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, true, false);
         writer.writeEvents(getSampleAuditEventsWithUser());
 
         String expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -115,12 +117,28 @@ public class AsyncTaskAuditEventWriterTest {
                 "form save,,1548106953600,,User1\n" +
                 "form exit,,1548106953601,,User1\n" +
                 "form finalize,,1548106953601,,User1\n";
+        
         assertEquals(expectedData, expectedAuditContent);
     }
 
     @Test
+    public void saveAuditWithChangeReason() throws Exception {
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, false, true);
+        writer.writeEvents(asList(
+                new AuditEvent(1548108900606L, FORM_RESUME, false, false, null, null, null, null, true),
+                new AuditEvent(1548108900606L, CHANGE_REASON, false, false, null, null, null, "A good reason", true)
+        ));
+
+        String auditContent = FileUtils.readFileToString(auditFile);
+        String expectedData =  "event,node,start,end,change-reason\n" +
+                "form resume,,1548108900606,,\n" +
+                "change reason,,1548108900606,,A good reason\n";
+        assertEquals(expectedData, auditContent);
+    }
+
+    @Test
     public void whenUserHasCommaOrQuotes_escapesThem() throws Exception {
-        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, true);
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, true, false);
 
         List<AuditEvent> auditEvents = getSampleAuditEventsWithUser().subList(0, 1);
         auditEvents.get(0).setUser("User,\"1\"");
@@ -140,7 +158,7 @@ public class AsyncTaskAuditEventWriterTest {
     @Test
     public void whenAppUpdatedBetweenInstances_updatesHeader() throws Exception {
         // Use a form with enabled audit but without location
-        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, false);
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, false, false);
         writer.writeEvents(getSampleAuditEventsWithoutLocations());
 
         String expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -159,7 +177,7 @@ public class AsyncTaskAuditEventWriterTest {
         assertEquals(expectedData, expectedAuditContent);
 
         // Upgrade a form to use location
-        writer = new AsyncTaskAuditEventWriter(auditFile, true, false, false);
+        writer = new AsyncTaskAuditEventWriter(auditFile, true, false, false, false);
         writer.writeEvents(getMoreSampleAuditEventsWithLocations());
 
         expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -187,7 +205,7 @@ public class AsyncTaskAuditEventWriterTest {
         assertEquals(expectedData2, expectedAuditContent);
 
         // Upgrade a form to use location and tracking changes
-        writer = new AsyncTaskAuditEventWriter(auditFile, true, true, false);
+        writer = new AsyncTaskAuditEventWriter(auditFile, true, true, false, false);
         writer.writeEvents(getMoreSampleAuditEventsWithLocationsAndTrackingChanges());
 
         expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -223,7 +241,7 @@ public class AsyncTaskAuditEventWriterTest {
         assertEquals(expectedData3, expectedAuditContent);
 
         // Upgrade a form to use location and tracking changes and user
-        writer = new AsyncTaskAuditEventWriter(auditFile, true, true, true);
+        writer = new AsyncTaskAuditEventWriter(auditFile, true, true, true, false);
         writer.writeEvents(getMoreSampleAuditEventsWithLocationsAndTrackingChangesAndUser());
 
         expectedAuditContent = FileUtils.readFileToString(auditFile);
@@ -289,22 +307,22 @@ public class AsyncTaskAuditEventWriterTest {
         AuditEvent event;
         ArrayList<AuditEvent> auditEvents = new ArrayList<>();
         auditEvents.add(new AuditEvent(1548106927319L, FORM_START));
-        event = new AuditEvent(1548106927323L, QUESTION, false, false, getTestFormIndex("/data/q1"), "", null);
+        event = new AuditEvent(1548106927323L, QUESTION, false, false, getTestFormIndex("/data/q1"), "", null, null, false);
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[1]"), "", null);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[1]"), "", null, null, false);
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106931612L, QUESTION, false, false, getTestFormIndex("/data/g1[1]/q2"), "", null);
+        event = new AuditEvent(1548106931612L, QUESTION, false, false, getTestFormIndex("/data/g1[1]/q2"), "", null, null, false);
         event.setEnd(1548106937122L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[2]"), "", null);
+        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[2]"), "", null, null, false);
         event.setEnd(1548106938276L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106938277L, QUESTION, false, false, getTestFormIndex("/data/g1[2]/q2"), "", null);
+        event = new AuditEvent(1548106938277L, QUESTION, false, false, getTestFormIndex("/data/g1[2]/q2"), "", null, null, false);
         event.setEnd(1548106948127L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[3]"), "", null);
+        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, false, false, getTestFormIndex("/data/g1[3]"), "", null, null, false);
         event.setEnd(1548106949446L);
         auditEvents.add(event);
         event = new AuditEvent(1548106949448L, END_OF_FORM);
@@ -357,19 +375,19 @@ public class AsyncTaskAuditEventWriterTest {
         event = new AuditEvent(1548108900606L, FORM_RESUME, true, true);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548108900700L, QUESTION, true, true, null, "Old value", null);
+        event = new AuditEvent(1548108900700L, QUESTION, true, true, null, "Old value", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value");
         auditEvents.add(event);
-        event = new AuditEvent(1548108903100L, QUESTION, true, true, null, "Old value, with comma", null);
+        event = new AuditEvent(1548108903100L, QUESTION, true, true, null, "Old value, with comma", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value");
         auditEvents.add(event);
-        event = new AuditEvent(1548108903101L, QUESTION, true, true, null, "Old value \n with linebreak", null);
+        event = new AuditEvent(1548108903101L, QUESTION, true, true, null, "Old value \n with linebreak", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value \n with linebreak and \"quotes\"");
         auditEvents.add(event);
-        event = new AuditEvent(1548108904200L, QUESTION, true, true, null, "Old value", null);
+        event = new AuditEvent(1548108904200L, QUESTION, true, true, null, "Old value", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New value, with comma");
         auditEvents.add(event);
@@ -400,27 +418,27 @@ public class AsyncTaskAuditEventWriterTest {
         event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, false);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(1548106927323L, QUESTION, true, false, getTestFormIndex("/data/q1"), "", null);
+        event = new AuditEvent(1548106927323L, QUESTION, true, false, getTestFormIndex("/data/q1"), "", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[1]"), "", null);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[1]"), "", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106931612L, QUESTION, true, false, getTestFormIndex("/data/g1[1]/q2"), "", null);
+        event = new AuditEvent(1548106931612L, QUESTION, true, false, getTestFormIndex("/data/g1[1]/q2"), "", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106937122L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[2]"), "", null);
+        event = new AuditEvent(1548106937123L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[2]"), "", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106938276L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106938277L, QUESTION, true, false, getTestFormIndex("/data/g1[2]/q2"), "", null);
+        event = new AuditEvent(1548106938277L, QUESTION, true, false, getTestFormIndex("/data/g1[2]/q2"), "", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106948127L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[3]"), "", null);
+        event = new AuditEvent(1548106948128L, PROMPT_NEW_REPEAT, true, false, getTestFormIndex("/data/g1[3]"), "", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106949446L);
         auditEvents.add(event);
@@ -455,26 +473,26 @@ public class AsyncTaskAuditEventWriterTest {
         event = new AuditEvent(548108908259L, LOCATION_PROVIDERS_ENABLED, true, true);
         event.setLocationCoordinates("", "", "");
         auditEvents.add(event);
-        event = new AuditEvent(1548106927323L, QUESTION, true, true, getTestFormIndex("/data/q1"), "Old value", null);
+        event = new AuditEvent(1548106927323L, QUESTION, true, true, getTestFormIndex("/data/q1"), "Old value", null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.recordValueChange("New Value");
         event.setEnd(1548106930112L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, true, getTestFormIndex("/data/g1[1]"), null, null);
+        event = new AuditEvent(1548106930118L, PROMPT_NEW_REPEAT, true, true, getTestFormIndex("/data/g1[1]"), null, null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106931611L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106949448L, END_OF_FORM, true, true, null, null, null);
+        event = new AuditEvent(1548106949448L, END_OF_FORM, true, true, null, null, null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         event.setEnd(1548106953601L);
         auditEvents.add(event);
-        event = new AuditEvent(1548106953600L, FORM_SAVE, true, true, null, null, null);
+        event = new AuditEvent(1548106953600L, FORM_SAVE, true, true, null, null, null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_EXIT, true, true, null, null, null);
+        event = new AuditEvent(1548106953601L, FORM_EXIT, true, true, null, null, null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
-        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, true, null, null, null);
+        event = new AuditEvent(1548106953601L, FORM_FINALIZE, true, true, null, null, null, null, false);
         event.setLocationCoordinates("54.4112062", "18.5896652", "30.716999053955078");
         auditEvents.add(event);
         return auditEvents;

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AsyncTaskAuditEventWriterTest.java
@@ -137,6 +137,21 @@ public class AsyncTaskAuditEventWriterTest {
     }
 
     @Test
+    public void whenChangeReasonHasCommaOrQuotes_escapesThem() throws Exception {
+        AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, false, true);
+        writer.writeEvents(asList(
+                new AuditEvent(1548108900606L, FORM_RESUME, false, false, null, null, null, null, true),
+                new AuditEvent(1548108900606L, CHANGE_REASON, false, false, null, null, null, "A \"good\", reason", true)
+        ));
+
+        String auditContent = FileUtils.readFileToString(auditFile);
+        String expectedData =  "event,node,start,end,change-reason\n" +
+                "form resume,,1548108900606,,\n" +
+                "change reason,,1548108900606,,\"A \"\"good\"\", reason\"\n";
+        assertEquals(expectedData, auditContent);
+    }
+
+    @Test
     public void whenUserHasCommaOrQuotes_escapesThem() throws Exception {
         AsyncTaskAuditEventWriter writer = new AsyncTaskAuditEventWriter(auditFile, false, false, true, false);
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditConfigTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditConfigTest.java
@@ -31,7 +31,7 @@ public class AuditConfigTest {
 
     @Test
     public void testParameters() {
-        AuditConfig auditConfig = new AuditConfig("high-accuracy", "10", "60", true, false, false);
+        AuditConfig auditConfig = new AuditConfig.Builder().setMode("high-accuracy").setLocationMinInterval("10").setLocationMaxAge("60").setIsTrackingChangesEnabled(true).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
 
         assertTrue(auditConfig.isTrackingChangesEnabled());
         assertTrue(auditConfig.isLocationEnabled());
@@ -39,7 +39,7 @@ public class AuditConfigTest {
         assertEquals(10000, auditConfig.getLocationMinInterval().intValue());
         assertEquals(60000, auditConfig.getLocationMaxAge().intValue());
 
-        auditConfig = new AuditConfig("high-accuracy", "0", "60", false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("high-accuracy").setLocationMinInterval("0").setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
 
         assertFalse(auditConfig.isTrackingChangesEnabled());
         assertTrue(auditConfig.isLocationEnabled());
@@ -50,53 +50,53 @@ public class AuditConfigTest {
 
     @Test
     public void logLocationCoordinatesOnlyIfAllParametersAreSet() {
-        AuditConfig auditConfig = new AuditConfig("high-accuracy", "10", "60", false, false, false);
+        AuditConfig auditConfig = new AuditConfig.Builder().setMode("high-accuracy").setLocationMinInterval("10").setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertTrue(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, "10", "60", false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode(null).setLocationMinInterval("10").setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, null, "60", false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig("balanced", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("balanced").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig("balanced", "10", null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("balanced").setLocationMinInterval("10").setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig("balanced", null, "60", false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("balanced").setLocationMinInterval(null).setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, null, "60", false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertFalse(auditConfig.isLocationEnabled());
     }
 
     @Test
     public void testPriorities() {
-        AuditConfig auditConfig = new AuditConfig("high_accuracy", null, null, false, false, false);
+        AuditConfig auditConfig = new AuditConfig.Builder().setMode("high_accuracy").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("high-accuracy", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("high-accuracy").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("HIGH_ACCURACY", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("HIGH_ACCURACY").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("balanced", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("balanced").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_BALANCED_POWER_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("BALANCED", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("BALANCED").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_BALANCED_POWER_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("low_power", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("low_power").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_LOW_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("low-power", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("low-power").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_LOW_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("low_POWER", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("low_POWER").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_LOW_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("no_power", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("no_power").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_NO_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("no-power", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("no-power").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_NO_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("NO_power", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("NO_power").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_NO_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("qwerty", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("qwerty").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("", null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode("").setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig(null, null, null, false, false, false);
+        auditConfig = new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
         assertNull(auditConfig.getLocationPriority());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditConfigTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditConfigTest.java
@@ -31,7 +31,7 @@ public class AuditConfigTest {
 
     @Test
     public void testParameters() {
-        AuditConfig auditConfig = new AuditConfig("high-accuracy", "10", "60", true, false);
+        AuditConfig auditConfig = new AuditConfig("high-accuracy", "10", "60", true, false, false);
 
         assertTrue(auditConfig.isTrackingChangesEnabled());
         assertTrue(auditConfig.isLocationEnabled());
@@ -39,7 +39,7 @@ public class AuditConfigTest {
         assertEquals(10000, auditConfig.getLocationMinInterval().intValue());
         assertEquals(60000, auditConfig.getLocationMaxAge().intValue());
 
-        auditConfig = new AuditConfig("high-accuracy", "0", "60", false, false);
+        auditConfig = new AuditConfig("high-accuracy", "0", "60", false, false, false);
 
         assertFalse(auditConfig.isTrackingChangesEnabled());
         assertTrue(auditConfig.isLocationEnabled());
@@ -50,53 +50,53 @@ public class AuditConfigTest {
 
     @Test
     public void logLocationCoordinatesOnlyIfAllParametersAreSet() {
-        AuditConfig auditConfig = new AuditConfig("high-accuracy", "10", "60", false, false);
+        AuditConfig auditConfig = new AuditConfig("high-accuracy", "10", "60", false, false, false);
         assertTrue(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, "10", "60", false, false);
+        auditConfig = new AuditConfig(null, "10", "60", false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, null, "60", false, false);
+        auditConfig = new AuditConfig(null, null, "60", false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, null, null, false, false);
+        auditConfig = new AuditConfig(null, null, null, false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig("balanced", null, null, false, false);
+        auditConfig = new AuditConfig("balanced", null, null, false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig("balanced", "10", null, false, false);
+        auditConfig = new AuditConfig("balanced", "10", null, false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig("balanced", null, "60", false, false);
+        auditConfig = new AuditConfig("balanced", null, "60", false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
-        auditConfig = new AuditConfig(null, null, "60", false, false);
+        auditConfig = new AuditConfig(null, null, "60", false, false, false);
         assertFalse(auditConfig.isLocationEnabled());
     }
 
     @Test
     public void testPriorities() {
-        AuditConfig auditConfig = new AuditConfig("high_accuracy", null, null, false, false);
+        AuditConfig auditConfig = new AuditConfig("high_accuracy", null, null, false, false, false);
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("high-accuracy", null, null, false, false);
+        auditConfig = new AuditConfig("high-accuracy", null, null, false, false, false);
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("HIGH_ACCURACY", null, null, false, false);
+        auditConfig = new AuditConfig("HIGH_ACCURACY", null, null, false, false, false);
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("balanced", null, null, false, false);
+        auditConfig = new AuditConfig("balanced", null, null, false, false, false);
         assertEquals(PRIORITY_BALANCED_POWER_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("BALANCED", null, null, false, false);
+        auditConfig = new AuditConfig("BALANCED", null, null, false, false, false);
         assertEquals(PRIORITY_BALANCED_POWER_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("low_power", null, null, false, false);
+        auditConfig = new AuditConfig("low_power", null, null, false, false, false);
         assertEquals(PRIORITY_LOW_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("low-power", null, null, false, false);
+        auditConfig = new AuditConfig("low-power", null, null, false, false, false);
         assertEquals(PRIORITY_LOW_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("low_POWER", null, null, false, false);
+        auditConfig = new AuditConfig("low_POWER", null, null, false, false, false);
         assertEquals(PRIORITY_LOW_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("no_power", null, null, false, false);
+        auditConfig = new AuditConfig("no_power", null, null, false, false, false);
         assertEquals(PRIORITY_NO_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("no-power", null, null, false, false);
+        auditConfig = new AuditConfig("no-power", null, null, false, false, false);
         assertEquals(PRIORITY_NO_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("NO_power", null, null, false, false);
+        auditConfig = new AuditConfig("NO_power", null, null, false, false, false);
         assertEquals(PRIORITY_NO_POWER, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("qwerty", null, null, false, false);
+        auditConfig = new AuditConfig("qwerty", null, null, false, false, false);
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig("", null, null, false, false);
+        auditConfig = new AuditConfig("", null, null, false, false, false);
         assertEquals(PRIORITY_HIGH_ACCURACY, auditConfig.getLocationPriority());
-        auditConfig = new AuditConfig(null, null, null, false, false);
+        auditConfig = new AuditConfig(null, null, null, false, false, false);
         assertNull(auditConfig.getLocationPriority());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventCSVLineTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventCSVLineTest.java
@@ -1,0 +1,239 @@
+package org.odk.collect.android.formentry.audit;
+
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.instance.TreeReference;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.BEGINNING_OF_FORM;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.CONSTRAINT_ERROR;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.DELETE_REPEAT;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.END_OF_FORM;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FINALIZE_ERROR;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_EXIT;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_FINALIZE;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_RESUME;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_SAVE;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_START;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.GOOGLE_PLAY_SERVICES_NOT_AVAILABLE;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.GROUP;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.HIERARCHY;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PERMISSIONS_GRANTED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PERMISSIONS_NOT_GRANTED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_DISABLED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_ENABLED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_TRACKING_DISABLED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_TRACKING_ENABLED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.PROMPT_NEW_REPEAT;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.QUESTION;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.REPEAT;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.SAVE_ERROR;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.UNKNOWN_EVENT_TYPE;
+import static org.odk.collect.android.formentry.audit.AuditEventCSVLine.toCSVLine;
+
+public class AuditEventCSVLineTest {
+
+    private static final long START_TIME = 1545392727685L;
+    private static final long END_TIME = 1545392728527L;
+
+    @Test
+    public void toString_() {
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, getTestFormIndex(), "", null, null);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertEquals("question,/data/text1,1545392727685,", toCSVLine(auditEvent, false, false, false));
+        assertFalse(auditEvent.isEndTimeSet());
+        auditEvent.setEnd(END_TIME);
+        assertTrue(auditEvent.isEndTimeSet());
+        assertFalse(auditEvent.isLocationAlreadySet());
+        assertEquals("question,/data/text1,1545392727685,1545392728527", toCSVLine(auditEvent, false, false, false));
+    }
+
+    @Test
+    public void toString_withLocationCoordinates() {
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, getTestFormIndex(), "", null, null);
+        assertNotNull(auditEvent);
+        auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertFalse(auditEvent.isEndTimeSet());
+        auditEvent.setEnd(END_TIME);
+        assertTrue(auditEvent.isEndTimeSet());
+        assertTrue(auditEvent.isLocationAlreadySet());
+        assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10", toCSVLine(auditEvent, true, false, false));
+    }
+
+    @Test
+    public void toString_withTrackingChanges() {
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, getTestFormIndex(), "First answer", null, null);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertFalse(auditEvent.isEndTimeSet());
+        auditEvent.setEnd(END_TIME);
+        assertTrue(auditEvent.isEndTimeSet());
+        assertFalse(auditEvent.isLocationAlreadySet());
+        auditEvent.recordValueChange("Second answer");
+        assertEquals("question,/data/text1,1545392727685,1545392728527,First answer,Second answer", toCSVLine(auditEvent, false, true, false));
+    }
+
+    @Test
+    public void toString_withLocationCoordinates_andTrackingChanges() {
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, getTestFormIndex(), "First answer", null, null);
+        assertNotNull(auditEvent);
+        auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertFalse(auditEvent.isEndTimeSet());
+        auditEvent.setEnd(END_TIME);
+        assertTrue(auditEvent.isEndTimeSet());
+        assertTrue(auditEvent.isLocationAlreadySet());
+        auditEvent.recordValueChange("Second, answer");
+        assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10,First answer,\"Second, answer\"", toCSVLine(auditEvent, true, true, false));
+    }
+
+    @Test
+    public void toStringNullValues() {
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, getTestFormIndex(), "Old value", null, null);
+        assertNotNull(auditEvent);
+        auditEvent.setLocationCoordinates("", "", "");
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertFalse(auditEvent.isEndTimeSet());
+        auditEvent.setEnd(END_TIME);
+        assertTrue(auditEvent.isEndTimeSet());
+        assertFalse(auditEvent.isLocationAlreadySet());
+        auditEvent.recordValueChange("New value");
+        assertEquals("question,/data/text1,1545392727685,1545392728527,,,,Old value,New value", toCSVLine(auditEvent, true, true, false));
+    }
+
+    @Test
+    public void testEventTypes() {
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertEquals("question,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, FORM_START);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("form start,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, END_OF_FORM);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertEquals("end screen,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, REPEAT);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("repeat,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, PROMPT_NEW_REPEAT);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertEquals("add repeat,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, GROUP);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertEquals("group questions,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, BEGINNING_OF_FORM);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("beginning of form,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, FORM_EXIT);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("form exit,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, FORM_RESUME);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("form resume,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, FORM_SAVE);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("form save,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, FORM_FINALIZE);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("form finalize,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, HIERARCHY);
+        assertNotNull(auditEvent);
+        assertTrue(auditEvent.isIntervalAuditEventType());
+        assertEquals("jump,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, SAVE_ERROR);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("save error,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, FINALIZE_ERROR);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("finalize error,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, CONSTRAINT_ERROR);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("constraint error,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, DELETE_REPEAT);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("delete repeat,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, GOOGLE_PLAY_SERVICES_NOT_AVAILABLE);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("google play services not available,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, LOCATION_PERMISSIONS_GRANTED);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("location permissions granted,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, LOCATION_PERMISSIONS_NOT_GRANTED);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("location permissions not granted,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, LOCATION_TRACKING_ENABLED);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("location tracking enabled,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, LOCATION_TRACKING_DISABLED);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("location tracking disabled,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, LOCATION_PROVIDERS_ENABLED);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("location providers enabled,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, LOCATION_PROVIDERS_DISABLED);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("location providers disabled,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+
+        auditEvent = new AuditEvent(START_TIME, UNKNOWN_EVENT_TYPE);
+        assertNotNull(auditEvent);
+        assertFalse(auditEvent.isIntervalAuditEventType());
+        assertEquals("Unknown AuditEvent Type,,1545392727685,", toCSVLine(auditEvent, false, false, false));
+    }
+
+    private FormIndex getTestFormIndex() {
+        TreeReference treeReference = new TreeReference();
+        treeReference.add("data", 0);
+        treeReference.add("text1", 0);
+
+        return new FormIndex(0, treeReference);
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
@@ -60,9 +60,9 @@ import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.
 public class AuditEventLoggerTest {
 
     // All values are set so location coordinates should be collected
-    private final AuditConfig testAuditConfig = new AuditConfig("high-priority", "10", "60", false, false);
+    private final AuditConfig testAuditConfig = new AuditConfig("high-priority", "10", "60", false, false, false);
     // At least one value is not set so location coordinates shouldn't be collected
-    private final AuditConfig testAuditConfigWithNullValues = new AuditConfig("high-priority", "10", null, false, false);
+    private final AuditConfig testAuditConfigWithNullValues = new AuditConfig("high-priority", "10", null, false, false, false);
 
     private final TestWriter testWriter = new TestWriter();
     private final FormController formController = mock(FormController.class);
@@ -184,7 +184,7 @@ public class AuditEventLoggerTest {
 
     @Test
     public void withUserSet_addsUserToEvents() {
-        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, true), testWriter, formController);
+        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, true, false), testWriter, formController);
         auditEventLogger.setUser("Riker");
 
         auditEventLogger.logEvent(END_OF_FORM, false, 0);

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
@@ -196,7 +196,7 @@ public class AuditEventLoggerTest {
 
     @Test
     public void logEvent_WithChangeReason_addsChangeReasonToEvent() {
-        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, false, false), testWriter, formController);
+        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, false, true), testWriter, formController);
 
         auditEventLogger.logEvent(CHANGE_REASON, null, false, null, 123L, "Blah");
         auditEventLogger.exitView(); // Triggers event writing

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.BEGINNING_OF_FORM;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.CHANGE_REASON;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.CONSTRAINT_ERROR;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.DELETE_REPEAT;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.END_OF_FORM;
@@ -191,6 +192,16 @@ public class AuditEventLoggerTest {
         auditEventLogger.exitView(); // Triggers event writing
 
         assertEquals("Riker", testWriter.auditEvents.get(0).getUser());
+    }
+
+    @Test
+    public void logEvent_WithChangeReason_addsChangeReasonToEvent() {
+        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, false, false), testWriter, formController);
+
+        auditEventLogger.logEvent(CHANGE_REASON, null, false, null, 123L, "Blah");
+        auditEventLogger.exitView(); // Triggers event writing
+
+        assertEquals("Blah", testWriter.auditEvents.get(0).getChangeReason());
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
@@ -61,9 +61,9 @@ import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.
 public class AuditEventLoggerTest {
 
     // All values are set so location coordinates should be collected
-    private final AuditConfig testAuditConfig = new AuditConfig("high-priority", "10", "60", false, false, false);
+    private final AuditConfig testAuditConfig = new AuditConfig.Builder().setMode("high-priority").setLocationMinInterval("10").setLocationMaxAge("60").setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
     // At least one value is not set so location coordinates shouldn't be collected
-    private final AuditConfig testAuditConfigWithNullValues = new AuditConfig("high-priority", "10", null, false, false, false);
+    private final AuditConfig testAuditConfigWithNullValues = new AuditConfig.Builder().setMode("high-priority").setLocationMinInterval("10").setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(false).createAuditConfig();
 
     private final TestWriter testWriter = new TestWriter();
     private final FormController formController = mock(FormController.class);
@@ -185,7 +185,7 @@ public class AuditEventLoggerTest {
 
     @Test
     public void withUserSet_addsUserToEvents() {
-        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, true, false), testWriter, formController);
+        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(true).setIsTrackChangesReasonEnabled(false).createAuditConfig(), testWriter, formController);
         auditEventLogger.setUser("Riker");
 
         auditEventLogger.logEvent(END_OF_FORM, false, 0);
@@ -196,7 +196,7 @@ public class AuditEventLoggerTest {
 
     @Test
     public void logEvent_WithChangeReason_addsChangeReasonToEvent() {
-        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig(null, null, null, false, false, true), testWriter, formController);
+        AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(true).createAuditConfig(), testWriter, formController);
 
         auditEventLogger.logEvent(CHANGE_REASON, null, false, null, 123L, "Blah");
         auditEventLogger.exitView(); // Triggers event writing

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventTest.java
@@ -16,233 +16,18 @@
 
 package org.odk.collect.android.formentry.audit;
 
-import org.javarosa.core.model.FormIndex;
-import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.form.api.FormEntryController;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.BEGINNING_OF_FORM;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.CONSTRAINT_ERROR;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.DELETE_REPEAT;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.END_OF_FORM;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FINALIZE_ERROR;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_EXIT;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_FINALIZE;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_RESUME;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_SAVE;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.FORM_START;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.GOOGLE_PLAY_SERVICES_NOT_AVAILABLE;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.GROUP;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.HIERARCHY;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PERMISSIONS_GRANTED;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PERMISSIONS_NOT_GRANTED;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_DISABLED;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_ENABLED;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_TRACKING_DISABLED;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_TRACKING_ENABLED;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.PROMPT_NEW_REPEAT;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.QUESTION;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.REPEAT;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.SAVE_ERROR;
 import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.UNKNOWN_EVENT_TYPE;
 
 public class AuditEventTest {
-    private static final long START_TIME = 1545392727685L;
-    private static final long END_TIME = 1545392728527L;
-
-    @Test
-    public void toString_() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, false, getTestFormIndex(), "", null, null, false);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertEquals("question,/data/text1,1545392727685,", auditEvent.toString());
-        assertFalse(auditEvent.isEndTimeSet());
-        auditEvent.setEnd(END_TIME);
-        assertTrue(auditEvent.isEndTimeSet());
-        assertFalse(auditEvent.isLocationAlreadySet());
-        assertEquals("question,/data/text1,1545392727685,1545392728527", auditEvent.toString());
-    }
-
-    @Test
-    public void toString_withLocationCoordinates() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, false, getTestFormIndex(), "", null, null, false);
-        assertNotNull(auditEvent);
-        auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertFalse(auditEvent.isEndTimeSet());
-        auditEvent.setEnd(END_TIME);
-        assertTrue(auditEvent.isEndTimeSet());
-        assertTrue(auditEvent.isLocationAlreadySet());
-        assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10", auditEvent.toString());
-    }
-
-    @Test
-    public void toString_withTrackingChanges() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, true, getTestFormIndex(), "First answer", null, null, false);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertFalse(auditEvent.isEndTimeSet());
-        auditEvent.setEnd(END_TIME);
-        assertTrue(auditEvent.isEndTimeSet());
-        assertFalse(auditEvent.isLocationAlreadySet());
-        auditEvent.recordValueChange("Second answer");
-        assertEquals("question,/data/text1,1545392727685,1545392728527,First answer,Second answer", auditEvent.toString());
-    }
-
-    @Test
-    public void toString_withLocationCoordinates_andTrackingChanges() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getTestFormIndex(), "First answer", null, null, false);
-        assertNotNull(auditEvent);
-        auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertFalse(auditEvent.isEndTimeSet());
-        auditEvent.setEnd(END_TIME);
-        assertTrue(auditEvent.isEndTimeSet());
-        assertTrue(auditEvent.isLocationAlreadySet());
-        auditEvent.recordValueChange("Second, answer");
-        assertEquals("question,/data/text1,1545392727685,1545392728527,54.35202520000001,18.64663840000003,10,First answer,\"Second, answer\"", auditEvent.toString());
-    }
-
-    @Test
-    public void toStringNullValues() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getTestFormIndex(), "Old value", null, null, false);
-        assertNotNull(auditEvent);
-        auditEvent.setLocationCoordinates("", "", "");
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertFalse(auditEvent.isEndTimeSet());
-        auditEvent.setEnd(END_TIME);
-        assertTrue(auditEvent.isEndTimeSet());
-        assertFalse(auditEvent.isLocationAlreadySet());
-        auditEvent.recordValueChange("New value");
-        assertEquals("question,/data/text1,1545392727685,1545392728527,,,,Old value,New value", auditEvent.toString());
-    }
-
-    @Test
-    public void testEventTypes() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertEquals("question,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, FORM_START);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("form start,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, END_OF_FORM);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertEquals("end screen,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, REPEAT);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("repeat,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, PROMPT_NEW_REPEAT);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertEquals("add repeat,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, GROUP);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertEquals("group questions,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, BEGINNING_OF_FORM);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("beginning of form,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, FORM_EXIT);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("form exit,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, FORM_RESUME);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("form resume,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, FORM_SAVE);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("form save,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, FORM_FINALIZE);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("form finalize,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, HIERARCHY);
-        assertNotNull(auditEvent);
-        assertTrue(auditEvent.isIntervalAuditEventType());
-        assertEquals("jump,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, SAVE_ERROR);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("save error,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, FINALIZE_ERROR);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("finalize error,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, CONSTRAINT_ERROR);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("constraint error,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, DELETE_REPEAT);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("delete repeat,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, GOOGLE_PLAY_SERVICES_NOT_AVAILABLE);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("google play services not available,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, LOCATION_PERMISSIONS_GRANTED);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("location permissions granted,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, LOCATION_PERMISSIONS_NOT_GRANTED);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("location permissions not granted,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, LOCATION_TRACKING_ENABLED);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("location tracking enabled,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, LOCATION_TRACKING_DISABLED);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("location tracking disabled,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, LOCATION_PROVIDERS_ENABLED);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("location providers enabled,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, LOCATION_PROVIDERS_DISABLED);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("location providers disabled,,1545392727685,", auditEvent.toString());
-
-        auditEvent = new AuditEvent(START_TIME, UNKNOWN_EVENT_TYPE);
-        assertNotNull(auditEvent);
-        assertFalse(auditEvent.isIntervalAuditEventType());
-        assertEquals("Unknown AuditEvent Type,,1545392727685,", auditEvent.toString());
-    }
 
     @Test
     public void getAuditEventTypeFromFecTypeTest() {
@@ -252,13 +37,5 @@ public class AuditEventTest {
         assertEquals(PROMPT_NEW_REPEAT, AuditEvent.getAuditEventTypeFromFecType(FormEntryController.EVENT_PROMPT_NEW_REPEAT));
         assertEquals(END_OF_FORM, AuditEvent.getAuditEventTypeFromFecType(FormEntryController.EVENT_END_OF_FORM));
         assertEquals(UNKNOWN_EVENT_TYPE, AuditEvent.getAuditEventTypeFromFecType(100));
-    }
-
-    private FormIndex getTestFormIndex() {
-        TreeReference treeReference = new TreeReference();
-        treeReference.add("data", 0);
-        treeReference.add("text1", 0);
-
-        return new FormIndex(0, treeReference);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventTest.java
@@ -56,7 +56,7 @@ public class AuditEventTest {
 
     @Test
     public void toString_() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, false, getTestFormIndex(), "", null);
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, false, getTestFormIndex(), "", null, null, false);
         assertNotNull(auditEvent);
         assertTrue(auditEvent.isIntervalAuditEventType());
         assertEquals("question,/data/text1,1545392727685,", auditEvent.toString());
@@ -69,7 +69,7 @@ public class AuditEventTest {
 
     @Test
     public void toString_withLocationCoordinates() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, false, getTestFormIndex(), "", null);
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, false, getTestFormIndex(), "", null, null, false);
         assertNotNull(auditEvent);
         auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
         assertTrue(auditEvent.isIntervalAuditEventType());
@@ -82,7 +82,7 @@ public class AuditEventTest {
 
     @Test
     public void toString_withTrackingChanges() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, true, getTestFormIndex(), "First answer", null);
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, false, true, getTestFormIndex(), "First answer", null, null, false);
         assertNotNull(auditEvent);
         assertTrue(auditEvent.isIntervalAuditEventType());
         assertFalse(auditEvent.isEndTimeSet());
@@ -95,7 +95,7 @@ public class AuditEventTest {
 
     @Test
     public void toString_withLocationCoordinates_andTrackingChanges() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getTestFormIndex(), "First answer", null);
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getTestFormIndex(), "First answer", null, null, false);
         assertNotNull(auditEvent);
         auditEvent.setLocationCoordinates("54.35202520000001", "18.64663840000003", "10");
         assertTrue(auditEvent.isIntervalAuditEventType());
@@ -109,7 +109,7 @@ public class AuditEventTest {
 
     @Test
     public void toStringNullValues() {
-        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getTestFormIndex(), "Old value", null);
+        AuditEvent auditEvent = new AuditEvent(START_TIME, QUESTION, true, true, getTestFormIndex(), "Old value", null, null, false);
         assertNotNull(auditEvent);
         auditEvent.setLocationCoordinates("", "", "");
         assertTrue(auditEvent.isIntervalAuditEventType());

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragmentTest.java
@@ -1,0 +1,51 @@
+package org.odk.collect.android.formentry.audit;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class ChangesReasonPromptDialogFragmentTest {
+
+    @Test
+    public void show_onlyEverOpensOneDialog() {
+        ChangesReasonPromptViewModel viewModel = mock(ChangesReasonPromptViewModel.class);
+        when(viewModel.requiresReasonToContinue()).thenReturn(new MutableLiveData<>(true));
+        ChangesReasonPromptViewModel.Factory factory = new TestFactory(viewModel);
+
+        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class);
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+        ChangesReasonPromptDialogFragment.show("Best Form", fragmentManager, factory);
+        ChangesReasonPromptDialogFragment.show("Best Form", fragmentManager, factory);
+
+        assertThat(fragmentManager.getFragments().size(), equalTo(1));
+    }
+
+    private static class TestFactory extends ChangesReasonPromptViewModel.Factory {
+
+        private final ChangesReasonPromptViewModel viewModel;
+
+        TestFactory(ChangesReasonPromptViewModel viewModel) {
+            this.viewModel = viewModel;
+        }
+
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            return (T) viewModel;
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragmentTest.java
@@ -5,6 +5,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,20 +22,25 @@ public class ChangesReasonPromptDialogFragmentTest {
 
     @Test
     public void show_onlyEverOpensOneDialog() {
-        ChangesReasonPromptViewModel viewModel = mock(ChangesReasonPromptViewModel.class);
-        when(viewModel.requiresReasonToContinue()).thenReturn(new MutableLiveData<>(true));
-        ChangesReasonPromptViewModel.Factory factory = new TestFactory(viewModel);
-
         FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class);
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
 
-        ChangesReasonPromptDialogFragment.show("Best Form", fragmentManager, factory);
-        ChangesReasonPromptDialogFragment.show("Best Form", fragmentManager, factory);
+        ChangesReasonPromptViewModel viewModel = mock(ChangesReasonPromptViewModel.class);
+        when(viewModel.requiresReasonToContinue()).thenReturn(new MutableLiveData<>(true));
+        ViewModelProvider.Factory factory = new TestFactory(viewModel);
+
+        ChangesReasonPromptDialogFragment dialog1 = new ChangesReasonPromptDialogFragment();
+        dialog1.viewModelFactory = factory;
+        dialog1.show("Best Form", fragmentManager);
+
+        ChangesReasonPromptDialogFragment dialog2 = new ChangesReasonPromptDialogFragment();
+        dialog2.viewModelFactory = factory;
+        dialog2.show("Best Form", fragmentManager);
 
         assertThat(fragmentManager.getFragments().size(), equalTo(1));
     }
 
-    private static class TestFactory extends ChangesReasonPromptViewModel.Factory {
+    private static class TestFactory implements ViewModelProvider.Factory {
 
         private final ChangesReasonPromptViewModel viewModel;
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
@@ -1,0 +1,27 @@
+package org.odk.collect.android.formentry.audit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class ChangesReasonPromptViewModelTest {
+
+    @Test
+    public void save_logsChangeReasonAuditEvent() {
+        AuditEventLogger logger = mock(AuditEventLogger.class);
+        when(logger.isChangeReasonRequired()).thenReturn(true);
+
+        ChangesReasonPromptViewModel viewModel = new ChangesReasonPromptViewModel();
+        viewModel.setAuditEventLogger(logger);
+
+        viewModel.setReason("Blah");
+        viewModel.save(123L);
+
+        verify(logger).logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, 123L, "Blah");
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,5 +25,21 @@ public class ChangesReasonPromptViewModelTest {
         viewModel.saveReason(123L);
 
         verify(logger).logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, 123L, "Blah");
+    }
+
+    @Test
+    public void promptDismissed_sets_isChangeReasonRequired_false() {
+        AuditEventLogger logger = mock(AuditEventLogger.class);
+        when(logger.isChangeReasonRequired()).thenReturn(true);
+        when(logger.isChangesMade()).thenReturn(true);
+        when(logger.isEditing()).thenReturn(true);
+
+        ChangesReasonPromptViewModel viewModel = new ChangesReasonPromptViewModel();
+        viewModel.setAuditEventLogger(logger);
+        viewModel.savingForm();
+        assertThat(viewModel.requiresReasonToContinue().getValue(), equalTo(true));
+
+        viewModel.promptDismissed();
+        assertThat(viewModel.requiresReasonToContinue().getValue(), equalTo(false));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
@@ -36,7 +36,7 @@ public class ChangesReasonPromptViewModelTest {
 
         ChangesReasonPromptViewModel viewModel = new ChangesReasonPromptViewModel();
         viewModel.setAuditEventLogger(logger);
-        viewModel.saveForm(true, "");
+        viewModel.saveForm(true, "", true);
         assertThat(viewModel.requiresReasonToContinue().getValue(), equalTo(true));
 
         viewModel.promptDismissed();

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
@@ -36,7 +36,7 @@ public class ChangesReasonPromptViewModelTest {
 
         ChangesReasonPromptViewModel viewModel = new ChangesReasonPromptViewModel();
         viewModel.setAuditEventLogger(logger);
-        viewModel.savingForm();
+        viewModel.saveForm(true, "");
         assertThat(viewModel.requiresReasonToContinue().getValue(), equalTo(true));
 
         viewModel.promptDismissed();

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
@@ -20,7 +20,7 @@ public class ChangesReasonPromptViewModelTest {
         viewModel.setAuditEventLogger(logger);
 
         viewModel.setReason("Blah");
-        viewModel.save(123L);
+        viewModel.saveReason(123L);
 
         verify(logger).logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, 123L, "Blah");
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationManagerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationManagerTest.java
@@ -132,7 +132,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo",  "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo",  "2", "3", true, false, false));
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -198,7 +198,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo",  "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo",  "2", "3", true, false, false));
 
         fakeLocationClient.setLocationAvailable(false);
 
@@ -228,7 +228,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -266,7 +266,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -299,7 +299,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(false);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -327,7 +327,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -363,7 +363,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
 
         backgroundLocationManager.formFinishedLoading();
 
@@ -424,7 +424,7 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
 
         backgroundLocationManager.activityDisplayed();
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationManagerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationManagerTest.java
@@ -10,9 +10,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.odk.collect.android.formentry.audit.AuditConfig;
 import org.odk.collect.android.location.LocationTestUtils;
 import org.odk.collect.android.location.client.FakeLocationClient;
-import org.odk.collect.android.formentry.audit.AuditConfig;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.robolectric.RobolectricTestRunner;
 
@@ -132,7 +132,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo",  "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -198,7 +205,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo",  "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         fakeLocationClient.setLocationAvailable(false);
 
@@ -228,7 +242,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -266,7 +287,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -299,7 +327,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(false);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -327,7 +362,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.formFinishedLoading();
         backgroundLocationManager.activityDisplayed();
@@ -363,7 +405,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.formFinishedLoading();
 
@@ -424,7 +473,14 @@ public class BackgroundLocationManagerTest {
         when(locationHelper.arePlayServicesAvailable()).thenReturn(true);
         when(locationHelper.isBackgroundLocationPreferenceEnabled()).thenReturn(true);
         when(locationHelper.isAndroidLocationPermissionGranted()).thenReturn(true);
-        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig("foo", "2", "3", true, false, false));
+        when(locationHelper.getCurrentFormAuditConfig()).thenReturn(new AuditConfig.Builder()
+                .setMode("foo")
+                .setLocationMinInterval("2")
+                .setLocationMaxAge("3")
+                .setIsTrackingChangesEnabled(true)
+                .setIsIdentifyUserEnabled(false)
+                .setIsTrackChangesReasonEnabled(false)
+                .createAuditConfig());
 
         backgroundLocationManager.activityDisplayed();
 


### PR DESCRIPTION
Closes #3471. This implements the feature described (with designs and specs) in that issue.

Some notes on the implementation:

* I seperated all knowlege of audit confiuguration out from the `AuditEvent` as I was finding hard to keep track of all the places this needed passed. There is now a helper dedicated to converting an `AuditEvent` to a CSV line as a consequence of that. This also makes the `AuditEvent` more of a data object which I think makes sense given how it's used.
* The implementation uses a ViewModel to encapsualte the logic around when to show the Changes Reason prompt. This requires "notification" style messages to be sent to the ViewModel from the `FormEntryActivity` (`savingForm` etc). The smell here is that both the ViewModel and the Activity need to know a lot about the loading/saving lifecycle of a form. It's feel like a better and better idea to have a `FormEntryViewModel` that deals with loading and saving forms. This would let us move loading/saving logic out of `FormEntryActivity` and have it bind to LiveData values t let it know when it should display the form, show a dialog etc. I'm keen to give this refactor a shot for 1.26.
* I've bumped the font size up for both this new Dialog and the Identify User one. They know use `Body1` for their description text rather than `Body2`. It seems that we're all feeling like the font sizes are "too damn small" and I've also receieved that feedback from at least one real life designer.
* I've extracted a `MaterialFullScreenDialogFragment` we can use for flows like this in the future. Hopefully we can replace this with a Material Components implementation in the future.

#### What has been done to verify that this works as intended?

Ran throught the acceptance in #3471 using a form I built with the [XLSForm part of this feature](https://github.com/XLSForm/pyxform/pull/400).

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There shouldn't be any changes other than the new feature. Would be good to test form entry in general to make sure we haven't messed up any existing flows.

#### Do we need any specific form for testing your changes? If so, please attach one.

The code has an example form used for testing (`track-changes-reason-on-edit`) that can be used.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)