### PR TITLE
Revert attempt to fix audit header tests failing on Windows

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -38,13 +38,10 @@ import org.javarosa.xform.util.XFormUtils;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -63,7 +60,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.UUID;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import timber.log.Timber;
@@ -85,7 +81,6 @@ public class FileUtils {
     public static final String AUTO_DELETE = "autoDelete";
     public static final String AUTO_SEND = "autoSend";
     public static final String GEOMETRY_XPATH = "geometryXpath";
-    public static final String TEMPORARY_FILE_PREFIX = "temp";
 
     /** Suffix for the form media directory. */
     public static final String MEDIA_SUFFIX = "-media";
@@ -271,68 +266,6 @@ public class FileUtils {
             IOUtils.closeQuietly(src);
             IOUtils.closeQuietly(dst);
         }
-    }
-
-    public static boolean replaceHeaderRow(File existingFile, String header) {
-        return replaceHeaderRow(existingFile, header, "\n");
-    }
-
-    public static boolean replaceHeaderRow(File existingFile, String header, String lineEnding) {
-        if (existingFile == null || !existingFile.exists()) {
-            return false;
-        }
-
-        boolean insertSucceeded = false;
-        FileWriter newContents = null;
-        BufferedReader originalContents = null;
-
-        try {
-            String temporaryFileName = TEMPORARY_FILE_PREFIX + existingFile.getName() + UUID.randomUUID().toString();
-            String temporaryFilePath = existingFile.getParentFile().getAbsolutePath() + File.separator + temporaryFileName;
-            File originalFileRenamed = new File(temporaryFilePath);
-
-            // Attempt to rename the file first. If this fails because of locks or permissions issues
-            // then leave the original file intact.
-            if (!existingFile.renameTo(originalFileRenamed)) {
-                Timber.e("Unable to rename the file to be updated: " + originalFileRenamed.getAbsolutePath());
-            } else {
-                originalContents = new BufferedReader(new FileReader(originalFileRenamed));
-                newContents = new FileWriter(existingFile, false);
-
-                // Insert header & copy remaining contents
-                newContents.write(header + lineEnding);
-                originalContents.readLine(); // consume and ignore the old header
-                String line;
-                while ((line = originalContents.readLine()) != null) {
-                    newContents.write(line);
-                    newContents.write(lineEnding);
-                }
-
-                // Cleanup
-                originalContents.close();
-                newContents.close();
-                if (!originalFileRenamed.delete()) {
-                    Timber.e("Unable to clean up the temporary copy of the original file at: " + originalFileRenamed.getAbsolutePath());
-                } else {
-                    insertSucceeded = true;
-                }
-            }
-        } catch (IOException e) {
-            Timber.e(e);
-        } finally {
-            try {
-                if (originalContents != null) {
-                    originalContents.close();
-                }
-                if (newContents != null) {
-                    newContents.close();
-                }
-            } catch (Exception e) {
-                Timber.e(e);
-            }
-        }
-
-        return insertSucceeded;
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -1,12 +1,9 @@
 package org.odk.collect.android.utilities;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
@@ -278,49 +275,5 @@ public class FileUtilsTest {
         assertThat(metadataFromFormDefinition.get(FileUtils.TITLE), is("Setgeopoint before"));
         assertThat(metadataFromFormDefinition.get(FileUtils.FORMID), is("set-geopoint-before"));
         assertThat(metadataFromFormDefinition.get(FileUtils.GEOMETRY_XPATH), is("/data/location1"));
-    }
-
-    @Test
-    public void testInsertHeaderRowIntoEmptyFile() throws IOException {
-        final String headerRow = "header row";
-
-        // setup
-        File tempFile = File.createTempFile("testInsertHeaderRow", "");
-        tempFile.deleteOnExit();
-
-        Assert.assertTrue(FileUtils.replaceHeaderRow(tempFile, headerRow));
-
-        // check the results
-        StringBuilder results = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new FileReader(tempFile));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            results.append(line);
-        }
-        assertEquals("header row", results.toString());
-    }
-
-    @Test
-    public void testReplaceHeaderRow() throws IOException {
-        final String headerRow = "new header row";
-
-        // setup
-        File tempFile = File.createTempFile("testInsertHeaderRow", "");
-        tempFile.deleteOnExit();
-        BufferedWriter out = new BufferedWriter(new FileWriter(tempFile));
-        out.write("old header row\n");
-        out.write("data row\n");
-        out.close();
-
-        Assert.assertTrue(FileUtils.replaceHeaderRow(tempFile, headerRow));
-
-        // check the results
-        StringBuilder results = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new FileReader(tempFile));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            results.append(line + "\n");
-        }
-        assertEquals("new header row\ndata row\n", results.toString());
     }
 }


### PR DESCRIPTION
This reverts commits 647a62a59596f4abf0594d323b614cadb35b3e07, df003a069ed27884a4ae240a7cc71d73cbeb8c8d and 4eacab91d5f33bf3dceba87d4fc6ac6681116b6c. I have filed https://github.com/opendatakit/collect/issues/3583 to track the Windows test failure so it can be addressed in its own PR.

#### What has been done to verify that this works as intended?
Ran tests.

#### Why is this the best possible solution? Were any other approaches considered?
I also considered reverting the whole PR but there were two unrelated sets of changes in there and the ones that fixed the original issue were verified and allow progress to be made on #3335.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We know that after this tests will be broken on Windows. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)