### PR TITLE
Manifest cleanup in preparation for FileProvider changes

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@ the specific language governing permissions and limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.odk.collect.android">
+    package="org.odk.collect.android"
+    tools:ignore="GoogleAppIndexingWarning">
 
     <uses-feature
         android:name="android.hardware.location"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -65,13 +65,6 @@ the specific language governing permissions and limitations under the License.
     <uses-feature
         android:glEsVersion="0x00020000"
         android:required="true" />
-    <!--
-    for Maps v2 functionality, want:
-    <uses-feature android:glEsVersion="0x00020000" android:required="false"/>
-    uses-feature android:glEsVersion="0x00020000" android:required="false"
-    BUT, the gl setting is not modified by the required parameter, so
-    do not declare anything here - detect capabilities at runtime.
-    -->
 
     <supports-screens
         android:anyDensity="true"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -78,7 +78,8 @@ the specific language governing permissions and limitations under the License.
         android:label="@string/app_name"
         android:largeHeap="true"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -62,9 +62,6 @@ the specific language governing permissions and limitations under the License.
     <uses-feature
         android:name="android.hardware.screen.portrait"
         android:required="false" />
-    <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true" />
 
     <supports-screens
         android:anyDensity="true"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -190,7 +190,8 @@ the specific language governing permissions and limitations under the License.
 
         <activity-alias
             android:name=".activities.FormEntryActivity"
-            android:targetActivity=".activities.FormEntryActivity">
+            android:targetActivity=".activities.FormEntryActivity"
+            tools:ignore="AppLinkUrlError">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
@@ -204,7 +205,8 @@ the specific language governing permissions and limitations under the License.
 
         <activity-alias
             android:name=".activities.InstanceChooserList"
-            android:targetActivity=".activities.InstanceChooserList">
+            android:targetActivity=".activities.InstanceChooserList"
+            tools:ignore="AppLinkUrlError">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
@@ -217,7 +219,8 @@ the specific language governing permissions and limitations under the License.
 
         <activity-alias
             android:name=".activities.FormChooserList"
-            android:targetActivity=".activities.FormChooserListActivity">
+            android:targetActivity=".activities.FormChooserListActivity"
+            tools:ignore="AppLinkUrlError">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />


### PR DESCRIPTION
I am looking at designing the API to support external applications that currently directly read from or write to `/sdcard/odk` and won't be able to after #3360. There are currently several Android Studio checks failing and those make it hard to see clearly in the manifest. I'd like to make these quick cleanup changes before starting work.

#### What has been done to verify that this works as intended?
There should be no behavioral changes. I ran all tests and also made sure that the app actually launches.

#### Why is this the best possible solution? Were any other approaches considered?
I split each change into its own commit to explicitly explain why they're being made.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no behavior change. The riskiest part is probably 8573897 but the documentation is very explicit about not needing this block and devices that don't support OpenGL 2 must be quite rare by now.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
I have filed https://github.com/opendatakit/docs/issues/1168 to document backup behavior since it seems like something that users would like to explicitly know about.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)