### PR TITLE
Fixed audio_video_image_text_label layout

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -26,6 +26,7 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -75,6 +76,9 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
     @BindView(R.id.text_container)
     FrameLayout textContainer;
+
+    @BindView(R.id.media_buttons)
+    LinearLayout mediaButtonsContainer;
 
     private TextView labelTextView;
     private String videoURI;
@@ -258,11 +262,13 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
     private void setupVideoButton() {
         videoButton.setVisibility(VISIBLE);
+        mediaButtonsContainer.setVisibility(VISIBLE);
         videoButton.setOnClickListener(this);
     }
 
     private void setupAudioButton(String audioURI, AudioHelper audioHelper) {
         audioButton.setVisibility(VISIBLE);
+        mediaButtonsContainer.setVisibility(VISIBLE);
 
         ScreenContext activity = getScreenContext();
         String clipID = getTag() != null ? getTag().toString() : "";

--- a/collect_app/src/main/res/layout/audio_video_image_text_label.xml
+++ b/collect_app/src/main/res/layout/audio_video_image_text_label.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content">
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
@@ -26,6 +26,8 @@
             android:layout_height="wrap_content"
             android:paddingStart="@dimen/margin_standard"
             android:paddingLeft="@dimen/margin_standard"
+            android:paddingRight="@dimen/margin_standard"
+            android:paddingEnd="@dimen/margin_standard"
             android:paddingBottom="@dimen/margin_standard"
             android:scaleType="fitStart"
             android:visibility="gone" />
@@ -36,6 +38,8 @@
             android:layout_height="wrap_content"
             android:paddingStart="@dimen/margin_standard"
             android:paddingLeft="@dimen/margin_standard"
+            android:paddingRight="@dimen/margin_standard"
+            android:paddingEnd="@dimen/margin_standard"
             android:paddingBottom="@dimen/margin_standard"
             android:visibility="gone"
             tools:text="media missing"
@@ -51,12 +55,12 @@
         android:layout_alignParentRight="true"
         android:gravity="end"
         android:orientation="vertical"
-        android:paddingLeft="@dimen/margin_standard"
-        android:paddingStart="@dimen/margin_standard"
         android:paddingRight="@dimen/margin_standard"
         android:paddingEnd="@dimen/margin_standard"
         android:paddingTop="@dimen/margin_extra_small"
-        android:paddingBottom="@dimen/margin_extra_small">
+        android:paddingBottom="@dimen/margin_extra_small"
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <org.odk.collect.android.audio.AudioButton
             android:id="@+id/audioButton"


### PR DESCRIPTION
Closes #3508 
Closes #3509 

#### What has been done to verify that this works as intended?
I tested the attached form and confirmed everything seems to work fine.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that media_buttons layout (which is a container for audio/video buttons) was always visible and took a lot of place. Now I make it visible only if it's needed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test `select_one` and `select_multiple` questions with media elements. The media_buttons layout shouldn't be visible if it's not needed what should give us more space.
Please test also RTL languages.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms attached to the issues and a form with audio/video buttons like:
https://drive.google.com/file/d/1jZg3ye-27zkZeBhxUIzDNyoAusjt2UeF/view?usp=sharing

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)