### PR TITLE
Disable custom swipe animation when animations are off

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/test/FormActivityTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/test/FormActivityTestRule.java
@@ -26,10 +26,4 @@ public class FormActivityTestRule extends IntentsTestRule<FormEntryActivity> {
 
         return intent;
     }
-
-    @Override
-    protected void afterActivityLaunched() {
-        this.getActivity().setShouldOverrideAnimations(true);
-        super.afterActivityLaunched();
-    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -39,7 +39,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.IconMenuListAdapter;
 import org.odk.collect.android.adapters.model.IconMenuItem;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.utilities.AnimateUtils;
+import org.odk.collect.android.utilities.AnimationUtils;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.views.DrawView;
@@ -118,12 +118,12 @@ public class DrawActivity extends CollectAbstractActivity {
                     fabActions.animate().rotation(45).setInterpolator(new AccelerateDecelerateInterpolator())
                             .setDuration(100).start();
 
-                    AnimateUtils.scaleInAnimation(fabSetColor, 50, 150, new OvershootInterpolator(), true);
-                    AnimateUtils.scaleInAnimation(cardViewSetColor, 50, 150, new OvershootInterpolator(), true);
-                    AnimateUtils.scaleInAnimation(fabSaveAndClose, 100, 150, new OvershootInterpolator(), true);
-                    AnimateUtils.scaleInAnimation(cardViewSaveAndClose, 100, 150, new OvershootInterpolator(), true);
-                    AnimateUtils.scaleInAnimation(fabClear, 150, 150, new OvershootInterpolator(), true);
-                    AnimateUtils.scaleInAnimation(cardViewClear, 150, 150, new OvershootInterpolator(), true);
+                    AnimationUtils.scaleInAnimation(fabSetColor, 50, 150, new OvershootInterpolator(), true);
+                    AnimationUtils.scaleInAnimation(cardViewSetColor, 50, 150, new OvershootInterpolator(), true);
+                    AnimationUtils.scaleInAnimation(fabSaveAndClose, 100, 150, new OvershootInterpolator(), true);
+                    AnimationUtils.scaleInAnimation(cardViewSaveAndClose, 100, 150, new OvershootInterpolator(), true);
+                    AnimationUtils.scaleInAnimation(fabClear, 150, 150, new OvershootInterpolator(), true);
+                    AnimationUtils.scaleInAnimation(cardViewClear, 150, 150, new OvershootInterpolator(), true);
 
                     fabSetColor.show();
                     cardViewSetColor.setVisibility(View.VISIBLE);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -45,7 +45,6 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup.LayoutParams;
 import android.view.animation.Animation;
 import android.view.animation.Animation.AnimationListener;
-import android.view.animation.AnimationUtils;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -95,7 +94,6 @@ import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.external.ExternalDataManager;
 import org.odk.collect.android.formentry.FormSaveViewModel;
-import org.odk.collect.android.formentry.repeats.AddRepeatDialog;
 import org.odk.collect.android.formentry.QuitFormDialog;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.ChangesReasonPromptDialogFragment;
@@ -104,6 +102,7 @@ import org.odk.collect.android.formentry.audit.IdentityPromptViewModel;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationHelper;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationManager;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationViewModel;
+import org.odk.collect.android.formentry.repeats.AddRepeatDialog;
 import org.odk.collect.android.fragments.MediaLoadingFragment;
 import org.odk.collect.android.fragments.dialogs.CustomDatePickerDialog;
 import org.odk.collect.android.fragments.dialogs.FormLoadingDialogFragment;
@@ -175,8 +174,10 @@ import timber.log.Timber;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
+import static android.view.animation.AnimationUtils.loadAnimation;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_MOVING_BACKWARDS;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_BACKGROUND_LOCATION;
+import static org.odk.collect.android.utilities.AnimationUtils.areAnimationsEnabled;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 import static org.odk.collect.android.utilities.PermissionUtils.areStoragePermissionsGranted;
 import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivities;
@@ -299,8 +300,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     private boolean showNavigationButtons;
 
     private Bundle state;
-
-    private boolean shouldOverrideAnimations;
 
     @Inject
     RxEventBus eventBus;
@@ -1565,24 +1564,24 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         // by createView()
         switch (from) {
             case RIGHT:
-                inAnimation = AnimationUtils.loadAnimation(this,
+                inAnimation = loadAnimation(this,
                         R.anim.push_left_in);
-                outAnimation = AnimationUtils.loadAnimation(this,
+                outAnimation = loadAnimation(this,
                         R.anim.push_left_out);
                 // if animation is left or right then it was a swipe, and we want to re-save on
                 // entry
                 autoSaved = false;
                 break;
             case LEFT:
-                inAnimation = AnimationUtils.loadAnimation(this,
+                inAnimation = loadAnimation(this,
                         R.anim.push_right_in);
-                outAnimation = AnimationUtils.loadAnimation(this,
+                outAnimation = loadAnimation(this,
                         R.anim.push_right_out);
                 autoSaved = false;
                 break;
             case FADE:
-                inAnimation = AnimationUtils.loadAnimation(this, R.anim.fade_in);
-                outAnimation = AnimationUtils.loadAnimation(this, R.anim.fade_out);
+                inAnimation = loadAnimation(this, R.anim.fade_in);
+                outAnimation = loadAnimation(this, R.anim.fade_out);
                 break;
         }
 
@@ -1590,7 +1589,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         inAnimation.setAnimationListener(this);
         outAnimation.setAnimationListener(this);
 
-        if (shouldOverrideAnimations) {
+        if (!areAnimationsEnabled(this)) {
             inAnimation.setDuration(0);
             outAnimation.setDuration(0);
         }
@@ -2792,10 +2791,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             return (ODKView) currentView;
         }
         return null;
-    }
-
-    public void setShouldOverrideAnimations(boolean shouldOverrideAnimations) {
-        this.shouldOverrideAnimations = shouldOverrideAnimations;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AnimationUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AnimationUtils.java
@@ -1,6 +1,9 @@
 package org.odk.collect.android.utilities;
 
 import androidx.core.view.animation.PathInterpolatorCompat;
+
+import android.content.Context;
+import android.provider.Settings;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
@@ -13,11 +16,11 @@ import org.odk.collect.android.listeners.Result;
 /**
  * Created by Ing. Oscar G. Medina Cruz on 18/06/2016.
  */
-public class AnimateUtils {
+public class AnimationUtils {
 
     private static final Interpolator EASE_IN_OUT_QUART = PathInterpolatorCompat.create(0.77f, 0f, 0.175f, 1f);
 
-    private AnimateUtils() {
+    private AnimationUtils() {
 
     }
 
@@ -151,5 +154,16 @@ public class AnimateUtils {
     private static int computeDurationFromHeight(View view) {
         // 1dp/ms * multiplier
         return (int) (view.getMeasuredHeight() / view.getContext().getResources().getDisplayMetrics().density);
+    }
+
+    public static boolean areAnimationsEnabled(Context context) {
+        float duration = Settings.System.getFloat(
+                context.getContentResolver(),
+                Settings.System.ANIMATOR_DURATION_SCALE, 1);
+        float transition = Settings.System.getFloat(
+                context.getContentResolver(),
+                Settings.System.TRANSITION_ANIMATION_SCALE, 1);
+
+        return duration != 0 && transition != 0;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -53,7 +53,7 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GuidanceHint;
-import org.odk.collect.android.utilities.AnimateUtils;
+import org.odk.collect.android.utilities.AnimationUtils;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
@@ -188,17 +188,17 @@ public abstract class QuestionWidget
              */
             icon.setOnClickListener(v -> {
                 if (!expanded.get()) {
-                    AnimateUtils.expand(guidanceTextLayout, result -> expanded.set(true));
+                    AnimationUtils.expand(guidanceTextLayout, result -> expanded.set(true));
                 } else {
-                    AnimateUtils.collapse(guidanceTextLayout, result -> expanded.set(false));
+                    AnimationUtils.collapse(guidanceTextLayout, result -> expanded.set(false));
                 }
             });
 
             getHelpTextView().setOnClickListener(v -> {
                 if (!expanded.get()) {
-                    AnimateUtils.expand(guidanceTextLayout, result -> expanded.set(true));
+                    AnimationUtils.expand(guidanceTextLayout, result -> expanded.set(true));
                 } else {
-                    AnimateUtils.collapse(guidanceTextLayout, result -> expanded.set(false));
+                    AnimationUtils.collapse(guidanceTextLayout, result -> expanded.set(false));
                 }
             });
         }


### PR DESCRIPTION
This makes sure that the custom swipe animation we use in `FormEntryActivity` is disabled when the emulator/device has animations off. This should give some speed up for UI tests that deal with form entry.

#### What has been done to verify that this works as intended?

Ran tests locally and on test lab.

#### Why is this the best possible solution? Were any other approaches considered?

We could have used the custom disabling we already had but I think it's better to be able to use Android's own animation scale to determine when we have animations turned off or not. Means we have less code to maintain on our side!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only really changes to tests so should be good to merge aftert approval.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)