### PR TITLE
Fixed 'Shared with Me/My Drive' button when user navigates to deeper directories in Get Blank form activity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -460,8 +460,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             return;
         }
 
-        myDrive = !myDrive;
-        if (myDrive) {
+        if (currentPath.peek().equals(getString(R.string.go_drive))) {
             rootButton.setText(getString(R.string.go_shared));
         } else {
             rootButton.setText(getString(R.string.go_drive));
@@ -555,7 +554,13 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.root_button:
+                myDrive = currentPath.peek().equals(getString(R.string.go_drive));
                 getResultsFromApi();
+                if (currentPath.peek().equals(getString(R.string.go_drive))) {
+                    rootButton.setText(getString(R.string.go_shared));
+                } else {
+                    rootButton.setText(getString(R.string.go_drive));
+                }
                 break;
 
             case R.id.back_button:
@@ -573,6 +578,11 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                     listFiles(parentId);
                     currentPath.pop();
                     // }
+                    if (currentPath.peek().equals(getString(R.string.go_drive))) {
+                        rootButton.setText(getString(R.string.go_shared));
+                    } else {
+                        rootButton.setText(getString(R.string.go_drive));
+                    }
                 } else {
                     createAlertDialog(getString(R.string.no_connection));
                 }
@@ -595,6 +605,11 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                 listFiles(item.getDriveId());
                 folderIdStack.push(item.getDriveId());
                 currentPath.push(item.getName());
+                if (myDrive) {
+                    rootButton.setText(getString(R.string.go_shared));
+                } else {
+                    rootButton.setText(getString(R.string.go_drive));
+                }
             } else {
                 createAlertDialog(getString(R.string.no_connection));
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -460,10 +460,10 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             return;
         }
 
-        if (currentPath.peek().equals(getString(R.string.go_drive))) {
-            rootButton.setText(getString(R.string.go_shared));
-        } else {
+        if (myDrive) {
             rootButton.setText(getString(R.string.go_drive));
+        } else {
+            rootButton.setText(getString(R.string.go_shared));
         }
 
         if (folderIdStack.empty()) {
@@ -554,8 +554,8 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.root_button:
-                myDrive = currentPath.peek().equals(getString(R.string.go_drive));
                 getResultsFromApi();
+                myDrive = !myDrive;
                 break;
 
             case R.id.back_button:

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleDriveActivity.java
@@ -556,11 +556,6 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             case R.id.root_button:
                 myDrive = currentPath.peek().equals(getString(R.string.go_drive));
                 getResultsFromApi();
-                if (currentPath.peek().equals(getString(R.string.go_drive))) {
-                    rootButton.setText(getString(R.string.go_shared));
-                } else {
-                    rootButton.setText(getString(R.string.go_drive));
-                }
                 break;
 
             case R.id.back_button:
@@ -578,11 +573,6 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                     listFiles(parentId);
                     currentPath.pop();
                     // }
-                    if (currentPath.peek().equals(getString(R.string.go_drive))) {
-                        rootButton.setText(getString(R.string.go_shared));
-                    } else {
-                        rootButton.setText(getString(R.string.go_drive));
-                    }
                 } else {
                     createAlertDialog(getString(R.string.no_connection));
                 }
@@ -605,11 +595,6 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                 listFiles(item.getDriveId());
                 folderIdStack.push(item.getDriveId());
                 currentPath.push(item.getName());
-                if (myDrive) {
-                    rootButton.setText(getString(R.string.go_shared));
-                } else {
-                    rootButton.setText(getString(R.string.go_drive));
-                }
             } else {
                 createAlertDialog(getString(R.string.no_connection));
             }


### PR DESCRIPTION
Closes #3071

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it on Android P.

![Issue#3071](https://user-images.githubusercontent.com/35730054/71771993-75a46100-2f69-11ea-84a6-7ddfa7bcf6c7.gif)

#### Why is this the best possible solution? Were any other approaches considered?
I used `currentPath` variable to check whether we are currently in Shared with me or in MyDrive.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No specific form required

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)