### PR TITLE
Set up the reference manager when doing form discovery parse

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -20,6 +20,7 @@ import android.database.SQLException;
 import android.net.Uri;
 import android.os.AsyncTask;
 
+import org.javarosa.core.reference.ReferenceManager;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
@@ -36,6 +37,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.forms.FormUtils.setupReferenceManagerForForm;
 
 /**
  * Background task for adding to the forms content provider, any forms that have been added to the
@@ -257,6 +260,10 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
 
         HashMap<String, String> fields;
         try {
+            // If the form definition includes external secondary instances, they need to be resolved
+            final File formMediaDir = FileUtils.getFormMediaDir(formDefFile);
+            setupReferenceManagerForForm(ReferenceManager.instance(), formMediaDir);
+
             fields = FileUtils.getMetadataFromFormDefinition(formDefFile);
         } catch (RuntimeException e) {
             throw new IllegalArgumentException(formDefFile.getName() + " :: " + e.toString());

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -20,6 +20,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.xform.parse.XFormParser;
 import org.kxml2.kdom.Element;
 import org.odk.collect.android.R;
@@ -45,6 +46,8 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.forms.FormUtils.setupReferenceManagerForForm;
 
 public class FormDownloader {
 
@@ -168,6 +171,9 @@ public class FormDownloader {
             try {
                 final long start = System.currentTimeMillis();
                 Timber.w("Parsing document %s", fileResult.file.getAbsolutePath());
+                // If the form definition includes external secondary instances, they need to be resolved
+                setupReferenceManagerForForm(ReferenceManager.instance(), new File(tempMediaPath));
+
                 parsedFields = FileUtils.getMetadataFromFormDefinition(fileResult.file);
                 Timber.i("Parse finished in %.3f seconds.",
                         (System.currentTimeMillis() - start) / 1000F);


### PR DESCRIPTION
Closes #3522

#### What has been done to verify that this works as intended?
Copied and downloaded forms with external secondary instances and verified they could be filled.

Tried with external XML instance ([external-select-xml.zip](https://github.com/opendatakit/collect/files/3953809/external-select-xml.zip)) and CSV instance ([external-csv.zip](https://github.com/opendatakit/collect/files/3952973/external-csv.zip)).

#### Why is this the best possible solution? Were any other approaches considered?
The true fix would be not requiring the presence of those secondary instance files to build a `FormDef` because in this case there's no point to parsing them and it just slows things down. However, that would be a JR change with sweeping consequences. The change in this PR is safe and it's easy to verify that it does nothing in the common case so it's the best change for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should only make forms with external secondary instances work and should have no other effect.

#### Do we need any specific form for testing your changes? If so, please attach one.
external XML instance ([external-select-xml.zip](https://github.com/opendatakit/collect/files/3953809/external-select-xml.zip)) and CSV instance ([external-csv.zip](https://github.com/opendatakit/collect/files/3952973/external-csv.zip))

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

CC @OpenDataNerd 