### PR TITLE
Return error message immediately when an exception occurs during downloading forms

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -158,7 +158,7 @@ public class FormDownloader {
             // do not download additional forms.
             throw e;
         } catch (Exception e) {
-            message += getExceptionMessage(e);
+            return message + getExceptionMessage(e);
         }
 
         if (stateListener != null && stateListener.isTaskCanceled()) {
@@ -181,7 +181,7 @@ public class FormDownloader {
                 Timber.i("Parse finished in %.3f seconds.",
                         (System.currentTimeMillis() - start) / 1000F);
             } catch (RuntimeException e) {
-                message += e.getMessage();
+                return message + e.getMessage();
             }
         }
 


### PR DESCRIPTION
Closes #3600 

#### What has been done to verify that this works as intended?
I tested the changes with the server mentioned in https://forum.opendatakit.org/t/blank-surveys-wont-download-please-help/24371/1

#### Why is this the best possible solution? Were any other approaches considered?
Once an exception occurs we should stop downloading a form and performing other operations in that method.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should improve the messaged displayed for a user when downloading a form fails. As I described in the issue the part related to media files was misleading and not related to the problem at all.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)