### PR TITLE
Make sure save requests are cleared once they're dealt with

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -430,8 +430,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 );
             }
         });
-        changesReasonPromptViewModel.saveRequests().observe(this, saveRequest -> {
+        changesReasonPromptViewModel.saveRequest().observe(this, saveRequest -> {
             if (saveRequest != null) {
+                showDialog(SAVING_DIALOG);
                 save(saveRequest.isComplete(), saveRequest.getUpdatedSaveName(), saveRequest.isExitAfter());
             }
         });
@@ -1892,7 +1893,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 updatedSaveName);
         saveToDiskTask.setFormSavedListener(this);
         autoSaved = true;
-        showDialog(SAVING_DIALOG);
         // show dialog before we execute...
         saveToDiskTask.execute();
     }
@@ -2548,6 +2548,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void savingComplete(SaveResult saveResult) {
         dismissDialog(SAVING_DIALOG);
+        changesReasonPromptViewModel.saveComplete();
 
         int saveStatus = saveResult.getSaveResult();
         FormController formController = getFormController();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModel.java
@@ -11,7 +11,7 @@ import static org.odk.collect.android.utilities.StringUtils.isBlank;
 public class ChangesReasonPromptViewModel extends ViewModel {
 
     private final MutableLiveData<Boolean> requiresReasonToContinue = new MutableLiveData<>(false);
-    private final MutableLiveData<SaveRequest> saveRequests = new MutableLiveData<>(null);
+    private final MutableLiveData<SaveRequest> saveRequest = new MutableLiveData<>(null);
 
     private AuditEventLogger auditEventLogger;
     private String reason;
@@ -21,8 +21,8 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         return requiresReasonToContinue;
     }
 
-    public LiveData<SaveRequest> saveRequests() {
-        return saveRequests;
+    public LiveData<SaveRequest> saveRequest() {
+        return saveRequest;
     }
 
     public void setAuditEventLogger(AuditEventLogger auditEventLogger) {
@@ -33,10 +33,14 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         lastSaveRequest = new SaveRequest(complete, updatedSaveName, exitAfter);
 
         if (!requiresReasonToSave()) {
-            saveRequests.setValue(lastSaveRequest);
+            saveRequest.setValue(lastSaveRequest);
         } else {
             requiresReasonToContinue.setValue(true);
         }
+    }
+
+    public void saveComplete() {
+        saveRequest.setValue(null);
     }
 
     public void editingForm() {
@@ -55,7 +59,7 @@ public class ChangesReasonPromptViewModel extends ViewModel {
         if (reason != null && !isBlank(reason)) {
             this.auditEventLogger.logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, currentTime, reason);
             requiresReasonToContinue.setValue(false);
-            saveRequests.setValue(lastSaveRequest);
+            saveRequest.setValue(lastSaveRequest);
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptViewModelTest.java
@@ -1,11 +1,14 @@
 package org.odk.collect.android.formentry.audit;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,9 +16,16 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class ChangesReasonPromptViewModelTest {
 
+    private AuditEventLogger logger;
+
+    @Before
+    public void setup() {
+        logger = mock(AuditEventLogger.class);
+        when(logger.isChangeReasonRequired()).thenReturn(false);
+    }
+
     @Test
     public void save_logsChangeReasonAuditEvent() {
-        AuditEventLogger logger = mock(AuditEventLogger.class);
         when(logger.isChangeReasonRequired()).thenReturn(true);
 
         ChangesReasonPromptViewModel viewModel = new ChangesReasonPromptViewModel();
@@ -29,7 +39,6 @@ public class ChangesReasonPromptViewModelTest {
 
     @Test
     public void promptDismissed_sets_isChangeReasonRequired_false() {
-        AuditEventLogger logger = mock(AuditEventLogger.class);
         when(logger.isChangeReasonRequired()).thenReturn(true);
         when(logger.isChangesMade()).thenReturn(true);
         when(logger.isEditing()).thenReturn(true);
@@ -41,5 +50,16 @@ public class ChangesReasonPromptViewModelTest {
 
         viewModel.promptDismissed();
         assertThat(viewModel.requiresReasonToContinue().getValue(), equalTo(false));
+    }
+
+    @Test
+    public void saveComplete_sets_saveRequest_null() {
+        ChangesReasonPromptViewModel viewModel = new ChangesReasonPromptViewModel();
+        viewModel.setAuditEventLogger(logger);
+        viewModel.saveForm(true, "", true);
+        assertThat(viewModel.saveRequest().getValue(), notNullValue());
+
+        viewModel.saveComplete();
+        assertThat(viewModel.saveRequest().getValue(), nullValue());
     }
 }


### PR DESCRIPTION
Closes #3519 

#### What has been done to verify that this works as intended?

Ran through repro steps and played with differnet ways of saving form.

#### Why is this the best possible solution? Were any other approaches considered?

Best possible solution would be to move saving out of the `FormEntryActivity` so we don't have a ping pong between it and its ViewModels. This refactor will be pretty intensive and has been talked about a few times for 1.26 so leaving it now (I'll create an issue and make a comment on this). 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Hopefully nothing other than the bug fix. Would be good to play with the new audit features and form saving in general as we're still in a place where the `FormEntryActivity` doesn't feel like it has great test coverage (again moving cricital work like saving out of it is a good move).

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)