### PR TITLE
fix: Undesirable button is visible on readOnly video widgets. #3653

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -24,8 +24,6 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore.Video;
-import androidx.annotation.NonNull;
-import androidx.core.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
@@ -54,6 +52,8 @@ import org.odk.collect.android.widgets.utilities.FileWidgetUtils;
 import java.io.File;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+import androidx.core.content.FileProvider;
 import timber.log.Timber;
 
 import static org.odk.collect.android.formentry.questions.WidgetViewUtils.createSimpleButton;
@@ -106,7 +106,11 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
 
         // retrieve answer from data model and update ui
         binaryName = questionDetails.getPrompt().getAnswerText();
-        playButton.setEnabled(binaryName != null);
+        if (binaryName == null) {
+            playButton.setVisibility(GONE);
+        } else {
+            playButton.setEnabled(true);
+        }
 
         // finish complex layout
         LinearLayout answerLayout = new LinearLayout(getContext());

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -5,8 +5,6 @@ import android.net.Uri;
 import android.provider.MediaStore;
 import android.view.View;
 
-import androidx.annotation.NonNull;
-
 import net.bytebuddy.utility.RandomString;
 
 import org.javarosa.core.model.data.StringData;
@@ -20,6 +18,8 @@ import org.odk.collect.android.utilities.MediaUtil;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 
 import java.io.File;
+
+import androidx.annotation.NonNull;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -131,6 +131,10 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
 
         assertThat(getWidget().captureButton.getVisibility(), is(View.GONE));
         assertThat(getWidget().chooseButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().playButton.getVisibility(), is(View.VISIBLE));
+        if (getWidget().getQuestionDetails().getPrompt().getAnswerText() == null) {
+            assertThat(getWidget().playButton.getVisibility(), is(View.GONE));
+        } else {
+            assertThat(getWidget().playButton.getVisibility(), is(View.VISIBLE));
+        }
     }
 }


### PR DESCRIPTION
Closes #3653 

#### What has been done to verify that this works as intended?
In read-only mode, the buttons are disabled in the createSimpleButton() method of WidgetViewUtils.java. A line of code in VideoWidget.java was making the button visible. So I simply removed it. I later checked that it works properly on a normal form as well.
#### Why is this the best possible solution? Were any other approaches considered?
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Now, the unnecessary button will not be visible.
#### Do we need any specific form for testing your changes? If so, please attach one.
No
#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No
#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)