### PR TITLE
Fixed checkboxes in Reset Settings dialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
@@ -25,8 +25,9 @@ import android.os.Bundle;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.CheckBox;
 import android.widget.CompoundButton;
+
+import androidx.appcompat.widget.AppCompatCheckBox;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.dialogs.ResetSettingsResultDialog;
@@ -41,12 +42,12 @@ import static org.odk.collect.android.fragments.dialogs.ResetSettingsResultDialo
 import static org.odk.collect.android.utilities.ResetUtility.ResetAction.RESET_PREFERENCES;
 
 public class ResetDialogPreference extends DialogPreference implements CompoundButton.OnCheckedChangeListener {
-    private CheckBox preferences;
-    private CheckBox instances;
-    private CheckBox forms;
-    private CheckBox layers;
-    private CheckBox cache;
-    private CheckBox osmDroid;
+    private AppCompatCheckBox preferences;
+    private AppCompatCheckBox instances;
+    private AppCompatCheckBox forms;
+    private AppCompatCheckBox layers;
+    private AppCompatCheckBox cache;
+    private AppCompatCheckBox osmDroid;
     private ProgressDialog progressDialog;
 
     public ResetDialogPreference(Context context, AttributeSet attrs) {

--- a/collect_app/src/main/res/layout/reset_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/reset_dialog_layout.xml
@@ -35,7 +35,7 @@ limitations under the License.
             android:padding="5dp"
             android:text="@string/reset_app_state_warning" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/preferences"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -47,7 +47,7 @@ limitations under the License.
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/instances"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -59,7 +59,7 @@ limitations under the License.
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/forms"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -71,7 +71,7 @@ limitations under the License.
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/cache"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -83,7 +83,7 @@ limitations under the License.
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/layers"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -95,7 +95,7 @@ limitations under the License.
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
 
-        <CheckBox
+        <androidx.appcompat.widget.AppCompatCheckBox
             android:id="@+id/osmdroid"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/collect_app/src/main/res/layout/reset_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/reset_dialog_layout.xml
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_margin="5dp"
@@ -42,6 +42,7 @@ limitations under the License.
             android:text="@string/reset_settings"
             android:padding="5dp"
             android:button="@null"
+            app:buttonCompat="@null"
             android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
@@ -53,6 +54,7 @@ limitations under the License.
             android:text="@string/reset_saved_forms"
             android:padding="5dp"
             android:button="@null"
+            app:buttonCompat="@null"
             android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
@@ -64,6 +66,7 @@ limitations under the License.
             android:text="@string/reset_blank_forms"
             android:padding="5dp"
             android:button="@null"
+            app:buttonCompat="@null"
             android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
@@ -75,6 +78,7 @@ limitations under the License.
             android:text="@string/reset_cache"
             android:padding="5dp"
             android:button="@null"
+            app:buttonCompat="@null"
             android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
@@ -86,6 +90,7 @@ limitations under the License.
             android:text="@string/reset_layers"
             android:padding="5dp"
             android:button="@null"
+            app:buttonCompat="@null"
             android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />
@@ -97,6 +102,7 @@ limitations under the License.
             android:text="@string/reset_osm_tiles"
             android:padding="5dp"
             android:button="@null"
+            app:buttonCompat="@null"
             android:background="?android:attr/selectableItemBackground"
             android:drawableEnd="?android:attr/listChoiceIndicatorMultiple"
             android:drawableRight="?android:attr/listChoiceIndicatorMultiple" />


### PR DESCRIPTION
Closes #3150 

#### What has been done to verify that this works as intended?
I was able to reproduce the issue and confirmed that this pr fixes the problem with doubled checkboxes.

#### Why is this the best possible solution? Were any other approaches considered?
It is the only way to fix the problem on Android 4.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change and testing the `Reset Settings` dialog (just its appearance not functionality) would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)