### PR TITLE
Add needed permission to FormMapTest

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/FormMapTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/FormMapTest.java
@@ -33,7 +33,8 @@ public class FormMapTest {
     @Rule public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
             ))
             .around(new ResetStateRule())
             .around(new CopyFormRule(SINGLE_GEOPOINT_FORM))


### PR DESCRIPTION
Adds permissions needed for `FormMapTest`. This hopefully gets the build back to green - I believe it was timing out getting stuck on the permission dialog.

Shouldn't need a QA run as it's just test changes.

#### What has been done to verify that this works as intended?

Ran locally and on test lab.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)