### PR TITLE
Remove Firebase performance annotation processing from debug build

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -122,6 +122,9 @@ android {
             resValue("bool", "CRASHLYTICS_ENABLED", "false")
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             buildConfigField 'String', "MAPBOX_ACCESS_TOKEN", '"' + mapboxToken + '"'
+            FirebasePerformance {
+                instrumentationEnabled false
+            }
         }
     }
 


### PR DESCRIPTION
I noticed that this was running in my debug builds and was taking ~30s. This should speed up local debug builds.

#### What has been done to verify that this works as intended?

Ran builds and tests just to check nothing broke.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No regression risks. We can merge after the PR is approved.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)