### PR TITLE
Fixes #3355: Added Scroll bar to make the input method in geotrace and geoshape widget to adjust to vertical position of the device 

### DIFF
--- a/collect_app/src/main/res/layout/geopoly_dialog.xml
+++ b/collect_app/src/main/res/layout/geopoly_dialog.xml
@@ -1,87 +1,93 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
-
-    <RadioGroup
-        android:id="@+id/radio_group"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <RadioButton
-            android:id="@+id/placement_mode"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="10dp"
-            android:text="@string/placement_mode"/>
-
-        <RadioButton
-            android:id="@+id/manual_mode"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp"
-            android:text="@string/manual_mode"/>
-
-        <RadioButton
-            android:id="@+id/automatic_mode"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp"
-            android:text="@string/automatic_mode"/>
-
-    </RadioGroup>
+    android:layout_width="wrap_content">
 
     <LinearLayout
-        android:id="@+id/auto_options"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <RadioGroup
+            android:id="@+id/radio_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RadioButton
+                android:id="@+id/placement_mode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:text="@string/placement_mode"/>
+
+            <RadioButton
+                android:id="@+id/manual_mode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginStart="10dp"
+                android:text="@string/manual_mode"/>
+
+            <RadioButton
+                android:id="@+id/automatic_mode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:layout_marginLeft="10dp"
+                android:layout_marginStart="10dp"
+                android:text="@string/automatic_mode"/>
+
+        </RadioGroup>
+
         <LinearLayout
+            android:id="@+id/auto_options"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <TextView
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingLeft="42dp"
-                android:paddingStart="42dp"
-                android:text="@string/recording_interval"/>
+                android:layout_marginBottom="10dp"
+                android:orientation="horizontal">
 
-            <Spinner
-                android:id="@+id/auto_interval"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-        </LinearLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="42dp"
+                    android:paddingStart="42dp"
+                    android:text="@string/recording_interval"/>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                <Spinner
+                    android:id="@+id/auto_interval"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+            </LinearLayout>
 
-            <TextView
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingLeft="42dp"
-                android:paddingStart="42dp"
-                android:text="@string/accuracy_requirement"/>
+                android:orientation="horizontal">
 
-            <Spinner
-                android:id="@+id/accuracy_threshold"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="42dp"
+                    android:paddingStart="42dp"
+                    android:text="@string/accuracy_requirement"/>
+
+                <Spinner
+                    android:id="@+id/accuracy_threshold"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+            </LinearLayout>
+
         </LinearLayout>
 
     </LinearLayout>
 
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Closes #3355 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it on Android 9 and 4.2.

![odk#3355](https://user-images.githubusercontent.com/35730054/73146095-d8a39680-40d6-11ea-8595-079c9ef0cb00.png)

#### Why is this the best possible solution? Were any other approaches considered?
I added a `ScrollView` outside the `LinearLayout`, so as to make the `geopolydialog` scrollable, when there we are running the app on a smaller screen device, say 5.0 inch.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks.

#### Do we need any specific form for testing your changes? If so, please attach one.
A form having geoshape or geotrace widget like All Widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)