### PR TITLE
Fixed paddings for select widgets with compact and columns no-buttons appearances

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -153,7 +153,6 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
 
     View setUpNoButtonsView(int index) {
         View view = new View(context);
-        int itemPadding = context.getResources().getDimensionPixelSize(R.dimen.select_item_border);
 
         SelectChoice selectChoice = filteredItems.get(index);
 
@@ -170,7 +169,6 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
 
                     if (bitmap != null) {
                         ImageView imageView = new ImageView(context);
-                        imageView.setPadding(itemPadding, itemPadding, itemPadding, itemPadding);
                         imageView.setImageBitmap(ImageConverter.scaleImageToNewWidth(bitmap, context.getResources().getDisplayMetrics().widthPixels / numColumns));
                         imageView.setAdjustViewBounds(true);
                         view = imageView;
@@ -191,7 +189,6 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             TextView missingImage = new TextView(context);
             missingImage.setTextSize(TypedValue.COMPLEX_UNIT_DIP, getAnswerFontSize());
             missingImage.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
-            missingImage.setPadding(itemPadding, itemPadding, itemPadding, itemPadding);
 
             String choiceText = FormEntryPromptUtils.getItemText(getFormEntryPrompt(), selectChoice).toString();
 
@@ -205,8 +202,11 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             view = missingImage;
         }
 
-        view.setOnClickListener(v -> onItemClick(selectChoice.selection(), v));
         view.setEnabled(!getFormEntryPrompt().isReadOnly());
+        int itemPadding = context.getResources().getDimensionPixelSize(R.dimen.select_item_border);
+        int paddingStartEnd = context.getResources().getDimensionPixelSize(R.dimen.margin_standard);
+        view.setPadding(paddingStartEnd, itemPadding, paddingStartEnd, itemPadding);
+
         return view;
     }
 
@@ -243,6 +243,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             if (noButtonsMode) {
                 view.removeAllViews();
                 view.addView(setUpNoButtonsView(index));
+                view.setOnClickListener(v -> onItemClick(filteredItems.get(index).selection(), v));
             } else {
                 addMediaFromChoice(audioVideoImageTextLabel, index, createButton(index, audioVideoImageTextLabel), filteredItems);
                 audioVideoImageTextLabel.setEnabled(!getFormEntryPrompt().isReadOnly());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
 
 import androidx.appcompat.widget.AppCompatCheckBox;
 import androidx.appcompat.widget.AppCompatRadioButton;
+import androidx.core.content.ContextCompat;
 
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.reference.InvalidReferenceException;
@@ -60,9 +61,6 @@ import static org.odk.collect.android.formentry.media.FormMediaHelpers.getPlayab
  * is calculated based on items size.
  */
 public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceWidget {
-
-    final int bgOrange = getResources().getColor(R.color.highContrastHighlight);
-
     private static final int PADDING = 7;
     private static final int SPACING = 2;
 
@@ -200,7 +198,7 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
     void selectItem(int index) {
         selectedItems.add(index);
         if (noButtonsMode) {
-            itemViews[index].setBackgroundColor(bgOrange);
+            itemViews[index].setBackground(ContextCompat.getDrawable(getContext(), R.drawable.select_item_border));
         } else {
             ((CompoundButton) itemViews[index]).setChecked(true);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
@@ -192,6 +192,8 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         gridView.setScrollContainer(false);
         gridView.setStretchMode(GridView.NO_STRETCH);
         gridView.setAdapter(new ImageAdapter());
+        int paddingStartEnd = getContext().getResources().getDimensionPixelSize(R.dimen.margin_standard);
+        gridView.setPadding(paddingStartEnd, 0, paddingStartEnd, 0);
         addAnswerView(gridView);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GridMultiWidget.java
@@ -17,10 +17,13 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.content.Context;
 
+import androidx.core.content.ContextCompat;
+
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.odk.collect.android.R;
 import org.odk.collect.android.audio.Clip;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
@@ -65,7 +68,7 @@ public class GridMultiWidget extends BaseGridWidget {
         } else {
             selectedItems.add(index);
             if (noButtonsMode) {
-                itemViews[index].setBackgroundColor(bgOrange);
+                itemViews[index].setBackground(ContextCompat.getDrawable(getContext(), R.drawable.select_item_border));
 
                 SelectChoice item = items.get(index);
                 Clip clip = getClip(getFormEntryPrompt(), item, getReferenceManager());


### PR DESCRIPTION
Closes #3513 

#### What has been done to verify that this works as intended?
I tested the form from #3509 and confirmed this pr fixes the issue.

#### Why is this the best possible solution? Were any other approaches considered?
We just should use the same padding across all select widgets. It was a bug and this pr fixes it..

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Select widgets with appearances `compact` and `columns no buttons` will be affected (fixed paddings) so we need to test them.
Additionally in the second commit I fixed the orange background we used for `compact` and `columns-pack` appearances. From now it will be an orange frame like we use in other cases not an orange background.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to #3509 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)