### PR TITLE
Fixes Issue#3054: Months in Myanmar calendar displayed in English on devices running API level lower than 21

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
@@ -70,7 +70,9 @@ public class MyanmarDateUtils {
     public static LanguageCatalog getLanguageCatalog() {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             return new LanguageCatalog(Language.MYANMAR);
-        } else return new LanguageCatalog(Language.ENGLISH);
+        } else {
+            return new LanguageCatalog(Language.ENGLISH);
+        }
     }
 
     public static int getFirstMonthDay(MyanmarDate myanmarDate) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
@@ -68,7 +68,7 @@ public class MyanmarDateUtils {
     }
 
     public static LanguageCatalog getLanguageCatalog() {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (android.os.Build.VERSION.SDK_INT >= 4.4) {
             return new LanguageCatalog(Language.MYANMAR);
         } else {
             return new LanguageCatalog(Language.ENGLISH);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
@@ -16,8 +16,6 @@
 
 package org.odk.collect.android.utilities;
 
-import android.os.Build;
-
 import org.joda.time.LocalDateTime;
 
 import mmcalendar.Language;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
@@ -16,6 +16,8 @@
 
 package org.odk.collect.android.utilities;
 
+import android.os.Build;
+
 import org.joda.time.LocalDateTime;
 
 import mmcalendar.Language;
@@ -59,10 +61,18 @@ public class MyanmarDateUtils {
     }
 
     public static String[] getMyanmarMonthsArray(int myanmarYear) {
-        return MyanmarDateKernel
-                .getMyanmarMonth(myanmarYear, 1)
-                .getMonthNameList(new LanguageCatalog(Language.MYANMAR))
-                .toArray(new String[0]);
+        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return MyanmarDateKernel
+                    .getMyanmarMonth(myanmarYear, 1)
+                    .getMonthNameList(new LanguageCatalog(Language.MYANMAR))
+                    .toArray(new String[0]);
+        }
+        else {
+            return MyanmarDateKernel
+                    .getMyanmarMonth(myanmarYear, 1)
+                    .getMonthNameList(new LanguageCatalog(Language.ENGLISH))
+                    .toArray(new String[0]);
+        }
     }
 
     public static int getFirstMonthDay(MyanmarDate myanmarDate) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
@@ -61,13 +61,12 @@ public class MyanmarDateUtils {
     }
 
     public static String[] getMyanmarMonthsArray(int myanmarYear) {
-        if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             return MyanmarDateKernel
                     .getMyanmarMonth(myanmarYear, 1)
                     .getMonthNameList(new LanguageCatalog(Language.MYANMAR))
                     .toArray(new String[0]);
-        }
-        else {
+        } else {
             return MyanmarDateKernel
                     .getMyanmarMonth(myanmarYear, 1)
                     .getMonthNameList(new LanguageCatalog(Language.ENGLISH))

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MyanmarDateUtils.java
@@ -61,17 +61,16 @@ public class MyanmarDateUtils {
     }
 
     public static String[] getMyanmarMonthsArray(int myanmarYear) {
+        return MyanmarDateKernel
+                .getMyanmarMonth(myanmarYear, 1)
+                .getMonthNameList(getLanguageCatalog())
+                .toArray(new String[0]);
+    }
+
+    public static LanguageCatalog getLanguageCatalog() {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            return MyanmarDateKernel
-                    .getMyanmarMonth(myanmarYear, 1)
-                    .getMonthNameList(new LanguageCatalog(Language.MYANMAR))
-                    .toArray(new String[0]);
-        } else {
-            return MyanmarDateKernel
-                    .getMyanmarMonth(myanmarYear, 1)
-                    .getMonthNameList(new LanguageCatalog(Language.ENGLISH))
-                    .toArray(new String[0]);
-        }
+            return new LanguageCatalog(Language.MYANMAR);
+        } else return new LanguageCatalog(Language.ENGLISH);
     }
 
     public static int getFirstMonthDay(MyanmarDate myanmarDate) {


### PR DESCRIPTION
Closes #3054 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it on Android devices running API level 16 onwards,  to confirm the API level from which the device start supporting Burmese language. 

![Screenshot from 2020-01-27 13-05-48](https://user-images.githubusercontent.com/35730054/73180808-1555a900-413c-11ea-8b04-22e9b8fa0596.png)

#### Why is this the best possible solution? Were any other approaches considered?
I found that for lower Android versions, the rendering does not take place for some script languages, even on browsers, so, for those devices (running Kitkat or lower android versions), the best is to display the names of Myanmar months in english language itself.  

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks

#### Do we need any specific form for testing your changes? If so, please attach one.
A from having Myanmar date widget, eg. All Widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)