### PR TITLE
Remove custom handling for file types handled by android itself

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
@@ -7,6 +7,11 @@ import androidx.annotation.NonNull;
 import org.odk.collect.android.http.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.utilities.FileUtils;
 
+/**
+ * This covers types not included in Android's MimeTypeMap
+ * Reference https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java
+ */
+
 public class CollectThenSystemContentTypeMapper implements OpenRosaHttpInterface.FileToContentTypeMapper {
 
     private final MimeTypeMap androidTypeMap;

--- a/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
@@ -33,21 +33,10 @@ public class CollectThenSystemContentTypeMapper implements OpenRosaHttpInterface
     }
 
     private enum CollectContentTypeMappings {
-        XML("xml",  "text/xml"),
-        _3GPP("3gpp", "audio/3gpp"),
-        _3GP("3gp",  "video/3gpp"),
-        AVI("avi",  "video/avi"),
         AMR("amr",  "audio/amr"),
-        CSV("csv",  "text/csv"),
-        JPG("jpg",  "image/jpeg"),
-        MP3("mp3",  "audio/mp3"),
-        MP4("mp4",  "video/mp4"),
         OGA("oga",  "audio/ogg"),
-        OGG("ogg",  "audio/ogg"),
         OGV("ogv",  "video/ogg"),
-        WAV("wav",  "audio/wav"),
-        WEBM("webm", "video/webm"),
-        XLS("xls",  "application/vnd.ms-excel");
+        WEBM("webm", "video/webm");
 
         private String extension;
         private String contentType;

--- a/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapper.java
@@ -11,7 +11,6 @@ import org.odk.collect.android.utilities.FileUtils;
  * This covers types not included in Android's MimeTypeMap
  * Reference https://android.googlesource.com/platform/frameworks/base/+/61ae88e/core/java/android/webkit/MimeTypeMap.java
  */
-
 public class CollectThenSystemContentTypeMapper implements OpenRosaHttpInterface.FileToContentTypeMapper {
 
     private final MimeTypeMap androidTypeMap;

--- a/collect_app/src/test/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapperTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/http/CollectThenSystemContentTypeMapperTest.java
@@ -26,21 +26,10 @@ public class CollectThenSystemContentTypeMapperTest {
 
     @Test
     public void whenExtensionIsRecognized_returnsTypeForFile() {
-        assertEquals("text/xml", mapper.map("file.xml"));
-        assertEquals("audio/3gpp", mapper.map("file.3gpp"));
-        assertEquals("video/3gpp", mapper.map("file.3gp"));
-        assertEquals("video/avi", mapper.map("file.avi"));
         assertEquals("audio/amr", mapper.map("file.amr"));
-        assertEquals("text/csv", mapper.map("file.csv"));
-        assertEquals("image/jpeg", mapper.map("file.jpg"));
-        assertEquals("audio/mp3", mapper.map("file.mp3"));
-        assertEquals("video/mp4", mapper.map("file.mp4"));
         assertEquals("audio/ogg", mapper.map("file.oga"));
-        assertEquals("audio/ogg", mapper.map("file.ogg"));
         assertEquals("video/ogg", mapper.map("file.ogv"));
-        assertEquals("audio/wav", mapper.map("file.wav"));
         assertEquals("video/webm", mapper.map("file.webm"));
-        assertEquals("application/vnd.ms-excel", mapper.map("file.xls"));
     }
 
     @Test


### PR DESCRIPTION
Closes #3173


It passes `./gradlew testDebug ` 
Failes `./gradlew checkAll` with these errors :(
```
> Task :collect:collect:collect_app:lintDebug FAILED
> Task :collect:checkCode FAILED
```


These are the mappings that are present in android's MimeTypeMap class:
```
XML("xml",  "text/xml"),
_3GPP("3gpp", "audio/3gpp"),
_3GP("3gp",  "video/3gpp"),
AVI("avi",  "video/avi"),
CSV("csv",  "text/csv"),
JPG("jpg",  "image/jpeg"),
MP3("mp3",  "audio/mp3"),
MP4("mp4",  "video/mp4"),
OGG("ogg",  "audio/ogg"),
WAV("wav",  "audio/wav"),
XLS("xls",  "application/vnd.ms-excel");
```
Some of the extensions above have multiple mappings, for example "3gpp", i have currently deleted them too.

This change should not effect users.