### PR TITLE
Fixed ImageView in audio_video_image_text_label layout

### DIFF
--- a/collect_app/src/main/res/layout/audio_video_image_text_label.xml
+++ b/collect_app/src/main/res/layout/audio_video_image_text_label.xml
@@ -42,6 +42,7 @@
             android:paddingRight="@dimen/margin_standard"
             android:paddingBottom="@dimen/margin_standard"
             android:scaleType="fitStart"
+            android:adjustViewBounds="true"
             android:visibility="gone" />
 
         <TextView


### PR DESCRIPTION
Closes #3657 

#### What has been done to verify that this works as intended?
Tested with the form attached to the issue.

#### Why is this the best possible solution? Were any other approaches considered?
| Before  | After1 | After2 |
| ------------- | ------------- | ------------- |
| ![Screenshot_2020-02-28-13-01-26](https://user-images.githubusercontent.com/3276264/75544765-ebd2ba80-5a24-11ea-97e1-324537088544.png)  | ![Screenshot_2020-02-28-13-03-16](https://user-images.githubusercontent.com/3276264/75544768-ed03e780-5a24-11ea-83d8-05d23ea56471.png)  | ![Screenshot_2020-02-28-13-03-53](https://user-images.githubusercontent.com/3276264/75544770-ed9c7e00-5a24-11ea-9f98-36e59e5996e0.png)  |

There is still to much space because of that arrow...
![cat](https://user-images.githubusercontent.com/3276264/75544938-4a983400-5a25-11ea-8eb2-457e6fe5e0dc.png)

The arrow is not even clickable. Do you think it still make sense to keep it @lognaturel @seadowg?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
it's a small not risky fix so testing the attached form should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)