### PR TITLE
Fixed crash in Mapbox

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -104,7 +104,6 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
     private boolean isDragging;
     private String styleUrl = Style.MAPBOX_STREETS;
     private File referenceLayerFile;
-    private final List<Layer> overlayLayers = new ArrayList<>();
     private final List<Source> overlaySources = new ArrayList<>();
     private static String lastLocationProvider;
 
@@ -499,7 +498,6 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
      * is fully loaded, in setStyle()'s OnStyleLoaded callback.
      */
     private void loadReferenceOverlay() {
-        clearOverlays();
         if (referenceLayerFile != null) {
             addMbtiles(referenceLayerFile.getName(), referenceLayerFile);
         }
@@ -579,26 +577,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
         return tileSet;
     }
 
-    private void clearOverlays() {
-        Style style = map.getStyle();
-        for (Layer layer : overlayLayers) {
-            style.removeLayer(layer);
-        }
-        overlayLayers.clear();
-        // NOTE(ping): It would make sense to remove the overlaySources from
-        // the map here, but that can lead to a SEGV in libmapbox-gl.so.  See
-        // https://github.com/mapbox/mapbox-gl-native/issues/15182 for details.
-        /*
-        for (Source source : overlaySources) {
-            style.removeSource(source);
-        }
-        overlaySources.clear();
-        */
-    }
-
     private void addOverlayLayer(Layer layer) {
-        overlayLayers.add(layer);
-
         // If there is a LocationComponent, it will have added some layers to the
         // style.  The SymbolManager and LineManager also add their own layers
         // where they place their symbols and lines.  We need to insert the new


### PR DESCRIPTION
Closes #3479 

#### What has been done to verify that this works as intended?
I reproduced the crash and confirmed the pr fixes the issue. I also debugged the code to confirm that the code I removes was redundant.

#### Why is this the best possible solution? Were any other approaches considered?
Just to clarify: the issue is not related to changing the layer to `None` but generally to changing any layers.

The crash was caused [here](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3479?expand=1#diff-fdd039fc806c853bc4ba175e0ab623edL585) because we tried to remove a layer that doesn't exist. It didn't cause a problem when we had mapbxox v8.3.0 but since we updated to 8.4.0 it's been crashing.

I removed the code because as I said above it always tried to remove a layer that didn't exist. The code was redundant. It was called just in `loadReferenceOverlay()` which is called in two places:
https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java#L208
https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java#L161
in both cases after we call: `map.setStyle` what clears layers we then again tried to remove.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing changing layers in Mapbox would be enough. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with geo widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)