### PR TITLE
main menu: change delete form button text

### DIFF
--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -95,7 +95,7 @@
     <string name="location_accuracy">Accuracy is %1$s m</string>
     <string name="main_menu">Main Menu</string>
     <string name="main_menu_details">Data collection made easier…</string>
-    <string name="manage_files">Delete Saved Form</string>
+    <string name="manage_files">Delete Form</string>
     <string name="mark_finished">Mark form as finalized</string>
     <string name="noselect_error">Sorry, you have not selected any forms!</string>
     <string name="no_connection">No network connection available</string>


### PR DESCRIPTION
Changes button text from "Delete Saved Form" to "Delete Form". This button is used to delete both "saved" and "blank" forms, so it's confusing that the button text specifies "saved".

----
There is no GitHub issue for this. Should I open one first?

---

#### What has been done to verify that this works as intended?
I'll be honest: I don't have a development environment set up for this app. However, this is the only place in the source code where `"Delete Saved Form"` appears.

#### Why is this the best possible solution? Were any other approaches considered?
I can't think of a better value for this string than "Delete Form".

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
N/A

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)