### PR TITLE
Pull display code out of FormMapViewModel and add Activity-level tests

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -54,14 +54,6 @@ public class FormMapViewModel extends ViewModel {
         return totalInstanceCount;
     }
 
-    /**
-     * Returns a list of filled instances of this form that can be mapped.
-     */
-    public List<MappableFormInstance> getMappableFormInstances() {
-        initializeFormInstances();
-        return mappableFormInstances;
-    }
-
     private void initializeFormInstances() {
         List<Instance> instances = instancesRepository.getAllBy(form.getJrFormId());
 
@@ -72,6 +64,14 @@ public class FormMapViewModel extends ViewModel {
             totalInstanceCount = instances.size();
             mappableFormInstances = getMappableFormInstances(instances);
         }
+    }
+
+    /**
+     * Returns a list of filled instances of this form that can be mapped.
+     */
+    public List<MappableFormInstance> getMappableFormInstances() {
+        initializeFormInstances();
+        return mappableFormInstances;
     }
 
     private List<MappableFormInstance> getMappableFormInstances(List<Instance> allInstances) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -5,21 +5,13 @@ import androidx.lifecycle.ViewModel;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.odk.collect.android.R;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.geo.MapFragment;
-import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
 
 import timber.log.Timber;
 
@@ -30,26 +22,14 @@ public class FormMapViewModel extends ViewModel {
     private final Form form;
 
     /**
-     * Cached count of all of this form's instances, including ones that don't have a geometry to
-     * map.
+     * The count of all filled instances of this form, including unmappable ones.
      */
     private int totalInstanceCount;
 
     /**
-     * Quick lookup of instance objects from map feature IDs.
+     * The filled instances of this form that can be mapped.
      */
-    private final Map<Integer, Instance> instancesByFeatureId = new HashMap<>();
-
-    /**
-     * Points to be mapped. Note: kept separately from {@link #instancesByFeatureId} so we can
-     * quickly zoom to bounding box.
-     */
-    private final List<MapPoint> points = new ArrayList<>();
-
-    /**
-     * True if the map viewport has been initialized, false otherwise.
-     */
-    private boolean viewportInitialized;
+    private List<MappableFormInstance> mappableFormInstances;
 
     private final InstancesRepository instancesRepository;
 
@@ -66,26 +46,37 @@ public class FormMapViewModel extends ViewModel {
         return form.getJrFormId();
     }
 
-    public int getInstanceCount() {
+    /**
+     * Returns the count of all filled instances of this form, including unmappable ones.
+     */
+    public int getTotalInstanceCount() {
+        initializeFormInstances();
         return totalInstanceCount;
     }
 
-    public int getMappedPointCount() {
-        return points.size();
+    /**
+     * Returns a list of filled instances of this form that can be mapped.
+     */
+    public List<MappableFormInstance> getMappableFormInstances() {
+        initializeFormInstances();
+        return mappableFormInstances;
     }
 
-    /**
-     * Clears the existing features on the given map and places features for the current form's
-     * instances. If features were added to the map and the map view was not previously initialized,
-     * zooms to display all points.
-     */
-    public void mapUpdateRequested(MapFragment map) {
-        points.clear();
-        map.clearFeatures();
-
+    private void initializeFormInstances() {
         List<Instance> instances = instancesRepository.getAllBy(form.getJrFormId());
-        totalInstanceCount = instances.size();
-        for (Instance instance : instances) {
+
+        // Note: there is currently no way to delete instances from FormMapActivity so this works
+        // because a change in size means a refresh is needed. Compromise because we don't currently
+        // have an easy way to observe database changes.
+        if (mappableFormInstances == null || instances.size() != totalInstanceCount) {
+            totalInstanceCount = instances.size();
+            mappableFormInstances = getMappableFormInstances(instances);
+        }
+    }
+
+    private List<MappableFormInstance> getMappableFormInstances(List<Instance> allInstances) {
+        List<MappableFormInstance> mappableFormInstances = new ArrayList<>();
+        for (Instance instance : allInstances) {
             if (instance.getGeometry() != null) {
                 try {
                     JSONObject geometry = new JSONObject(instance.getGeometry());
@@ -93,17 +84,15 @@ public class FormMapViewModel extends ViewModel {
                         case "Point":
                             JSONArray coordinates = geometry.getJSONArray("coordinates");
                             // In GeoJSON, longitude comes before latitude.
-                            double lon = coordinates.getDouble(0);
-                            double lat = coordinates.getDouble(1);
+                            Double lon = coordinates.getDouble(0);
+                            Double lat = coordinates.getDouble(1);
 
-                            MapPoint point = new MapPoint(lat, lon);
-                            int featureId = map.addMarker(point, false);
-
-                            int drawableId = getDrawableIdForStatus(instance.getStatus());
-                            map.setMarkerIcon(featureId, drawableId);
-
-                            instancesByFeatureId.put(featureId, instance);
-                            points.add(point);
+                            mappableFormInstances.add(new MappableFormInstance(
+                                    instance.getDatabaseId(),
+                                    lat, lon,
+                                    instance.getStatus(),
+                                    getClickActionForInstance(instance)
+                            ));
                     }
                 } catch (JSONException e) {
                     Timber.w("Invalid JSON in instances table: %s", instance.getGeometry());
@@ -111,84 +100,72 @@ public class FormMapViewModel extends ViewModel {
             }
         }
 
-        if (!viewportInitialized && !points.isEmpty()) {
-            mapZoomToBoundingBoxRequested(map);
-            viewportInitialized = true;
-        }
+        return mappableFormInstances;
     }
 
-    public void mapZoomToBoundingBoxRequested(MapFragment map) {
-        map.zoomToBoundingBox(points, 0.8, false);
-    }
-
-    /**
-     * Zooms the map to the new location if the map viewport hasn't been initialized yet.
-     */
-    public void locationChanged(MapPoint point, MapFragment map) {
-        if (!viewportInitialized) {
-            map.zoomToPoint(point, true);
-            viewportInitialized = true;
-        }
-    }
-
-    public FeatureStatus getStatusOfClickedFeature(int featureId) {
-        Instance instance = instancesByFeatureId.get(featureId);
-
+    private ClickAction getClickActionForInstance(Instance instance) {
         if (instance != null) {
             if (instance.getDeletedDate() != null) {
-                return FeatureStatus.DELETED;
+                return ClickAction.DELETED_TOAST;
             }
 
             if ((instance.getStatus().equals(InstanceProviderAPI.STATUS_COMPLETE)
                     || instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED)
                     || instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMISSION_FAILED))
                     && !instance.canEditWhenComplete()) {
-                return FeatureStatus.NOT_VIEWABLE;
+                return ClickAction.NOT_VIEWABLE_TOAST;
             } else if (instance.getDatabaseId() != null) {
                 if (instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED)) {
-                    return FeatureStatus.VIEW_ONLY;
+                    return ClickAction.OPEN_READ_ONLY;
                 }
-                return FeatureStatus.EDITABLE;
+                return ClickAction.OPEN_EDIT;
             }
         }
 
-        return FeatureStatus.UNKNOWN;
+        return ClickAction.NONE;
     }
 
-    @Nullable
-    public Date getDeletedDateOf(int featureId) {
-        Instance instance = instancesByFeatureId.get(featureId);
-        if (instance != null) {
-            return new Date(instance.getDeletedDate());
-        } else {
-            return null;
+    public long getDeletedDateOf(long databaseId) {
+        return instancesRepository.getBy(databaseId).getDeletedDate();
+    }
+
+    public enum ClickAction {
+        DELETED_TOAST, NOT_VIEWABLE_TOAST, OPEN_READ_ONLY, OPEN_EDIT, NONE
+    }
+
+    public class MappableFormInstance {
+        private final long databaseId;
+        private final Double latitude;
+        private final Double longitude;
+        private final String status;
+        private final ClickAction clickAction;
+
+        MappableFormInstance(long databaseId, Double latitude, Double longitude, String status, ClickAction clickAction) {
+            this.databaseId = databaseId;
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.status = status;
+            this.clickAction = clickAction;
         }
-    }
 
-    public Long getDatabaseIdOf(int featureId) {
-        Instance instance = instancesByFeatureId.get(featureId);
-        if (instance != null) {
-            return instance.getDatabaseId();
-        } else {
-            return null;
+        public long getDatabaseId() {
+            return databaseId;
         }
-    }
 
-    private static int getDrawableIdForStatus(String status) {
-        switch (status) {
-            case InstanceProviderAPI.STATUS_INCOMPLETE:
-                return R.drawable.ic_room_blue_24dp;
-            case InstanceProviderAPI.STATUS_COMPLETE:
-                return R.drawable.ic_room_deep_purple_24dp;
-            case InstanceProviderAPI.STATUS_SUBMITTED:
-                return R.drawable.ic_room_green_24dp;
-            case InstanceProviderAPI.STATUS_SUBMISSION_FAILED:
-                return R.drawable.ic_room_red_24dp;
+        public Double getLatitude() {
+            return latitude;
         }
-        return R.drawable.ic_map_point;
-    }
 
-    public enum FeatureStatus {
-        DELETED, NOT_VIEWABLE, VIEW_ONLY, EDITABLE, UNKNOWN
+        public Double getLongitude() {
+            return longitude;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public ClickAction getClickAction() {
+            return clickAction;
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -25,7 +25,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
 
     @Override
     public Instance getBy(long databaseId) {
-        Cursor c = dao.getInstancesCursorForId("" + databaseId);
+        Cursor c = dao.getInstancesCursorForId(Long.toString(databaseId));
         List<Instance> result = dao.getInstancesFromCursor(c);
         return !result.isEmpty() ? result.get(0) : null;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -24,6 +24,13 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     private final InstancesDao dao = new InstancesDao();
 
     @Override
+    public Instance getBy(long databaseId) {
+        Cursor c = dao.getInstancesCursorForId("" + databaseId);
+        List<Instance> result = dao.getInstancesFromCursor(c);
+        return !result.isEmpty() ? result.get(0) : null;
+    }
+
+    @Override
     public List<Instance> getAllBy(String formId) {
         Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ?",
         new String[] {formId});

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
  * without introducing new specialized methods (e.g. get(Specification s) instead of getBy(XYZ).
  */
 public interface InstancesRepository {
+    Instance getBy(long databaseId);
     List<Instance> getAllBy(String formId);
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -13,6 +13,7 @@ import java.util.List;
  */
 public interface InstancesRepository {
     Instance getBy(long databaseId);
+
     List<Instance> getAllBy(String formId);
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
@@ -45,18 +45,18 @@ public class FormMapActivityTest {
     private ActivityController activityController;
     private FormMapActivity activity;
 
-    private List<MapPoint> expectedPoints = Arrays.asList(new MapPoint(10.0, 125.6),
+    private final List<MapPoint> expectedPoints = Arrays.asList(new MapPoint(10.0, 125.6),
             new MapPoint(10.1, 125.6), new MapPoint(10.1, 126.6),
             new MapPoint(10.3, 125.6), new MapPoint(10.3, 125.7),
             new MapPoint(10.4, 125.6));
-    private MapPoint currentLocation = new MapPoint(5, 5);
+    private final MapPoint currentLocation = new MapPoint(5, 5);
 
     @Before public void setUpActivity() {
         activityController = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
         activity = (FormMapActivity) activityController.get();
 
         TestInstancesRepository testInstancesRepository = new TestInstancesRepository(Arrays.asList(testInstances));
-        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, testInstancesRepository);
         activity.viewModelFactory = new TestFactory(viewModel);
 
         activity.map = new TestMapFragment();
@@ -78,7 +78,7 @@ public class FormMapActivityTest {
         FormMapActivity activity = (FormMapActivity) controller.get();
 
         TestInstancesRepository testInstancesRepository = new TestInstancesRepository(new ArrayList<>());
-        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, testInstancesRepository);
         activity.viewModelFactory = new TestFactory(viewModel);
         activity.map = new TestMapFragment();
 
@@ -93,7 +93,7 @@ public class FormMapActivityTest {
         FormMapActivity activity = (FormMapActivity) controller.get();
 
         TestInstancesRepository testInstancesRepository = new TestInstancesRepository(new ArrayList<>());
-        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, testInstancesRepository);
         activity.viewModelFactory = new TestFactory(viewModel);
         activity.map = new TestMapFragment();
 

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
@@ -1,0 +1,268 @@
+package org.odk.collect.android.activities;
+
+import android.app.Fragment;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.viewmodels.FormMapViewModel;
+import org.odk.collect.android.geo.MapPoint;
+import org.odk.collect.android.geo.TestMapFragment;
+import org.odk.collect.android.instances.TestInstancesRepository;
+import org.odk.collect.android.preferences.AdminKeys;
+import org.odk.collect.android.preferences.AdminSharedPreferences;
+import org.odk.collect.android.preferences.MapsPreferences;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.odk.collect.android.utilities.ApplicationConstants;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowToast;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.odk.collect.android.activities.FormMapViewModelTest.testInstances;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class FormMapActivityTest {
+    private ActivityController activityController;
+    private FormMapActivity activity;
+
+    private List<MapPoint> expectedPoints = Arrays.asList(new MapPoint(10.0, 125.6),
+            new MapPoint(10.1, 125.6), new MapPoint(10.1, 126.6),
+            new MapPoint(10.3, 125.6), new MapPoint(10.3, 125.7),
+            new MapPoint(10.4, 125.6));
+    private MapPoint currentLocation = new MapPoint(5, 5);
+
+    @Before public void setUpActivity() {
+        activityController = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
+        activity = (FormMapActivity) activityController.get();
+
+        TestInstancesRepository testInstancesRepository = new TestInstancesRepository(Arrays.asList(testInstances));
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.testForm1, testInstancesRepository);
+        activity.viewModelFactory = new TestFactory(viewModel);
+
+        activity.map = new TestMapFragment();
+
+        activityController.setup();
+    }
+
+    @Test public void startingFormMap_zoomsToFitAllInstanceMarkers_ifThereAreInstanceMarkers() {
+        TestMapFragment map = (TestMapFragment) activity.map;
+        assertThat(map.getZoomCount(), is(1));
+        assertThat(map.getLatestZoomPoint(), is(nullValue()));
+        assertThat(map.getLatestZoomBoundingBox(), is(expectedPoints));
+        assertThat(map.getLatestScaleFactor(), is(0.8));
+        assertThat(map.wasLatestZoomCallAnimated(), is(false));
+    }
+
+    @Test public void startingFormMap_doesNotZoom_ifThereAreNoInstanceMarkers_andLocationIsUnavailable() {
+        ActivityController controller = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
+        FormMapActivity activity = (FormMapActivity) controller.get();
+
+        TestInstancesRepository testInstancesRepository = new TestInstancesRepository(new ArrayList<>());
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.testForm1, testInstancesRepository);
+        activity.viewModelFactory = new TestFactory(viewModel);
+        activity.map = new TestMapFragment();
+
+        controller.setup();
+
+        TestMapFragment map = (TestMapFragment) activity.map;
+        assertThat(map.getZoomCount(), is(0));
+    }
+
+    @Test public void locationChange_zoomsToCurrentLocation_ifTheViewportWasNotPreviouslyUpdated() {
+        ActivityController controller = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
+        FormMapActivity activity = (FormMapActivity) controller.get();
+
+        TestInstancesRepository testInstancesRepository = new TestInstancesRepository(new ArrayList<>());
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.testForm1, testInstancesRepository);
+        activity.viewModelFactory = new TestFactory(viewModel);
+        activity.map = new TestMapFragment();
+
+        controller.setup();
+
+        TestMapFragment map = (TestMapFragment) activity.map;
+        assertThat(map.getZoomCount(), is(0));
+
+        map.onLocationChanged(currentLocation);
+
+        assertThat(map.getZoomCount(), is(1));
+        assertThat(map.getLatestZoomPoint(), is(currentLocation));
+        assertThat(map.wasLatestZoomCallAnimated(), is(true));
+    }
+
+    @Test public void tappingOnZoomToCurrentLocationButton_zoomsToCurrentLocationWithAnimation() {
+        activity.findViewById(R.id.zoom_to_location).performClick();
+
+        TestMapFragment map = (TestMapFragment) activity.map;
+        assertThat(map.getZoomCount(), is(2)); // once on initialization and once on click
+        assertThat(map.getLatestZoomPoint(), is(currentLocation));
+        assertThat(map.wasLatestZoomCallAnimated(), is(true));
+    }
+
+    @Test public void tappingOnZoomToFitButton_zoomsToFitAllInstanceMarkersWithoutAnimation() {
+        activity.findViewById(R.id.zoom_to_bounds).performClick();
+
+        TestMapFragment map = (TestMapFragment) activity.map;
+        assertThat(map.getZoomCount(), is(2));
+        assertThat(map.getLatestZoomPoint(), is(nullValue()));
+        assertThat(map.getLatestZoomBoundingBox(), is(expectedPoints));
+        assertThat(map.getLatestScaleFactor(), is(0.8));
+        assertThat(map.wasLatestZoomCallAnimated(), is(false));
+    }
+
+    @Test public void tappingOnLayerMenu_opensLayerDialog() {
+        List<Fragment> fragments = activity.getFragmentManager().getFragments();
+        assertThat(fragments, not(hasItem(isA(MapsPreferences.class))));
+
+        activity.findViewById(R.id.layer_menu).performClick();
+
+        fragments = activity.getFragmentManager().getFragments();
+        assertThat(fragments, hasItem(isA(MapsPreferences.class)));
+    }
+
+    @Test public void tappingOnNewInstanceButton_opensNewInstance() {
+        activity.findViewById(R.id.new_instance).performClick();
+
+        Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+
+        assertThat(actual.getAction(), is(Intent.ACTION_EDIT));
+        assertThat(actual.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE), is(nullValue()));
+    }
+
+    @Ignore("Doesn't work with field-based dependency injection because we don't get an opportunity" +
+            "to set test doubles before onCreate() is called after the orientation change")
+    @Test public void centerAndZoomLevel_areRestoredAfterOrientationChange() {
+        activity.map.zoomToPoint(new MapPoint(7, 7), 7, false);
+
+        RuntimeEnvironment.setQualifiers("+land");
+        activityController.configurationChange();
+
+        assertThat(activity.map.getCenter(), is(new MapPoint(7, 7)));
+        assertThat(activity.map.getZoom(), is(7));
+    }
+
+    // Note that there's a point with deleted status included. This shouldn't be possible in real
+    // usage because deleting a form removes the geometry from the database. However, the database
+    // allows a deleted instance with geometry so we test it.
+    @Test public void mappedPoints_matchInstancesWithGeometry() {
+        TestMapFragment map = (TestMapFragment) activity.map;
+
+        assertThat(map.getMappedPointCount(), is(expectedPoints.size()));
+        for (MapPoint expectedPoint : expectedPoints) {
+            assertThat(map.isMapped(expectedPoint), is(true));
+        }
+    }
+
+    @Test public void tappingOnEditableInstances_launchesEditActivity() {
+        TestMapFragment map = (TestMapFragment) activity.map;
+
+        MapPoint editableAndFinalized = new MapPoint(10.1, 125.6);
+        MapPoint unfinalized = new MapPoint(10.1, 126.6);
+        MapPoint failedToSend = new MapPoint(10.3, 125.6);
+
+        MapPoint[] testPoints = {editableAndFinalized, unfinalized, failedToSend};
+
+        for (MapPoint toTap : testPoints) {
+            int featureId = map.getFeatureIdFor(toTap);
+
+            activity.onFeatureClicked(featureId);
+            Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+
+            assertThat(actual.getAction(), is(Intent.ACTION_EDIT));
+            assertThat(actual.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE), is(nullValue()));
+        }
+    }
+
+    @Test public void tappingOnEditableInstance_whenEditingSettingisOff_launchesViewActivity() {
+        AdminSharedPreferences.getInstance().save(AdminKeys.KEY_EDIT_SAVED, false);
+
+        TestMapFragment map = (TestMapFragment) activity.map;
+
+        MapPoint editableAndFinalized = new MapPoint(10.1, 125.6);
+        MapPoint unfinalized = new MapPoint(10.1, 126.6);
+        MapPoint failedToSend = new MapPoint(10.3, 125.6);
+
+        MapPoint[] testPoints = {editableAndFinalized, unfinalized, failedToSend};
+
+        for (MapPoint toTap : testPoints) {
+            int featureId = map.getFeatureIdFor(toTap);
+
+            activity.onFeatureClicked(featureId);
+            Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+
+            assertThat(actual.getAction(), is(Intent.ACTION_EDIT));
+            assertThat(actual.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE), is(ApplicationConstants.FormModes.VIEW_SENT));
+        }
+    }
+
+    @Test public void tappingOnUneditableInstances_launchesViewActivity() {
+        TestMapFragment map = (TestMapFragment) activity.map;
+        MapPoint sent = new MapPoint(10.3, 125.7);
+
+        int featureId = map.getFeatureIdFor(sent);
+
+        activity.onFeatureClicked(featureId);
+        Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
+
+        assertThat(actual.getAction(), is(Intent.ACTION_EDIT));
+        assertThat(actual.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE), is(ApplicationConstants.FormModes.VIEW_SENT));
+    }
+
+    // Geometry is removed from the database on instance encryption but just in case there is an
+    // encrypted instance with geometry available, show an encrypted toast.
+    @Test public void tappingOnEncryptedInstances_showsUneditableToast() {
+        TestMapFragment map = (TestMapFragment) activity.map;
+        MapPoint submissionFailedCantEditWhenFinalized = new MapPoint(10.4, 125.6);
+
+        int featureId = map.getFeatureIdFor(submissionFailedCantEditWhenFinalized);
+
+        activity.onFeatureClicked(featureId);
+        assertThat(ShadowToast.getTextOfLatestToast(), is("This form cannot be edited once it has been marked as finalized. It may be encrypted."));
+    }
+
+    // Geometry is removed from the database on instance deletion but just in case there is a
+    // deleted instance with geometry available, show a deleted toast.
+    @Test public void tappingOnDeletedInstances_showsDeletedToast() {
+        TestMapFragment map = (TestMapFragment) activity.map;
+        MapPoint deleted = new MapPoint(10.0, 125.6);
+
+        int featureId = map.getFeatureIdFor(deleted);
+
+        activity.onFeatureClicked(featureId);
+        assertThat(ShadowToast.getTextOfLatestToast(), containsString("Deleted on"));
+    }
+
+    private static class TestFactory implements ViewModelProvider.Factory {
+
+        private final FormMapViewModel viewModel;
+
+        TestFactory(FormMapViewModel viewModel) {
+            this.viewModel = viewModel;
+        }
+
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            return (T) viewModel;
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -63,7 +63,7 @@ public class FormMapViewModelTest {
     @Test public void getDeletedDateOf_returnsDeletedDate() {
         FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
 
-        assertThat(viewModel.getDeletedDateOf(0L), is(1487782554846L));
+        assertThat(viewModel.getDeletedDateOf(0L), is(testInstances[0].getDeletedDate()));
     }
 
     // Should not actually be possible from UI because geometry is deleted on sent instance delete

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -3,48 +3,31 @@ package org.odk.collect.android.activities;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.FormMapViewModel;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.geo.MapFragment;
-import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.instances.TestInstancesRepository;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyDouble;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.not;
 
 public class FormMapViewModelTest {
     @Rule public MockitoRule rule = MockitoJUnit.rule();
 
     private InstancesRepository testInstancesRepository;
 
-    @Mock private MapFragment map;
-
     @Before public void setUp() {
         testInstancesRepository = new TestInstancesRepository(Arrays.asList(testInstances));
-
-        when(map.addMarker(new MapPoint(10.0, 125.6), false)).thenReturn(0);
-        when(map.addMarker(new MapPoint(10.1, 125.6), false)).thenReturn(1);
-        when(map.addMarker(new MapPoint(10.1, 126.6), false)).thenReturn(2);
-        when(map.addMarker(new MapPoint(10.3, 125.6), false)).thenReturn(4);
-        when(map.addMarker(new MapPoint(10.3, 125.7), false)).thenReturn(5);
-        when(map.addMarker(new MapPoint(10.4, 125.6), false)).thenReturn(6);
-        when(map.addMarker(new MapPoint(11.1, 127.6), false)).thenReturn(8);
     }
 
     @Test public void getFormTitle_returnsFormTitle() {
@@ -52,129 +35,87 @@ public class FormMapViewModelTest {
         assertThat(viewModel.getFormTitle(), is("Form with ID 1"));
     }
 
-    @Test public void updatingMap_forFormWithoutMappedInstances_doesNotMapPoints() {
+    @Test public void getFormId_returnsFormId() {
+        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        assertThat(viewModel.getFormId(), is("formId1"));
+    }
+
+    @Test public void getTotalInstanceCount_returnsCountOfAllInstances() {
+        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        assertThat(viewModel.getTotalInstanceCount(), is(7));
+    }
+
+    @Test public void getMappableInstances_excludesInstancesWithoutGeometry() {
+        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        List<FormMapViewModel.MappableFormInstance> mappableFormInstances = viewModel.getMappableFormInstances();
+
+        assertThat(mappableFormInstances.size(), is(6));
+        assertThat(mappableFormInstances, not(contains(hasProperty("databaseId"), is(3L))));
+    }
+
+    @Test public void getMappableInstances_excludesInstancesWithCorruptGeometry() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm2, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> mappableFormInstances = viewModel.getMappableFormInstances();
 
-        verify(map, never()).addMarker(any(), anyBoolean());
-        assertThat(viewModel.getMappedPointCount(), is(0));
+        assertThat(mappableFormInstances.size(), is(0));
     }
 
-    @Test public void updatingMap_forFormWithoutMappedInstances_doesNotUpdateViewPort() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm2, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-
-        assertThat(viewModel.getMappedPointCount(), is(0));
-        verify(map, never()).zoomToBoundingBox(any(), anyDouble(), anyBoolean());
-    }
-
-    @Test public void updatingMap_forFormWithMappedInstances_updatesViewPort() {
+    @Test public void getDeletedDateOf_returnsDeletedDate() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
 
-        assertThat(viewModel.getInstanceCount(), is(7));
-        verify(map, times(1)).zoomToBoundingBox(any(), anyDouble(), anyBoolean());
-    }
-
-    @Test public void receivingLocationUpdate_withoutPoints_updatesViewPort() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm2, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-        verify(map, never()).zoomToBoundingBox(any(), anyDouble(), anyBoolean());
-
-        assertThat(viewModel.getMappedPointCount(), is(0));
-        viewModel.locationChanged(new MapPoint(0, 0), map);
-        verify(map, times(1)).zoomToPoint(new MapPoint(0, 0), true);
-    }
-
-    @Test public void totalInstanceCount_countsAllInstancesForForm() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-
-        assertThat(viewModel.getInstanceCount(), is(7));
-    }
-
-    @Test public void mappedPointCount_omitsInstancesWithoutGeometry() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-
-        assertThat(viewModel.getMappedPointCount(), is(6));
-    }
-
-    @Test public void mapMarkersPlaced_forEachInstanceWithGeometry() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-
-        verify(map, times(1)).addMarker(new MapPoint(10.0, 125.6), false);
-        verify(map, times(1)).addMarker(new MapPoint(10.1, 125.6), false);
-        verify(map, times(1)).addMarker(new MapPoint(10.1, 126.6), false);
-        verify(map, times(1)).addMarker(new MapPoint(10.3, 125.6), false);
-        verify(map, times(1)).addMarker(new MapPoint(10.3, 125.7), false);
-        verify(map, times(1)).addMarker(new MapPoint(10.4, 125.6), false);
-    }
-
-    @Test public void mapMakersHaveExpectedIcon_forInstanceStatus() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-
-        verify(map, times(1)).setMarkerIcon(0, R.drawable.ic_room_green_24dp);
-        verify(map, times(1)).setMarkerIcon(1, R.drawable.ic_room_deep_purple_24dp);
-        verify(map, times(1)).setMarkerIcon(2, R.drawable.ic_room_blue_24dp);
-        verify(map, times(1)).setMarkerIcon(4, R.drawable.ic_room_red_24dp);
-        verify(map, times(1)).setMarkerIcon(5, R.drawable.ic_room_green_24dp);
-        verify(map, times(1)).setMarkerIcon(6, R.drawable.ic_room_red_24dp);
+        assertThat(viewModel.getDeletedDateOf(0L), is(1487782554846L));
     }
 
     // Should not actually be possible from UI because geometry is deleted on sent instance delete
-    @Test public void tappingMapMarker_forDeletedInstance_returnsDeletedStatus() {
+    @Test public void deletedInstance_hasDeletedClickAction() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(viewModel.getStatusOfClickedFeature(0), is(FormMapViewModel.FeatureStatus.DELETED));
+        assertThat(instances.get(0).getClickAction(), is(FormMapViewModel.ClickAction.DELETED_TOAST));
     }
 
-    @Test public void tappingMapMarker_forFinalizedInstance_thatCanBeEdited_returnsEditableStatus() {
+    @Test public void finalizedInstance_thatCanBeEdited_hasEditableClickAction() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(viewModel.getStatusOfClickedFeature(1), is(FormMapViewModel.FeatureStatus.EDITABLE));
+        assertThat(instances.get(1).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
-    @Test public void tappingMapMarker_forUnfinalizedInstance_returnsEditableStatus() {
+    @Test public void unfinalizedInstance_hasEditableStatus() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(viewModel.getStatusOfClickedFeature(2), is(FormMapViewModel.FeatureStatus.EDITABLE));
+        assertThat(instances.get(2).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
-    @Test public void tappingMapMarker_forInstanceThatFailedToSend_thatCanBeEdited_returnsEditableStatus() {
+    @Test public void instanceThatFailedToSend_thatCanBeEdited_hasEditableStatus() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(viewModel.getStatusOfClickedFeature(4), is(FormMapViewModel.FeatureStatus.EDITABLE));
+        assertThat(instances.get(3).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
     // Sent instances should never be editable.
-    @Test public void tappingMapMarker_forSubmittedInstance_thatCanBeEdited_returnsViewableStatus() {
+    @Test public void submittedInstance_thatCanBeEdited_returnsViewableStatus() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(viewModel.getStatusOfClickedFeature(5), is(FormMapViewModel.FeatureStatus.VIEW_ONLY));
+        assertThat(instances.get(4).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_READ_ONLY));
     }
 
-    @Test public void tappingMapMarker_forInstanceThatFailedToSend_thatCantBeEdited_returnsNotViewableStatus() {
+    @Test public void instanceThatFailedToSend_thatCantBeEdited_returnsNotViewableStatus() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(viewModel.getStatusOfClickedFeature(6), is(FormMapViewModel.FeatureStatus.NOT_VIEWABLE));
+        assertThat(instances.get(5).getClickAction(), is(FormMapViewModel.ClickAction.NOT_VIEWABLE_TOAST));
     }
 
-    @Test public void addingAnInstance_shouldBeReflectedInInstanceCountsAndMap() {
+    @Test public void addingAnInstance_isReflectedInInstanceCountsAndList() {
         FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
 
-        assertThat(viewModel.getInstanceCount(), is(7));
-        assertThat(viewModel.getMappedPointCount(), is(6));
-        assertThat(viewModel.getStatusOfClickedFeature(8), is(FormMapViewModel.FeatureStatus.UNKNOWN));
+        List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
+        assertThat(viewModel.getTotalInstanceCount(), is(7));
+        assertThat(instances.size(), is(6));
 
         Instance newInstance = new Instance.Builder().databaseId(8L)
                 .jrFormId("formId1")
@@ -186,25 +127,10 @@ public class FormMapViewModelTest {
 
         ((TestInstancesRepository) testInstancesRepository).addInstance(newInstance);
 
-        viewModel.mapUpdateRequested(map);
-        assertThat(viewModel.getInstanceCount(), is(8));
-        assertThat(viewModel.getMappedPointCount(), is(7));
-        assertThat(viewModel.getStatusOfClickedFeature(8), is(FormMapViewModel.FeatureStatus.EDITABLE));
-    }
-
-    @Test public void deletingAnInstance_shouldBeReflectedInInstanceCountsAndMap() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
-        viewModel.mapUpdateRequested(map);
-
-        assertThat(viewModel.getInstanceCount(), is(7));
-        assertThat(viewModel.getMappedPointCount(), is(6));
-        assertThat(viewModel.getStatusOfClickedFeature(6), is(FormMapViewModel.FeatureStatus.NOT_VIEWABLE));
-
-        ((TestInstancesRepository) testInstancesRepository).removeInstanceById(6);
-
-        viewModel.mapUpdateRequested(map);
-        assertThat(viewModel.getInstanceCount(), is(6));
-        assertThat(viewModel.getMappedPointCount(), is(5));
+        instances = viewModel.getMappableFormInstances();
+        assertThat(viewModel.getTotalInstanceCount(), is(8));
+        assertThat(instances.size(), is(7));
+        assertThat(instances.get(6).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
     private final Form testForm1 = new Form.Builder().id(0L)
@@ -277,6 +203,15 @@ public class FormMapViewModelTest {
             new Instance.Builder().databaseId(7L)
                     .jrFormId("formId2")
                     .jrVersion("2019103101")
+                    .geometryType("Point")
+                    .geometry("Crazy stuff")
+                    .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
+
+            new Instance.Builder().databaseId(8L)
+                    .jrFormId("formId2")
+                    .jrVersion("2019103101")
+                    .geometryType("Crazy stuff")
+                    .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.4]}")
                     .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
             };
 }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -133,7 +133,7 @@ public class FormMapViewModelTest {
         assertThat(instances.get(6).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
-    private final Form testForm1 = new Form.Builder().id(0L)
+    static final Form testForm1 = new Form.Builder().id(0L)
             .jrFormId("formId1")
             .jrVersion("2019103104")
             .displayName("Form with ID 1")
@@ -147,7 +147,7 @@ public class FormMapViewModelTest {
             .geometryXpath("/data/my-point2")
             .build();
 
-    private static Instance[] testInstances = {
+    static Instance[] testInstances = {
             new Instance.Builder().databaseId(0L)
                     .jrFormId("formId1")
                     .jrVersion("2019103101")

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -31,22 +31,22 @@ public class FormMapViewModelTest {
     }
 
     @Test public void getFormTitle_returnsFormTitle() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         assertThat(viewModel.getFormTitle(), is("Form with ID 1"));
     }
 
     @Test public void getFormId_returnsFormId() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         assertThat(viewModel.getFormId(), is("formId1"));
     }
 
     @Test public void getTotalInstanceCount_returnsCountOfAllInstances() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         assertThat(viewModel.getTotalInstanceCount(), is(7));
     }
 
     @Test public void getMappableInstances_excludesInstancesWithoutGeometry() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> mappableFormInstances = viewModel.getMappableFormInstances();
 
         assertThat(mappableFormInstances.size(), is(6));
@@ -54,42 +54,42 @@ public class FormMapViewModelTest {
     }
 
     @Test public void getMappableInstances_excludesInstancesWithCorruptGeometry() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm2, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_2, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> mappableFormInstances = viewModel.getMappableFormInstances();
 
         assertThat(mappableFormInstances.size(), is(0));
     }
 
     @Test public void getDeletedDateOf_returnsDeletedDate() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
 
         assertThat(viewModel.getDeletedDateOf(0L), is(1487782554846L));
     }
 
     // Should not actually be possible from UI because geometry is deleted on sent instance delete
     @Test public void deletedInstance_hasDeletedClickAction() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
         assertThat(instances.get(0).getClickAction(), is(FormMapViewModel.ClickAction.DELETED_TOAST));
     }
 
     @Test public void finalizedInstance_thatCanBeEdited_hasEditableClickAction() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
         assertThat(instances.get(1).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
     @Test public void unfinalizedInstance_hasEditableStatus() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
         assertThat(instances.get(2).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
     @Test public void instanceThatFailedToSend_thatCanBeEdited_hasEditableStatus() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
         assertThat(instances.get(3).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
@@ -97,21 +97,21 @@ public class FormMapViewModelTest {
 
     // Sent instances should never be editable.
     @Test public void submittedInstance_thatCanBeEdited_returnsViewableStatus() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
         assertThat(instances.get(4).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_READ_ONLY));
     }
 
     @Test public void instanceThatFailedToSend_thatCantBeEdited_returnsNotViewableStatus() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
         assertThat(instances.get(5).getClickAction(), is(FormMapViewModel.ClickAction.NOT_VIEWABLE_TOAST));
     }
 
     @Test public void addingAnInstance_isReflectedInInstanceCountsAndList() {
-        FormMapViewModel viewModel = new FormMapViewModel(testForm1, testInstancesRepository);
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
 
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
         assertThat(viewModel.getTotalInstanceCount(), is(7));
@@ -133,14 +133,14 @@ public class FormMapViewModelTest {
         assertThat(instances.get(6).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
-    static final Form testForm1 = new Form.Builder().id(0L)
+    static final Form TEST_FORM_1 = new Form.Builder().id(0L)
             .jrFormId("formId1")
             .jrVersion("2019103104")
             .displayName("Form with ID 1")
             .geometryXpath("/data/my-point")
             .build();
 
-    private final Form testForm2 = new Form.Builder().id(0L)
+    private static final Form TEST_FORM_2 = new Form.Builder().id(0L)
             .jrFormId("formId2")
             .jrVersion("2019103103")
             .displayName("Form with ID 2")

--- a/collect_app/src/test/java/org/odk/collect/android/geo/TestMapFragment.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/TestMapFragment.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TestMapFragment implements MapFragment {
-    private int zoomCount = 0;
+    private int zoomCount;
 
     private boolean animate;
     private MapPoint zoomPoint;
@@ -20,8 +20,8 @@ public class TestMapFragment implements MapFragment {
     private double zoomLevel;
     private PointListener locationListener;
 
-    private int lastFeatureId = 0;
-    private Map<MapPoint, Integer> mappedPoints = new HashMap<>();
+    private int lastFeatureId;
+    private final Map<MapPoint, Integer> mappedPoints = new HashMap<>();
 
     public int getZoomCount() {
         return zoomCount;

--- a/collect_app/src/test/java/org/odk/collect/android/geo/TestMapFragment.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/TestMapFragment.java
@@ -1,0 +1,210 @@
+package org.odk.collect.android.geo;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestMapFragment implements MapFragment {
+    private int zoomCount = 0;
+
+    private boolean animate;
+    private MapPoint zoomPoint;
+    private Iterable<MapPoint> zoomBoundingBox;
+    private double scaleFactor;
+    private double zoomLevel;
+    private PointListener locationListener;
+
+    private int lastFeatureId = 0;
+    private Map<MapPoint, Integer> mappedPoints = new HashMap<>();
+
+    public int getZoomCount() {
+        return zoomCount;
+    }
+
+    public boolean wasLatestZoomCallAnimated() {
+        return animate;
+    }
+
+    public MapPoint getLatestZoomPoint() {
+        return zoomPoint;
+    }
+
+    public Iterable<MapPoint> getLatestZoomBoundingBox() {
+        return zoomBoundingBox;
+    }
+
+    public double getLatestScaleFactor() {
+        return scaleFactor;
+    }
+
+    public void onLocationChanged(MapPoint point) {
+        if (locationListener != null) {
+            locationListener.onPoint(point);
+        }
+    }
+
+    public int getMappedPointCount() {
+        return mappedPoints.size();
+    }
+
+    public boolean isMapped(MapPoint point) {
+        return mappedPoints.containsKey(point);
+    }
+
+    public int getFeatureIdFor(@NonNull MapPoint point) {
+        return mappedPoints.get(point);
+    }
+
+    @Override
+    public void applyConfig(Bundle config) {
+
+    }
+
+    @Override
+    public void addTo(@NonNull FragmentActivity activity, int containerId, @Nullable ReadyListener readyListener, @Nullable ErrorListener errorListener) {
+        readyListener.onReady(this);
+    }
+
+    @NonNull
+    @Override
+    public MapPoint getCenter() {
+        return null;
+    }
+
+    @Override
+    public double getZoom() {
+        return zoomLevel;
+    }
+
+    @Override
+    public void setCenter(@Nullable MapPoint center, boolean animate) {
+
+    }
+
+    @Override
+    public void zoomToPoint(@Nullable MapPoint center, boolean animate) {
+        this.zoomPoint = center;
+        this.animate = animate;
+
+        zoomCount++;
+    }
+
+    @Override
+    public void zoomToPoint(@Nullable MapPoint center, double zoom, boolean animate) {
+        this.zoomPoint = center;
+        this.zoomLevel = zoom;
+        this.animate = animate;
+
+        zoomCount++;
+    }
+
+    @Override
+    public void zoomToBoundingBox(Iterable<MapPoint> points, double scaleFactor, boolean animate) {
+        this.zoomBoundingBox = points;
+        this.scaleFactor = scaleFactor;
+        this.animate = animate;
+
+        zoomCount++;
+    }
+
+    @Override
+    public int addMarker(MapPoint point, boolean draggable) {
+        mappedPoints.put(point, lastFeatureId);
+
+        return lastFeatureId++;
+    }
+
+    @Override
+    public void setMarkerIcon(int featureId, int drawableId) {
+
+    }
+
+    @Override
+    public MapPoint getMarkerPoint(int featureId) {
+        return null;
+    }
+
+    @Override
+    public int addDraggablePoly(@NonNull Iterable<MapPoint> points, boolean closedPolygon) {
+        return 0;
+    }
+
+    @Override
+    public void appendPointToPoly(int featureId, @NonNull MapPoint point) {
+
+    }
+
+    @Override
+    public void removePolyLastPoint(int featureId) {
+
+    }
+
+    @NonNull
+    @Override
+    public List<MapPoint> getPolyPoints(int featureId) {
+        return null;
+    }
+
+    @Override
+    public void removeFeature(int featureId) {
+
+    }
+
+    @Override
+    public void clearFeatures() {
+        mappedPoints.clear();
+    }
+
+    @Override
+    public void setClickListener(@Nullable PointListener listener) {
+
+    }
+
+    @Override
+    public void setLongPressListener(@Nullable PointListener listener) {
+
+    }
+
+    @Override
+    public void setFeatureClickListener(@Nullable FeatureListener listener) {
+
+    }
+
+    @Override
+    public void setDragEndListener(@Nullable FeatureListener listener) {
+
+    }
+
+    @Override
+    public void setGpsLocationEnabled(boolean enabled) {
+
+    }
+
+    @Nullable
+    @Override
+    public MapPoint getGpsLocation() {
+        return new MapPoint(5, 5);
+    }
+
+    @Nullable
+    @Override
+    public String getLocationProvider() {
+        return null;
+    }
+
+    @Override
+    public void runOnGpsLocationReady(@NonNull ReadyListener listener) {
+
+    }
+
+    @Override
+    public void setGpsLocationListener(@Nullable PointListener listener) {
+        locationListener = listener;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/instances/TestInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/instances/TestInstancesRepository.java
@@ -11,6 +11,17 @@ public final class TestInstancesRepository implements InstancesRepository {
     }
 
     @Override
+    public Instance getBy(long databaseId) {
+        for (Instance instance : instances) {
+            if (instance.getDatabaseId() == databaseId) {
+                return instance;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
     public List<Instance> getAllBy(String formId) {
         List<Instance> result = new ArrayList<>();
 


### PR DESCRIPTION
In response to @seadowg's feedback at https://github.com/opendatakit/collect/pull/3447#discussion_r350645070, I have pulled out display-related code from the `FormMapViewModel`.

Incidentally closes #3546 

#### What has been done to verify that this works as intended?
I have added automated tests and clicked around a map for All Widgets for basic manual verification.

#### Why is this the best possible solution? Were any other approaches considered?

I decided to write my own test double for the `MapFragment`. I took a stateful spy approach since these maps are inherently stateful. I'm pretty happy with how it lets me test behavior without being too tightly coupled to the implementation.

I'm not sure I'm super happy with the `map` field of `FormMapActivity` being public and set by the test but I couldn't come up with a great alternative other than using Dagger which y'all know I really try to avoid. The unfortunate thing about this setup is that I can't test configuration changes as far as I can tell. I've put the test in so we don't forget about it but ignored it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This change is isolated to the submission map feature so that's where the risk is. Everything for that feature gets moved around but it should all be supported by tests. The only change to cross-cutting code is adding methods so nothing else is at risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any with a geopoint.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)