### PR TITLE
Use renamed isAncestorOf() method

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -560,7 +560,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 // retrieve the current group
                 TreeReference curGroup = (visibleGroupRef == null) ? contextGroupRef : visibleGroupRef;
 
-                if (curGroup != null && !curGroup.isParentOf(currentRef, false)) {
+                if (curGroup != null && !curGroup.isAncestorOf(currentRef, false)) {
                     // We have left the current group
                     if (visibleGroupRef == null) {
                         // We are done.
@@ -611,7 +611,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         }
 
                         // Don't render other groups' children.
-                        if (contextGroupRef != null && !contextGroupRef.isParentOf(currentRef, false)) {
+                        if (contextGroupRef != null && !contextGroupRef.isAncestorOf(currentRef, false)) {
                             break;
                         }
 
@@ -643,7 +643,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         FormEntryCaption fc = formController.getCaptionPrompt();
 
                         // Don't render other groups' children.
-                        if (contextGroupRef != null && !contextGroupRef.isParentOf(currentRef, false)) {
+                        if (contextGroupRef != null && !contextGroupRef.isAncestorOf(currentRef, false)) {
                             break;
                         }
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Tested collect with javarosa's master branch.

#### Why is this the best possible solution? Were any other approaches considered?
in https://github.com/opendatakit/javarosa/pull/515/files#diff-0c84c5364a094f70c8aa2c2ca3376a1a
the method isParentOf() has been renamed to isAncestorOf(). We use it in Collect so **we need to merge this pr one we add javarosa with the mentioned fix**.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)