### PR TITLE
Enable external CSV secondary instances (issue #3334) 

### DIFF
--- a/collect_app/src/androidTest/assets/forms/external_csv_form.xml
+++ b/collect_app/src/androidTest/assets/forms/external_csv_form.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head><!-- ODK Aggregate upload time: 2015-04-09T23:26:16.409+0000 on https://enketo-aggregate.appspot.com -->
+    <h:title>Form with external CSV files</h:title>
+    <model>
+      <instance>
+        <ecsv id="ecsv" version="">
+          <country/>
+          <city/>
+          <neighborhood/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </ecsv>
+      </instance>
+      <instance id="cities" src="jr://file-csv/external_csv_cities.csv" />
+      <instance id="neighborhoods" src="jr://file-csv/external_csv_neighbourhoods.csv" />
+      <instance id="countries" src="jr://file-csv/external_csv_countries.csv" />
+      <bind nodeset="/ecsv/country" type="select1"/>
+      <bind nodeset="/ecsv/city" type="select1"/>
+      <bind nodeset="/ecsv/neighborhood" type="select1"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/ecsv/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <select1 ref="/ecsv/country">
+      <label>Country</label>
+      <itemset nodeset="instance('countries')/root/item">
+          <value ref="name"/>
+          <label ref="label"/>
+      </itemset>
+    </select1>
+    <select1 ref="/ecsv/city">
+      <label>City</label>
+      <itemset nodeset="instance('cities')/root/item[country= /ecsv/country ]">
+        <value ref="name"/>
+        <label ref="label"/>
+      </itemset>
+    </select1>
+    <select1 ref="/ecsv/neighborhood">
+      <label>Neighborhood</label>
+      <itemset nodeset="instance('neighborhoods')/root/item[country= /ecsv/country  and city= /ecsv/city ]">
+        <value ref="name"/>
+        <label ref="label"/>
+      </itemset>
+    </select1>
+  </h:body>
+</h:html>

--- a/collect_app/src/androidTest/assets/media/external_csv_cities.csv
+++ b/collect_app/src/androidTest/assets/media/external_csv_cities.csv
@@ -1,0 +1,7 @@
+name,label,country
+ams,Amsterdam,nl
+den,Denver,usa
+nyc,New York City,usa
+la,Los Angeles,usa
+rot,Rotterdam,nl
+dro,Dronten,nl

--- a/collect_app/src/androidTest/assets/media/external_csv_countries.csv
+++ b/collect_app/src/androidTest/assets/media/external_csv_countries.csv
@@ -1,0 +1,3 @@
+name,label
+nl,The Netherlands
+usa,United States

--- a/collect_app/src/androidTest/assets/media/external_csv_neighbourhoods.csv
+++ b/collect_app/src/androidTest/assets/media/external_csv_neighbourhoods.csv
@@ -1,0 +1,10 @@
+name,label,country,city
+bronx,Bronx,usa,nyc
+harlem,Harlem,usa,nyc
+belair,Bel Air,usa,la
+wes,Westerpark,nl,ams
+parkhill,Park Hill,usa,den
+haven,Harbor,nl,rot
+dam,Dam,nl,ams
+centrum,Downtown,nl,rot
+haven,Harbor,nl,dro

--- a/collect_app/src/androidTest/java/org/odk/collect/android/forms/FormUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/forms/FormUtilsTest.java
@@ -16,7 +16,6 @@ import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 public class FormUtilsTest {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/forms/FormUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/forms/FormUtilsTest.java
@@ -1,0 +1,79 @@
+package org.odk.collect.android.forms;
+
+import android.Manifest;
+
+import androidx.test.rule.GrantPermissionRule;
+
+import org.javarosa.core.reference.RootTranslator;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.tasks.FormLoaderTask;
+import org.odk.collect.android.utilities.FileUtils;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+public class FormUtilsTest {
+    private static final String BASIC_FORM = "basic.xml";
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ))
+            .around(new ResetStateRule())
+            .around(new CopyFormRule(BASIC_FORM));
+
+    /* Verify that each host string matches only a single root translator, allowing for them to
+     be defined in any order. See: https://github.com/opendatakit/collect/issues/3334
+    */
+    @Test
+    public void sessionRootTranslatorOrderDoesNotMatter() throws Exception {
+        final String formPath = Collect.FORMS_PATH + File.separator + BASIC_FORM;
+        // Load the form in order to populate the ReferenceManager
+        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null);
+        formLoaderTask.execute(formPath).get();
+
+        final File formXml = new File(formPath);
+        final File formMediaDir = FileUtils.getFormMediaDir(formXml);
+        List<RootTranslator> rootTranslators = FormUtils.buildSessionRootTranslators(formMediaDir.getName(), FormUtils.enumerateHostStrings());
+
+        // Check each type of host string to determine that only one match is resolved.
+        for (String hostString : FormUtils.enumerateHostStrings()) {
+            String uri = String.format("jr://%s/test", hostString);
+            int matchCount = 0;
+            for (RootTranslator rootTranslator : rootTranslators) {
+                if (rootTranslator.derives(uri)) {
+                    matchCount++;
+                }
+            }
+            Assert.assertEquals("Expected only a single match for URI: " + uri, 1, matchCount);
+        }
+    }
+
+    /* Verify that the host strings appear in an order that does not allow for greedy matches, e.g.
+     matching 'file' instead of 'file-csv'. According to the behavior in the test above,
+     sessionRootTranslatorOrderDoesNotMatter, it is not actually a requirement to have the test
+     below pass. This simply follows the cautionary remarks in the following issue:
+     https://github.com/opendatakit/collect/issues/3334
+     */
+    @Test
+    public void hostStringsOrderedCorrectly() throws Exception {
+        String[] hostStrings = FormUtils.enumerateHostStrings();
+        // No host string should be a substring of the subsequent ones.
+        for (int i = 0; i < hostStrings.length; ++i) {
+            String currentHostString = hostStrings[i];
+            for (int j = i + 1; j < hostStrings.length; ++j) {
+                String subsequentHostString = hostStrings[j];
+                Assert.assertFalse(subsequentHostString.contains(currentHostString));
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
@@ -4,7 +4,6 @@ import android.Manifest;
 
 import androidx.test.rule.GrantPermissionRule;
 
-import org.javarosa.core.reference.RootTranslator;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,11 +11,9 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
-import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.List;
 
 public class FormLoaderTaskTest {
     private static final String EXTERNAL_CSV_FORM = "external_csv_form.xml";

--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class FormLoaderTaskTest {
-    private static final String BASIC_FORM = "basic.xml";
     private static final String EXTERNAL_CSV_FORM = "external_csv_form.xml";
 
     @Rule
@@ -29,55 +28,8 @@ public class FormLoaderTaskTest {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
             ))
             .around(new ResetStateRule())
-            .around(new CopyFormRule(BASIC_FORM))
             .around(new CopyFormRule(EXTERNAL_CSV_FORM,
                     Arrays.asList("external_csv_cities.csv", "external_csv_countries.csv", "external_csv_neighbourhoods.csv")));
-
-    /* Verify that each host string matches only a single root translator, allowing for them to
-     be defined in any order. See: https://github.com/opendatakit/collect/issues/3334
-    */
-    @Test
-    public void sessionRootTranslatorOrderDoesNotMatter() throws Exception {
-        final String formPath = Collect.FORMS_PATH + File.separator + BASIC_FORM;
-        // Load the form in order to populate the ReferenceManager
-        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null);
-        formLoaderTask.execute(formPath).get();
-
-        final File formXml = new File(formPath);
-        final File formMediaDir = FileUtils.getFormMediaDir(formXml);
-        List<RootTranslator> rootTranslators = formLoaderTask.buildSessionRootTranslators(formMediaDir.getName(), FormLoaderTask.enumerateHostStrings());
-
-        // Check each type of host string to determine that only one match is resolved.
-        for (String hostString : FormLoaderTask.enumerateHostStrings()) {
-            String uri = String.format("jr://%s/test", hostString);
-            int matchCount = 0;
-            for (RootTranslator rootTranslator : rootTranslators) {
-                if (rootTranslator.derives(uri)) {
-                    matchCount++;
-                }
-            }
-            Assert.assertEquals("Expected only a single match for URI: " + uri, 1, matchCount);
-        }
-    }
-
-    /* Verify that the host strings appear in an order that does not allow for greedy matches, e.g.
-     matching 'file' instead of 'file-csv'. According to the behavior in the test above,
-     sessionRootTranslatorOrderDoesNotMatter, it is not actually a requirement to have the test
-     below pass. This simply follows the cautionary remarks in the following issue:
-     https://github.com/opendatakit/collect/issues/3334
-     */
-    @Test
-    public void hostStringsOrderedCorrectly() throws Exception {
-        String[] hostStrings = FormLoaderTask.enumerateHostStrings();
-        // No host string should be a substring of the subsequent ones.
-        for (int i = 0; i < hostStrings.length; ++i) {
-            String currentHostString = hostStrings[i];
-            for (int j = i + 1; j < hostStrings.length; ++j) {
-                String subsequentHostString = hostStrings[j];
-                Assert.assertFalse(subsequentHostString.contains(currentHostString));
-            }
-        }
-    }
 
     @Test
     public void loadFormWithSecondaryCSV() throws Exception {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
@@ -1,0 +1,77 @@
+package org.odk.collect.android.tasks;
+
+import android.Manifest;
+
+import androidx.test.rule.GrantPermissionRule;
+
+import org.javarosa.core.reference.RootTranslator;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.utilities.FileUtils;
+
+import java.io.File;
+import java.util.List;
+
+public class FormLoaderTaskTest {
+    private static final String BASIC_FORM = "basic.xml";
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ))
+            .around(new ResetStateRule())
+            .around(new CopyFormRule(BASIC_FORM));
+
+    /* Verify that each host string matches only a single root translator, allowing for them to
+     be defined in any order. See: https://github.com/opendatakit/collect/issues/3334
+    */
+    @Test
+    public void sessionRootTranslatorOrderDoesNotMatter() throws Exception {
+        final String formPath = Collect.FORMS_PATH + File.separator + BASIC_FORM;
+        // Load the form in order to populate the ReferenceManager
+        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null);
+        formLoaderTask.execute(formPath).get();
+
+        final File formXml = new File(formPath);
+        final File formMediaDir = FileUtils.getFormMediaDir(formXml);
+        List<RootTranslator> rootTranslators = formLoaderTask.buildSessionRootTranslators(formMediaDir.getName(), FormLoaderTask.enumerateHostStrings());
+
+        // Check each type of host string to determine that only one match is resolved.
+        for (String hostString : FormLoaderTask.enumerateHostStrings()) {
+            String uri = String.format("jr://%s/test", hostString);
+            int matchCount = 0;
+            for (RootTranslator rootTranslator : rootTranslators) {
+                if (rootTranslator.derives(uri)) {
+                    matchCount++;
+                }
+            }
+            Assert.assertEquals("Expected only a single match for URI: " + uri, 1, matchCount);
+        }
+    }
+
+    /* Verify that the host strings appear in an order that does not allow for greedy matches, e.g.
+     matching 'file' instead of 'file-csv'. According to the behavior in the test above,
+     sessionRootTranslatorOrderDoesNotMatter, it is not actually a requirement to have the test
+     below pass. This simply follows the cautionary remarks in the following issue:
+     https://github.com/opendatakit/collect/issues/3334
+     */
+    @Test
+    public void hostStringsOrderedCorrectly() throws Exception {
+        String[] hostStrings = FormLoaderTask.enumerateHostStrings();
+        // No host string should be a substring of the subsequent ones.
+        for (int i = 0; i < hostStrings.length; ++i) {
+            String currentHostString = hostStrings[i];
+            for (int j = i + 1; j < hostStrings.length; ++j) {
+                String subsequentHostString = hostStrings[j];
+                Assert.assertFalse(subsequentHostString.contains(currentHostString));
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
@@ -15,10 +15,12 @@ import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 public class FormLoaderTaskTest {
     private static final String BASIC_FORM = "basic.xml";
+    private static final String EXTERNAL_CSV_FORM = "external_csv_form.xml";
 
     @Rule
     public RuleChain copyFormChain = RuleChain
@@ -27,7 +29,9 @@ public class FormLoaderTaskTest {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
             ))
             .around(new ResetStateRule())
-            .around(new CopyFormRule(BASIC_FORM));
+            .around(new CopyFormRule(BASIC_FORM))
+            .around(new CopyFormRule(EXTERNAL_CSV_FORM,
+                    Arrays.asList("external_csv_cities.csv", "external_csv_countries.csv", "external_csv_neighbourhoods.csv")));
 
     /* Verify that each host string matches only a single root translator, allowing for them to
      be defined in any order. See: https://github.com/opendatakit/collect/issues/3334
@@ -73,5 +77,13 @@ public class FormLoaderTaskTest {
                 Assert.assertFalse(subsequentHostString.contains(currentHostString));
             }
         }
+    }
+
+    @Test
+    public void loadFormWithSecondaryCSV() throws Exception {
+        final String formPath = Collect.FORMS_PATH + File.separator + EXTERNAL_CSV_FORM;
+        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null);
+        FormLoaderTask.FECWrapper wrapper = formLoaderTask.execute(formPath).get();
+        Assert.assertNotNull(wrapper);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormUtils.java
@@ -6,6 +6,8 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FileReferenceFactory;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FormUtils {
 
@@ -24,15 +26,27 @@ public class FormUtils {
             referenceManager.addReferenceFactory(new FileReferenceFactory(Collect.ODK_ROOT));
         }
 
-        addSessionRootTranslators(formMediaDir.getName(), referenceManager,
-                "images", "image", "audio", "video", "file");
+        addSessionRootTranslators(referenceManager,
+                buildSessionRootTranslators(formMediaDir.getName(), enumerateHostStrings()));
     }
 
-    private static void addSessionRootTranslators(String formMediaDir, ReferenceManager referenceManager, String... hostStrings) {
+    public static String[] enumerateHostStrings() {
+        return new String[] {"images", "image", "audio", "video", "file-csv", "file"};
+    }
+
+    public static List<RootTranslator> buildSessionRootTranslators(String formMediaDir, String[] hostStrings) {
+        List<RootTranslator> rootTranslators = new ArrayList<>();
         // Set jr://... to point to /sdcard/odk/forms/formBasename-media/
         final String translatedPrefix = String.format("jr://file/forms/" + formMediaDir + "/");
         for (String t : hostStrings) {
-            referenceManager.addSessionRootTranslator(new RootTranslator(String.format("jr://%s/", t), translatedPrefix));
+            rootTranslators.add(new RootTranslator(String.format("jr://%s/", t), translatedPrefix));
+        }
+        return rootTranslators;
+    }
+
+    public static void addSessionRootTranslators(ReferenceManager referenceManager, List<RootTranslator> rootTranslators) {
+        for (RootTranslator rootTranslator : rootTranslators) {
+            referenceManager.addSessionRootTranslator(rootTranslator);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -301,7 +301,8 @@ public class FileUtils {
 
                 // Insert header & copy remaining contents
                 newContents.write(header + lineEnding);
-                String line = originalContents.readLine(); // consume and ignore the old header
+                originalContents.readLine(); // consume and ignore the old header
+                String line;
                 while ((line = originalContents.readLine()) != null) {
                     newContents.write(line);
                     newContents.write(lineEnding);

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -1,9 +1,12 @@
 package org.odk.collect.android.utilities;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
@@ -275,5 +278,49 @@ public class FileUtilsTest {
         assertThat(metadataFromFormDefinition.get(FileUtils.TITLE), is("Setgeopoint before"));
         assertThat(metadataFromFormDefinition.get(FileUtils.FORMID), is("set-geopoint-before"));
         assertThat(metadataFromFormDefinition.get(FileUtils.GEOMETRY_XPATH), is("/data/location1"));
+    }
+
+    @Test
+    public void testInsertHeaderRowIntoEmptyFile() throws IOException {
+        final String headerRow = "header row";
+
+        // setup
+        File tempFile = File.createTempFile("testInsertHeaderRow", "");
+        tempFile.deleteOnExit();
+
+        Assert.assertTrue(FileUtils.replaceHeaderRow(tempFile, headerRow));
+
+        // check the results
+        StringBuilder results = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new FileReader(tempFile));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            results.append(line);
+        }
+        assertEquals("header row", results.toString());
+    }
+
+    @Test
+    public void testReplaceHeaderRow() throws IOException {
+        final String headerRow = "new header row";
+
+        // setup
+        File tempFile = File.createTempFile("testInsertHeaderRow", "");
+        tempFile.deleteOnExit();
+        BufferedWriter out = new BufferedWriter(new FileWriter(tempFile));
+        out.write("old header row\n");
+        out.write("data row\n");
+        out.close();
+
+        Assert.assertTrue(FileUtils.replaceHeaderRow(tempFile, headerRow));
+
+        // check the results
+        StringBuilder results = new StringBuilder();
+        BufferedReader reader = new BufferedReader(new FileReader(tempFile));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            results.append(line + "\n");
+        }
+        assertEquals("new header row\ndata row\n", results.toString());
     }
 }


### PR DESCRIPTION
Closes #3334

#### What has been done to verify that this works as intended?
gradlew testDebug
gradlew connectedAndroidTest

#### Why is this the best possible solution? Were any other approaches considered?
The only solution to the issue was to add an extra host string to handle "file-csv". The tests seemed to require a fair bit of state (CopyFormRule, global singletons) so they are mostly integration tests. I'm open to discussing ways to make the tests more narrow, but the implementation itself is not and would require more refactoring to support true unit tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This enables users to work with secondary instances defined by CSV files. The regression risk is clear: it exposes issue #3335.

#### Do we need any specific form for testing your changes? If so, please attach one.
Same form as is listed in issue #3334: https://github.com/opendatakit/javarosa/files/3095508/external_csv.zip

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
.... maybe?

#### Before submitting this PR, please make sure you have:
- [ X ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ X ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ n/a ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)