### PR TITLE
Disabled certain Findbug Warnings

### DIFF
--- a/config/findbugs-filter.xml
+++ b/config/findbugs-filter.xml
@@ -120,6 +120,9 @@
         <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
     </Match>
     <Match>
+        <Bug pattern="SBSC_USE_STRINGBUFFER_CONCATENATION" />
+    </Match>
+    <Match>
         <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
     </Match>
     <Match>
@@ -128,10 +131,22 @@
 
     <!-- Dodgy code Warnings -->
     <Match>
+        <Bug pattern="DB_DUPLICATE_SWITCH_CLAUSES" />
+    </Match>
+    <Match>
+        <Bug pattern="INT_BAD_REM_BY_1" />
+    </Match>
+    <Match>
         <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
     </Match>
     <Match>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" />
+    </Match>
+    <Match>
+        <Bug pattern="NS_NON_SHORT_CIRCUIT" />
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
     </Match>
     <Match>
         <Bug pattern="SF_SWITCH_NO_DEFAULT" />


### PR DESCRIPTION
Closes #2946 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it by running `./gradlew spotbugs` on examples of failing pieces of codes, with without including the warnings in the `findbugs-filter.xml`. 

#### Why is this the best possible solution? Were any other approaches considered?
I included the five mentioned warnings in the issue in `findbugs-filter.xml`. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No such risks

#### Do we need any specific form for testing your changes? If so, please attach one.
No, developer-related issue

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)