### PR TITLE
Clear geometry after encryption

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -29,4 +29,16 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
         new String[] {formId});
         return dao.getInstancesFromCursor(c);
     }
+
+    @Override
+    public Instance getByPath(String instancePath) {
+        Cursor c = dao.getInstancesCursor(InstanceColumns.INSTANCE_FILE_PATH + "=?",
+                new String[] {instancePath});
+        List<Instance> instances = dao.getInstancesFromCursor(c);
+        if (instances.size() == 1) {
+            return instances.get(0);
+        } else {
+            return null;
+        }
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -13,4 +13,9 @@ import java.util.List;
  */
 public interface InstancesRepository {
     List<Instance> getAllBy(String formId);
+
+    /**
+     * Get the Instance corresponding to the given path or null if no unique Instance matches.
+     */
+    Instance getByPath(String instancePath);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -260,6 +260,8 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                 EncryptionUtils.generateEncryptedSubmission(instanceXml, submissionXml, formInfo);
 
                 values.put(InstanceColumns.CAN_EDIT_WHEN_COMPLETE, Boolean.toString(false));
+                values.put(InstanceColumns.GEOMETRY_TYPE, (String) null);
+                values.put(InstanceColumns.GEOMETRY, (String) null);
                 instancesDao.updateInstance(values, InstanceColumns.INSTANCE_FILE_PATH + "=?", new String[]{candidateInstance});
 
                 SaveToDiskTask.manageFilesAfterSavingEncryptedForm(instanceXml, submissionXml);

--- a/collect_app/src/test/java/org/odk/collect/android/instances/TestInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/instances/TestInstancesRepository.java
@@ -23,6 +23,23 @@ public final class TestInstancesRepository implements InstancesRepository {
         return result;
     }
 
+    @Override
+    public Instance getByPath(String instancePath) {
+        List<Instance> result = new ArrayList<>();
+
+        for (Instance instance : instances) {
+            if (instance.getInstanceFilePath().equals(instancePath)) {
+                result.add(instance);
+            }
+        }
+
+        if (result.size() == 1) {
+            return result.get(0);
+        } else {
+            return null;
+        }
+    }
+
     public void addInstance(Instance instance) {
         instances.add(instance);
     }


### PR DESCRIPTION
Closes #3506 
Closes #3510

I addressed these together because the "manually tap the save button" case described in #3510 requires knowing which instance row to save the geometry to and the solution to #3506 ended up providing that. 

#### What has been done to verify that this works as intended?
Manually verified with [encrypted-geopoint.xml.txt](https://github.com/opendatakit/collect/files/3941409/encrypted-geopoint.xml.txt) that:
- when new instances are saved but not finalized, they appear on the map
- when instances are finalized, they disappear from the map and the display count updates accordingly

Manually verified with All Widgets that new instances that are saved manually with steps described in #3510 are updated on the map.

#### Why is this the best possible solution? Were any other approaches considered?
I really had to hold back from refactoring `updateInstanceDatabase` more significantly. I think this is the best given that we are working towards a release and really want to minimize risk.

I feel badly about not including a test. The only test I can think to write at this point would be an integration test over the encrypted-geopoint form linked above. I'd rather come back and do a lower-level test along with refactors if reviewers think that's ok.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should only fix the two bugs described in #3506 and #3510. However, it does touch how every form instance which poses a risk. I tried to limit risk as much as possible by leaving existing code alone and adding to it. 

One particular type of risk is that if I didn't address error states, there could be additional crashes introduced (see https://github.com/opendatakit/collect/pull/3511#discussion_r355626021 for an example of one I almost didn't catch). There's a lot of state involved so it's hard to tell where there might e.g. be nulls.

#### Do we need any specific form for testing your changes? If so, please attach one.
[encrypted-geopoint.xml.txt](https://github.com/opendatakit/collect/files/3941409/encrypted-geopoint.xml.txt) 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
It will be described as part of https://github.com/opendatakit/docs/issues/1144 which I'm working on.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)