### PR TITLE
Bump up Firebase test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
               --device model=Pixel2,version=27,locale=en,orientation=portrait \
               --results-bucket opendatakit-collect-test-results \
               --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
-              --directories-to-pull /sdcard --timeout 20m
+              --directories-to-pull /sdcard --timeout 30m
             fi
           no_output_timeout: 60m
       - run:


### PR DESCRIPTION
This should allow our tests more time to run so we don't get timeout failures.

#### What has been done to verify that this works as intended?

I've ran this command locally to double check bumping the timeout didn't cause it fail. 

#### Why is this the best possible solution? Were any other approaches considered?

Long term we need to look at other strategies for improving the instrumentation run time but I don't ever expect it to be short given the number of features in the app. I'm going to file an issue around looking at parallelizing our test runs.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)