### PR TITLE
Don't allow selecting basemap that is unavailable

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -90,8 +90,14 @@ public class MapsPreferences extends BasePreferenceFragment {
         );
         onBasemapSourceChanged(MapProvider.getConfigurator());
         basemapSourcePref.setOnPreferenceChangeListener((pref, value) -> {
-            onBasemapSourceChanged(MapProvider.getConfigurator(value.toString()));
-            return true;
+            MapConfigurator cftor = MapProvider.getConfigurator(value.toString());
+            if (!cftor.isAvailable(context)) {
+                cftor.showUnavailableMessage(context);
+                return false;
+            } else {
+                onBasemapSourceChanged(cftor);
+                return true;
+            }
         });
     }
 
@@ -101,10 +107,7 @@ public class MapsPreferences extends BasePreferenceFragment {
         PreferenceCategory baseCategory = (PreferenceCategory) findPreference(CATEGORY_BASEMAP);
         baseCategory.removeAll();
         baseCategory.addPreference(basemapSourcePref);
-        if (!cftor.isAvailable(context)) {
-            cftor.showUnavailableMessage(context);
-            return;
-        }
+
         for (Preference pref : cftor.createPrefs(context)) {
             baseCategory.addPreference(pref);
         }


### PR DESCRIPTION
Closes #3497 

#### What has been done to verify that this works as intended?
I reproduced the issue and confirmed this pr fixes it.

#### Why is this the best possible solution? Were any other approaches considered?
It was strange that we could select a basemap that is unavailable.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Now if a basemap is unavailable we won't be able to select it.
The only thing we should test is changing basemaps in General Settings -> Maps.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)