### PR TITLE
Fixes Issue#3493: Fixed margin for widgets with buttons when value is added manually

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -16,11 +16,10 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.widget.RadioButton;
+
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
-
-import android.content.res.Resources;
-import android.widget.RadioButton;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
@@ -28,7 +27,6 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.data.helper.Selection;
-import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.SelectOneListAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
@@ -38,9 +36,6 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
-import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * SelectOneWidgets handles select-one fields using radio buttons.
@@ -104,11 +99,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
             recyclerView.setAdapter(adapter);
             answerLayout.addView(recyclerView);
             adjustRecyclerViewSize(adapter, recyclerView);
-
-            Resources resources = context.getResources();
-            int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
-            int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
-            addAnswerView(answerLayout, margin);
+            addAnswerView(answerLayout);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -18,6 +18,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.content.res.Resources;
 import android.widget.RadioButton;
 
 import org.javarosa.core.model.FormIndex;
@@ -26,6 +28,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.SelectOneListAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
@@ -35,6 +38,9 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * SelectOneWidgets handles select-one fields using radio buttons.
@@ -90,7 +96,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
                     : new SelectOneData(new Selection(selectChoice));
     }
 
-    protected void createLayout() {
+    protected void createLayout(Context context) {
         adapter = new SelectOneListAdapter(items, selectedValue, this, numColumns, this.getFormEntryPrompt(), this.getReferenceManager(), this.getAnswerFontSize(), this.getAudioHelper(), getPlayColor(getFormEntryPrompt(), themeUtils), this.getContext(), autoAdvance);
 
         if (items != null) {
@@ -98,7 +104,11 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
             recyclerView.setAdapter(adapter);
             answerLayout.addView(recyclerView);
             adjustRecyclerViewSize(adapter, recyclerView);
-            addAnswerView(answerLayout);
+
+            Resources resources = context.getResources();
+            int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+            int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+            addAnswerView(answerLayout, margin);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -18,6 +18,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
@@ -42,6 +43,8 @@ import timber.log.Timber;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Image widget that supports annotations on the image.
@@ -63,7 +66,11 @@ public class AnnotateWidget extends BaseImageWidget {
         imageCaptureHandler = new ImageCaptureHandler();
         setUpLayout();
         addCurrentImageToLayout();
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -19,17 +19,17 @@ package org.odk.collect.android.widgets;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Resources;
 import android.net.Uri;
 import android.provider.MediaStore;
-import androidx.annotation.NonNull;
-import androidx.core.content.FileProvider;
 import android.view.Gravity;
 import android.webkit.MimeTypeMap;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.FileProvider;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -49,9 +49,6 @@ import org.odk.collect.android.widgets.utilities.FileWidgetUtils;
 import java.io.File;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
-import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
 
@@ -175,10 +172,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
         widgetLayout.addView(chooseFileButton);
         widgetLayout.addView(answerLayout);
 
-        Resources resources = this.getResources();
-        int marginStandard = dpFromPx(getContext(), resources.getDimensionPixelSize(R.dimen.margin_standard));
-        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
-        addAnswerView(widgetLayout, margin);
+        addAnswerView(widgetLayout);
     }
 
     private void performFileSearch() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.widgets;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.provider.MediaStore;
 import androidx.annotation.NonNull;
@@ -48,6 +49,9 @@ import org.odk.collect.android.widgets.utilities.FileWidgetUtils;
 import java.io.File;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
 
@@ -171,7 +175,10 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
         widgetLayout.addView(chooseFileButton);
         widgetLayout.addView(answerLayout);
 
-        addAnswerView(widgetLayout);
+        Resources resources = this.getResources();
+        int marginStandard = dpFromPx(getContext(), resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(widgetLayout, margin);
     }
 
     private void performFileSearch() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -20,6 +20,7 @@ import android.content.ActivityNotFoundException;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.provider.MediaStore.Audio;
 import android.view.View;
@@ -50,6 +51,8 @@ import java.util.Locale;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -95,7 +98,11 @@ public class AudioWidget extends QuestionWidget implements FileWidget {
         answerLayout.addView(captureButton);
         answerLayout.addView(chooseButton);
         answerLayout.addView(audioController);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
 
         hideButtonsIfNeeded();
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.widgets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Resources;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -34,6 +35,9 @@ import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Widget that allows user to scan barcodes and add them to the form.
@@ -62,7 +66,11 @@ public class BarcodeWidget extends QuestionWidget implements BinaryWidget {
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(getBarcodeButton);
         answerLayout.addView(stringAnswer);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGeoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGeoWidget.java
@@ -2,13 +2,18 @@ package org.odk.collect.android.widgets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Resources;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.widgets.interfaces.GeoWidget;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 public abstract class BaseGeoWidget extends QuestionWidget implements GeoWidget {
     public Button startGeoButton;
@@ -20,7 +25,7 @@ public abstract class BaseGeoWidget extends QuestionWidget implements GeoWidget 
         answerDisplay = getCenteredAnswerTextView();
         startGeoButton = getSimpleButton(getDefaultButtonLabel());
         readOnly = questionDetails.getPrompt().isReadOnly();
-        setUpLayout(questionDetails.getPrompt().getAnswerText());
+        setUpLayout(context, questionDetails.getPrompt().getAnswerText());
     }
 
     @Override
@@ -65,12 +70,16 @@ public abstract class BaseGeoWidget extends QuestionWidget implements GeoWidget 
         });
     }
 
-    protected void setUpLayout(String answerText) {
+    protected void setUpLayout(Context context, String answerText) {
         LinearLayout answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(startGeoButton);
         answerLayout.addView(answerDisplay);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
 
         boolean dataAvailable = false;
         if (answerText != null && !answerText.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
@@ -17,6 +17,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.util.TypedValue;
 import android.view.Gravity;
@@ -55,6 +56,8 @@ import java.util.List;
 import timber.log.Timber;
 
 import static org.odk.collect.android.formentry.media.FormMediaHelpers.getPlayableAudioURI;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * GridWidget handles select-one/multiple fields using a grid options. The number of columns
@@ -81,7 +84,7 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         itemViews = new View[items.size()];
 
         setUpItems();
-        setUpGridView();
+        setUpGridView(context);
         fillInAnswer();
 
         logAnalytics(questionDetails);
@@ -179,7 +182,7 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         return item;
     }
 
-    private void setUpGridView() {
+    private void setUpGridView(Context context) {
         ExpandedHeightGridView gridView = new ExpandedHeightGridView(getContext());
         gridView.setNumColumns(GridView.AUTO_FIT);
         gridView.setColumnWidth(maxColumnWidth);
@@ -192,7 +195,11 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         gridView.setAdapter(new ImageAdapter());
         int paddingStartEnd = getContext().getResources().getDimensionPixelSize(R.dimen.margin_standard);
         gridView.setPadding(paddingStartEnd, 0, paddingStartEnd, 0);
-        addAnswerView(gridView);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(gridView, margin);
     }
 
     void selectItem(int index) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -18,6 +18,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.hardware.Sensor;
 import android.hardware.SensorManager;
@@ -40,6 +41,8 @@ import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * BearingWidget is the widget that allows the user to get a compass heading.
@@ -78,7 +81,11 @@ public class BearingWidget extends QuestionWidget implements BinaryWidget {
             }
             setBinaryData(s);
         }
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -60,6 +60,7 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget, Widg
         if (!dateWidget.isDayHidden()) {
             linearLayout.addView(timeWidget);
         }
+
         addAnswerView(linearLayout);
 
         timeWidget.setValueChangedListener(this);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -54,6 +54,8 @@ import java.util.Date;
 import timber.log.Timber;
 
 import static org.odk.collect.android.fragments.dialogs.CustomDatePickerDialog.DATE_PICKER_DIALOG;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Displays a DatePicker widget. DateWidget handles leap years and does not allow dates that do not
@@ -75,14 +77,15 @@ public class DateWidget extends QuestionWidget implements DatePickerDialog.OnDat
 
     public DateWidget(Context context, QuestionDetails prompt) {
         super(context, prompt);
-        createWidget();
+        createWidget(context);
     }
 
-    protected void createWidget() {
+    protected void createWidget(Context context) {
         datePickerDetails = DateTimeUtils.getDatePickerDetails(getFormEntryPrompt().getQuestion().getAppearanceAttr());
         dateButton = getSimpleButton(getContext().getString(R.string.select_date));
         dateTextView = getAnswerTextView();
-        addViews();
+        addViews(context);
+
         if (getFormEntryPrompt().getAnswerValue() == null) {
             clearAnswer();
             setDateToCurrent();
@@ -147,12 +150,16 @@ public class DateWidget extends QuestionWidget implements DatePickerDialog.OnDat
         return isNullAnswer;
     }
 
-    private void addViews() {
+    private void addViews(Context context) {
         LinearLayout linearLayout = new LinearLayout(getContext());
         linearLayout.setOrientation(LinearLayout.VERTICAL);
         linearLayout.addView(dateButton);
         linearLayout.addView(dateTextView);
-        addAnswerView(linearLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(linearLayout, margin);
     }
 
     protected void setDateToCurrent() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DrawWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.view.View;
 import android.widget.Button;
 
@@ -25,6 +26,8 @@ import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Free drawing widget.
@@ -41,7 +44,11 @@ public class DrawWidget extends BaseImageWidget {
         imageClickHandler = new DrawImageClickHandler(DrawActivity.OPTION_DRAW, RequestCodes.DRAW_IMAGE, R.string.draw_image);
         setUpLayout();
         addCurrentImageToLayout();
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExPrinterWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.widget.Button;
@@ -28,6 +29,9 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.interfaces.BinaryWidget;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * <p>Use the ODK Sensors framework to print data to a connected printer.</p>
@@ -127,7 +131,11 @@ public class ExPrinterWidget extends QuestionWidget implements BinaryWidget {
         LinearLayout printLayout = new LinearLayout(getContext());
         printLayout.setOrientation(LinearLayout.VERTICAL);
         printLayout.addView(launchIntentButton);
-        addAnswerView(printLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(printLayout, margin);
     }
 
     protected void firePrintingActivity(String intentName) throws ActivityNotFoundException {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -114,14 +114,14 @@ public class ExStringWidget extends StringWidget implements BinaryWidget {
         answerText.setText(getFormEntryPrompt().getAnswerText());
         launchIntentButton = getSimpleButton(getButtonText());
 
-        Resources resources = context.getResources();
-        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
-        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
-
         LinearLayout answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(launchIntentButton);
         answerLayout.addView(answerText);
+        
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
         addAnswerView(answerLayout, margin);
 
         Collect.getInstance().logRemoteAnalytics("WidgetType", "ExternalApp", Collect.getCurrentFormIdentifierHash());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.text.Editable;
 import android.text.Selection;
@@ -50,6 +51,7 @@ import timber.log.Timber;
 import static android.content.Intent.ACTION_SENDTO;
 import static org.odk.collect.android.injection.DaggerUtils.getComponent;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
 
 /**
  * <p>Launch an external app to supply a string value. If the app
@@ -112,11 +114,15 @@ public class ExStringWidget extends StringWidget implements BinaryWidget {
         answerText.setText(getFormEntryPrompt().getAnswerText());
         launchIntentButton = getSimpleButton(getButtonText());
 
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+
         LinearLayout answerLayout = new LinearLayout(getContext());
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(launchIntentButton);
         answerLayout.addView(answerText);
-        addAnswerView(answerLayout);
+        addAnswerView(answerLayout, margin);
 
         Collect.getInstance().logRemoteAnalytics("WidgetType", "ExternalApp", Collect.getCurrentFormIdentifierHash());
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import androidx.core.content.FileProvider;
@@ -40,6 +41,8 @@ import java.util.Locale;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the form.
@@ -60,7 +63,11 @@ public class ImageWidget extends BaseImageWidget {
         imageCaptureHandler = new ImageCaptureHandler();
         setUpLayout();
         addCurrentImageToLayout();
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ItemsetWidget.java
@@ -76,7 +76,7 @@ public class ItemsetWidget extends AbstractSelectOneWidget {
 
         items = getItems();
 
-        createLayout();
+        createLayout(context);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -7,6 +7,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.view.View;
@@ -32,6 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Widget that allows the user to launch OpenMapKit to get an OSM Feature with a
@@ -123,7 +126,11 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
         answerLayout.addView(errorTextView);
         answerLayout.addView(osmFileNameHeaderTextView);
         answerLayout.addView(osmFileNameTextView);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
 
         errorTextView.setVisibility(View.GONE);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RangeWidget.java
@@ -17,6 +17,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Build;
 import androidx.annotation.IdRes;
 import androidx.annotation.LayoutRes;
@@ -40,6 +41,9 @@ import org.odk.collect.android.widgets.interfaces.ButtonWidget;
 import java.math.BigDecimal;
 
 import timber.log.Timber;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 @SuppressWarnings("BigDecimalMethodWithoutRoundingCalled")
 public abstract class RangeWidget extends QuestionWidget implements ButtonWidget, SeekBar.OnSeekBarChangeListener {
@@ -80,7 +84,10 @@ public abstract class RangeWidget extends QuestionWidget implements ButtonWidget
             seekBar.setEnabled(false);
         }
 
-        addAnswerView(view);
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(view, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -17,6 +17,7 @@
 package org.odk.collect.android.widgets;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -37,8 +38,12 @@ import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
+
 public class RankingWidget extends ItemsWidget implements BinaryWidget {
 
+    private int margin;
     private List<SelectChoice> savedItems;
     private LinearLayout widgetLayout;
     Button showRankingDialogButton;
@@ -46,6 +51,9 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
     public RankingWidget(Context context, QuestionDetails prompt) {
         super(context, prompt);
 
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
         setUpLayout(getOrderedItems());
     }
 
@@ -136,7 +144,7 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
         widgetLayout.addView(showRankingDialogButton);
         widgetLayout.addView(setUpAnswerTextView());
 
-        addAnswerView(widgetLayout);
+        addAnswerView(widgetLayout, margin);
         SpacesInUnderlyingValuesWarning
                 .forQuestionWidget(this)
                 .renderWarningIfNecessary(items);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -43,7 +43,7 @@ import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARG
 
 public class RankingWidget extends ItemsWidget implements BinaryWidget {
 
-    private int margin;
+    private final int margin;
     private List<SelectChoice> savedItems;
     private LinearLayout widgetLayout;
     Button showRankingDialogButton;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RatingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RatingWidget.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.widgets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 import android.widget.GridLayout;
@@ -26,6 +27,9 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 public class RatingWidget extends QuestionWidget {
 
@@ -56,7 +60,10 @@ public class RatingWidget extends QuestionWidget {
             }
         }
 
-        addAnswerView(gridLayout);
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(gridLayout, margin);
     }
 
     private void renderGrid(Context context, int numberOfStars, int columns, int rows) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Resources;
 import android.text.Html;
 import android.view.MotionEvent;
 import android.view.ViewGroup;
@@ -55,6 +56,9 @@ import javax.xml.transform.stream.StreamResult;
 
 import timber.log.Timber;
 
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
+
 /**
  * A base widget class which is responsible for sharing the code used by image map select widgets like
  * {@link SelectOneImageMapWidget} and {@link SelectMultiImageMapWidget}.
@@ -84,7 +88,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
             Timber.w(e);
         }
 
-        createLayout();
+        createLayout(context);
     }
 
     private static String convertDocumentToString(Document doc) {
@@ -115,7 +119,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
         return webView.suppressFlingGesture();
     }
 
-    private void createLayout() {
+    private void createLayout(Context context) {
         webView = new CustomWebView(getContext());
 
         selectedAreasLabel = getAnswerTextView();
@@ -129,7 +133,10 @@ public abstract class SelectImageMapWidget extends SelectWidget {
         int paddingInPx = (int) (paddingInDp * scale + 0.5f);
         answerLayout.setPadding(0, 0, paddingInPx, 0);
 
-        addAnswerView(answerLayout);
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
         setUpWebView();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectMultiWidget.java
@@ -16,11 +16,14 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.Resources;
+
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.SelectMultipleListAdapter;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
@@ -28,6 +31,9 @@ import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * SelectMultiWidget handles multiple selection fields using checkboxes.
@@ -45,7 +51,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
         //noinspection unchecked
         ve = getFormEntryPrompt().getAnswerValue() == null ? new ArrayList<>() :
                 (List<Selection>) getFormEntryPrompt().getAnswerValue().getValue();
-        createLayout();
+        createLayout(context);
     }
 
     @Override
@@ -59,7 +65,7 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
         return vc.isEmpty() ? null : new SelectMultiData(vc);
     }
 
-    private void createLayout() {
+    private void createLayout(Context context) {
         adapter = new SelectMultipleListAdapter(items, ve, this, numColumns, this.getFormEntryPrompt(), this.getReferenceManager(), this.getAnswerFontSize(), this.getAudioHelper(), getPlayColor(getFormEntryPrompt(), themeUtils), this.getContext());
 
         if (items != null) {
@@ -70,7 +76,11 @@ public class SelectMultiWidget extends SelectTextWidget implements MultiChoiceWi
             recyclerView.setAdapter(adapter);
             answerLayout.addView(recyclerView);
             adjustRecyclerViewSize(adapter, recyclerView);
-            addAnswerView(answerLayout);
+
+            Resources resources = context.getResources();
+            int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+            int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+            addAnswerView(answerLayout, margin);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneAutocompleteWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneAutocompleteWidget.java
@@ -32,7 +32,7 @@ import org.odk.collect.android.utilities.SoftKeyboardUtils;
 public class SelectOneAutocompleteWidget extends AbstractSelectOneWidget {
     public SelectOneAutocompleteWidget(Context context, QuestionDetails questionDetails, boolean autoAdvance) {
         super(context, questionDetails, autoAdvance);
-        createLayout();
+        createLayout(context);
         setUpSearchBox(context);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectOneWidget.java
@@ -23,6 +23,6 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 public class SelectOneWidget extends AbstractSelectOneWidget {
     public SelectOneWidget(Context context, QuestionDetails prompt, boolean autoAdvance) {
         super(context, prompt, autoAdvance);
-        createLayout();
+        createLayout(context);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SignatureWidget.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.widgets;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.view.View;
 import android.widget.Button;
 
@@ -24,6 +25,8 @@ import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Signature widget.
@@ -39,7 +42,11 @@ public class SignatureWidget extends BaseImageWidget {
         imageClickHandler = new DrawImageClickHandler(DrawActivity.OPTION_SIGNATURE, RequestCodes.SIGNATURE_CAPTURE, R.string.signature_capture);
         setUpLayout();
         addCurrentImageToLayout();
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerMultiWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.res.Resources;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
@@ -35,6 +36,9 @@ import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * SpinnerMultiWidget, like SelectMultiWidget handles multiple selection fields using checkboxes,
@@ -110,7 +114,11 @@ public class SpinnerMultiWidget extends ItemsWidget implements ButtonWidget, Mul
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(button);
         answerLayout.addView(selectionText);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
 
         SpacesInUnderlyingValuesWarning.forQuestionWidget(this).renderWarningIfNecessary(items);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SpinnerWidget.java
@@ -17,6 +17,8 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.Nullable;
+
+import android.content.res.Resources;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
@@ -33,6 +35,9 @@ import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.ViewIds;
 import org.odk.collect.android.views.ScrolledToTopSpinner;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * SpinnerWidget handles select-one fields. Instead of a list of buttons it uses a spinner, wherein
@@ -87,7 +92,11 @@ public class SpinnerWidget extends ItemsWidget implements MultiChoiceWidget {
         });
 
         fillInPreviousAnswer(questionDetails.getPrompt());
-        addAnswerView(view);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(view, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -17,6 +17,7 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.TimePickerDialog;
 import android.content.Context;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
@@ -43,6 +44,9 @@ import java.util.Date;
 
 import timber.log.Timber;
 
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
+
 /**
  * Displays a TimePicker widget.
  *
@@ -68,7 +72,7 @@ public class TimeWidget extends QuestionWidget implements ButtonWidget, TimePick
         createTimeButton();
         timeTextView = getAnswerTextView();
         createTimePickerDialog();
-        addViews();
+        addViews(context);
     }
 
     @Override
@@ -110,12 +114,16 @@ public class TimeWidget extends QuestionWidget implements ButtonWidget, TimePick
         timeButton = getSimpleButton(getContext().getString(R.string.select_time));
     }
 
-    private void addViews() {
+    private void addViews(Context context) {
         LinearLayout linearLayout = new LinearLayout(getContext());
         linearLayout.setOrientation(LinearLayout.VERTICAL);
         linearLayout.addView(timeButton);
         linearLayout.addView(timeTextView);
-        addAnswerView(linearLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(linearLayout, margin);
     }
 
     public void setTimeLabel() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TriggerWidget.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.Resources;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
@@ -28,6 +29,9 @@ import org.javarosa.core.model.data.StringData;
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.ViewIds;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 @SuppressLint("ViewConstructor")
 public class TriggerWidget extends QuestionWidget {
@@ -47,7 +51,11 @@ public class TriggerWidget extends QuestionWidget {
         triggerButton.setEnabled(!getFormEntryPrompt().isReadOnly());
         triggerButton.setChecked(OK_TEXT.equals(getFormEntryPrompt().getAnswerText()));
         triggerButton.setOnCheckedChangeListener((buttonView, isChecked) -> widgetValueChanged());
-        addAnswerView(answerView);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerView, margin);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.widgets;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -28,6 +29,9 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.CustomTabHelper;
 import org.odk.collect.android.widgets.interfaces.ButtonWidget;
+
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Widget that allows user to open URLs from within the form
@@ -60,7 +64,11 @@ public class UrlWidget extends QuestionWidget implements ButtonWidget {
         answerLayout.setOrientation(LinearLayout.VERTICAL);
         answerLayout.addView(openUrlButton);
         answerLayout.addView(stringAnswer);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
 
         customTabHelper = new CustomTabHelper();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -21,6 +21,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -62,6 +63,8 @@ import timber.log.Timber;
 
 import static android.os.Build.MODEL;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.ViewUtils.dpFromPx;
+import static org.odk.collect.android.widgets.StringWidget.FIELD_HORIZONTAL_MARGIN_MODIFIER;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -124,7 +127,11 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
         answerLayout.addView(captureButton);
         answerLayout.addView(chooseButton);
         answerLayout.addView(playButton);
-        addAnswerView(answerLayout);
+
+        Resources resources = context.getResources();
+        int marginStandard = dpFromPx(context, resources.getDimensionPixelSize(R.dimen.margin_standard));
+        int margin = marginStandard - FIELD_HORIZONTAL_MARGIN_MODIFIER;
+        addAnswerView(answerLayout, margin);
 
         hideButtonsIfNeeded();
 


### PR DESCRIPTION
Closes #3493 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it on Android 9.0.


Before adding margin           |     After adding margin
:-------------------------:|:-------------------------:
![Screenshot_20191230_034615](https://user-images.githubusercontent.com/35730054/71579492-d32c4e00-2b22-11ea-896d-655686503322.jpeg)  |  ![Screenshot_20191230_033317](https://user-images.githubusercontent.com/35730054/71579501-dcb5b600-2b22-11ea-95ef-6d2df49ed301.jpeg)

   

#### Why is this the best possible solution? Were any other approaches considered?
I used the default margin value, that is being used in the other widgets, for uniformity. It adds the margin to the answer layout, where the answer field will appear. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I don't think there are any regression risks.

#### Do we need any specific form for testing your changes? If so, please attach one.
Allwidges or any form that has any of the three widgets:

- Ex-integer widget
- Ex-decimal widget
- Ex-string widget 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
no

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)