### PR TITLE
Stop repeat dialog closing when app is backgrounded

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -479,7 +479,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 } else {
                     Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath);
-                    showFormLoadingDialogFragment();
+                    DialogUtils.showIfNotShowing(FormLoadingDialogFragment.newInstance(), getSupportFragmentManager());
                     formLoaderTask.execute(formPath);
                 }
                 return;
@@ -614,7 +614,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
 
         formLoaderTask = new FormLoaderTask(instancePath, null, null);
-        showFormLoadingDialogFragment();
+        DialogUtils.showIfNotShowing(FormLoadingDialogFragment.newInstance(), getSupportFragmentManager());
         formLoaderTask.execute(formPath);
     }
 
@@ -853,8 +853,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                  * Android 1.6) we want to handle images the audio and video
                  */
 
-                ProgressDialogFragment.newInstance(null, getString(R.string.please_wait))
-                        .show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+                ProgressDialogFragment progressDialog = new ProgressDialogFragment();
+                progressDialog.setMessage(getString(R.string.please_wait));
+                progressDialog.show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
 
                 mediaLoadingFragment.beginMediaLoadingTask(intent.getData());
                 break;
@@ -1832,8 +1833,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 case SAVING:
                     autoSaved = true;
 
-                     SaveFormProgressDialogFragment progressDialog = (SaveFormProgressDialogFragment) DialogUtils.showIfNotShowing(
-                            new SaveFormProgressDialogFragment().setArguments(getString(R.string.saving_form), getString(R.string.please_wait)),
+                    SaveFormProgressDialogFragment progressDialog = DialogUtils.showIfNotShowing(
+                            new SaveFormProgressDialogFragment(),
                             getSupportFragmentManager()
                     );
 
@@ -2169,7 +2170,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         loadingComplete(formLoaderTask, formLoaderTask.getFormDef(), null);
                     }
                 } else {
-                    dismissFormLoadingDialogFragment();
+                    DialogUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
                     FormLoaderTask t = formLoaderTask;
                     formLoaderTask = null;
                     t.cancel(true);
@@ -2318,7 +2319,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      */
     @Override
     public void loadingComplete(FormLoaderTask task, FormDef formDef, String warningMsg) {
-        dismissFormLoadingDialogFragment();
+        DialogUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
 
         final FormController formController = task.getFormController();
         if (formController != null) {
@@ -2499,7 +2500,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      */
     @Override
     public void loadingError(String errorMsg) {
-        dismissFormLoadingDialogFragment();
+        DialogUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
 
         if (errorMsg != null) {
             createErrorDialog(errorMsg, EXIT);
@@ -2509,10 +2510,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     public void onProgressStep(String stepMessage) {
-        FormLoadingDialogFragment formLoadingDialogFragment = getFormLoadingDialogFragment();
-        if (formLoadingDialogFragment != null) {
-            formLoadingDialogFragment.setMessage(getString(R.string.please_wait) + "\n\n" + stepMessage);
-        }
+        DialogUtils.showIfNotShowing(
+                new FormLoadingDialogFragment(),
+                getSupportFragmentManager()
+        ).setMessage(getString(R.string.please_wait) + "\n\n" + stepMessage);
     }
 
     public void next() {
@@ -2555,19 +2556,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         }
         finish();
-    }
-
-    private FormLoadingDialogFragment getFormLoadingDialogFragment() {
-        return (FormLoadingDialogFragment) getSupportFragmentManager()
-                .findFragmentByTag(FormLoadingDialogFragment.class.getName());
-    }
-
-    private void showFormLoadingDialogFragment() {
-        DialogUtils.showIfNotShowing(FormLoadingDialogFragment.newInstance(), getSupportFragmentManager());
-    }
-
-    private void dismissFormLoadingDialogFragment() {
-        DialogUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -91,6 +91,7 @@ import org.odk.collect.android.events.ReadPhoneStatePermissionRxEvent;
 import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.external.ExternalDataManager;
+import org.odk.collect.android.formentry.FormLoadingDialogFragment;
 import org.odk.collect.android.formentry.FormSaveViewModel;
 import org.odk.collect.android.formentry.QuitFormDialog;
 import org.odk.collect.android.formentry.SaveFormProgressDialogFragment;
@@ -104,7 +105,6 @@ import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationVi
 import org.odk.collect.android.formentry.repeats.AddRepeatDialog;
 import org.odk.collect.android.fragments.MediaLoadingFragment;
 import org.odk.collect.android.fragments.dialogs.CustomDatePickerDialog;
-import org.odk.collect.android.fragments.dialogs.FormLoadingDialogFragment;
 import org.odk.collect.android.fragments.dialogs.LocationProvidersDisabledDialog;
 import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
@@ -853,7 +853,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                  * Android 1.6) we want to handle images the audio and video
                  */
 
-                ProgressDialogFragment.create(null, getString(R.string.please_wait))
+                ProgressDialogFragment.newInstance(null, getString(R.string.please_wait))
                         .show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
 
                 mediaLoadingFragment.beginMediaLoadingTask(intent.getData());
@@ -2521,7 +2521,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     public void onProgressStep(String stepMessage) {
         FormLoadingDialogFragment formLoadingDialogFragment = getFormLoadingDialogFragment();
         if (formLoadingDialogFragment != null) {
-            formLoadingDialogFragment.updateMessage(getString(R.string.please_wait) + "\n\n" + stepMessage);
+            formLoadingDialogFragment.setMessage(getString(R.string.please_wait) + "\n\n" + stepMessage);
         }
     }
 
@@ -2569,20 +2569,15 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     private FormLoadingDialogFragment getFormLoadingDialogFragment() {
         return (FormLoadingDialogFragment) getSupportFragmentManager()
-                .findFragmentByTag(FormLoadingDialogFragment.FORM_LOADING_DIALOG_FRAGMENT_TAG);
+                .findFragmentByTag(FormLoadingDialogFragment.class.getName());
     }
 
     private void showFormLoadingDialogFragment() {
-        FormLoadingDialogFragment
-                .newInstance()
-                .show(getSupportFragmentManager(), FormLoadingDialogFragment.FORM_LOADING_DIALOG_FRAGMENT_TAG);
+        DialogUtils.showIfNotShowing(FormLoadingDialogFragment.newInstance(), getSupportFragmentManager());
     }
 
     private void dismissFormLoadingDialogFragment() {
-        FormLoadingDialogFragment formLoadingDialogFragment = getFormLoadingDialogFragment();
-        if (formLoadingDialogFragment != null) {
-            formLoadingDialogFragment.dismiss();
-        }
+        DialogUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2063,15 +2063,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     /**
-     * Dismiss any showing dialogs that we manually manage.
-     */
-    private void dismissDialogs() {
-        if (alertDialog != null && alertDialog.isShowing()) {
-            alertDialog.dismiss();
-        }
-    }
-
-    /**
      * Shows the next or back button, neither or both. Both buttons are displayed unless:
      * - we are at the first question in the form so the back button is hidden
      * - we are at the end screen so the next button is hidden
@@ -2125,7 +2116,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     protected void onPause() {
         FormController formController = getFormController();
-        dismissDialogs();
 
         // make sure we're not already saving to disk. if we are, currentPrompt
         // is getting constantly updated

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormLoadingDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormLoadingDialogFragment.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.odk.collect.android.fragments.dialogs;
+package org.odk.collect.android.formentry;
 
 import android.app.Dialog;
 import android.app.ProgressDialog;
@@ -29,7 +29,6 @@ import org.odk.collect.android.R;
 import timber.log.Timber;
 
 public class FormLoadingDialogFragment extends DialogFragment {
-    public static final String FORM_LOADING_DIALOG_FRAGMENT_TAG = "formLoadingDialogFragmentTag";
 
     public interface FormLoadingDialogFragmentListener {
         void onCancelFormLoading();
@@ -78,7 +77,7 @@ public class FormLoadingDialogFragment extends DialogFragment {
         return dialog;
     }
 
-    public void updateMessage(String message) {
+    public void setMessage(String message) {
         ((ProgressDialog) getDialog()).setMessage(message);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaveViewModel.java
@@ -13,6 +13,7 @@ import androidx.lifecycle.ViewModelProvider;
 import org.javarosa.form.api.FormEntryController;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
+import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 import org.odk.collect.android.tasks.SaveFormToDisk;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 import org.odk.collect.utilities.Clock;
@@ -21,7 +22,7 @@ import static org.odk.collect.android.tasks.SaveFormToDisk.SAVED;
 import static org.odk.collect.android.tasks.SaveFormToDisk.SAVED_AND_EXIT;
 import static org.odk.collect.android.utilities.StringUtils.isBlank;
 
-public class FormSaveViewModel extends ViewModel {
+public class FormSaveViewModel extends ViewModel implements ProgressDialogFragment.Cancellable {
 
     private final Clock clock;
     private final FormSaver formSaver;
@@ -72,7 +73,8 @@ public class FormSaveViewModel extends ViewModel {
         return saveResult.getValue() != null && saveResult.getValue().getState().equals(SaveResult.State.SAVING);
     }
 
-    public boolean cancelSaving() {
+    @Override
+    public boolean cancel() {
         return saveTask.cancel(true);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
@@ -1,10 +1,22 @@
 package org.odk.collect.android.formentry;
 
+import android.content.Context;
+
+import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProviders;
 
+import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 
 public class SaveFormProgressDialogFragment extends ProgressDialogFragment {
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        setTitle(getString(R.string.saving_form));
+        setMessage(getString(R.string.please_wait));
+    }
 
     @Override
     protected Cancellable getCancellable() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
@@ -1,0 +1,15 @@
+package org.odk.collect.android.formentry;
+
+import androidx.lifecycle.ViewModelProviders;
+
+import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
+
+public class SaveFormProgressDialogFragment extends ProgressDialogFragment {
+
+    @Override
+    protected Cancellable getCancellable() {
+        return ViewModelProviders
+                .of(getActivity(), new FormSaveViewModel.Factory())
+                .get(FormSaveViewModel.class);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
@@ -2,27 +2,56 @@ package org.odk.collect.android.fragments.dialogs;
 
 import android.app.Dialog;
 import android.app.ProgressDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.FragmentManager;
 import android.view.Window;
 
-import org.odk.collect.android.R;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
 
 import timber.log.Timber;
 
 public class ProgressDialogFragment extends DialogFragment {
+
     public static final String COLLECT_PROGRESS_DIALOG_TAG = "collectProgressDialogTag";
 
+    private static final String TITLE = "title";
     private static final String MESSAGE = "message";
 
-    public static ProgressDialogFragment newInstance(String message) {
-        Bundle bundle = new Bundle();
-        bundle.putString(MESSAGE, message);
+    private String message;
 
+    public static ProgressDialogFragment create(@Nullable String title, @Nullable String message) {
         ProgressDialogFragment dialogFragment = new ProgressDialogFragment();
-        dialogFragment.setArguments(bundle);
+        dialogFragment.setArguments(title, message);
         return dialogFragment;
+    }
+
+    public ProgressDialogFragment setArguments(String title, String message) {
+        Bundle bundle = new Bundle();
+        bundle.putString(TITLE, title);
+        bundle.putString(MESSAGE, message);
+        this.setArguments(bundle);
+
+        return this;
+    }
+
+    /**
+     * Override to have something cancelled when the ProgressDialog's cancel button is pressed
+     */
+    protected Cancellable getCancellable() {
+        return null;
+    }
+
+    public void setMessage(String message) {
+        ProgressDialog dialog = (ProgressDialog) getDialog();
+
+        if (dialog != null) {
+            dialog.setMessage(message);
+        } else {
+            this.message = message;
+        }
     }
 
     /*
@@ -48,15 +77,32 @@ public class ProgressDialogFragment extends DialogFragment {
 
         setRetainInstance(true);
 
-        setCancelable(false);
-
         ProgressDialog dialog = new ProgressDialog(getActivity(), getTheme());
         dialog.getWindow().requestFeature(Window.FEATURE_NO_TITLE);
-        dialog.setMessage(getString(R.string.please_wait));
-        dialog.setCancelable(false);
+
+        String title = getArguments().getString(TITLE);
+        if (title != null) {
+            dialog.setTitle(title);
+        }
+
+        if (message != null) {
+            dialog.setMessage(message);
+        } else {
+            dialog.setMessage(getArguments().getString(MESSAGE));
+        }
+
         dialog.setIndeterminate(true);
         dialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+
         return dialog;
+    }
+
+    @Override
+    public void onCancel(@NonNull DialogInterface dialog) {
+        Cancellable cancellable = getCancellable();
+        if (cancellable != null) {
+            cancellable.cancel();
+        }
     }
 
     @Override
@@ -66,5 +112,9 @@ public class ProgressDialogFragment extends DialogFragment {
             dialog.setDismissMessage(null);
         }
         super.onDestroyView();
+    }
+
+    public interface Cancellable {
+        boolean cancel();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
@@ -22,7 +22,7 @@ public class ProgressDialogFragment extends DialogFragment {
 
     private String message;
 
-    public static ProgressDialogFragment create(@Nullable String title, @Nullable String message) {
+    public static ProgressDialogFragment newInstance(@Nullable String title, @Nullable String message) {
         ProgressDialogFragment dialogFragment = new ProgressDialogFragment();
         dialogFragment.setArguments(title, message);
         return dialogFragment;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -127,29 +127,6 @@ public final class DialogUtils {
     }
 
     /**
-     * Ensures that a dialog is dismissed safely and doesn't causes a crash. Useful in the event
-     * of a screen rotation, async operations or activity navigation.
-     *
-     * @param dialog   that needs to be shown
-     * @param activity that has the dialog
-     */
-    public static void dismissDialog(Dialog dialog, Activity activity) {
-
-        if (activity == null || activity.isFinishing()) {
-            return;
-        }
-        if (dialog == null || !dialog.isShowing()) {
-            return;
-        }
-
-        try {
-            dialog.dismiss();
-        } catch (Exception e) {
-            Timber.e(e);
-        }
-    }
-
-    /**
      * Creates an error dialog on an activity
      *
      * @param errorMsg The message to show on the dialog box
@@ -174,11 +151,22 @@ public final class DialogUtils {
         return alertDialog;
     }
 
-    public static void showIfNotShowing(DialogFragment dialog, FragmentManager fragmentManager) {
-        String tag = dialog.getClass().getName();
+    public static DialogFragment showIfNotShowing(DialogFragment newDialog, FragmentManager fragmentManager) {
+        String tag = newDialog.getClass().getName();
+        DialogFragment existingDialog = (DialogFragment) fragmentManager.findFragmentByTag(tag);
 
-        if (fragmentManager.findFragmentByTag(tag) == null) {
-            dialog.show(fragmentManager.beginTransaction(), tag);
+        if (existingDialog == null) {
+            newDialog.show(fragmentManager.beginTransaction(), tag);
+            return newDialog;
+        } else {
+            return existingDialog;
+        }
+    }
+
+    public static void dismissDialog(Class dialogClazz, FragmentManager fragmentManager) {
+        DialogFragment existingDialog = (DialogFragment) fragmentManager.findFragmentByTag(dialogClazz.getName());
+        if (existingDialog != null) {
+            existingDialog.dismiss();
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -151,9 +151,9 @@ public final class DialogUtils {
         return alertDialog;
     }
 
-    public static DialogFragment showIfNotShowing(DialogFragment newDialog, FragmentManager fragmentManager) {
+    public static <T extends DialogFragment> T showIfNotShowing(T newDialog, FragmentManager fragmentManager) {
         String tag = newDialog.getClass().getName();
-        DialogFragment existingDialog = (DialogFragment) fragmentManager.findFragmentByTag(tag);
+        T existingDialog = (T) fragmentManager.findFragmentByTag(tag);
 
         if (existingDialog == null) {
             newDialog.show(fragmentManager.beginTransaction(), tag);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -129,7 +129,7 @@ public final class DialogUtils {
     /**
      * Creates an error dialog on an activity
      *
-     * @param errorMsg The message to show on the dialog box
+     * @param errorMsg   The message to show on the dialog box
      * @param shouldExit Finish the activity if Ok is clicked
      */
     public static Dialog createErrorDialog(@NonNull Activity activity, String errorMsg, final boolean shouldExit) {
@@ -157,6 +157,12 @@ public final class DialogUtils {
 
         if (existingDialog == null) {
             newDialog.show(fragmentManager.beginTransaction(), tag);
+
+            // We need to execute this transaction. Otherwise a follow up call to this method
+            // could happen before the Fragment exists in the Fragment Manager and so the
+            // call to findFragmentByTag would return null and result in second dialog being show.
+            fragmentManager.executePendingTransactions();
+
             return newDialog;
         } else {
             return existingDialog;

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragmentTest.java
@@ -1,0 +1,75 @@
+package org.odk.collect.android.fragments.dialogs;
+
+import android.app.ProgressDialog;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowProgressDialog;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class ProgressDialogFragmentTest {
+
+    private FragmentManager fragmentManager;
+
+    @Before
+    public void setup() {
+        FragmentActivity activity = Robolectric.setupActivity(FragmentActivity.class);
+        fragmentManager = activity.getSupportFragmentManager();
+    }
+
+    @Test
+    public void create_setsTitleAndMessage() {
+        ProgressDialogFragment fragment = ProgressDialogFragment.create("A title", "A message");
+        fragment.show(fragmentManager, "TAG");
+
+        ShadowProgressDialog dialog = shadowOf((ProgressDialog) fragment.getDialog());
+        assertThat(dialog.getTitle(), equalTo("A title"));
+        assertThat(dialog.getMessage(), equalTo("A message"));
+    }
+
+    @Test
+    public void setMessage_beforeDialogExists_setsMessageWhenDialogShown() {
+        ProgressDialogFragment fragment = ProgressDialogFragment.create("A title", "A message");
+        fragment.setMessage("blah");
+
+        fragment.show(fragmentManager, "TAG");
+        CharSequence message = shadowOf((ProgressDialog) fragment.getDialog()).getMessage();
+        assertThat(message, equalTo("blah"));
+    }
+
+    @Test
+    public void clickingCancel_callsCancelOnCancellable() {
+        ProgressDialogFragment.Cancellable cancellable = mock(ProgressDialogFragment.Cancellable.class);
+        ProgressDialogFragment fragment = new TestProgressDialogFragment(cancellable);
+        fragment.setArguments("title", "A title");
+
+        fragment.onCancel(fragment.getDialog());
+        verify(cancellable).cancel();
+    }
+
+    public static class TestProgressDialogFragment extends ProgressDialogFragment {
+
+        private final Cancellable cancellable;
+
+         TestProgressDialogFragment(Cancellable cancellable) {
+            this.cancellable = cancellable;
+        }
+
+        @Override
+        protected Cancellable getCancellable() {
+            return cancellable;
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragmentTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.fragments.dialogs;
 
 import android.app.ProgressDialog;
+import android.content.DialogInterface;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -10,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.shadows.ShadowProgressDialog;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -30,18 +30,18 @@ public class ProgressDialogFragmentTest {
     }
 
     @Test
-    public void create_setsTitleAndMessage() {
-        ProgressDialogFragment fragment = ProgressDialogFragment.newInstance("A title", "A message");
+    public void setMessage_updatesMessage() {
+        ProgressDialogFragment fragment = new ProgressDialogFragment();
         fragment.show(fragmentManager, "TAG");
 
-        ShadowProgressDialog dialog = shadowOf((ProgressDialog) fragment.getDialog());
-        assertThat(dialog.getTitle(), equalTo("A title"));
-        assertThat(dialog.getMessage(), equalTo("A message"));
+        fragment.setMessage("blah");
+        CharSequence message = shadowOf((ProgressDialog) fragment.getDialog()).getMessage();
+        assertThat(message, equalTo("blah"));
     }
 
     @Test
     public void setMessage_beforeDialogExists_setsMessageWhenDialogShown() {
-        ProgressDialogFragment fragment = ProgressDialogFragment.newInstance("A title", "A message");
+        ProgressDialogFragment fragment = new ProgressDialogFragment();
         fragment.setMessage("blah");
 
         fragment.show(fragmentManager, "TAG");
@@ -50,21 +50,83 @@ public class ProgressDialogFragmentTest {
     }
 
     @Test
-    public void clickingCancel_callsCancelOnCancellable() {
+    public void restoringFragment_retainsMessage() {
+        ProgressDialogFragment fragment = new ProgressDialogFragment();
+        fragment.show(fragmentManager, "TAG");
+        fragment.setMessage("blah");
+
+        ProgressDialogFragment restoredFragment = new ProgressDialogFragment();
+        restoredFragment.setArguments(fragment.getArguments());
+        restoredFragment.show(fragmentManager, "TAG");
+        CharSequence message = shadowOf((ProgressDialog) restoredFragment.getDialog()).getMessage();
+        assertThat(message, equalTo("blah"));
+    }
+
+    @Test
+    public void setTitle_updatesTitle() {
+        ProgressDialogFragment fragment = new ProgressDialogFragment();
+        fragment.show(fragmentManager, "TAG");
+
+        fragment.setTitle("blah");
+        CharSequence message = shadowOf((ProgressDialog) fragment.getDialog()).getTitle();
+        assertThat(message, equalTo("blah"));
+    }
+
+    @Test
+    public void setTitle_beforeDialogExists_setsTitleWhenDialogShown() {
+        ProgressDialogFragment fragment = new ProgressDialogFragment();
+        fragment.setTitle("blah");
+
+        fragment.show(fragmentManager, "TAG");
+        CharSequence message = shadowOf((ProgressDialog) fragment.getDialog()).getTitle();
+        assertThat(message, equalTo("blah"));
+    }
+
+    @Test
+    public void restoringFragment_retainsTitle() {
+        ProgressDialogFragment fragment = new ProgressDialogFragment();
+        fragment.show(fragmentManager, "TAG");
+        fragment.setTitle("blah");
+
+        ProgressDialogFragment restoredFragment = new ProgressDialogFragment();
+        restoredFragment.setArguments(fragment.getArguments());
+        restoredFragment.show(fragmentManager, "TAG");
+        CharSequence message = shadowOf((ProgressDialog) restoredFragment.getDialog()).getTitle();
+        assertThat(message, equalTo("blah"));
+    }
+
+    @Test
+    public void cancelling_callsCancelOnCancellable() {
         ProgressDialogFragment.Cancellable cancellable = mock(ProgressDialogFragment.Cancellable.class);
         ProgressDialogFragment fragment = new TestProgressDialogFragment(cancellable);
-        fragment.setArguments("title", "A title");
 
         fragment.onCancel(fragment.getDialog());
         verify(cancellable).cancel();
+    }
+
+    @Test
+    public void whenThereIsCancelButtonText_clickingCancel_dismissesAndCallsCancelOnCancellable() {
+        ProgressDialogFragment.Cancellable cancellable = mock(ProgressDialogFragment.Cancellable.class);
+        ProgressDialogFragment fragment = new TestProgressDialogFragment(cancellable);
+        fragment.show(fragmentManager, "TAG");
+        ProgressDialog dialog = (ProgressDialog) fragment.getDialog();
+
+        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
+        verify(cancellable).cancel();
+        assertThat(dialog.isShowing(), equalTo(false));
     }
 
     public static class TestProgressDialogFragment extends ProgressDialogFragment {
 
         private final Cancellable cancellable;
 
-         TestProgressDialogFragment(Cancellable cancellable) {
+        TestProgressDialogFragment(Cancellable cancellable) {
             this.cancellable = cancellable;
+        }
+
+        @Override
+        protected String getCancelButtonText() {
+            return "Blah";
         }
 
         @Override

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragmentTest.java
@@ -31,7 +31,7 @@ public class ProgressDialogFragmentTest {
 
     @Test
     public void create_setsTitleAndMessage() {
-        ProgressDialogFragment fragment = ProgressDialogFragment.create("A title", "A message");
+        ProgressDialogFragment fragment = ProgressDialogFragment.newInstance("A title", "A message");
         fragment.show(fragmentManager, "TAG");
 
         ShadowProgressDialog dialog = shadowOf((ProgressDialog) fragment.getDialog());
@@ -41,7 +41,7 @@ public class ProgressDialogFragmentTest {
 
     @Test
     public void setMessage_beforeDialogExists_setsMessageWhenDialogShown() {
-        ProgressDialogFragment fragment = ProgressDialogFragment.create("A title", "A message");
+        ProgressDialogFragment fragment = ProgressDialogFragment.newInstance("A title", "A message");
         fragment.setMessage("blah");
 
         fragment.show(fragmentManager, "TAG");


### PR DESCRIPTION
Closes #3322. Depends on #3576.

This removes code in `FormEntryActivity` that was dismissing dialogs in `onPause`. As far as I can see there was no reason for that to happen but if someone needed that code speak now!

As well as fixing the issues this PR:
* Removes the use of `showDialog`/`dismissDialog` from `FormEntryActivity`
* Use our `ProgressDialogFragment` for form loading and saving

#### What has been done to verify that this works as intended?

Played around with repeats and backgrounding. I wasn't able to write a test for this as it requires backgrounding the app which we can't do with Espresso and a Robolectric test for `FormEntryActivity` isn't really feasable right now.

#### Why is this the best possible solution? Were any other approaches considered?

As long as the code I deleted wasn't needed in someway then it's certainly the simplest solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue. Good to test repeats, form loading and saving as the dialogs have all had code changes in someway. Would also be good to investigate any other dialog involving scenarios during form entry to check that the code I've removed wasn't needed for something.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)