### PR TITLE
Modified checkstyle EmptyLineSeparator rule allowing empty lines between static blocks

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -99,6 +99,7 @@
             <property name="allowMultipleEmptyLines" value="false"/>
             <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
             <property name="allowNoEmptyLineBetweenFields" value="true" />
+            <property name="tokens" value="STATIC_INIT"/>
         </module>
         <module name="SeparatorWrap">
             <property name="id" value="SeparatorWrapDot" />


### PR DESCRIPTION
Closes #3075 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it by running `./gradlew checkstyle` for the example mentioned in the issue.

#### Why is this the best possible solution? Were any other approaches considered?
I added another property to EmprtyLineSeparator rule, which does not allow empty lines between static fields. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)