### PR TITLE
Parallelizing Instrumentation Tests using flank

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,26 +159,37 @@ jobs:
     steps:
       - *attach_debug_workspace
       - run:
-          name: Authorize gcloud
+          name: Prepare wget
           command: |
-            if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-              gcloud config set project api-project-322300403941
-              echo $GCLOUD_SERVICE_KEY | base64 --decode > client-secret.json
-              gcloud auth activate-service-account --key-file client-secret.json
-            fi
+            apt-get update
+            apt install python2.7 python-pip -y
+            apt-get install wget
+      - run:
+          name: Authorize service account
+          command: |
+            mkdir -p $HOME/.config/gcloud/
+            echo $GCLOUD_KEY | base64 -di > $HOME/.config/gcloud/application_default_credentials.json
       - run:
           name: Run integration tests
           command: |
-            if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-              echo "y" | gcloud firebase test android run \
-              --type instrumentation \
-              --app collect_app/build/outputs/apk/debug/*.apk \
-              --test collect_app/build/outputs/apk/androidTest/debug/*.apk \
-              --device model=Pixel2,version=27,locale=en,orientation=portrait \
-              --results-bucket opendatakit-collect-test-results \
-              --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
-              --directories-to-pull /sdcard --timeout 30m
-            fi
+            wget --quiet https://github.com/TestArmada/flank/releases/download/v8.1.0/flank.jar -O ./flank.jar
+            cat <<- 'EOF' > ./flank.yml
+            gcloud:
+              timeout: 30m
+              num-flaky-test-attempts: 1
+              app: collect_app/build/outputs/apk/debug/*.apk
+              test: collect_app/build/outputs/apk/androidTest/debug/*.apk
+              device:
+                - model: Pixel2
+                  version: 27
+                  locale: en
+                  orientation: portrait
+            flank:
+              max-test-shards: 5
+              num-test-runs: 1
+              project: propane-analogy-263606
+            EOF
+            java -jar ./flank.jar android run
           no_output_timeout: 60m
       - run:
           name: Copy integration test results

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/matchers/ToastMatcher.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/matchers/ToastMatcher.java
@@ -1,0 +1,27 @@
+package org.odk.collect.android.support.matchers;
+
+import android.os.IBinder;
+import android.view.WindowManager;
+
+import androidx.test.espresso.Root;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class ToastMatcher extends TypeSafeMatcher<Root> {
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("is toast");
+    }
+
+    @Override
+    protected boolean matchesSafely(Root item) {
+        int type = item.getWindowLayoutParams().get().type;
+        if (type == WindowManager.LayoutParams.TYPE_TOAST) {
+            IBinder windowToken = item.getDecorView().getWindowToken();
+            IBinder appToken = item.getDecorView().getApplicationWindowToken();
+            return windowToken == appToken;
+        }
+        return false;
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -27,7 +27,6 @@ import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition;
-import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
@@ -36,7 +35,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibilit
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.core.StringContains.containsString;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -15,6 +15,7 @@ import androidx.test.runner.lifecycle.Stage;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.actions.RotateAction;
 import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
+import org.odk.collect.android.support.matchers.ToastMatcher;
 
 import timber.log.Timber;
 
@@ -124,7 +125,7 @@ abstract class Page<T extends Page<T>> {
 
     public T checkIsToastWithMessageDisplayed(String message) {
         onView(withText(message))
-                .inRoot(withDecorView(not(is(getCurrentActivity().getWindow().getDecorView()))))
+                .inRoot(new ToastMatcher())
                 .check(matches(isDisplayed()));
 
         return (T) this;


### PR DESCRIPTION
Closes #3578 

#### What has been done to verify that this works as intended?
Currently, i am using my service account for testing and i've verified that the changes work as intended by running the build on CircleCi.
Current setting creates 5 different matrices which run in parallel. One or two(max.) of the matrices fail sometimes due to a single test(but not the same set of tests everytime) being flaky. I've fixed this currently by using `num-flaky-test-attempts: 1` and it happens the test which fails in the first run, passes the next time.
Currently parametrized tests are not being run, because flank uses orchestrator by default, which is useful for parallel tests, but we can turn it off if we want to run parametrized tests too.

Results:
**5 shards:** approx 10 mins
**3 shards:** approx 17 mins

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)