### PR TITLE
Used Number Picker to change line width in Annotate and Draw Widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -31,6 +31,7 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.OvershootInterpolator;
 import android.widget.AdapterView;
 import android.widget.ListView;
+import android.widget.NumberPicker;
 
 import com.google.common.collect.ImmutableList;
 import com.rarepebble.colorpicker.ColorPickerView;
@@ -104,6 +105,8 @@ public class DrawActivity extends CollectAbstractActivity {
         fabActions = findViewById(R.id.fab_actions);
         final FloatingActionButton fabSetColor = findViewById(R.id.fab_set_color);
         final CardView cardViewSetColor = findViewById(R.id.cv_set_color);
+        final FloatingActionButton fabSetLineWidth = findViewById(R.id.fab_set_line_width);
+        final CardView cardViewSetLineWidth = findViewById(R.id.cv_set_line_width);
         final FloatingActionButton fabSaveAndClose = findViewById(R.id.fab_save_and_close);
         final CardView cardViewSaveAndClose = findViewById(R.id.cv_save_and_close);
         final FloatingActionButton fabClear = findViewById(R.id.fab_clear);
@@ -120,6 +123,8 @@ public class DrawActivity extends CollectAbstractActivity {
 
                     AnimateUtils.scaleInAnimation(fabSetColor, 50, 150, new OvershootInterpolator(), true);
                     AnimateUtils.scaleInAnimation(cardViewSetColor, 50, 150, new OvershootInterpolator(), true);
+                    AnimateUtils.scaleInAnimation(fabSetLineWidth, 50, 150, new OvershootInterpolator(), true);
+                    AnimateUtils.scaleInAnimation(cardViewSetLineWidth, 50, 150, new OvershootInterpolator(), true);
                     AnimateUtils.scaleInAnimation(fabSaveAndClose, 100, 150, new OvershootInterpolator(), true);
                     AnimateUtils.scaleInAnimation(cardViewSaveAndClose, 100, 150, new OvershootInterpolator(), true);
                     AnimateUtils.scaleInAnimation(fabClear, 150, 150, new OvershootInterpolator(), true);
@@ -127,6 +132,8 @@ public class DrawActivity extends CollectAbstractActivity {
 
                     fabSetColor.show();
                     cardViewSetColor.setVisibility(View.VISIBLE);
+                    fabSetLineWidth.show();
+                    cardViewSetLineWidth.setVisibility(View.VISIBLE);
                     fabSaveAndClose.show();
                     cardViewSaveAndClose.setVisibility(View.VISIBLE);
                     fabClear.show();
@@ -138,6 +145,8 @@ public class DrawActivity extends CollectAbstractActivity {
 
                     fabSetColor.hide();
                     cardViewSetColor.setVisibility(View.INVISIBLE);
+                    fabSetLineWidth.hide();
+                    cardViewSetLineWidth.setVisibility(View.INVISIBLE);
                     fabSaveAndClose.hide();
                     cardViewSaveAndClose.setVisibility(View.INVISIBLE);
                     fabClear.hide();
@@ -327,16 +336,35 @@ public class DrawActivity extends CollectAbstractActivity {
         if (view.getVisibility() == View.VISIBLE) {
             fabActions.performClick();
 
-            final ColorPickerView picker = new ColorPickerView(this);
-            picker.setColor(drawView.getColor());
-            picker.showAlpha(false);
-            picker.showHex(false);
+            final ColorPickerView colorPicker = new ColorPickerView(this);
+            colorPicker.setColor(drawView.getColor());
+            colorPicker.showAlpha(false);
+            colorPicker.showHex(false);
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            builder
+                    .setView(colorPicker)
+                    .setPositiveButton(R.string.ok, (dialog, which) -> drawView.setColor(colorPicker.getColor()))
+                    .show();
+        }
+    }
+
+    public void setLineWidth(View view) {
+        if (view.getVisibility() == View.VISIBLE) {
+            fabActions.performClick();
+
+            final NumberPicker picker = new NumberPicker(this);
+            picker.setMaxValue(100);
+            picker.setMinValue(1);
+            picker.setValue((int) drawView.getStrokeWidth());
+            picker.setWrapSelectorWheel(true);
 
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder
                     .setView(picker)
-                    .setPositiveButton(R.string.ok, (dialog, which) -> drawView.setColor(picker.getColor()))
+                    .setPositiveButton(R.string.ok, (dialog, which) -> drawView.setStrokeWidth(picker.getValue()))
                     .show();
         }
+
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
@@ -49,6 +49,7 @@ public class DrawView extends View {
     private float valueY;
 
     private int currentColor = 0xFF000000;
+    private float currentStrokeWidth = 10;
 
     public DrawView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -68,14 +69,14 @@ public class DrawView extends View {
         paint.setColor(currentColor);
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeJoin(Paint.Join.ROUND);
-        paint.setStrokeWidth(10);
+        paint.setStrokeWidth(currentStrokeWidth);
 
         pointPaint = new Paint();
         pointPaint.setAntiAlias(true);
         pointPaint.setDither(true);
         pointPaint.setColor(currentColor);
         pointPaint.setStyle(Paint.Style.FILL_AND_STROKE);
-        pointPaint.setStrokeWidth(10);
+        pointPaint.setStrokeWidth(currentStrokeWidth);
     }
 
     public void reset() {
@@ -201,7 +202,17 @@ public class DrawView extends View {
         pointPaint.setColor(color);
     }
 
+    public void setStrokeWidth(float width) {
+        currentStrokeWidth = width;
+        paint.setStrokeWidth(width);
+        pointPaint.setStrokeWidth(width);
+    }
+
     public int getColor() {
         return currentColor;
+    }
+
+    public float getStrokeWidth() {
+        return currentStrokeWidth;
     }
 }

--- a/collect_app/src/main/res/drawable/ic_line_width_white.xml
+++ b/collect_app/src/main/res/drawable/ic_line_width_white.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M61,153.5l0,10.5 195,-0 195,-0 0,-10.5 0,-10.5 -195,-0 -195,-0 0,10.5z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M61,256l0,21 195,-0 195,-0 0,-21 0,-21 -195,-0 -195,-0 0,21z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M61,379l0,31 195,-0 195,-0 0,-31 0,-31 -195,-0 -195,-0 0,31z"/>
+</vector>

--- a/collect_app/src/main/res/layout/draw_layout.xml
+++ b/collect_app/src/main/res/layout/draw_layout.xml
@@ -18,7 +18,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginBottom="192dp"
+        android:layout_marginBottom="242dp"
         android:layout_marginEnd="72dp"
         android:layout_marginStart="72dp"
         android:layout_marginRight="72dp"
@@ -44,7 +44,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginBottom="198dp"
+        android:layout_marginBottom="249dp"
         android:layout_marginEnd="24dp"
         android:layout_marginStart="24dp"
         android:layout_marginRight="24dp"
@@ -61,7 +61,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginBottom="142dp"
+        android:layout_marginBottom="192dp"
         android:layout_marginEnd="72dp"
         android:layout_marginStart="72dp"
         android:layout_marginRight="72dp"
@@ -87,7 +87,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginBottom="147dp"
+        android:layout_marginBottom="198dp"
         android:layout_marginEnd="24dp"
         android:layout_marginStart="24dp"
         android:layout_marginRight="24dp"
@@ -98,6 +98,49 @@
         app:fabSize="mini"
         app:srcCompat="@drawable/ic_save_white"
         android:onClick="close"/>
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cv_set_line_width"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginBottom="142dp"
+        android:layout_marginEnd="72dp"
+        android:layout_marginStart="72dp"
+        android:layout_marginRight="72dp"
+        android:layout_marginLeft="72dp"
+        android:visibility="invisible"
+        app:cardCornerRadius="4dp"
+        app:cardElevation="6dp"
+        app:cardPreventCornerOverlap="true"
+        app:cardUseCompatPadding="true"
+        android:onClick="setLineWidth">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="6dp"
+            android:text="@string/set_line_width"
+            android:textSize="14sp" />
+
+    </androidx.cardview.widget.CardView>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_set_line_width"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginBottom="147dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginRight="24dp"
+        android:layout_marginLeft="24dp"
+        android:visibility="invisible"
+        app:backgroundTint="@android:color/black"
+        app:elevation="6dp"
+        app:fabSize="mini"
+        app:srcCompat="@drawable/ic_line_width_white"
+        android:onClick="setLineWidth"/>
 
     <androidx.cardview.widget.CardView
         android:id="@+id/cv_set_color"

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -724,4 +724,5 @@
     <string name="reason">Reason</string>
     <string name="save">Save</string>
     <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
+    <string name="set_line_width">Set Line Width</string>
 </resources>


### PR DESCRIPTION
Closes #3089 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
 I tested it on Android 9.0.

![Issue#3089](https://user-images.githubusercontent.com/35730054/72205000-221f9f00-34a4-11ea-8b3f-4b9ca22d645c.gif)

#### Why is this the best possible solution? Were any other approaches considered?
I added a `floatingActionButton`, that allows the user to change stroke width and choose any value from 1 to 100, using the standard NumberPicker android widget. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks, as of now.

#### Do we need any specific form for testing your changes? If so, please attach one.
AllWidgetsForm or any form having draw or annotate widget.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)