### PR TITLE
Run tests in parallel on 50 separate devices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ jobs:
             if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
               echo "y" | gcloud firebase test android run \
               --type instrumentation \
+              --num-uniform-shards=50 \
               --app collect_app/build/outputs/apk/debug/*.apk \
               --test collect_app/build/outputs/apk/androidTest/debug/*.apk \
               --device model=Pixel2,version=27,locale=en,orientation=portrait \


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Nothing.

#### Why is this the best possible solution? Were any other approaches considered?
I use this option manually running test on Firebase Test Lab and it works much faster.
https://cloud.google.com/sdk/gcloud/reference/beta/firebase/test/android/run#--num-uniform-shards

> Specifies the number of shards into which you want to evenly distribute test cases. The shards are run in parallel on separate devices. For example, if your test execution contains 20 test cases and you specify four shards, each shard executes five test cases.
> The number of shards should be less than the total number of test cases. The number of shards specified must be >= 1 and <= 50.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)