### PR TITLE
Fix rendering of google map labels on top of offline layers

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -463,10 +463,16 @@ public class GoogleMapFragment extends SupportMapFragment implements
             referenceOverlay = this.map.addTileOverlay(new TileOverlayOptions().tileProvider(
                 new GoogleMapsMapBoxOfflineTileProvider(referenceLayerFile)
             ));
-            map.setMapStyle(new MapStyleOptions(getResources().getString(R.string.google_map_labels_switch, "off")));
+            switch_google_map_labels("off");
         } else {
-            map.setMapStyle(new MapStyleOptions(getResources().getString(R.string.google_map_labels_switch, "on")));
+            switch_google_map_labels("on");
         }
+    }
+
+    // Turns off google map labels for offline layers to work correctly
+    private void switch_google_map_labels(String state) {
+        String style = String.format(" [ { featureType: all, elementType: labels, stylers: [ { visibility: %s } ] } ]", state);
+        map.setMapStyle(new MapStyleOptions(style));
     }
 
     private LatLngBounds expandBounds(LatLngBounds bounds, double factor) {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -33,6 +33,7 @@ import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.CircleOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.Polyline;
@@ -462,6 +463,9 @@ public class GoogleMapFragment extends SupportMapFragment implements
             referenceOverlay = this.map.addTileOverlay(new TileOverlayOptions().tileProvider(
                 new GoogleMapsMapBoxOfflineTileProvider(referenceLayerFile)
             ));
+            map.setMapStyle(new MapStyleOptions(getResources().getString(R.string.google_map_labels_switch, "off")));
+        } else {
+            map.setMapStyle(new MapStyleOptions(getResources().getString(R.string.google_map_labels_switch, "on")));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -463,14 +463,13 @@ public class GoogleMapFragment extends SupportMapFragment implements
             referenceOverlay = this.map.addTileOverlay(new TileOverlayOptions().tileProvider(
                 new GoogleMapsMapBoxOfflineTileProvider(referenceLayerFile)
             ));
-            switch_google_map_labels("off");
+            setLabelsVisibility("off");
         } else {
-            switch_google_map_labels("on");
+            setLabelsVisibility("on");
         }
     }
 
-    // Turns off google map labels for offline layers to work correctly
-    private void switch_google_map_labels(String state) {
+    private void setLabelsVisibility(String state) {
         String style = String.format(" [ { featureType: all, elementType: labels, stylers: [ { visibility: %s } ] } ]", state);
         map.setMapStyle(new MapStyleOptions(style));
     }

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -308,6 +308,20 @@
     <string name="tell_your_friends_msg">Are your colleagues still collecting data on paper? Share ODK Collect with them.</string>
     <string name="leave_a_review">Leave a Play Store review</string>
     <string name="leave_a_review_msg">Your (hopefully positive) review increases the visibility of the App in the Play Store.</string>
+    <!-- Fix labels for Google Maps with reference layer -->
+    <string name="google_map_labels_switch">
+                  [
+                    {
+                      \"featureType\": \"all\",
+                      \"elementType\": \"labels\",
+                      \"stylers\": [
+                        {
+                          \"visibility\": \"%s\"
+                        }
+                      ]
+                    }
+                  ]
+    </string>
     <!-- Geo string added in feature-geofeatures branch-->
 
     <string name="maps">Maps</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -308,20 +308,6 @@
     <string name="tell_your_friends_msg">Are your colleagues still collecting data on paper? Share ODK Collect with them.</string>
     <string name="leave_a_review">Leave a Play Store review</string>
     <string name="leave_a_review_msg">Your (hopefully positive) review increases the visibility of the App in the Play Store.</string>
-    <!-- Fix labels for Google Maps with reference layer -->
-    <string name="google_map_labels_switch">
-                  [
-                    {
-                      \"featureType\": \"all\",
-                      \"elementType\": \"labels\",
-                      \"stylers\": [
-                        {
-                          \"visibility\": \"%s\"
-                        }
-                      ]
-                    }
-                  ]
-    </string>
     <!-- Geo string added in feature-geofeatures branch-->
 
     <string name="maps">Maps</string>


### PR DESCRIPTION
Closes #3004 


#### What has been done to verify that this works as intended?
Tested on android 9, with 
[countries-raster.zip](https://github.com/opendatakit/collect/files/4092637/countries-raster.zip)



#### Why is this the best possible solution? Were any other approaches considered?
As discussed on the forums, google maps labels are rendered dynamically so our only option is to turn them off completely in case of offline layers.

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)