### PR TITLE
Fixed RankingWidget layout

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/RankingWidget.java
@@ -44,8 +44,8 @@ import static org.odk.collect.android.formentry.questions.WidgetViewUtils.create
 public class RankingWidget extends ItemsWidget implements BinaryWidget {
 
     private List<SelectChoice> savedItems;
-    private LinearLayout widgetLayout;
     Button showRankingDialogButton;
+    private TextView answerTextView;
 
     public RankingWidget(Context context, QuestionDetails prompt) {
         super(context, prompt);
@@ -68,7 +68,7 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
     @Override
     public void clearAnswer() {
         savedItems = null;
-        setUpLayout(items);
+        answerTextView.setText(getAnswerText());
     }
 
     @Override
@@ -89,7 +89,7 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
     @Override
     public void setBinaryData(Object values) {
         savedItems = (List<SelectChoice>) values;
-        setUpLayout(savedItems);
+        answerTextView.setText(getAnswerText());
     }
 
     @Override
@@ -132,13 +132,13 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
     }
 
     private void setUpLayout(List<SelectChoice> items) {
-        removeView(widgetLayout);
-
-        widgetLayout = new LinearLayout(getContext());
-        widgetLayout.setOrientation(LinearLayout.VERTICAL);
         showRankingDialogButton = createSimpleButton(getContext(), getFormEntryPrompt().isReadOnly(), getContext().getString(R.string.rank_items), getAnswerFontSize(), this);
+        answerTextView = createAnswerTextView(getContext(), getAnswerText(), getAnswerFontSize());
+
+        LinearLayout widgetLayout = new LinearLayout(getContext());
+        widgetLayout.setOrientation(LinearLayout.VERTICAL);
         widgetLayout.addView(showRankingDialogButton);
-        widgetLayout.addView(setUpAnswerTextView());
+        widgetLayout.addView(answerTextView);
 
         addAnswerView(widgetLayout, WidgetViewUtils.getStandardMargin(getContext()));
         SpacesInUnderlyingValuesWarning
@@ -146,7 +146,7 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
                 .renderWarningIfNecessary(items);
     }
 
-    private TextView setUpAnswerTextView() {
+    private String getAnswerText() {
         StringBuilder answerText = new StringBuilder();
         if (savedItems != null) {
             for (SelectChoice item : savedItems) {
@@ -159,6 +159,6 @@ public class RankingWidget extends ItemsWidget implements BinaryWidget {
                 }
             }
         }
-        return createAnswerTextView(getContext(), answerText.toString(), getAnswerFontSize());
+        return answerText.toString();
     }
 }


### PR DESCRIPTION
Closes #3663 

#### What has been done to verify that this works as intended?
I tested a form with RankingWidget.

#### Why is this the best possible solution? Were any other approaches considered?
I fixed the layout which were created again and again every time a user sets the answer, now it's juts updated.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It just fixes the layout so testing just that one widget would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with Ranking widget like All widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)