### PR TITLE
Fix error when downloading forms with references to external secondary instances including last-saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Certain functions in ODK Collect depend on cloud services that require API keys 
   - Follow [these instructions to generate a signing certificate fingerprint and register the application with the Google API Console](https://developers.google.com/drive/android/auth#generate_the_signing_certificate_fingerprint_and_register_your_application).
   - [Enable the Google Drive API](https://console.developers.google.com/apis/api/drive.googleapis.com).
   - [Enable the Google Sheets API](https://console.developers.google.com/apis/api/sheets.googleapis.com).
+  - Copy the oauth clientID from [the developer console](https://console.developers.google.com/apis/credentials) into the `client_id` of `collect_app/google-services.json` file
 
 **Google Maps API**: When the "Google Maps SDK" option is selected in the "User interface" settings, ODK Collect uses the Google Maps API for displaying maps in the geospatial widgets (GeoPoint, GeoTrace, and GeoShape).  To enable this API:
   - [Get a Google Maps API key](https://developers.google.com/maps/documentation/android-api/signup).  Note that this requires a credit card number, though the card will not be charged immediately; some free API usage is permitted.  You should carefully read the terms before providing a credit card number.

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -163,7 +163,7 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
         String errorMsg = null;
         if (imageURI != null) {
             try {
-                final File imageFile = new File(ReferenceManager.instance().DeriveReference(imageURI).getLocalURI());
+                final File imageFile = new File(ReferenceManager.instance().deriveReference(imageURI).getLocalURI());
                 if (imageFile.exists()) {
                     Bitmap bitmap = FileUtils.getBitmap(imageFile.getPath(), new BitmapFactory.Options());
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -227,7 +227,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
     private void openImage() {
         try {
-            File bigImage = new File(referenceManager.DeriveReference(bigImageURI).getLocalURI());
+            File bigImage = new File(referenceManager.deriveReference(bigImageURI).getLocalURI());
             Intent intent = new Intent("android.intent.action.VIEW");
             Uri uri =
                     FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", bigImage);

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormUtils.java
@@ -16,14 +16,20 @@ public class FormUtils {
         
     }
 
+    /**
+     * Configures the given reference manager to resolve jr:// URIs to a folder in the root ODK forms
+     * directory with name matching the name of the directory represented by {@code formMediaDir}.
+     *
+     * E.g. if /foo/bar/baz is passed in as {@code formMediaDir}, jr:// URIs will be resolved to
+     * /odk/root/forms/baz.
+     */
     public static void setupReferenceManagerForForm(ReferenceManager referenceManager, File formMediaDir) {
-
-        // Remove previous forms
+        // Clear mappings to the media dir for the previous form that was configured
         referenceManager.clearSession();
 
         // This should get moved to the Application Class
         if (referenceManager.getFactories().length == 0) {
-            // this is /sdcard/odk
+            // Always build URIs against the ODK root, regardless of the absolute path of formMediaDir
             referenceManager.addReferenceFactory(new FileReferenceFactory(new StoragePathProvider().getDirPath(StorageSubdirectory.ODK)));
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DiskSyncTask.java
@@ -276,6 +276,7 @@ public class DiskSyncTask extends AsyncTask<Void, String, String> {
             final File formMediaDir = FileUtils.getFormMediaDir(formDefFile);
             setupReferenceManagerForForm(ReferenceManager.instance(), formMediaDir);
 
+            FileUtils.getOrCreateLastSavedSrc(formDefFile);
             fields = FileUtils.getMetadataFromFormDefinition(formDefFile);
         } catch (RuntimeException e) {
             throw new IllegalArgumentException(formDefFile.getName() + " :: " + e.toString());

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -89,7 +89,7 @@ public class FileUtils {
     public static final String LAST_SAVED_FILENAME = "last-saved.xml";
 
     /** Valid XML stub that can be parsed without error. */
-    private static final String STUB_XML = "<?xml version='1.0' ?><stub />";
+    public static final String STUB_XML = "<?xml version='1.0' ?><stub />";
 
     /** True if we have checked whether /sdcard points to getExternalStorageDirectory(). */
     private static boolean isSdcardSymlinkChecked;
@@ -275,8 +275,7 @@ public class FileUtils {
      * public key, auto-delete and auto-send may be included.
      */
     public static HashMap<String, String> getMetadataFromFormDefinition(File formDefinitionXml) {
-        String lastSavedSrc = FileUtils.getOrCreateLastSavedSrc(formDefinitionXml);
-        FormDef formDef = XFormUtils.getFormFromFormXml(formDefinitionXml.getAbsolutePath(), lastSavedSrc);
+        FormDef formDef = XFormUtils.getFormFromFormXml(formDefinitionXml.getAbsolutePath(), "jr://file/" + LAST_SAVED_FILENAME);
 
         final HashMap<String, String> fields = new HashMap<>();
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -21,6 +21,7 @@ import android.database.Cursor;
 import android.net.Uri;
 
 import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.reference.RootTranslator;
 import org.javarosa.xform.parse.XFormParser;
 import org.kxml2.kdom.Element;
 import org.odk.collect.android.R;
@@ -184,6 +185,7 @@ public class FormDownloader {
                 write(tmpLastSaved, STUB_XML.getBytes(Charset.forName("UTF-8")));
                 ReferenceManager.instance().reset();
                 ReferenceManager.instance().addReferenceFactory(new FileReferenceFactory(tempMediaPath));
+                ReferenceManager.instance().addSessionRootTranslator(new RootTranslator("jr://file-csv/", "jr://file/"));
 
                 parsedFields = FileUtils.getMetadataFromFormDefinition(fileResult.file);
                 ReferenceManager.instance().reset();

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -26,10 +26,11 @@ import org.kxml2.kdom.Element;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
-import org.odk.collect.android.openrosa.OpenRosaAPIClient;
 import org.odk.collect.android.listeners.FormDownloaderListener;
+import org.odk.collect.android.logic.FileReferenceFactory;
 import org.odk.collect.android.logic.FormDetails;
 import org.odk.collect.android.logic.MediaFile;
+import org.odk.collect.android.openrosa.OpenRosaAPIClient;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,7 +51,9 @@ import javax.inject.Inject;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.forms.FormUtils.setupReferenceManagerForForm;
+import static org.odk.collect.android.utilities.FileUtils.LAST_SAVED_FILENAME;
+import static org.odk.collect.android.utilities.FileUtils.STUB_XML;
+import static org.odk.collect.android.utilities.FileUtils.write;
 
 public class FormDownloader {
 
@@ -132,7 +136,9 @@ public class FormDownloader {
             throw new TaskCancelledException();
         }
 
-        String tempMediaPath = null;
+        // use a temporary media path until everything is ok.
+        String tempMediaPath = new File(new StoragePathProvider().getDirPath(StorageSubdirectory.CACHE),
+                String.valueOf(System.currentTimeMillis())).getAbsolutePath();
         final String finalMediaPath;
         FileResult fileResult = null;
         try {
@@ -141,9 +147,6 @@ public class FormDownloader {
             fileResult = downloadXform(fd.getFormName(), fd.getDownloadUrl());
 
             if (fd.getManifestUrl() != null) {
-                // use a temporary media path until everything is ok.
-                tempMediaPath = new File(new StoragePathProvider().getDirPath(StorageSubdirectory.CACHE),
-                        String.valueOf(System.currentTimeMillis())).getAbsolutePath();
                 finalMediaPath = FileUtils.constructMediaPath(
                         fileResult.getFile().getAbsolutePath());
                 String error = downloadManifestAndMediaFiles(tempMediaPath, finalMediaPath, fd,
@@ -174,13 +177,16 @@ public class FormDownloader {
             try {
                 final long start = System.currentTimeMillis();
                 Timber.w("Parsing document %s", fileResult.file.getAbsolutePath());
-                // If the form definition includes attachments, set up the reference manager in case
-                // one of them defines a secondary instance (required to build a FormDef)
-                if (tempMediaPath != null) {
-                    setupReferenceManagerForForm(ReferenceManager.instance(), new File(tempMediaPath));
-                }
+
+                File tmpLastSaved = new File(tempMediaPath, LAST_SAVED_FILENAME);
+                write(tmpLastSaved, STUB_XML.getBytes(Charset.forName("UTF-8")));
+                ReferenceManager.instance().reset();
+                ReferenceManager.instance().addReferenceFactory(new FileReferenceFactory(tempMediaPath));
 
                 parsedFields = FileUtils.getMetadataFromFormDefinition(fileResult.file);
+                ReferenceManager.instance().reset();
+                FileUtils.deleteAndReport(tmpLastSaved);
+
                 Timber.i("Parse finished in %.3f seconds.",
                         (System.currentTimeMillis() - start) / 1000F);
             } catch (RuntimeException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -178,6 +178,8 @@ public class FormDownloader {
                 final long start = System.currentTimeMillis();
                 Timber.w("Parsing document %s", fileResult.file.getAbsolutePath());
 
+                // Add a stub last-saved instance to the tmp media directory so it will be resolved
+                // when parsing a form definition with last-saved reference
                 File tmpLastSaved = new File(tempMediaPath, LAST_SAVED_FILENAME);
                 write(tmpLastSaved, STUB_XML.getBytes(Charset.forName("UTF-8")));
                 ReferenceManager.instance().reset();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseGridWidget.java
@@ -120,7 +120,7 @@ public abstract class BaseGridWidget extends ItemsWidget implements MultiChoiceW
         String errorMsg = null;
         if (imageURI != null) {
             try {
-                final File imageFile = new File(ReferenceManager.instance().DeriveReference(imageURI).getLocalURI());
+                final File imageFile = new File(ReferenceManager.instance().deriveReference(imageURI).getLocalURI());
                 if (imageFile.exists()) {
                     Bitmap b = FileUtils.getBitmapScaledToDisplay(imageFile, ScreenUtils.getScreenHeight(), ScreenUtils.getScreenWidth());
                     if (b != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/LabelWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/LabelWidget.java
@@ -83,7 +83,7 @@ public class LabelWidget extends ItemsWidget {
                 if (imageURI != null) {
                     try {
                         String imageFilename =
-                                ReferenceManager.instance().DeriveReference(imageURI).getLocalURI();
+                                ReferenceManager.instance().deriveReference(imageURI).getLocalURI();
                         final File imageFile = new File(imageFilename);
                         if (imageFile.exists()) {
                             Bitmap b = null;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/LikertWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/LikertWidget.java
@@ -1,8 +1,5 @@
 package org.odk.collect.android.widgets;
 
-import java.io.File;
-import java.util.HashMap;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -11,9 +8,9 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
-import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -31,6 +28,9 @@ import org.odk.collect.android.external.ExternalSelectChoice;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.ViewIds;
+
+import java.io.File;
+import java.util.HashMap;
 
 import timber.log.Timber;
 
@@ -288,7 +288,7 @@ public class LikertWidget extends ItemsWidget {
         String errorMsg = null;
         try {
             String imageFilename =
-                    ReferenceManager.instance().DeriveReference(imageURI).getLocalURI();
+                    ReferenceManager.instance().deriveReference(imageURI).getLocalURI();
             final File imageFile = new File(imageFilename);
             if (imageFile.exists()) {
                 Bitmap b = null;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ListMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ListMultiWidget.java
@@ -134,7 +134,7 @@ public class ListMultiWidget extends ItemsWidget implements MultiChoiceWidget {
                 if (imageURI != null) {
                     try {
                         String imageFilename =
-                                ReferenceManager.instance().DeriveReference(imageURI).getLocalURI();
+                                ReferenceManager.instance().deriveReference(imageURI).getLocalURI();
                         final File imageFile = new File(imageFilename);
                         if (imageFile.exists()) {
                             Bitmap b = null;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ListWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ListWidget.java
@@ -124,7 +124,7 @@ public class ListWidget extends ItemsWidget implements MultiChoiceWidget, OnChec
                 if (imageURI != null) {
                     try {
                         String imageFilename =
-                                ReferenceManager.instance().DeriveReference(imageURI).getLocalURI();
+                                ReferenceManager.instance().deriveReference(imageURI).getLocalURI();
                         final File imageFile = new File(imageFilename);
                         if (imageFile.exists()) {
                             Bitmap b = null;

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FormDownloaderTest.java
@@ -1,13 +1,28 @@
 package org.odk.collect.android.utilities;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kxml2.io.KXmlParser;
+import org.kxml2.kdom.Document;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.logic.FormDetails;
+import org.odk.collect.android.openrosa.OpenRosaAPIClient;
+import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
+import org.xmlpull.v1.XmlPullParser;
 
 import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -18,9 +33,25 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class FormDownloaderTest {
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    OpenRosaAPIClient openRosaAPIClient;
+
+    @Before
+    public void overrideDependencyModule() {
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+               @Override
+               public OpenRosaAPIClient provideCollectServerClient(OpenRosaHttpInterface httpInterface, WebCredentialsUtils webCredentialsUtils) {
+                   return openRosaAPIClient;
+               }
+        });}
+
     /**
      * Verifies that a form without media can successfully go through the download process. Regression
      * test for https://github.com/opendatakit/collect/issues/3535.
@@ -49,26 +80,26 @@ public class FormDownloaderTest {
                 "        </input>\n" +
                 "    </h:body>\n" +
                 "</h:html>";
-        File temp = File.createTempFile("basicNoMedia", ".xml");
-        temp.deleteOnExit();
+        File formXml = File.createTempFile("basicNoMedia", ".xml");
+        formXml.deleteOnExit();
 
-        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        BufferedWriter out = new BufferedWriter(new FileWriter(formXml));
         out.write(basicNoMedia);
         out.close();
 
         FormDownloader downloader = spy(new FormDownloader());
-        FormDetails test1 = new FormDetails("No media", "https://testserver/no-media.xml",
-                null, "test1", "2019121201",
+        FormDetails formDetails = new FormDetails("No media", "https://testserver/no-media.xml",
+                null, "basic", "2019121201",
                 "hash", null, false, false);
-        FormDownloader.FileResult result = new FormDownloader.FileResult(temp, true);
-        doReturn(result).when(downloader).downloadXform(test1.getFormName(), test1.getDownloadUrl());
+        FormDownloader.FileResult result = new FormDownloader.FileResult(formXml, true);
+        doReturn(result).when(downloader).downloadXform(formDetails.getFormName(), formDetails.getDownloadUrl());
         doReturn(true).when(downloader).installEverything(any(), any(), any());
 
         List<FormDetails> forms = new ArrayList<>();
-        forms.add(test1);
+        forms.add(formDetails);
 
         HashMap<FormDetails, String> messages = downloader.downloadForms(forms);
-        assertThat(messages.get(test1), is("Success"));
+        assertThat(messages.get(formDetails), is("Success"));
     }
 
     /**
@@ -107,18 +138,124 @@ public class FormDownloaderTest {
                 "        </input>\n" +
                 "    </h:body>\n" +
                 "</h:html>";
-        File temp = File.createTempFile("basicMedia", ".xml");
-        temp.deleteOnExit();
+        File formXml = File.createTempFile("basicMedia", ".xml");
+        formXml.deleteOnExit();
 
-        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        BufferedWriter out = new BufferedWriter(new FileWriter(formXml));
         out.write(basicMedia);
         out.close();
 
         FormDownloader downloader = spy(new FormDownloader());
-        FormDetails test1 = new FormDetails("Media", "https://testserver/media.xml",
+        FormDetails formDetails = new FormDetails("Media", "https://testserver/media.xml",
                 "https://testserver/media-manifest.xml", "media", "2019121201",
                 "hash", "manifestHash", false, false);
-        FormDownloader.FileResult result = new FormDownloader.FileResult(temp, true);
+        FormDownloader.FileResult result = new FormDownloader.FileResult(formXml, true);
+        doReturn(result).when(downloader).downloadXform(formDetails.getFormName(), formDetails.getDownloadUrl());
+        doReturn("").when(downloader).downloadManifestAndMediaFiles(any(), any(), any(), anyInt(), anyInt());
+        doReturn(true).when(downloader).installEverything(any(), any(), any());
+
+        List<FormDetails> forms = new ArrayList<>();
+        forms.add(formDetails);
+
+        HashMap<FormDetails, String> messages = downloader.downloadForms(forms);
+        assertThat(messages.get(formDetails), is("Success"));
+    }
+
+    /**
+     * Forms with references to external secondary instance need to have the secondary instance
+     * available at time of form parse.
+     *
+     * See https://github.com/opendatakit/collect/issues/3635
+     */
+    @Test
+    public void downloadingFormWithExternalSecondaryInstance_Succeeds() throws Exception {
+        String basicLastSaved = "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\" >\n" +
+                "    <h:head>\n" +
+                "        <h:title>basic-external-xml-instance</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"basic-external-xml-instance\">\n" +
+                "                    <first/>\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "            <instance id=\"external-xml\" src=\"jr://file/external-data.xml\" />\n" +
+                "            <bind nodeset=\"/data/first\" type=\"select1\"/>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "        <select1 ref=\"/data/first\">\n" +
+                "            <label>First</label>\n" +
+                "            <itemset nodeset=\"instance('external-xml')/root/item[first='']\">\n" +
+                "                <value ref=\"name\"/>\n" +
+                "                <label ref=\"label\"/>\n" +
+                "            </itemset>\n" +
+                "        </select1>\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+        File formXml = File.createTempFile("basicExternalXmlInstance", ".xml");
+        formXml.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(formXml));
+        out.write(basicLastSaved);
+        out.close();
+
+        when(openRosaAPIClient.getXML("https://testserver/manifest.xml")).thenReturn(buildManifestFetchResult());
+        when(openRosaAPIClient.getFile("https://testserver/external-data.xml",
+                null)).thenReturn(buildExternalInstanceFetchResult());
+
+        FormDownloader downloader = spy(new FormDownloader());
+        FormDetails test1 = new FormDetails("basic-external-xml-instance", "https://testserver/form.xml",
+                "https://testserver/manifest.xml", "basic-external-xml-instance", "20200101",
+                "hash", "manifestHash", false, false);
+        FormDownloader.FileResult result = new FormDownloader.FileResult(formXml, true);
+        doReturn(result).when(downloader).downloadXform(test1.getFormName(), test1.getDownloadUrl());
+        doReturn(true).when(downloader).installEverything(any(), any(), any());
+
+        List<FormDetails> forms = new ArrayList<>();
+        forms.add(test1);
+
+        HashMap<FormDetails, String> messages = downloader.downloadForms(forms);
+        assertThat(messages.get(test1), is("Success"));
+    }
+
+    /**
+     * Forms with last-saved references are a special case of external secondary instances because
+     * last-saved doesn't come from the remote server but is generated locally.
+     */
+    @Test
+    public void downloadingFormWithLastSavedReference_Succeeds() throws Exception {
+        String basicLastSaved = "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\">\n" +
+                "    <h:head>\n" +
+                "        <h:title>basic-last-saved</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"basic-last-saved\">\n" +
+                "                    <q1/>\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "            <instance id=\"__last-saved\" src=\"jr://instance/last-saved\"/>\n" +
+                "            <bind nodeset=\"/data/q1\" type=\"string\"/>\n" +
+                "           <setvalue event=\"odk-instance-first-load\" ref=\"/data/q1\" value=\" instance('__last-saved')/data/q1 \"/>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "        <input ref=\"/data/q1\">\n" +
+                "            <label>Question</label>\n" +
+                "        </input>\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+        File formXml = File.createTempFile("basicLastSaved", ".xml");
+        formXml.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(formXml));
+        out.write(basicLastSaved);
+        out.close();
+
+        FormDownloader downloader = spy(new FormDownloader());
+        FormDetails test1 = new FormDetails("Last Saved", "https://testserver/media.xml",
+                "https://testserver/media-manifest.xml", "basic-last-saved", "20200101",
+                "hash", "manifestHash", false, false);
+        FormDownloader.FileResult result = new FormDownloader.FileResult(formXml, true);
         doReturn(result).when(downloader).downloadXform(test1.getFormName(), test1.getDownloadUrl());
         doReturn("").when(downloader).downloadManifestAndMediaFiles(any(), any(), any(), anyInt(), anyInt());
         doReturn(true).when(downloader).installEverything(any(), any(), any());
@@ -128,5 +265,39 @@ public class FormDownloaderTest {
 
         HashMap<FormDetails, String> messages = downloader.downloadForms(forms);
         assertThat(messages.get(test1), is("Success"));
+    }
+
+    public static DocumentFetchResult buildManifestFetchResult() throws Exception {
+        String manifest = "<manifest xmlns=\"http://openrosa.org/xforms/xformsManifest\">\n" +
+                " <mediaFile>\n" +
+                "  <filename>external-data.xml</filename>\n" +
+                "  <hash>hash</hash>\n" +
+                "  <downloadUrl>https://testserver/external-data.xml</downloadUrl>\n" +
+                " </mediaFile>\n" +
+                "</manifest>";
+        org.kxml2.kdom.Document doc = new Document();
+        KXmlParser parser = new KXmlParser();
+        parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
+        parser.setInput(new InputStreamReader(new ByteArrayInputStream(manifest.getBytes())));
+        doc.parse(parser);
+        return new DocumentFetchResult(doc, true, "hash");
+    }
+
+    public static InputStream buildExternalInstanceFetchResult() {
+        String externalInstance = "<root>\n" +
+                "    <item>\n" +
+                "        <label>A</label>\n" +
+                "        <name>a</name>\n" +
+                "    </item>\n" +
+                "    <item>\n" +
+                "        <label>B</label>\n" +
+                "        <name>b</name>\n" +
+                "    </item>\n" +
+                "    <item>\n" +
+                "        <label>C</label>\n" +
+                "        <name>c</name>\n" +
+                "    </item>\n" +
+                " </root>";
+        return new ByteArrayInputStream(externalInstance.getBytes());
     }
 }


### PR DESCRIPTION
Closes #3635

Reviewers: I recommend running and understanding the tests in the first commit first since there's a lot going on here.

#### What has been done to verify that this works as intended?
I added and ran automated tests. I also configured a device with the following Central QR code to try forms with CSV attachments (but remember that https://github.com/opendatakit/collect/issues/3335 means it won't load more than once) and last-saved: 
![central-app-user-external-instances](https://user-images.githubusercontent.com/967540/74373963-58e22100-4d92-11ea-983e-b67387ce7f16.gif)

I tried a form with a XML attachment locally but both Aggregate and Central seem to currently choke on those.

#### Why is this the best possible solution? Were any other approaches considered?
The changes are to always create a temporary media directory whether or not a form definition comes with media, to always create a temporary last-saved.xml file in that directory, and to configure the global `ReferenceManager` to resolve `jr://file` and `jr://file-csv` URIs to that directory.

I tried to be as minimal and surgical as possible here because we're going to put this out as a point release. I also considered removing the temporary media directory concept because I don't see an advantage to it. It seems as easy to clean up files out of the final directory that they will belong in as it is from a temp directory. However, that felt too aggressive for now. Hopefully the test coverage will allow us to be more ambitious with refactors if this code needs to be modified again.

I also really had to hold myself back from trying to redesign how `last-saved` works. It doesn't make sense that the `last-saved.xml` file is stored with form media. Ideally, a whole new process would be introduced to handle virtual `jr://instance` endpoints. Again, though, now is not the time for that.

As described in https://github.com/opendatakit/collect/pull/3537, I don't love the use of a spy in the test but I think it's the best we can do now and it gives us further coverage for any future refactor we may want to do.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The intentional change is the fix to #3635.

One risky thing that I didn't know how to test is the resetting of the global `ReferenceManager`. The risk would be that under certain circumstances form media can't be resolved. I think resetting it is fine because the root session translators have to be configured each time a new form definition is loaded and I've verified that this is done in `FormLoaderTask` but it does make me a bit nervous.

Download of any form goes through this code path so special cases around form downloads should be considered. One I thought of and added a test for is a `last-saved.xml` attachment.

#### Do we need any specific form for testing your changes? If so, please attach one.

See server configured by QR code above and `FormDownloadTest`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)