### PR TITLE
Add scoped storage strings for translation

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -278,6 +278,10 @@ public class Collect extends Application {
         setupRemoteAnalytics();
         setupLeakCanary();
         setupOSMDroid();
+
+        // Force inclusion of scoped storage strings so they can be translated
+        Timber.i("%s %s", getString(R.string.scoped_storage_banner_text),
+                                   getString(R.string.scoped_storage_learn_more));
     }
 
     private void setupRemoteAnalytics() {

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -722,4 +722,7 @@
     <string name="reason">Reason</string>
     <string name="save">Save</string>
     <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
+
+    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage by August 2020 to comply with Android requirements.</string>
+    <string name="scoped_storage_learn_more">Learn more and migrate</string>
 </resources>


### PR DESCRIPTION
This PR adds the banner text for letting users know about the scoped storage migration. This has been discussed at https://forum.opendatakit.org/t/let-users-know-of-required-storage-location-change-and-let-them-opt-in-before-august-2020/24444/. The context for it is that we are going to be letting translators know about the change to repeat strings and we'd like to alert them to these at the same time even though the feature is not complete. Both of these are important because it would be particularly confusing for enumerators to come across text in a language they don't understand (English).

One deviation from the discussion there is to make the button text "Learn more and migrate." This is because we have decided not to make the banner dismissible as a first pass. I think the longer text is helpful but let me know if it feels too long. I can also take it back to the forum thread if needed.
