### PR TITLE
Fixed readOnly in select widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -202,7 +202,6 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
             view = missingImage;
         }
 
-        view.setEnabled(!getFormEntryPrompt().isReadOnly());
         int itemPadding = context.getResources().getDimensionPixelSize(R.dimen.select_item_border);
         int paddingStartEnd = context.getResources().getDimensionPixelSize(R.dimen.margin_standard);
         view.setPadding(paddingStartEnd, itemPadding, paddingStartEnd, itemPadding);
@@ -244,6 +243,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
                 view.removeAllViews();
                 view.addView(setUpNoButtonsView(index));
                 view.setOnClickListener(v -> onItemClick(filteredItems.get(index).selection(), v));
+                view.setEnabled(!getFormEntryPrompt().isReadOnly());
             } else {
                 addMediaFromChoice(audioVideoImageTextLabel, index, createButton(index, audioVideoImageTextLabel), filteredItems);
                 audioVideoImageTextLabel.setEnabled(!getFormEntryPrompt().isReadOnly());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/LikertWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/LikertWidget.java
@@ -150,6 +150,7 @@ public class LikertWidget extends ItemsWidget {
 
             optionView.addView(choice);
 
+            optionView.setEnabled(!getFormEntryPrompt().isReadOnly());
             optionView.setOnClickListener(new OnClickListener() {
 
                 @Override


### PR DESCRIPTION
Closes #3530 

#### What has been done to verify that this works as intended?
I tested the attached forms.

#### Why is this the best possible solution? Were any other approaches considered?
It is just a bug fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change and testing the attached forms would be enough to confirm that everything is fine.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue and:
[likert_test_readOnly.zip](https://github.com/opendatakit/collect/files/3961253/likert_test_readOnly.zip)
[all-widgets_readOnly.xlsx](https://github.com/opendatakit/collect/files/3961254/all-widgets_readOnly.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)