### PR TITLE
Support items from search function in RankWidget

### DIFF
--- a/collect_app/src/androidTest/assets/forms/ranking_widget.xml
+++ b/collect_app/src/androidTest/assets/forms/ranking_widget.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<h:html
+	xmlns="http://www.w3.org/2002/xforms"
+	xmlns:ev="http://www.w3.org/2001/xml-events"
+	xmlns:h="http://www.w3.org/1999/xhtml"
+	xmlns:jr="http://openrosa.org/javarosa"
+	xmlns:odk="http://www.opendatakit.org/xforms"
+	xmlns:orx="http://openrosa.org/xforms"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>ranking_widget</h:title>
+		<model>
+			<instance>
+				<ranking_widget id="ranking_widget">
+					<q1/>
+					<meta>
+						<instanceID/>
+					</meta>
+				</ranking_widget>
+			</instance>
+			<bind nodeset="/ranking_widget/q1" type="odk:rank"/>
+			<bind jr:preload="uid" nodeset="/ranking_widget/meta/instanceID" readonly="true()" type="string"/>
+		</model>
+	</h:head>
+	<h:body>
+		<odk:rank appearance="search('fruits')" ref="/ranking_widget/q1">
+			<label>Items from an external csv file</label>
+			<item>
+				<label>name</label>
+				<value>name_key</value>
+			</item>
+		</odk:rank>
+	</h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/FormEntryPage.java
@@ -118,6 +118,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    public FormEntryPage clickRankingButton() {
+        onView(withId(R.id.simple_button)).perform(click());
+        return this;
+    }
+
     public FormEntryPage putTextOnIndex(int index, String text) {
         onView(withIndex(withClassName(endsWith("Text")), index)).perform(replaceText(text));
         return this;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/espressoutils/pages/Page.java
@@ -78,6 +78,13 @@ abstract class Page<T extends Page<T>> {
         return (T) this;
     }
 
+    public T checkIsTextDisplayed(String...  text) {
+        for (String s : text) {
+            onView(withText(s)).check(matches(isDisplayed()));
+        }
+        return (T) this;
+    }
+
     public T checkIsTranslationDisplayed(String... text) {
         for (String s : text) {
             try {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/RankingWidgetWIthCSVTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/RankingWidgetWIthCSVTest.java
@@ -1,0 +1,42 @@
+package org.odk.collect.android.formentry;
+
+import android.Manifest;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.espressoutils.pages.FormEntryPage;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.test.FormLoadingUtils;
+
+import java.util.Collections;
+
+public class RankingWidgetWIthCSVTest {
+
+    private static final String TEST_FORM = "ranking_widget.xml";
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+            )
+            .around(new ResetStateRule())
+            .around(new CopyFormRule(TEST_FORM, Collections.singletonList("fruits.csv")));
+
+    @Rule
+    public IntentsTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(TEST_FORM);
+
+    @Test
+    public void rankingWidget_shouldDisplayItemsFromSearchFunc() {
+        new FormEntryPage("ranking_widget", activityTestRule)
+                .clickRankingButton()
+                .checkIsTextDisplayed("Mango", "Oranges", "Strawberries");
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -76,6 +76,7 @@ import com.google.zxing.integration.android.IntentResult;
 import org.apache.commons.io.IOUtils;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.form.api.FormEntryCaption;
@@ -2821,11 +2822,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     @Override
-    public void onRankingChanged(List<String> values) {
+    public void onRankingChanged(List<SelectChoice> items) {
         ODKView odkView = getCurrentViewIfODKView();
         if (odkView != null) {
             QuestionWidget widgetGettingNewValue = getWidgetWaitingForBinaryData();
-            odkView.setBinaryData(values);
+            odkView.setBinaryData(items);
             widgetValueChanged(widgetGettingNewValue);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
@@ -25,26 +25,23 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.RankingListAdapter.ItemViewHolder;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormController;
+import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class RankingListAdapter extends Adapter<ItemViewHolder> {
 
-    private final List<String> values;
-    private final FormIndex formIndex;
+    private final List<SelectChoice> items;
 
-    public RankingListAdapter(List<String> values, FormIndex formIndex) {
-        this.values = new ArrayList<>(values);
-        this.formIndex = formIndex;
+    public RankingListAdapter(List<SelectChoice> items) {
+        this.items = items;
     }
 
     @NonNull
@@ -56,33 +53,22 @@ public class RankingListAdapter extends Adapter<ItemViewHolder> {
     @Override
     public void onBindViewHolder(@NonNull final ItemViewHolder holder, int position) {
         FormController formController = Collect.getInstance().getFormController();
-        String itemName = formController != null
-                ? formController.getQuestionPrompt(formIndex).getSelectChoiceText(getItem(formController, values.get(position)))
-                : values.get(position);
+        String itemName = String.valueOf(FormEntryPromptUtils.getItemText(formController.getQuestionPrompt(), items.get(position)));
         holder.textView.setText(itemName);
     }
 
-    private SelectChoice getItem(FormController formController, String value) {
-        for (SelectChoice item : formController.getQuestionPrompt(formIndex).getSelectChoices()) {
-            if (item.getValue().equals(value)) {
-                return item;
-            }
-        }
-        return null;
-    }
-
     public void onItemMove(int fromPosition, int toPosition) {
-        Collections.swap(values, fromPosition, toPosition);
+        Collections.swap(items, fromPosition, toPosition);
         notifyItemMoved(fromPosition, toPosition);
     }
 
     @Override
     public int getItemCount() {
-        return values.size();
+        return items.size();
     }
 
-    public List<String> getValues() {
-        return values;
+    public List<SelectChoice> getItems() {
+        return items;
     }
 
     public static class ItemViewHolder extends ViewHolder {

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/RankingListAdapter.java
@@ -25,6 +25,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.RankingListAdapter.ItemViewHolder;
@@ -39,9 +40,11 @@ import java.util.List;
 public class RankingListAdapter extends Adapter<ItemViewHolder> {
 
     private final List<SelectChoice> items;
+    private final FormIndex formIndex;
 
-    public RankingListAdapter(List<SelectChoice> items) {
+    public RankingListAdapter(List<SelectChoice> items, FormIndex formIndex) {
         this.items = items;
+        this.formIndex = formIndex;
     }
 
     @NonNull
@@ -53,7 +56,7 @@ public class RankingListAdapter extends Adapter<ItemViewHolder> {
     @Override
     public void onBindViewHolder(@NonNull final ItemViewHolder holder, int position) {
         FormController formController = Collect.getInstance().getFormController();
-        String itemName = String.valueOf(FormEntryPromptUtils.getItemText(formController.getQuestionPrompt(), items.get(position)));
+        String itemName = String.valueOf(FormEntryPromptUtils.getItemText(formController.getQuestionPrompt(formIndex), items.get(position)));
         holder.textView.setText(itemName);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalAnswerResolver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalAnswerResolver.java
@@ -50,7 +50,8 @@ public class ExternalAnswerResolver extends DefaultAnswerResolver {
         QuestionDef questionDef = XFormParser.ghettoGetQuestionDef(treeElement.getDataType(),
                 formDef, treeElement.getRef());
         if (questionDef != null && (questionDef.getControlType() == Constants.CONTROL_SELECT_ONE
-                || questionDef.getControlType() == Constants.CONTROL_SELECT_MULTI)) {
+                || questionDef.getControlType() == Constants.CONTROL_SELECT_MULTI
+                || questionDef.getControlType() == Constants.CONTROL_RANK)) {
             boolean containsSearchExpression = false;
 
             XPathFuncExpr xpathExpression = null;
@@ -93,7 +94,8 @@ public class ExternalAnswerResolver extends DefaultAnswerResolver {
                                 }
                                 break;
                             }
-                            case Constants.CONTROL_SELECT_MULTI: {
+                            case Constants.CONTROL_SELECT_MULTI:
+                            case Constants.CONTROL_RANK: {
                                 // we should search in a potential comma-separated string of
                                 // values for a match
                                 // copied from org.javarosa.xform.util.XFormAnswerDataParser
@@ -138,7 +140,8 @@ public class ExternalAnswerResolver extends DefaultAnswerResolver {
                                 customSelectChoice.setIndex(index);
                                 return new SelectOneData(customSelectChoice.selection());
                             }
-                            case Constants.CONTROL_SELECT_MULTI: {
+                            case Constants.CONTROL_SELECT_MULTI:
+                            case Constants.CONTROL_RANK: {
                                 // we should create multiple selections and add them to the pile
                                 List<SelectChoice> customSelectChoices = createCustomSelectChoices(
                                         textVal);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
@@ -33,6 +33,7 @@ import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
 
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
 import org.odk.collect.android.R;
 import org.odk.collect.android.R.string;
@@ -46,20 +47,23 @@ import java.util.List;
 public class RankingWidgetDialog extends DialogFragment {
 
     private static final String ITEMS = "items";
+    private static final String FORM_INDEX = "form_index";
 
     private RankingListener listener;
 
     private RankingListAdapter rankingListAdapter;
     private List<SelectChoice> items;
+    private FormIndex formIndex;
 
     public interface RankingListener {
         void onRankingChanged(List<SelectChoice> items);
     }
 
-    public static RankingWidgetDialog newInstance(List<SelectChoice> items) {
+    public static RankingWidgetDialog newInstance(List<SelectChoice> items, FormIndex formIndex) {
         RankingWidgetDialog dialog = new RankingWidgetDialog();
         Bundle bundle = new Bundle();
         bundle.putSerializable(ITEMS, (Serializable) items);
+        bundle.putSerializable(FORM_INDEX, formIndex);
         dialog.setArguments(bundle);
 
         return dialog;
@@ -79,12 +83,15 @@ public class RankingWidgetDialog extends DialogFragment {
         items = (List<SelectChoice>) (savedInstanceState == null
                 ? getArguments().getSerializable(ITEMS)
                 : savedInstanceState.getSerializable(ITEMS));
+        formIndex = (FormIndex) (savedInstanceState == null
+                ? getArguments().getSerializable(FORM_INDEX)
+                : savedInstanceState.getSerializable(FORM_INDEX));
     }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         return new Builder(getActivity())
-                .setView(setUpRankingLayout(items))
+                .setView(setUpRankingLayout())
                 .setPositiveButton(string.ok, (dialog, id) -> {
                     listener.onRankingChanged(rankingListAdapter.getItems());
                     dismiss();
@@ -96,14 +103,15 @@ public class RankingWidgetDialog extends DialogFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(ITEMS, (Serializable) rankingListAdapter.getItems());
+        outState.putSerializable(FORM_INDEX, formIndex);
         super.onSaveInstanceState(outState);
     }
 
-    private NestedScrollView setUpRankingLayout(List<SelectChoice> items) {
+    private NestedScrollView setUpRankingLayout() {
         LinearLayout rankingLayout = new LinearLayout(getContext());
         rankingLayout.setOrientation(LinearLayout.HORIZONTAL);
-        rankingLayout.addView(setUpPositionsLayout(items));
-        rankingLayout.addView(setUpRecyclerView(items));
+        rankingLayout.addView(setUpPositionsLayout());
+        rankingLayout.addView(setUpRecyclerView());
         rankingLayout.setPadding(10, 0, 10, 0);
 
         NestedScrollView scrollView = new NestedScrollView(getContext());
@@ -111,7 +119,7 @@ public class RankingWidgetDialog extends DialogFragment {
         return scrollView;
     }
 
-    private LinearLayout setUpPositionsLayout(List<SelectChoice> items) {
+    private LinearLayout setUpPositionsLayout() {
         LinearLayout positionsLayout = new LinearLayout(getContext());
         positionsLayout.setOrientation(LinearLayout.VERTICAL);
 
@@ -130,8 +138,8 @@ public class RankingWidgetDialog extends DialogFragment {
         return positionsLayout;
     }
 
-    private RecyclerView setUpRecyclerView(List<SelectChoice> items) {
-        rankingListAdapter = new RankingListAdapter(items);
+    private RecyclerView setUpRecyclerView() {
+        rankingListAdapter = new RankingListAdapter(items, formIndex);
 
         RecyclerView recyclerView = new RecyclerView(getContext());
         recyclerView.setHasFixedSize(true);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
@@ -33,7 +33,7 @@ import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
 
-import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.SelectChoice;
 import org.odk.collect.android.R;
 import org.odk.collect.android.R.string;
 import org.odk.collect.android.adapters.RankingListAdapter;
@@ -45,24 +45,21 @@ import java.util.List;
 
 public class RankingWidgetDialog extends DialogFragment {
 
-    private static final String VALUES = "values";
-    private static final String FORM_INDEX = "form_index";
+    private static final String ITEMS = "items";
 
     private RankingListener listener;
 
     private RankingListAdapter rankingListAdapter;
-    private List<String> values;
-    private FormIndex formIndex;
+    private List<SelectChoice> items;
 
     public interface RankingListener {
-        void onRankingChanged(List<String> values);
+        void onRankingChanged(List<SelectChoice> items);
     }
 
-    public static RankingWidgetDialog newInstance(List<String> values, FormIndex formIndex) {
+    public static RankingWidgetDialog newInstance(List<SelectChoice> items) {
         RankingWidgetDialog dialog = new RankingWidgetDialog();
         Bundle bundle = new Bundle();
-        bundle.putSerializable(VALUES, (Serializable) values);
-        bundle.putSerializable(FORM_INDEX, formIndex);
+        bundle.putSerializable(ITEMS, (Serializable) items);
         dialog.setArguments(bundle);
 
         return dialog;
@@ -79,20 +76,17 @@ public class RankingWidgetDialog extends DialogFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        values = (List<String>) (savedInstanceState == null
-                        ? getArguments().getSerializable(VALUES)
-                        : savedInstanceState.getSerializable(VALUES));
-        formIndex = (FormIndex) (savedInstanceState == null
-                        ? getArguments().getSerializable(FORM_INDEX)
-                        : savedInstanceState.getSerializable(FORM_INDEX));
+        items = (List<SelectChoice>) (savedInstanceState == null
+                ? getArguments().getSerializable(ITEMS)
+                : savedInstanceState.getSerializable(ITEMS));
     }
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         return new Builder(getActivity())
-                .setView(setUpRankingLayout(values, formIndex))
+                .setView(setUpRankingLayout(items))
                 .setPositiveButton(string.ok, (dialog, id) -> {
-                    listener.onRankingChanged(rankingListAdapter.getValues());
+                    listener.onRankingChanged(rankingListAdapter.getItems());
                     dismiss();
                 })
                 .setNegativeButton(string.cancel, (dialog, id) -> dismiss())
@@ -101,16 +95,15 @@ public class RankingWidgetDialog extends DialogFragment {
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        outState.putSerializable(VALUES, (Serializable) rankingListAdapter.getValues());
-        outState.putSerializable(FORM_INDEX, formIndex);
+        outState.putSerializable(ITEMS, (Serializable) rankingListAdapter.getItems());
         super.onSaveInstanceState(outState);
     }
 
-    private NestedScrollView setUpRankingLayout(List<String> values, FormIndex formIndex) {
+    private NestedScrollView setUpRankingLayout(List<SelectChoice> items) {
         LinearLayout rankingLayout = new LinearLayout(getContext());
         rankingLayout.setOrientation(LinearLayout.HORIZONTAL);
-        rankingLayout.addView(setUpPositionsLayout(values));
-        rankingLayout.addView(setUpRecyclerView(values, formIndex));
+        rankingLayout.addView(setUpPositionsLayout(items));
+        rankingLayout.addView(setUpRecyclerView(items));
         rankingLayout.setPadding(10, 0, 10, 0);
 
         NestedScrollView scrollView = new NestedScrollView(getContext());
@@ -118,7 +111,7 @@ public class RankingWidgetDialog extends DialogFragment {
         return scrollView;
     }
 
-    private LinearLayout setUpPositionsLayout(List<String> values) {
+    private LinearLayout setUpPositionsLayout(List<SelectChoice> items) {
         LinearLayout positionsLayout = new LinearLayout(getContext());
         positionsLayout.setOrientation(LinearLayout.VERTICAL);
 
@@ -126,10 +119,10 @@ public class RankingWidgetDialog extends DialogFragment {
         layoutParams.setMargins(0, 0, 10, 0);
         positionsLayout.setLayoutParams(layoutParams);
 
-        for (String value : values) {
+        for (SelectChoice item : items) {
             FrameLayout positionLayout = (FrameLayout) LayoutInflater.from(getContext()).inflate(R.layout.ranking_item, positionsLayout, false);
             TextView textView = positionLayout.findViewById(R.id.rank_item_text);
-            textView.setText(String.valueOf(values.indexOf(value) + 1));
+            textView.setText(String.valueOf(items.indexOf(item) + 1));
             textView.setTextSize(Collect.getQuestionFontsize());
 
             positionsLayout.addView(positionLayout);
@@ -137,8 +130,8 @@ public class RankingWidgetDialog extends DialogFragment {
         return positionsLayout;
     }
 
-    private RecyclerView setUpRecyclerView(List<String> values, FormIndex formIndex) {
-        rankingListAdapter = new RankingListAdapter(values, formIndex);
+    private RecyclerView setUpRecyclerView(List<SelectChoice> items) {
+        rankingListAdapter = new RankingListAdapter(items);
 
         RecyclerView recyclerView = new RecyclerView(getContext());
         recyclerView.setHasFixedSize(true);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -84,7 +84,7 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
 
     @Override
     public void setBinaryData(Object values) {
-        savedItems = getSavedItems((List<String>) values);
+        savedItems = (List<SelectChoice>) values;
         setUpLayout(savedItems);
     }
 
@@ -94,31 +94,8 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
         if (formController != null) {
             formController.setIndexWaitingForData(getFormEntryPrompt().getIndex());
         }
-        RankingWidgetDialog rankingWidgetDialog = RankingWidgetDialog.newInstance(savedItems == null
-                ? getValues(items)
-                : getValues(savedItems), getFormEntryPrompt().getIndex());
+        RankingWidgetDialog rankingWidgetDialog = RankingWidgetDialog.newInstance(savedItems == null ? items : savedItems);
         rankingWidgetDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), "RankingDialog");
-    }
-
-    private List<SelectChoice> getSavedItems(List<String> values) {
-        List<SelectChoice> savedItems = new ArrayList<>();
-        for (String value : values) {
-            for (SelectChoice item : items) {
-                if (item.getValue().equals(value)) {
-                    savedItems.add(item);
-                    break;
-                }
-            }
-        }
-        return savedItems;
-    }
-
-    private List<String> getValues(List<SelectChoice> items) {
-        List<String> values = new ArrayList<>();
-        for (SelectChoice item : items) {
-            values.add(item.getValue());
-        }
-        return values;
     }
 
     private List<SelectChoice> getOrderedItems() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -94,7 +94,7 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
         if (formController != null) {
             formController.setIndexWaitingForData(getFormEntryPrompt().getIndex());
         }
-        RankingWidgetDialog rankingWidgetDialog = RankingWidgetDialog.newInstance(savedItems == null ? items : savedItems);
+        RankingWidgetDialog rankingWidgetDialog = RankingWidgetDialog.newInstance(savedItems == null ? items : savedItems, getFormEntryPrompt().getIndex());
         rankingWidgetDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), "RankingDialog");
     }
 


### PR DESCRIPTION
Closes #3486 

#### What has been done to verify that this works as intended?
I tested the ranking widget manually and also added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
I refactored the code to allow using a list of `SelectChoices` in Ranking widget like other item widgets do. That's the simplest solution which is also consistent with other widgets.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is related just to the Ranking widget. We need to test it with items from the choices sheet (the one i All widgets form), and with items from an external csv file (the one attached below). That would be enough, nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
[ranking_widget.zip](https://github.com/opendatakit/collect/files/3916480/ranking_widget.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)