### PR TITLE
On form download, only set up the reference manager if the form has media

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -204,7 +204,7 @@ public class FormDownloader {
         return submission == null || Validator.isUrlValid(submission);
     }
 
-    private boolean installEverything(String tempMediaPath, FileResult fileResult, Map<String, String> parsedFields) {
+    boolean installEverything(String tempMediaPath, FileResult fileResult, Map<String, String> parsedFields) {
         UriResult uriResult = null;
         try {
             uriResult = findExistingOrCreateNewUri(fileResult.file, parsedFields);
@@ -325,7 +325,7 @@ public class FormDownloader {
      * Takes the formName and the URL and attempts to download the specified file. Returns a file
      * object representing the downloaded file.
      */
-    private FileResult downloadXform(String formName, String url)
+    FileResult downloadXform(String formName, String url)
             throws IOException, TaskCancelledException, Exception {
         // clean up friendly form name...
         String rootName = formName.replaceAll("[^\\p{L}\\p{Digit}]", " ");
@@ -504,12 +504,12 @@ public class FormDownloader {
         }
     }
 
-    private static class FileResult {
+    static class FileResult {
 
         private final File file;
         private final boolean isNew;
 
-        private FileResult(File file, boolean isNew) {
+        FileResult(File file, boolean isNew) {
             this.file = file;
             this.isNew = isNew;
         }
@@ -523,7 +523,7 @@ public class FormDownloader {
         }
     }
 
-    private String downloadManifestAndMediaFiles(String tempMediaPath, String finalMediaPath,
+    String downloadManifestAndMediaFiles(String tempMediaPath, String finalMediaPath,
                                                  FormDetails fd, int count,
                                                  int total) throws Exception {
         if (fd.getManifestUrl() == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -171,8 +171,11 @@ public class FormDownloader {
             try {
                 final long start = System.currentTimeMillis();
                 Timber.w("Parsing document %s", fileResult.file.getAbsolutePath());
-                // If the form definition includes external secondary instances, they need to be resolved
-                setupReferenceManagerForForm(ReferenceManager.instance(), new File(tempMediaPath));
+                // If the form definition includes attachments, set up the reference manager in case
+                // one of them defines a secondary instance (required to build a FormDef)
+                if (tempMediaPath != null) {
+                    setupReferenceManagerForForm(ReferenceManager.instance(), new File(tempMediaPath));
+                }
 
                 parsedFields = FileUtils.getMetadataFromFormDefinition(fileResult.file);
                 Timber.i("Parse finished in %.3f seconds.",

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FormDownloaderTest.java
@@ -1,0 +1,132 @@
+package org.odk.collect.android.utilities;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.logic.FormDetails;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@RunWith(RobolectricTestRunner.class)
+public class FormDownloaderTest {
+    /**
+     * Verifies that a form without media can successfully go through the download process. Regression
+     * test for https://github.com/opendatakit/collect/issues/3535.
+     *
+     * The focus of this test is the form parsing behavior triggered by a download and how it
+     * relates to a media folder that may or may not have been created. The downloading of forms and
+     * saving of parsed form  values are mocked (and those concerns should be separated).
+     */
+    @Test
+    public void downloadingFormWithoutMedia_Succeeds() throws Exception {
+        String basicNoMedia = "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\">\n" +
+                "    <h:head>\n" +
+                "        <h:title>basic</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"basic\">\n" +
+                "                    <q1/>\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "            <bind nodeset=\"/data/q1\" type=\"string\"/>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "        <input ref=\"/data/q1\">\n" +
+                "            <label>Question</label>\n" +
+                "        </input>\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+        File temp = File.createTempFile("basicNoMedia", ".xml");
+        temp.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        out.write(basicNoMedia);
+        out.close();
+
+        FormDownloader downloader = spy(new FormDownloader());
+        FormDetails test1 = new FormDetails("No media", "https://testserver/no-media.xml",
+                null, "test1", "2019121201",
+                "hash", null, false, false);
+        FormDownloader.FileResult result = new FormDownloader.FileResult(temp, true);
+        doReturn(result).when(downloader).downloadXform(test1.getFormName(), test1.getDownloadUrl());
+        doReturn(true).when(downloader).installEverything(any(), any(), any());
+
+        List<FormDetails> forms = new ArrayList<>();
+        forms.add(test1);
+
+        HashMap<FormDetails, String> messages = downloader.downloadForms(forms);
+        assertThat(messages.get(test1), is("Success"));
+    }
+
+    /**
+     * Companion to downloading form without media.
+     *
+     * The focus of this test is the form parsing behavior triggered by a download and how it
+     * relates to a media folder that may or may not have been created. The form downloading, media
+     * downloading and saving of parsed form values are mocked.
+     *
+     * Note: what's important in this test is that the manifestURL in the FormDetails object is set.
+     * It doesn't really matter that the form definition uses media but that's included to better
+     * match reality.
+     */
+    @Test
+    public void downloadingFormWithMedia_Succeeds() throws Exception {
+        String basicMedia = "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\">\n" +
+                "    <h:head>\n" +
+                "        <h:title>basic-media</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"basic-media\">\n" +
+                "                    <q1/>\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "            <bind nodeset=\"/data/q1\" type=\"string\"/>\n" +
+                "            <itext> \n" +
+                "                <translation default=\"true()\" lang=\"English\">\n" +
+                "                    <text id=\"/data/q1:label\"><value form=\"image\">jr://images/b.jpg</value></text>\n" +
+                "                </translation>\n" +
+                "            </itext>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "        <input ref=\"/data/q1\">\n" +
+                "            <label>Question</label>\n" +
+                "        </input>\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+        File temp = File.createTempFile("basicMedia", ".xml");
+        temp.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        out.write(basicMedia);
+        out.close();
+
+        FormDownloader downloader = spy(new FormDownloader());
+        FormDetails test1 = new FormDetails("Media", "https://testserver/media.xml",
+                "https://testserver/media-manifest.xml", "media", "2019121201",
+                "hash", "manifestHash", false, false);
+        FormDownloader.FileResult result = new FormDownloader.FileResult(temp, true);
+        doReturn(result).when(downloader).downloadXform(test1.getFormName(), test1.getDownloadUrl());
+        doReturn("").when(downloader).downloadManifestAndMediaFiles(any(), any(), any(), anyInt(), anyInt());
+        doReturn(true).when(downloader).installEverything(any(), any(), any());
+
+        List<FormDetails> forms = new ArrayList<>();
+        forms.add(test1);
+
+        HashMap<FormDetails, String> messages = downloader.downloadForms(forms);
+        assertThat(messages.get(test1), is("Success"));
+    }
+}


### PR DESCRIPTION
Closes #3535

#### What has been done to verify that this works as intended?
Ran the automated tests. Downloaded forms with and without media from the default Aggregate server.

#### Why is this the best possible solution? Were any other approaches considered?
The fix itself is a null check and I think that's the only possible option.

The tests I don't love but I couldn't come up with any other option without risky refactoring. They use Robolectric because of `FormDownloader`'s reliance on the `Collect` singleton for dependency injection, for looking up strings and for database access (this class, like many in this code base, has all the concerns). I mocked the actual download of files and tried to make it really clear in the test comments what the tests target.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I made the mistake of not thinking about this question carefully enough in #3523. This code is involved in the downloading of all forms from any server so that's where the risk is. There are different branches based on whether there is or isn't media attached and both should be verified.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms on https://opendatakit.appspot.com

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)