### PR TITLE
Open user-facing post with scoped storage migration details in browser

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/storage/StorageMigrationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/storage/StorageMigrationTest.java
@@ -121,7 +121,7 @@ public class StorageMigrationTest {
         new MainMenuPage(main)
                 .clickLearnMoreButton()
                 .clickMoreDetails()
-                .assertWebViewOpen();
+                .assertForumPostOpen();
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/StorageMigrationDialogPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/StorageMigrationDialogPage.java
@@ -1,20 +1,19 @@
 package org.odk.collect.android.support.pages;
 
+import android.net.Uri;
+
 import androidx.test.rule.ActivityTestRule;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.WebViewActivity;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
-import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
-import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.IsNot.not;
 
 public class StorageMigrationDialogPage extends Page<StorageMigrationDialogPage>  {
@@ -44,11 +43,8 @@ public class StorageMigrationDialogPage extends Page<StorageMigrationDialogPage>
         return new MainMenuPage(rule).assertOnPage();
     }
 
-    public StorageMigrationDialogPage assertWebViewOpen() {
-        intended(allOf(
-                hasComponent(WebViewActivity.class.getName()),
-                hasExtra("url", "https://forum.opendatakit.org/t/24159")
-        ));
+    public StorageMigrationDialogPage assertForumPostOpen() {
+        intended(hasData(Uri.parse("https://forum.opendatakit.org/t/25268")));
         return this;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.storage.migration;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,7 +14,6 @@ import android.widget.TextView;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.WebViewActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.fragments.dialogs.AdminPasswordDialog;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -137,8 +137,8 @@ public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
     }
 
     private void showMoreDetails() {
-        Intent intent = new Intent(getContext(), WebViewActivity.class);
-        intent.putExtra("url", "https://forum.opendatakit.org/t/24159");
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse("https://forum.opendatakit.org/t/25268"));
         startActivity(intent);
     }
 


### PR DESCRIPTION
The scoped storage text currently links to a developer-facing forum post. I want to make sure we simplify this for users and provide a dedicated thread for them to ask questions. I have added a post in the scheduled category that won't be visible to folks who aren't moderators. Here is a screenshot that includes the URL:
<img width="815" alt="Screen Shot 2020-03-03 at 9 22 53 PM" src="https://user-images.githubusercontent.com/967540/75847852-304bb680-5d95-11ea-9e10-fcc9c1742b65.png">

This PR also changes the way the forum post is presented. I had originally specified launching the page in a browser but I didn't explain why. The reason is that folks may want to log into the forum and using a browser means they'll have access to password managers, for example. We also want to encourage them to browse the forum and that will be easier to do if the link opens in a browser that can stay open concurrently with Collect.

#### What has been done to verify that this works as intended?
Ran tests and manually verified that the correct link was opened in a browser.

#### Why is this the best possible solution? Were any other approaches considered?
I considered leaving the developer-facing post but I think the content is not right for users.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just change the explanatory page that's opened and what browser it's opened in. I can't think of a regression risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)