### PR TITLE
Clear credentials when settings are being reset 

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/ResetAppStateTest.java
@@ -36,10 +36,12 @@ import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.utilities.ResetUtility;
+import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.osmdroid.config.Configuration;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -77,6 +79,9 @@ public class ResetAppStateTest {
 
     @Test
     public void resetSettingsTest() throws IOException {
+        WebCredentialsUtils webCredentialsUtils = new WebCredentialsUtils();
+        webCredentialsUtils.saveCredentials("https://opendatakit.appspot.com/", "admin", "admin");
+
         setupTestSettings();
         resetAppState(Collections.singletonList(ResetUtility.ResetAction.RESET_PREFERENCES));
 
@@ -87,6 +92,8 @@ public class ResetAppStateTest {
 
         assertEquals(0, getFormsCount());
         assertEquals(0, getInstancesCount());
+        assertEquals("", webCredentialsUtils.getCredentials(URI.create("https://opendatakit.appspot.com/")).getUsername());
+        assertEquals("", webCredentialsUtils.getCredentials(URI.create("https://opendatakit.appspot.com/")).getPassword());
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ResetUtility.java
@@ -72,6 +72,8 @@ public class ResetUtility {
     }
 
     private void resetPreferences(Context context) {
+        WebCredentialsUtils.clearAllCredentials();
+
         GeneralSharedPreferences.getInstance().loadDefaultPreferences();
         AdminSharedPreferences.getInstance().loadDefaultPreferences();
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
@@ -55,6 +55,10 @@ public class WebCredentialsUtils {
         }
     }
 
+    static void clearAllCredentials() {
+        HOST_CREDENTIALS.clear();
+    }
+
     public String getServerUrlFromPreferences() {
         if (GeneralSharedPreferences.getInstance() == null) {
             return "";


### PR DESCRIPTION
Closes #3481 

#### What has been done to verify that this works as intended?
I tested the scenario mentioned in the issue and confirmed the pr fixes it. I also improved tests.

#### Why is this the best possible solution? Were any other approaches considered?
We should just clear credentials when settings are being reset, it's the only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Testing the scenario described in the issue should be enough. It's not a risky change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)