### PR TITLE
Fix how change tracking works with save button

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -97,6 +97,7 @@ import org.odk.collect.android.formentry.ODKView;
 import org.odk.collect.android.formentry.QuitFormDialog;
 import org.odk.collect.android.formentry.SaveFormProgressDialogFragment;
 import org.odk.collect.android.formentry.audit.AuditEvent;
+import org.odk.collect.android.formentry.audit.AuditUtils;
 import org.odk.collect.android.formentry.audit.ChangesReasonPromptDialogFragment;
 import org.odk.collect.android.formentry.audit.IdentifyUserPromptDialogFragment;
 import org.odk.collect.android.formentry.audit.IdentityPromptViewModel;
@@ -477,7 +478,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 if (getFormController(true) != null) {
                     FormController formController = getFormController();
                     identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
-                    formSaveViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                    formSaveViewModel.setFormController(formController);
                     refreshCurrentView();
                 } else {
                     Timber.w("Reloading form and restoring state.");
@@ -1199,13 +1200,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case FormEntryController.EVENT_REPEAT:
                 // should only be a group here if the event_group is a field-list
                 try {
-                    FormEntryPrompt[] prompts = formController.getQuestionPrompts();
-                    for (FormEntryPrompt question : prompts) {
-                        String answer = question.getAnswerValue() != null ? question.getAnswerValue().getDisplayText() : null;
-                        formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.QUESTION, question.getIndex(), true, answer, System.currentTimeMillis(), null);
-                    }
+                    AuditUtils.logCurrentEvent(formController, formController.getAuditEventLogger(), System.currentTimeMillis());
+
                     FormEntryCaption[] groups = formController
                             .getGroupsForCurrentIndex();
+                    FormEntryPrompt[] prompts = formController.getQuestionPrompts();
 
                     odkView = createODKView(advancingPage, prompts, groups);
                     odkView.setWidgetValueChangedListener(this);
@@ -1861,7 +1860,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             }
                         }
 
-                        finishReturnInstance();
+                        finishAndReturnInstance();
                     }
 
                     break;
@@ -1884,7 +1883,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
                     showLongToast(String.format(getString(R.string.encryption_error_message),
                             result.getMessage()));
-                    finishReturnInstance();
+                    finishAndReturnInstance();
                     break;
 
                 case CONSTRAINT_ERROR: {
@@ -1939,7 +1938,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
                 removeTempInstance();
                 MediaManager.INSTANCE.revertChanges();
-                finishReturnInstance();
+                finishAndReturnInstance();
 
                 alertDialog.dismiss();
             }
@@ -2394,7 +2393,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 if (formController.getInstanceFile() == null) {
                     createInstanceDirectory(formController);
                     identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
-                    formSaveViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                    formSaveViewModel.setFormController(formController);
 
                     identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                         if (!requiresIdentity) {
@@ -2411,7 +2410,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         String formMode = reqIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
                         if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
                             identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
-                            formSaveViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                            formSaveViewModel.setFormController(formController);
 
                             identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                                 if (!requiresIdentity) {
@@ -2444,7 +2443,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         }
                     } else {
                         identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
-                        formSaveViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                        formSaveViewModel.setFormController(formController);
 
                         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                             if (!requiresIdentity) {
@@ -2549,7 +2548,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * Returns the instance that was just filled out to the calling activity, if
      * requested.
      */
-    private void finishReturnInstance() {
+    private void finishAndReturnInstance() {
         String action = getIntent().getAction();
         if (Intent.ACTION_PICK.equals(action) || Intent.ACTION_EDIT.equals(action)) {
             // caller is waiting on a picked form

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1200,7 +1200,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case FormEntryController.EVENT_REPEAT:
                 // should only be a group here if the event_group is a field-list
                 try {
-                    AuditUtils.logCurrentEvent(formController, formController.getAuditEventLogger(), System.currentTimeMillis());
+                    AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), System.currentTimeMillis());
 
                     FormEntryCaption[] groups = formController
                             .getGroupsForCurrentIndex();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1035,7 +1035,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
 
                 if (formController != null) {
-                    formController.getAuditEventLogger().exitView();
+                    formController.getAuditEventLogger().flush();
                     formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.HIERARCHY, true, System.currentTimeMillis());
                 }
 
@@ -1467,7 +1467,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 return;
             }
 
-            formController.getAuditEventLogger().exitView();    // Close events waiting for an end time
+            formController.getAuditEventLogger().flush();    // Close events waiting for an end time
 
             switch (event) {
                 case FormEntryController.EVENT_QUESTION:
@@ -1532,7 +1532,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             // create savepoint
                             nonblockingCreateSavePointData();
                         }
-                        formController.getAuditEventLogger().exitView();    // Close events
+                        formController.getAuditEventLogger().flush();    // Close events
                         View next = createView(event, false);
                         showView(next, AnimationType.LEFT);
                     } else {
@@ -1826,7 +1826,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         }
 
-        getFormController().getAuditEventLogger().exitView();
         formSaveViewModel.saveForm(getIntent().getData(), complete, updatedSaveName, exit).observe(this, result -> {
             switch (result.getState()) {
                 case CHANGE_REASON_REQUIRED:

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -92,7 +92,7 @@ import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.external.ExternalDataManager;
 import org.odk.collect.android.formentry.FormLoadingDialogFragment;
-import org.odk.collect.android.formentry.FormSaveViewModel;
+import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.formentry.ODKView;
 import org.odk.collect.android.formentry.QuitFormDialog;
 import org.odk.collect.android.formentry.SaveFormProgressDialogFragment;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -17,16 +17,17 @@ package org.odk.collect.android.activities;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
-import android.view.View;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.widget.Button;
-import android.widget.TextView;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
@@ -296,7 +297,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
      */
     void configureButtons(FormController formController) {
         jumpBeginningButton.setOnClickListener(v -> {
-            formController.getAuditEventLogger().exitView();
+            formController.getAuditEventLogger().flush();
             formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
 
             setResult(RESULT_OK);
@@ -304,7 +305,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         });
 
         jumpEndButton.setOnClickListener(v -> {
-            formController.getAuditEventLogger().exitView();
+            formController.getAuditEventLogger().flush();
             formController.jumpToIndex(FormIndex.createEndOfFormIndex());
 
             setResult(RESULT_OK);
@@ -782,7 +783,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     public void onBackPressed() {
         FormController formController = Collect.getInstance().getFormController();
         if (formController != null) {
-            formController.getAuditEventLogger().exitView();
+            formController.getAuditEventLogger().flush();
             formController.jumpToIndex(startIndex);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/DiskFormSaver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/DiskFormSaver.java
@@ -2,14 +2,15 @@ package org.odk.collect.android.formentry;
 
 import android.net.Uri;
 
+import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.tasks.SaveFormToDisk;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 
 public class DiskFormSaver implements FormSaver {
 
     @Override
-    public SaveToDiskResult save(Uri instanceContentURI, boolean shouldFinalize, String updatedSaveName, boolean exitAfter, ProgressListener progressListener) {
-        SaveFormToDisk saveFormToDisk = new SaveFormToDisk(instanceContentURI, exitAfter, shouldFinalize, updatedSaveName);
+    public SaveToDiskResult save(FormController formController, boolean shouldFinalize, String updatedSaveName, boolean exitAfter, ProgressListener progressListener, Uri instanceContentURI) {
+        SaveFormToDisk saveFormToDisk = new SaveFormToDisk(formController, exitAfter, shouldFinalize, updatedSaveName, instanceContentURI);
         return saveFormToDisk.saveForm(progressListener);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaveViewModel.java
@@ -56,6 +56,10 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             return new MutableLiveData<>(new SaveResult(SaveResult.State.ALREADY_SAVING, null));
         }
 
+        if (auditEventLogger != null) {
+            auditEventLogger.flush();
+        }
+
         SaveRequest saveRequest = new SaveRequest(instanceContentURI, viewExiting, updatedSaveName, shouldFinalize);
         this.saveResult = new MutableLiveData<>(null);
 
@@ -160,7 +164,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             case FormEntryController.ANSWER_CONSTRAINT_VIOLATED:
             case FormEntryController.ANSWER_REQUIRED_BUT_EMPTY: {
                 if (auditEventLogger != null) {
-                    auditEventLogger.exitView();
+                    auditEventLogger.flush();
                     auditEventLogger.logEvent(AuditEvent.AuditEventType.CONSTRAINT_ERROR, true, clock.getCurrentTime());
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaveViewModel.java
@@ -172,7 +172,6 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             case FormEntryController.ANSWER_CONSTRAINT_VIOLATED:
             case FormEntryController.ANSWER_REQUIRED_BUT_EMPTY: {
                 if (auditEventLogger != null) {
-                    auditEventLogger.flush();
                     auditEventLogger.logEvent(AuditEvent.AuditEventType.CONSTRAINT_ERROR, true, clock.getCurrentTime());
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormSaver.java
@@ -2,10 +2,11 @@ package org.odk.collect.android.formentry;
 
 import android.net.Uri;
 
+import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 
 public interface FormSaver {
-    SaveToDiskResult save(Uri instanceContentURI, boolean shouldFinalize, String updatedSaveName, boolean exitAfter, ProgressListener progressListener);
+    SaveToDiskResult save(FormController formController, boolean shouldFinalize, String updatedSaveName, boolean exitAfter, ProgressListener progressListener, Uri instanceContentURI);
 
     interface ProgressListener {
         void onProgressUpdate(String message);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 
 public class SaveFormProgressDialogFragment extends ProgressDialogFragment {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -97,6 +97,16 @@ public class AuditEventLogger {
         }
     }
 
+    /*
+     * Finalizes and writes events
+     */
+    public void flush() {
+        if (isAuditEnabled()) {
+            finalizeEvents();
+            writeEvents();
+        }
+    }
+
     private void addLocationCoordinatesToAuditEvent(AuditEvent auditEvent, long currentTime) {
         Location location = getMostAccurateLocation(currentTime);
         String latitude = location != null ? Double.toString(location.getLatitude()) : "";
@@ -137,16 +147,6 @@ public class AuditEventLogger {
             }
         }
         return false;
-    }
-
-    /*
-     * Exit a question
-     */
-    public void exitView() {
-        if (isAuditEnabled()) {
-            finalizeEvents();
-            writeEvents();
-        }
     }
 
     // Filter all events and set final parameters of interval events

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.java
@@ -13,7 +13,7 @@ public class AuditUtils {
 
     }
 
-    public static void logCurrentEvent(FormController formController, AuditEventLogger auditEventLogger, long currentTime) {
+    public static void logCurrentScreen(FormController formController, AuditEventLogger auditEventLogger, long currentTime) {
         if (formController.getEvent() == EVENT_QUESTION
                 || formController.getEvent() == EVENT_GROUP
                 || formController.getEvent() == EVENT_REPEAT) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.java
@@ -1,0 +1,27 @@
+package org.odk.collect.android.formentry.audit;
+
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.logic.FormController;
+
+import static org.javarosa.form.api.FormEntryController.EVENT_GROUP;
+import static org.javarosa.form.api.FormEntryController.EVENT_QUESTION;
+import static org.javarosa.form.api.FormEntryController.EVENT_REPEAT;
+
+public class AuditUtils {
+
+    private AuditUtils() {
+
+    }
+
+    public static void logCurrentEvent(FormController formController, AuditEventLogger auditEventLogger, long currentTime) {
+        if (formController.getEvent() == EVENT_QUESTION
+                || formController.getEvent() == EVENT_GROUP
+                || formController.getEvent() == EVENT_REPEAT) {
+            FormEntryPrompt[] prompts = formController.getQuestionPrompts();
+            for (FormEntryPrompt question : prompts) {
+                String answer = question.getAnswerValue() != null ? question.getAnswerValue().getDisplayText() : null;
+                auditEventLogger.logEvent(AuditEvent.AuditEventType.QUESTION, question.getIndex(), true, answer, currentTime, null);
+            }
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.formentry.FormSaveViewModel;
+import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 
 public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogFragment {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/DiskFormSaver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/DiskFormSaver.java
@@ -9,7 +9,7 @@ import org.odk.collect.android.tasks.SaveToDiskResult;
 public class DiskFormSaver implements FormSaver {
 
     @Override
-    public SaveToDiskResult save(FormController formController, boolean shouldFinalize, String updatedSaveName, boolean exitAfter, ProgressListener progressListener, Uri instanceContentURI) {
+    public SaveToDiskResult save(Uri instanceContentURI, FormController formController, boolean shouldFinalize, boolean exitAfter, String updatedSaveName, ProgressListener progressListener) {
         SaveFormToDisk saveFormToDisk = new SaveFormToDisk(formController, exitAfter, shouldFinalize, updatedSaveName, instanceContentURI);
         return saveFormToDisk.saveForm(progressListener);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/DiskFormSaver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/DiskFormSaver.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.formentry;
+package org.odk.collect.android.formentry.saving;
 
 import android.net.Uri;
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.formentry;
+package org.odk.collect.android.formentry.saving;
 
 import android.net.Uri;
 import android.os.AsyncTask;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -143,7 +143,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
                             auditEventLogger.logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, clock.getCurrentTime());
                         }
                     } else {
-                        AuditUtils.logCurrentEvent(formController, auditEventLogger, clock.getCurrentTime());
+                        AuditUtils.logCurrentScreen(formController, auditEventLogger, clock.getCurrentTime());
                     }
                 }
 
@@ -259,12 +259,11 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
 
         @Override
         protected SaveToDiskResult doInBackground(Void... voids) {
-            return formSaver.save(formController,
+            return formSaver.save(saveRequest.uri, formController,
                     saveRequest.shouldFinalize,
-                    saveRequest.updatedSaveName,
-                    saveRequest.viewExiting,
-                    this::publishProgress,
-                    saveRequest.uri);
+                    saveRequest.viewExiting, saveRequest.updatedSaveName,
+                    this::publishProgress
+            );
         }
 
         @Override

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaver.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.formentry;
+package org.odk.collect.android.formentry.saving;
 
 import android.net.Uri;
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaver.java
@@ -6,7 +6,7 @@ import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 
 public interface FormSaver {
-    SaveToDiskResult save(FormController formController, boolean shouldFinalize, String updatedSaveName, boolean exitAfter, ProgressListener progressListener, Uri instanceContentURI);
+    SaveToDiskResult save(Uri instanceContentURI, FormController formController, boolean shouldFinalize, boolean exitAfter, String updatedSaveName, ProgressListener progressListener);
 
     interface ProgressListener {
         void onProgressUpdate(String message);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -41,7 +41,7 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.exception.EncryptionException;
-import org.odk.collect.android.formentry.FormSaver;
+import org.odk.collect.android.formentry.saving.FormSaver;
 import org.odk.collect.android.instances.DatabaseInstancesRepository;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -75,6 +75,7 @@ public class SaveFormToDisk {
 
     private final boolean saveAndExit;
     private final boolean shouldFinalize;
+    private final FormController formController;
     private Uri uri;
     private String instanceName;
 
@@ -83,18 +84,18 @@ public class SaveFormToDisk {
     public static final int SAVED_AND_EXIT = 504;
     public static final int ENCRYPTION_ERROR = 505;
 
-    public SaveFormToDisk(Uri uri, boolean saveAndExit, boolean shouldFinalize, String updatedName) {
+    public SaveFormToDisk(FormController formController, boolean saveAndExit, boolean shouldFinalize, String updatedName, Uri uri) {
+        this.formController = formController;
         this.uri = uri;
         this.saveAndExit = saveAndExit;
         this.shouldFinalize = shouldFinalize;
-        instanceName = updatedName;
+        this.instanceName = updatedName;
     }
 
     @Nullable
     public SaveToDiskResult saveForm(FormSaver.ProgressListener progressListener) {
         SaveToDiskResult saveToDiskResult = new SaveToDiskResult();
 
-        FormController formController = Collect.getInstance().getFormController();
         progressListener.onProgressUpdate(Collect.getInstance().getString(R.string.survey_saving_validating_message));
 
         try {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
@@ -81,7 +81,7 @@ public class AuditEventLoggerTest {
         AuditEventLogger auditEventLogger = new AuditEventLogger(null, testWriter, formController);
 
         auditEventLogger.logEvent(END_OF_FORM, false, 0);
-        auditEventLogger.exitView(); // Triggers event writing
+        auditEventLogger.flush(); // Triggers event writing
         assertEquals(0, testWriter.auditEvents.size());
     }
 
@@ -125,7 +125,7 @@ public class AuditEventLoggerTest {
         auditEventLogger.addLocation(location5);
 
         auditEventLogger.logEvent(END_OF_FORM, false, 1548156712000L);
-        auditEventLogger.exitView();
+        auditEventLogger.flush();
 
         AuditEvent auditEvent = testWriter.auditEvents.get(0);
         assertEquals(String.valueOf(location4.getLatitude()), auditEvent.getLatitude());
@@ -152,7 +152,7 @@ public class AuditEventLoggerTest {
         auditEventLogger.addLocation(location2);
 
         auditEventLogger.logEvent(END_OF_FORM, false, 120 * 1000L);
-        auditEventLogger.exitView();
+        auditEventLogger.flush();
 
         AuditEvent auditEvent = testWriter.auditEvents.get(0);
         assertEquals(String.valueOf(location2.getLatitude()), auditEvent.getLatitude());
@@ -165,7 +165,7 @@ public class AuditEventLoggerTest {
         AuditEventLogger auditEventLogger = new AuditEventLogger(testAuditConfigWithNullValues, testWriter, formController);
 
         auditEventLogger.logEvent(END_OF_FORM, false, 0);
-        auditEventLogger.exitView(); // Triggers event writing
+        auditEventLogger.flush(); // Triggers event writing
 
         assertFalse(testWriter.auditEvents.get(0).isLocationAlreadySet());
     }
@@ -179,7 +179,7 @@ public class AuditEventLoggerTest {
         assertTrue(auditEventLogger.isDuplicateOfLastLocationEvent(LOCATION_PROVIDERS_DISABLED));
         assertFalse(auditEventLogger.isDuplicateOfLastLocationEvent(LOCATION_PROVIDERS_ENABLED));
 
-        auditEventLogger.exitView(); // Triggers event writing
+        auditEventLogger.flush(); // Triggers event writing
         assertEquals(2, testWriter.auditEvents.size());
     }
 
@@ -189,7 +189,7 @@ public class AuditEventLoggerTest {
         auditEventLogger.setUser("Riker");
 
         auditEventLogger.logEvent(END_OF_FORM, false, 0);
-        auditEventLogger.exitView(); // Triggers event writing
+        auditEventLogger.flush(); // Triggers event writing
 
         assertEquals("Riker", testWriter.auditEvents.get(0).getUser());
     }
@@ -199,7 +199,7 @@ public class AuditEventLoggerTest {
         AuditEventLogger auditEventLogger = new AuditEventLogger(new AuditConfig.Builder().setMode(null).setLocationMinInterval(null).setLocationMaxAge(null).setIsTrackingChangesEnabled(false).setIsIdentifyUserEnabled(false).setIsTrackChangesReasonEnabled(true).createAuditConfig(), testWriter, formController);
 
         auditEventLogger.logEvent(CHANGE_REASON, null, false, null, 123L, "Blah");
-        auditEventLogger.exitView(); // Triggers event writing
+        auditEventLogger.flush(); // Triggers event writing
 
         assertEquals("Blah", testWriter.auditEvents.get(0).getChangeReason());
     }
@@ -232,7 +232,7 @@ public class AuditEventLoggerTest {
         auditEventLogger.logEvent(LOCATION_PROVIDERS_DISABLED, false, 0);
         auditEventLogger.logEvent(UNKNOWN_EVENT_TYPE, false, 0);
 
-        auditEventLogger.exitView(); // Triggers event writing
+        auditEventLogger.flush(); // Triggers event writing
         assertEquals(21, testWriter.auditEvents.size());
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -56,29 +56,6 @@ public class FormSaveViewModelTest {
     }
 
     @Test
-    public void saveReason_logsChangeReasonAuditEvent() {
-        viewModel.setReason("Blah");
-        viewModel.saveReason();
-
-        verify(logger).logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, CURRENT_TIME, "Blah");
-    }
-
-    @Test
-    public void saveReason_whenReasonIsValid_returnsTrue() {
-        viewModel.setReason("Blah");
-        assertThat(viewModel.saveReason(), equalTo(true));
-    }
-
-    @Test
-    public void saveReason_whenReasonIsNotValid_returnsFalse() {
-        viewModel.setReason("");
-        assertThat(viewModel.saveReason(), equalTo(false));
-
-        viewModel.setReason("  ");
-        assertThat(viewModel.saveReason(), equalTo(false));
-    }
-
-    @Test
     public void saveForm_returnsNewSaveResult_inSavingState() {
         LiveData<FormSaveViewModel.SaveResult> saveResult1 = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         assertThat(saveResult1.getValue().getState(), equalTo(SAVING));
@@ -107,6 +84,12 @@ public class FormSaveViewModelTest {
 
         LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         assertThat(saveResult.getValue().getState(), equalTo(CHANGE_REASON_REQUIRED));
+    }
+
+    @Test
+    public void saveForm_flushesAuditEventLogger() {
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        verify(logger).flush();
     }
 
     @Test
@@ -199,7 +182,7 @@ public class FormSaveViewModelTest {
         whenFormSaverFinishes(FormEntryController.ANSWER_CONSTRAINT_VIOLATED);
 
         InOrder verifier = inOrder(logger);
-        verifier.verify(logger).exitView();
+        verifier.verify(logger).flush();
         verifier.verify(logger).logEvent(AuditEvent.AuditEventType.CONSTRAINT_ERROR, true, CURRENT_TIME);
     }
 
@@ -230,6 +213,29 @@ public class FormSaveViewModelTest {
         viewModel.setReason("blah");
         viewModel.saveReason();
         assertThat(saveResult.getValue().getState(), equalTo(SAVING));
+    }
+
+    @Test
+    public void saveReason_logsChangeReasonAuditEvent() {
+        viewModel.setReason("Blah");
+        viewModel.saveReason();
+
+        verify(logger).logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, CURRENT_TIME, "Blah");
+    }
+
+    @Test
+    public void saveReason_whenReasonIsValid_returnsTrue() {
+        viewModel.setReason("Blah");
+        assertThat(viewModel.saveReason(), equalTo(true));
+    }
+
+    @Test
+    public void saveReason_whenReasonIsNotValid_returnsFalse() {
+        viewModel.setReason("");
+        assertThat(viewModel.saveReason(), equalTo(false));
+
+        viewModel.setReason("  ");
+        assertThat(viewModel.saveReason(), equalTo(false));
     }
 
     private void whenReasonRequiredToSave() {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -98,12 +98,6 @@ public class FormSaveViewModelTest {
     }
 
     @Test
-    public void saveForm_flushesAuditEventLogger() {
-        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        verify(logger).flush();
-    }
-
-    @Test
     public void whenFormSaverFinishes_saved_setsSaveResultState_toSaved() {
         LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
 
@@ -199,20 +193,36 @@ public class FormSaveViewModelTest {
     }
 
     @Test
-    public void whenFormSaverFinishes_whenViewExiting_logsFormExitAuditEvent() {
+    public void whenFormSaverFinishes_whenViewExiting_logsFormSaveAndFormExitAuditEventAfterFlush() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", true);
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
-        verify(logger).logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, CURRENT_TIME);
+
+        InOrder verifier = inOrder(logger);
+        verifier.verify(logger).flush();
+        verifier.verify(logger).logEvent(
+                AuditEvent.AuditEventType.FORM_SAVE,
+                false,
+                CURRENT_TIME
+        );
+        verifier.verify(logger).logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, CURRENT_TIME);
     }
 
     @Test
-    public void whenFormSaverFinishes_whenFormComplete_andViewExiting_logsFormExitAndFinalizeAuditEvents() {
+    public void whenFormSaverFinishes_whenFormComplete_andViewExiting_logsFormExitAndFinalizeAuditEventsAfterFlush() {
         viewModel.saveForm(Uri.parse("file://form"), true, "", true);
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
-        verify(logger).logEvent(AuditEvent.AuditEventType.FORM_EXIT, false, CURRENT_TIME);
-        verify(logger).logEvent(AuditEvent.AuditEventType.FORM_FINALIZE, true, CURRENT_TIME);
+
+        InOrder verifier = inOrder(logger);
+        verifier.verify(logger).flush();
+        verifier.verify(logger).logEvent(
+                AuditEvent.AuditEventType.FORM_SAVE,
+                false,
+                CURRENT_TIME
+        );
+        verifier.verify(logger).logEvent(AuditEvent.AuditEventType.FORM_EXIT, false, CURRENT_TIME);
+        verifier.verify(logger).logEvent(AuditEvent.AuditEventType.FORM_FINALIZE, true, CURRENT_TIME);
     }
 
     @Test
@@ -233,11 +243,14 @@ public class FormSaveViewModelTest {
     }
 
     @Test
-    public void whenFormSaverFinishes_saveError_logsSaveErrorAuditEvent() {
+    public void whenFormSaverFinishes_saveError_logsSaveErrorAuditEvenAfterFlush() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
 
         whenFormSaverFinishes(SaveFormToDisk.SAVE_ERROR);
-        verify(logger).logEvent(AuditEvent.AuditEventType.SAVE_ERROR, true, CURRENT_TIME);
+
+        InOrder verifier = inOrder(logger);
+        verifier.verify(logger).flush();
+        verifier.verify(logger).logEvent(AuditEvent.AuditEventType.SAVE_ERROR, true, CURRENT_TIME);
     }
 
     @Test
@@ -250,11 +263,14 @@ public class FormSaveViewModelTest {
     }
 
     @Test
-    public void whenFormSaverFinishes_encryptionError_logsFinalizeErrorAuditEvent() {
+    public void whenFormSaverFinishes_encryptionError_logsFinalizeErrorAuditEventAfterFlush() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
 
         whenFormSaverFinishes(SaveFormToDisk.ENCRYPTION_ERROR);
-        verify(logger).logEvent(AuditEvent.AuditEventType.FINALIZE_ERROR, true, CURRENT_TIME);
+
+        InOrder verifier = inOrder(logger);
+        verifier.verify(logger).flush();
+        verifier.verify(logger).logEvent(AuditEvent.AuditEventType.FINALIZE_ERROR, true, CURRENT_TIME);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -10,8 +10,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
-import org.odk.collect.android.formentry.FormSaveViewModel;
-import org.odk.collect.android.formentry.FormSaver;
+import org.odk.collect.android.formentry.saving.FormSaveViewModel;
+import org.odk.collect.android.formentry.saving.FormSaver;
 import org.odk.collect.android.logic.FormController;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.tasks.SaveFormToDisk;
@@ -33,13 +33,13 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.ALREADY_SAVING;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.CHANGE_REASON_REQUIRED;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.CONSTRAINT_ERROR;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.FINALIZE_ERROR;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.SAVED;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.SAVE_ERROR;
-import static org.odk.collect.android.formentry.FormSaveViewModel.SaveResult.State.SAVING;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.ALREADY_SAVING;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.CHANGE_REASON_REQUIRED;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.CONSTRAINT_ERROR;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.FINALIZE_ERROR;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.SAVED;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.SAVE_ERROR;
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.SAVING;
 
 @RunWith(RobolectricTestRunner.class)
 public class FormSaveViewModelTest {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -359,7 +359,7 @@ public class FormSaveViewModelTest {
         saveToDiskResult.setSaveResult(result, true);
         saveToDiskResult.setSaveErrorMessage(message);
 
-        when(formSaver.save(any(), anyBoolean(), any(), anyBoolean(), any(), any())).thenReturn(saveToDiskResult);
+        when(formSaver.save(any(), any(), anyBoolean(), anyBoolean(), any(), any())).thenReturn(saveToDiskResult);
         Robolectric.getBackgroundThreadScheduler().runOneTask();
     }
 }


### PR DESCRIPTION
Closes #3498. We decided in the discussion in the issue that the solve would be for a second question event to appear after form-save with the old-value/new- value.

#### What has been done to verify that this works as intended?

Used a form with change tracking enabled to check the issue was solved. I also added tests to drive out the new (fixed) behaviour.

#### Why is this the best possible solution? Were any other approaches considered?

We discussed in #3498. In terms of the structure I think it makes sense to move audit logging into our `ViewModel`s as much as possible. This lets us abstract the details of all the interactions we need to make every time there is some 'action' performed in the UI. It does feel like we might end up with a lot of logic in the `ViewModel`s however so it probably would be good to start abstracting this to a more high level component responsible for handling logging logic (`EnumeratorBehaviourLogger` for example) before we go any further. I don't think we need an issue for this but it might be a good idea for the future.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It'd be good to try a few forms with change tracking and alos try repeats, groups and single questions as they all output "question" audit events. The new changes are tested so it feels less risky than a lot of changes to form entry.

#### Do we need any specific form for testing your changes? If so, please attach one

Any form with change tracking would be good to use but there aren't any other specific features we need to look at.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)