### PR TITLE
Use gcloud alpha firebase to use num-uniform-shards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
           name: Run integration tests
           command: |
             if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-              echo "y" | gcloud firebase test android run \
+              echo "y" | gcloud alpha firebase test android run \
               --type instrumentation \
               --num-uniform-shards=50 \
               --app collect_app/build/outputs/apk/debug/*.apk \


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Nothing.

#### Why is this the best possible solution? Were any other approaches considered?
In #3672 I added `--num-uniform-shards=50` but the build is broken now.
Turns out it requires `gcloud alpha firebase test android run`
https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
vs
https://cloud.google.com/sdk/gcloud/reference/alpha/firebase/test/android/run

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)