### PR TITLE
Fix flakey tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
@@ -2,24 +2,25 @@ package org.odk.collect.android.regression;
 
 import android.Manifest;
 
+import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
+import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.pages.AdminSettingsPage;
 import org.odk.collect.android.support.pages.GeneralSettingsPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
-import org.odk.collect.android.support.CopyFormRule;
-import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.pages.ResetApplicationDialog;
 
 //Issue NODK-240
-public class ResetApplicationTest extends BaseRegressionTest {
-    @Rule
-    public RuleChain ruleChain = RuleChain
-            .outerRule(new ResetStateRule());
+public class ResetApplicationTest {
+
+    public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
 
     @Rule
     public RuleChain copyFormChain = RuleChain
@@ -29,7 +30,8 @@ public class ResetApplicationTest extends BaseRegressionTest {
                     Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule())
-            .around(new CopyFormRule("All_widgets.xml"));
+            .around(new CopyFormRule("All_widgets.xml"))
+            .around(rule);
 
     @Test
     public void when_rotateScreen_should_resetDialogNotDisappear() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/storage/StorageMigrationCompletedBannerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/storage/StorageMigrationCompletedBannerTest.java
@@ -72,12 +72,4 @@ public class StorageMigrationCompletedBannerTest {
                 .recreateActivity()
                 .assertStorageMigrationCompletedBannerIsNotDisplayed();
     }
-
-    @Test
-    public void when_storageMigrationCompleted_should_bannerBeVisibleAndDismissAfterReopeningApp() {
-        new MainMenuPage(rule)
-                .assertStorageMigrationCompletedBannerIsDisplayed()
-                .recreateActivity()
-                .assertStorageMigrationCompletedBannerIsNotDisplayed();
-    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ResetDialogPreference.java
@@ -21,6 +21,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
@@ -107,17 +108,25 @@ public class ResetDialogPreference extends DialogPreference implements CompoundB
         if (osmDroid.isChecked()) {
             resetActions.add(ResetUtility.ResetAction.RESET_OSM_DROID);
         }
+
         if (!resetActions.isEmpty()) {
-            showProgressDialog();
-            Runnable runnable = new Runnable() {
+            new AsyncTask<Void, Void, List<Integer>>() {
                 @Override
-                public void run() {
-                    List<Integer> failedResetActions = new ResetUtility().reset(getContext(), resetActions);
+                protected void onPreExecute() {
+                    showProgressDialog();
+                }
+
+                @Override
+                protected List<Integer> doInBackground(Void... voids) {
+                    return new ResetUtility().reset(getContext(), resetActions);
+                }
+
+                @Override
+                protected void onPostExecute(List<Integer> failedResetActions) {
                     hideProgressDialog();
                     handleResult(resetActions, failedResetActions);
                 }
-            };
-            new Thread(runnable).start();
+            }.execute();
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.java
@@ -2,42 +2,84 @@ package org.odk.collect.android.activities;
 
 import android.content.Intent;
 import android.view.MenuItem;
+import android.view.View;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
+import org.odk.collect.android.injection.config.AppDependencyModule;
+import org.odk.collect.android.storage.StorageStateProvider;
+import org.odk.collect.android.storage.migration.StorageMigrationRepository;
+import org.odk.collect.android.storage.migration.StorageMigrationResult;
+import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.fakes.RoboMenuItem;
 import org.robolectric.shadows.ShadowEnvironment;
 
+import javax.inject.Singleton;
+
+import dagger.Provides;
+
 import static android.os.Environment.MEDIA_MOUNTED;
-import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(PAUSED)
 public class MainMenuActivityTest {
-    private MainMenuActivity mainMenuActivity;
 
-    /**
-     * Runs {@link Before} each test.
-     */
     @Before
     public void setUp() throws Exception {
-        ShadowEnvironment.setExternalStorageState(MEDIA_MOUNTED);
-        mainMenuActivity = Robolectric.setupActivity(MainMenuActivity.class);
+        ShadowEnvironment.setExternalStorageState(MEDIA_MOUNTED); // Required for ODK directories to be created
     }
 
     @Test
     public void pressingConfigureQRCode_launchesScanQRCodeActivity() throws Exception {
+        MainMenuActivity activity = Robolectric.setupActivity(MainMenuActivity.class);
+
         MenuItem item = new RoboMenuItem(R.id.menu_configure_qr_code);
+        activity.onOptionsItemSelected(item);
 
-        mainMenuActivity.onOptionsItemSelected(item);
-
-        Intent expectedIntent = new Intent(mainMenuActivity, ScanQRCodeActivity.class);
+        Intent expectedIntent = new Intent(activity, ScanQRCodeActivity.class);
         Intent actual = shadowOf(RuntimeEnvironment.application).getNextStartedActivity();
-        assertEquals(expectedIntent.getComponent(), actual.getComponent());
+        assertThat(expectedIntent.getComponent(), equalTo(actual.getComponent()));
+    }
+
+    @Test
+    public void whenStorageMigrationIsFinished_storageCompletionBannerOnlyShowsInOneInstance() {
+        whenStorageMigrationIsFinished();
+
+        ActivityController<MainMenuActivity> activityController = Robolectric.buildActivity(MainMenuActivity.class).setup();
+        assertThat(activityController.get().findViewById(R.id.storageMigrationBanner).getVisibility(), equalTo(View.VISIBLE));
+        activityController.pause().stop().destroy();
+
+        MainMenuActivity secondActivity = Robolectric.setupActivity(MainMenuActivity.class);
+        assertThat(secondActivity.findViewById(R.id.storageMigrationBanner).getVisibility(), equalTo(View.GONE));
+    }
+
+    private void whenStorageMigrationIsFinished() {
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Provides
+            @Singleton
+            public StorageMigrationRepository providesStorageMigrationRepository() {
+                StorageMigrationRepository storageMigrationRepository = new StorageMigrationRepository();
+                storageMigrationRepository.setResult(StorageMigrationResult.SUCCESS);
+                return storageMigrationRepository;
+            }
+
+            @Override
+            public StorageStateProvider providesStorageStateProvider() {
+                StorageStateProvider storageStateProvider = new StorageStateProvider();
+                storageStateProvider.enableUsingScopedStorage();
+                return storageStateProvider;
+            }
+        });
     }
 }


### PR DESCRIPTION
This moves one of the tests in `StorageMigrationCompletedBannerTest` to Robolectric and introduces an `AsyncTask` where a `Thread` was being used. For the former this stabilizes the test as for some reason recreating an `Activity` in Espresso appears to be flakey. For the latter this means that Espresso is in sync with the background work (it only knows about `AsyncTask`).

#### What has been done to verify that this works as intended?

Ran locally and on Test Lab.

#### Why is this the best possible solution? Were any other approaches considered?

I did consider using standard Robolectric for the `MainMenuActivityTest` but the `ActivityScenario` felt right as it lets us worry less about what exact lifecycle methods get called in what scenario (versus the `ActivityController`) which is pretty nice. I like this blend of `androidx` lifecycle control but not using `onView` etc.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should really only effect tests. The changes to reset feature feel pretty covered by the test that was flakey so I think I'd be ok merging this without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)