### PR TITLE
Restrict sending forms if error occurred

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -46,6 +46,7 @@ import timber.log.Timber;
 
 public class InstanceServerUploader extends InstanceUploader {
     private static final String URL_PATH_SEP = "/";
+    public static final String URL_ERROR = "explicit_url_error";
 
     private final OpenRosaHttpInterface httpInterface;
     private final WebCredentialsUtils webCredentialsUtils;
@@ -81,7 +82,7 @@ public class InstanceServerUploader extends InstanceUploader {
         } else {
             if (submissionUri.getHost() == null) {
                 saveFailedStatusToDatabase(instance);
-                throw new UploadException(FAIL + "Host name may not be null");
+                throw new UploadException(FAIL + "Host name may not be null" + URL_ERROR);
             }
 
             URI uri;
@@ -90,7 +91,7 @@ public class InstanceServerUploader extends InstanceUploader {
             } catch (IllegalArgumentException e) {
                 saveFailedStatusToDatabase(instance);
                 Timber.d(e.getMessage() != null ? e.getMessage() : e.toString());
-                throw new UploadException(Collect.getInstance().getString(R.string.url_error));
+                throw new UploadException(Collect.getInstance().getString(R.string.url_error) + URL_ERROR);
             }
 
             HttpHeadResult headResult;
@@ -111,7 +112,7 @@ public class InstanceServerUploader extends InstanceUploader {
             } catch (Exception e) {
                 saveFailedStatusToDatabase(instance);
                 throw new UploadException(FAIL
-                        + (e.getMessage() != null ? e.getMessage() : e.toString()));
+                        + (e.getMessage() != null ? e.getMessage() : e.toString()) + URL_ERROR);
             }
 
             if (headResult.getStatusCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
@@ -139,11 +140,11 @@ public class InstanceServerUploader extends InstanceUploader {
                             saveFailedStatusToDatabase(instance);
                             throw new UploadException(FAIL
                                     + "Unexpected redirection attempt to a different host: "
-                                    + newURI.toString());
+                                    + newURI.toString() + URL_ERROR);
                         }
                     } catch (Exception e) {
                         saveFailedStatusToDatabase(instance);
-                        throw new UploadException(FAIL + urlString + " " + e.toString());
+                        throw new UploadException(FAIL + urlString + " " + e.toString() + URL_ERROR);
                     }
                 }
             } else {
@@ -152,7 +153,7 @@ public class InstanceServerUploader extends InstanceUploader {
                         && headResult.getStatusCode() < HttpsURLConnection.HTTP_MULT_CHOICE) {
                     saveFailedStatusToDatabase(instance);
                     throw new UploadException(FAIL + "Invalid status code on Head request. If "
-                            + "you have a web proxy, you may need to log in to your network.");
+                            + "you have a web proxy, you may need to log in to your network." + URL_ERROR);
                 }
             }
         }
@@ -200,7 +201,7 @@ public class InstanceServerUploader extends InstanceUploader {
                     exception = new UploadException(FAIL + "Network login failure? Again?");
                 } else if (responseCode == HttpsURLConnection.HTTP_UNAUTHORIZED) {
                     exception = new UploadException(FAIL + postResult.getReasonPhrase()
-                            + " (" + responseCode + ") at " + urlString);
+                            + " (" + responseCode + ") at " + urlString + URL_ERROR);
                 } else {
                     if (messageParser.isValid()) {
                         exception = new UploadException(FAIL + messageParser.getMessageResponse());


### PR DESCRIPTION
Closes #1939 


#### What has been done to verify that this works as intended?
[backup1249.zip](https://github.com/opendatakit/collect/files/4047210/backup1249.zip) provided by @mmarciniak90 



#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The output message will contain a particular failure only once even if that occurs for different instances, unlike earlier when a particular failure would show up multiple times for multiple instances.
**And because we don't try to send all forms , all forms don't show the message `Sending failed...`, only the first form shows error, i will change this behaviour if desired.**
This is how it looks currently if try to send all those 1006 forms + sample all widgets form:

![Screenshot_20200111-000821](https://user-images.githubusercontent.com/47722139/72177789-758fdf80-3407-11ea-9788-77b04c4c525e.jpg)



#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)