### PR TITLE
Replace margin with padding to prevent RTL bug in Android 7

### DIFF
--- a/collect_app/src/main/res/layout/help_text_layout.xml
+++ b/collect_app/src/main/res/layout/help_text_layout.xml
@@ -29,8 +29,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="@dimen/margin_standard"
-            android:layout_marginRight="@dimen/margin_standard"
+            android:paddingLeft="@dimen/margin_standard"
+            android:paddingRight="@dimen/margin_standard"
             android:layout_toEndOf="@id/help_icon"
             android:layout_toRightOf="@id/help_icon"
             tools:text="Testing this out." />


### PR DESCRIPTION
Closes #3504

#### What has been done to verify that this works as intended?

Ran tests locally and went through `AllWidgetsForm.xml` manually in RTL and LTR on both Android 7 and 8.1.

#### Why is this the best possible solution? Were any other approaches considered?

It's not a great solution but I want to rework `QuestionWidget` and `ODKView` to use XML layouts for 1.26. I made a start on this in #3483 (but closed it to prevent distractions during the release) and it should make it a lot easier to understand layout issues for these screens. Right now understanding how all the programmatic margins/paddings interact is pretty hard. Given that, I didn't want to dig into this too far - especially as it appears to only effect one Android version.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to double check this hasn't created any other RTL (or other visual issues) but looked fine during the couple of sweep throughs I did.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)