### PR TITLE
Fix unexpected prompt to add not relevant repeat instances

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -645,7 +645,6 @@ public class FormController {
         return isindexrelev;
     }
 
-
     /**
      * Move the current form index to the index of the next question in the form.
      * Stop if we should ask to create a new repeat group or if we reach the end of the form.
@@ -664,7 +663,7 @@ public class FormController {
                         case FormEntryController.EVENT_END_OF_FORM:
                             break group_skip;
                         case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
-                            if(!isRepeatRelevant()) {
+                            if (!isRepeatRelevant()) {
                                 // skip Irrelevant repeat prompt
                                 return stepToNextScreenEvent();
                             }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -666,7 +666,7 @@ public class FormController {
                         case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                             if(!isRepeatRelevant()) {
                                 // skip Irrelevant repeat prompt
-                                return formEntryController.stepToNextEvent();
+                                return stepToNextScreenEvent();
                             }
                             break group_skip;
                         case FormEntryController.EVENT_GROUP:

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -628,6 +628,10 @@ public class FormController {
         }
     }
 
+    /**
+     * Used to check if a repeat is relevant before showing a prompt to add its instance.
+     * Returns true if any child is relevant, otherwise false.
+     */
     private boolean isRepeatRelevant() {
         boolean isindexrelev = false;
         newRepeat();

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -53,7 +53,6 @@ import org.odk.collect.android.external.ExternalDataUtil;
 import org.odk.collect.android.formentry.audit.AsyncTaskAuditEventWriter;
 import org.odk.collect.android.formentry.audit.AuditConfig;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
-import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.logic.actions.setgeopoint.CollectSetGeopointActionHandler;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormNameUtils;
@@ -631,30 +630,19 @@ public class FormController {
         }
     }
 
-    private boolean isRepeatRelevant(){
-        boolean isindexrelev = true;
-        int countrelevants = 0;
+    private boolean isRepeatRelevant() {
+        boolean isindexrelev = false;
         formEntryController.newRepeat();
         GroupDef groupDef = (GroupDef) formEntryController.getModel().getForm().getChild(getFormIndex());
         FormIndex currentChildIndex = formEntryController.getModel().incrementIndex(getFormIndex(), true);
         for (FormIndex index : getIndicesForGroup(groupDef, currentChildIndex, true)) {
             if (formEntryController.getModel().isIndexRelevant(index)) {
-                countrelevants += 1;
+                isindexrelev = true;
                 break;
             }
         }
-        if(countrelevants == 0){
-            isindexrelev = false;
-        }
-
-        if(!isindexrelev) {
-            deleteRepeat();
-            return false;
-        }else{
-            deleteRepeat();
-            return true;
-        }
-
+        deleteRepeat();
+        return isindexrelev;
     }
 
 
@@ -677,10 +665,10 @@ public class FormController {
                             break group_skip;
                         case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                             if(!isRepeatRelevant()) {
+                                // skip Irrelevant repeat prompt
                                 return formEntryController.stepToNextEvent();
-                            }else{
-                                break group_skip;
                             }
+                            break group_skip;
                         case FormEntryController.EVENT_GROUP:
                         case FormEntryController.EVENT_REPEAT:
                             if (indexIsInFieldList() && getQuestionPrompts().length != 0) {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -79,8 +79,6 @@ import static org.odk.collect.android.utilities.ApplicationConstants.Namespaces.
  */
 public class FormController {
 
-    private boolean IS_REPEAT_RELEVANT = true;
-
     public static final boolean STEP_INTO_GROUP = true;
     public static final boolean STEP_OVER_GROUP = false;
 
@@ -547,10 +545,6 @@ public class FormController {
      */
     public int stepToNextEvent(boolean stepIntoGroup) {
 
-        if (!IS_REPEAT_RELEVANT && formEntryController.stepToNextEvent() == formEntryController.EVENT_PROMPT_NEW_REPEAT && !stepIntoGroup) {
-            return stepOverGroup();
-        }
-
         if ((getEvent() == FormEntryController.EVENT_GROUP
                 || getEvent() == FormEntryController.EVENT_REPEAT)
                 && indexIsInFieldList() && !isGroupEmpty() && !stepIntoGroup) {
@@ -565,6 +559,7 @@ public class FormController {
      * the group represented by the FormIndex.
      */
     public int stepOverGroup() {
+
         GroupDef gd =
                 (GroupDef) formEntryController.getModel().getForm()
                         .getChild(getFormIndex());
@@ -653,16 +648,15 @@ public class FormController {
         }
 
         if(!isindexrelev) {
-            formEntryController.deleteRepeat();
-            IS_REPEAT_RELEVANT = false;
+            deleteRepeat();
             return false;
         }else{
-            formEntryController.deleteRepeat();
-            IS_REPEAT_RELEVANT = true;
+            deleteRepeat();
             return true;
         }
 
     }
+
 
     /**
      * Move the current form index to the index of the next question in the form.
@@ -683,8 +677,7 @@ public class FormController {
                             break group_skip;
                         case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                             if(!isRepeatRelevant()) {
-                                event = stepToNextEvent(FormController.STEP_OVER_GROUP);
-                                return event;
+                                return formEntryController.stepToNextEvent();
                             }else{
                                 break group_skip;
                             }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -543,7 +543,6 @@ public class FormController {
      * @return the next event that should be handled by a view.
      */
     public int stepToNextEvent(boolean stepIntoGroup) {
-
         if ((getEvent() == FormEntryController.EVENT_GROUP
                 || getEvent() == FormEntryController.EVENT_REPEAT)
                 && indexIsInFieldList() && !isGroupEmpty() && !stepIntoGroup) {
@@ -558,7 +557,6 @@ public class FormController {
      * the group represented by the FormIndex.
      */
     public int stepOverGroup() {
-
         GroupDef gd =
                 (GroupDef) formEntryController.getModel().getForm()
                         .getChild(getFormIndex());
@@ -632,7 +630,7 @@ public class FormController {
 
     private boolean isRepeatRelevant() {
         boolean isindexrelev = false;
-        formEntryController.newRepeat();
+        newRepeat();
         GroupDef groupDef = (GroupDef) formEntryController.getModel().getForm().getChild(getFormIndex());
         FormIndex currentChildIndex = formEntryController.getModel().incrementIndex(getFormIndex(), true);
         for (FormIndex index : getIndicesForGroup(groupDef, currentChildIndex, true)) {


### PR DESCRIPTION
Closes #2992 

#### What has been done to verify that this works as intended?
I have tested the change with these forms:
[hiddenRepeat1.xlsx](https://github.com/opendatakit/collect/files/4023810/hiddenRepeat1.xlsx)
[hiddenRepeat2.xlsx](https://github.com/opendatakit/collect/files/4023811/hiddenRepeat2.xlsx)
[hiddenRepeat3.xlsx](https://github.com/opendatakit/collect/files/4023814/hiddenRepeat3.xlsx)
[hiddenRepeat4.xlsx](https://github.com/opendatakit/collect/files/4023816/hiddenRepeat4.xlsx)


#### Why is this the best possible solution? Were any other approaches considered?
The relevance of a repeat group can be found by the relevance of its child indices i.e., child indices are not relevant if the group itself is not relevant, so before prompting to the user i create one dummy instance, check the relevance with the help of child indices and then delete that instance. 
I am open to discussion about any another approach.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
If the user adds a repeat group that does not contain any relevant child indices though the group itself is relevant, the group will not be considered relevant and user will not be shown the prompt to add this type of group. 

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No i don't think so.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)