### PR TITLE
Setup reference manager when copying forms in tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
@@ -48,11 +48,14 @@ public class FormLoadingUtils {
      */
     public static void copyFormToSdCard(String formFilename, List<String> mediaFilenames) throws IOException {
         Collect.createODKDirs();
-        copyForm(formFilename);
 
+        String pathname = copyForm(formFilename);
         if (mediaFilenames != null) {
             copyFormMediaFiles(formFilename, mediaFilenames);
         }
+
+        FormLoaderTask.prepareReferenceManager(FileUtils.getFormMediaDir(new File(pathname)));
+        saveFormToDatabase(new File(pathname));
     }
 
     /**
@@ -82,10 +85,10 @@ public class FormLoadingUtils {
         return new FormActivityTestRule(formFilename);
     }
 
-    private static void copyForm(String formFilename) throws IOException {
+    private static String copyForm(String formFilename) throws IOException {
         String pathname = Collect.FORMS_PATH + "/" + formFilename;
         copyFileFromAssets("forms/" + formFilename, pathname);
-        saveFormToDatabase(new File(pathname));
+        return pathname;
     }
 
     private static void copyFormMediaFiles(String formFilename, List<String> mediaFilenames) throws IOException {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormLoadingUtils.java
@@ -20,6 +20,7 @@ import android.content.ContentValues;
 
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 
+import org.javarosa.core.reference.ReferenceManager;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.odk.collect.android.forms.FormUtils.setupReferenceManagerForForm;
 import static org.odk.collect.android.test.FileUtils.copyFileFromAssets;
 
 public class FormLoadingUtils {
@@ -54,7 +56,7 @@ public class FormLoadingUtils {
             copyFormMediaFiles(formFilename, mediaFilenames);
         }
 
-        FormLoaderTask.prepareReferenceManager(FileUtils.getFormMediaDir(new File(pathname)));
+        setupReferenceManagerForForm(ReferenceManager.instance(), FileUtils.getFormMediaDir(new File(pathname)));
         saveFormToDatabase(new File(pathname));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormUtils.java
@@ -1,0 +1,38 @@
+package org.odk.collect.android.forms;
+
+import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.RootTranslator;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.FileReferenceFactory;
+
+import java.io.File;
+
+public class FormUtils {
+
+    private FormUtils() {
+        
+    }
+
+    public static void setupReferenceManagerForForm(ReferenceManager referenceManager, File formMediaDir) {
+
+        // Remove previous forms
+        referenceManager.clearSession();
+
+        // This should get moved to the Application Class
+        if (referenceManager.getFactories().length == 0) {
+            // this is /sdcard/odk
+            referenceManager.addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
+        }
+
+        addSessionRootTranslators(formMediaDir.getName(), referenceManager,
+                "images", "image", "audio", "video", "file");
+    }
+
+    private static void addSessionRootTranslators(String formMediaDir, ReferenceManager referenceManager, String... hostStrings) {
+        // Set jr://... to point to /sdcard/odk/forms/formBasename-media/
+        final String translatedPrefix = String.format("jr://file/forms/" + formMediaDir + "/");
+        for (String t : hostStrings) {
+            referenceManager.addSessionRootTranslator(new RootTranslator(String.format("jr://%s/", t), translatedPrefix));
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -130,19 +130,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         final File formXml = new File(formPath);
         final File formMediaDir = FileUtils.getFormMediaDir(formXml);
 
-        final ReferenceManager referenceManager = ReferenceManager.instance();
-
-        // Remove previous forms
-        referenceManager.clearSession();
-
-        // This should get moved to the Application Class
-        if (referenceManager.getFactories().length == 0) {
-            // this is /sdcard/odk
-            referenceManager.addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
-        }
-
-        addSessionRootTranslators(formMediaDir.getName(), referenceManager,
-                "images", "image", "audio", "video", "file");
+        prepareReferenceManager(formMediaDir);
 
         FormDef formDef = null;
         try {
@@ -225,7 +213,23 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         return data;
     }
 
-    private void addSessionRootTranslators(String formMediaDir, ReferenceManager referenceManager, String... hostStrings) {
+    public static void prepareReferenceManager(File formMediaDir) {
+        final ReferenceManager referenceManager = ReferenceManager.instance();
+
+        // Remove previous forms
+        referenceManager.clearSession();
+
+        // This should get moved to the Application Class
+        if (referenceManager.getFactories().length == 0) {
+            // this is /sdcard/odk
+            referenceManager.addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
+        }
+
+        addSessionRootTranslators(formMediaDir.getName(), referenceManager,
+                "images", "image", "audio", "video", "file");
+    }
+
+    private static void addSessionRootTranslators(String formMediaDir, ReferenceManager referenceManager, String... hostStrings) {
         // Set jr://... to point to /sdcard/odk/forms/formBasename-media/
         final String translatedPrefix = String.format("jr://file/forms/" + formMediaDir + "/");
         for (String t : hostStrings) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -26,7 +26,6 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
 import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.parse.XFormParser;
@@ -43,7 +42,6 @@ import org.odk.collect.android.external.ExternalDataReader;
 import org.odk.collect.android.external.ExternalDataReaderImpl;
 import org.odk.collect.android.external.handler.ExternalDataHandlerPull;
 import org.odk.collect.android.listeners.FormLoaderListener;
-import org.odk.collect.android.logic.FileReferenceFactory;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormDefCache;
@@ -59,6 +57,8 @@ import java.util.Map;
 
 import au.com.bytecode.opencsv.CSVReader;
 import timber.log.Timber;
+
+import static org.odk.collect.android.forms.FormUtils.setupReferenceManagerForForm;
 
 /**
  * Background task for loading a form.
@@ -130,7 +130,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         final File formXml = new File(formPath);
         final File formMediaDir = FileUtils.getFormMediaDir(formXml);
 
-        prepareReferenceManager(formMediaDir);
+        setupReferenceManagerForForm(ReferenceManager.instance(), formMediaDir);
 
         FormDef formDef = null;
         try {
@@ -211,30 +211,6 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
         data = new FECWrapper(fc, usedSavepoint);
         return data;
-    }
-
-    public static void prepareReferenceManager(File formMediaDir) {
-        final ReferenceManager referenceManager = ReferenceManager.instance();
-
-        // Remove previous forms
-        referenceManager.clearSession();
-
-        // This should get moved to the Application Class
-        if (referenceManager.getFactories().length == 0) {
-            // this is /sdcard/odk
-            referenceManager.addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
-        }
-
-        addSessionRootTranslators(formMediaDir.getName(), referenceManager,
-                "images", "image", "audio", "video", "file");
-    }
-
-    private static void addSessionRootTranslators(String formMediaDir, ReferenceManager referenceManager, String... hostStrings) {
-        // Set jr://... to point to /sdcard/odk/forms/formBasename-media/
-        final String translatedPrefix = String.format("jr://file/forms/" + formMediaDir + "/");
-        for (String t : hostStrings) {
-            referenceManager.addSessionRootTranslator(new RootTranslator(String.format("jr://%s/", t), translatedPrefix));
-        }
     }
 
     private FormDef createFormDefFromCacheOrXml(String formPath, File formXml) {


### PR DESCRIPTION
This fixes the failing tests we were seeing (`ExternalSecondaryInstancesTest`). 

#### What has been done to verify that this works as intended?

Ran tests locally.

#### Why is this the best possible solution? Were any other approaches considered?

I think we should use as much of the "real" form loading code as possible in tests as these problem will just keep coming up otherwise. This change is hopefully a small step in the right direction as it extracts some code from `FromLoaderTask` to the new `forms` package (which @lognaturel created in another PR). I'd like to see form loading extracted from the task as much as possible but definitely didn't want to carry out that refactor in the red.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't be any change in behaviour. Some code was moved but probably not worth a QA pass.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)