### PR TITLE
Prevent crashes when trying to dismiss dialog that hasn't been shown

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -59,7 +59,6 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
@@ -406,9 +405,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         identityPromptViewModel = ViewModelProviders.of(this).get(IdentityPromptViewModel.class);
         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
             if (requiresIdentity) {
-                FragmentManager fragmentManager = getSupportFragmentManager();
                 IdentifyUserPromptDialogFragment dialog = IdentifyUserPromptDialogFragment.create(getFormController().getFormTitle());
-                dialog.show(fragmentManager.beginTransaction(), IdentifyUserPromptDialogFragment.TAG);
+                DialogUtils.showIfNotShowing(dialog, getSupportFragmentManager());
             }
         });
         identityPromptViewModel.isFormEntryCancelled().observe(this, isFormEntryCancelled -> {
@@ -424,10 +422,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         changesReasonPromptViewModel.requiresReasonToContinue().observe(this, requiresReason -> {
             if (requiresReason) {
-                new ChangesReasonPromptDialogFragment().show(
-                        getFormController().getFormTitle(),
-                        getSupportFragmentManager()
-                );
+                ChangesReasonPromptDialogFragment dialog = ChangesReasonPromptDialogFragment.create(getFormController().getFormTitle());
+                DialogUtils.showIfNotShowing(dialog, getSupportFragmentManager());
             }
         });
         changesReasonPromptViewModel.saveRequest().observe(this, saveRequest -> {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1816,7 +1816,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * Creates and displays dialog with the given errorMsg.
      */
     private void createErrorDialog(String errorMsg, final boolean shouldExit) {
-
         if (alertDialog != null && alertDialog.isShowing()) {
             errorMsg = errorMessage + "\n\n" + errorMsg;
             errorMessage = errorMsg;
@@ -2547,7 +2546,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      */
     @Override
     public void savingComplete(SaveResult saveResult) {
-        dismissDialog(SAVING_DIALOG);
+        try {
+            dismissDialog(SAVING_DIALOG);
+        } catch (IllegalArgumentException ignored) {
+            // For some reason the dialog wasn't shown
+        }
+
         changesReasonPromptViewModel.saveComplete();
 
         int saveStatus = saveResult.getSaveResult();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -12,7 +12,6 @@ import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 
@@ -21,19 +20,17 @@ import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 
 public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogFragment {
 
-    public static final String TAG = "ChangesReasonPromptDialogFragment";
     private static final String ARG_FORM_NAME = "ArgFormName";
     private ChangesReasonPromptViewModel viewModel;
 
     public ViewModelProvider.Factory viewModelFactory = new ChangesReasonPromptViewModel.Factory();
 
-    public void show(String formName, FragmentManager fragmentManager) {
-        if (fragmentManager.findFragmentByTag(TAG) == null) {
-            Bundle bundle = new Bundle();
-            bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
-            setArguments(bundle);
-            show(fragmentManager.beginTransaction(), TAG);
-        }
+    public static ChangesReasonPromptDialogFragment create(String formName) {
+        ChangesReasonPromptDialogFragment fragment = new ChangesReasonPromptDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
+        fragment.setArguments(bundle);
+        return fragment;
     }
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
@@ -17,7 +17,6 @@ import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 
 public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFragment {
 
-    public static final String TAG = "IdentifyUserPromptDialogFragment";
     private static final String ARG_FORM_NAME = "ArgFormName";
 
     private IdentityPromptViewModel viewModel;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -23,14 +23,17 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
-import androidx.annotation.NonNull;
 import android.widget.ListView;
 
-import org.odk.collect.android.R;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
 
+import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.logic.FormController;
+
 import timber.log.Timber;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
@@ -169,5 +172,13 @@ public final class DialogUtils {
         alertDialog.setButton(activity.getString(R.string.ok), errorListener);
 
         return alertDialog;
+    }
+
+    public static void showIfNotShowing(DialogFragment dialog, FragmentManager fragmentManager) {
+        String tag = dialog.getClass().getName();
+
+        if (fragmentManager.findFragmentByTag(tag) == null) {
+            dialog.show(fragmentManager.beginTransaction(), tag);
+        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragmentTest.java
@@ -7,15 +7,12 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,33 +36,16 @@ public class ChangesReasonPromptDialogFragmentTest {
     }
 
     @Test
-    public void show_onlyEverOpensOneDialog() {
-        ChangesReasonPromptDialogFragment dialog1 = createFragment();
-        dialog1.show("Best Form", fragmentManager);
-
-        ChangesReasonPromptDialogFragment dialog2 = createFragment();
-        dialog2.show("Best Form", fragmentManager);
-
-        assertThat(fragmentManager.getFragments().size(), equalTo(1));
-    }
-
-    @Test
     public void onBackPressed_and_onCloseClicked_callPromptDismissed() {
-        ChangesReasonPromptDialogFragment dialog = createFragment();
-        dialog.show("Best Form", fragmentManager);
+        ChangesReasonPromptDialogFragment dialog = ChangesReasonPromptDialogFragment.create("Best Form");
+        dialog.viewModelFactory = testFactory;
+        dialog.show(fragmentManager, "TAG");
 
         dialog.onBackPressed();
         verify(viewModel, times(1)).promptDismissed();
 
         dialog.onCloseClicked();
         verify(viewModel, times(2)).promptDismissed();
-    }
-
-    @NotNull
-    private ChangesReasonPromptDialogFragment createFragment() {
-        ChangesReasonPromptDialogFragment dialog = new ChangesReasonPromptDialogFragment();
-        dialog.viewModelFactory = testFactory;
-        return dialog;
     }
 
     private static class TestFactory implements ViewModelProvider.Factory {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
@@ -1,0 +1,32 @@
+package org.odk.collect.android.utilities;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@RunWith(RobolectricTestRunner.class)
+public class DialogUtilsTest {
+
+    @Test
+    public void show_onlyEverOpensOneDialog() {
+        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class);
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+        DialogFragment dialog1 = new DialogFragment();
+        DialogUtils.showIfNotShowing(dialog1, fragmentManager);
+
+        DialogFragment dialog2 = new DialogFragment();
+        DialogUtils.showIfNotShowing(dialog2, fragmentManager);
+
+        assertThat(fragmentManager.getFragments().size(), equalTo(1));
+        assertThat(fragmentManager.getFragments().get(0), equalTo(dialog1));
+    }
+}


### PR DESCRIPTION
Closes #3547 

#### What has been done to verify that this works as intended?

I couldn't work out a way to reproduce even after searching around to see if others had had this issue. Just made sure all our tests pass.

#### Why is this the best possible solution? Were any other approaches considered?

The key problem here seemed to be that `Activity#dismissDialog` will throw an `IllegalArgumentException` if the dialog wasn't already shown. This behaviour is obviously really annoying because in that case we still get what we want - no dialog on screen. Catching and ignoring felt like the right option in this case. 

The `FormEntryActivity` acutally uses almost every mechanism possible for showing dialogs and the way (`showDialog` and `dismissDialog`) have been deprecated in favour of using the newer `DialogFragment`. I did look at refactoring to this for the saving dialog (hence the unrelated to refactor in `DialogUtils`) but realized that should be a lot simpler once we've done #3521 so backed off for the moment. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just be a bug fix. Would be good to check form saving as with rotations/backgrounding.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)