### PR TITLE
Fix version parsing for beta releases and dirty releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ RELEASE_KEY_PASSWORD=secure-alias-password
 
 Maintainers also have a `google-services.json` file in the `collect_app/src/odkCollectRelease` folder. The contents of the file are similar to the contents of `collect_app/src/google-services.json`.
 
+When ready to generate a build for the Play Store, maintainers tag the build by [adding a release](releases). Tags for full releases must have the format `vX.X.X`. Tags for beta releases must have the format `vX.X.X-beta.X`.
+
 To generate official signed releases, you'll need the keystore file, the keystore passwords, a configured `collect_app/secrets.properties` file, and a configured `collect_app/src/odkCollectRelease/google-services.json` file. Then run `./gradlew assembleOdkCollectRelease`. If successful, a signed release will be at `collect_app/build/outputs/apk`.
 
 ## Troubleshooting

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/MainMenuViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/MainMenuViewModel.java
@@ -17,7 +17,7 @@ public class MainMenuViewModel extends ViewModel {
     }
 
     public String getVersion() {
-        if (isBeta()) {
+        if (hasBetaTag()) {
             return getVersionDescriptionComponents()[0] + " Beta " + versionDescriptionProvider.getVersionDescription().split("beta")[1].substring(1, 2);
         } else {
             return getVersionDescriptionComponents()[0];
@@ -26,20 +26,24 @@ public class MainMenuViewModel extends ViewModel {
 
     @Nullable
     public String getVersionCommitDescription() {
-        if (isRelease()) {
+        if (isRelease() || isBetaRelease()) {
             return null;
         } else {
-            String commitDescription;
+            String commitDescription = "";
             String[] components = getVersionDescriptionComponents();
 
-            if (isBeta()) {
+            if (hasBetaTag() && getVersionDescriptionComponents().length > 3) {
                 commitDescription = components[2] + "-" + components[3];
-            } else {
+            } else if (!hasBetaTag() && getVersionDescriptionComponents().length > 2) {
                 commitDescription = components[1] + "-" + components[2];
             }
 
             if (isDirty()) {
-                commitDescription = commitDescription + "-dirty";
+                if (commitDescription.isEmpty()) {
+                    commitDescription = "dirty";
+                } else {
+                    commitDescription = commitDescription + "-dirty";
+                }
             }
 
             return commitDescription;
@@ -50,12 +54,16 @@ public class MainMenuViewModel extends ViewModel {
         return versionDescriptionProvider.getVersionDescription().contains("dirty");
     }
 
+    private boolean hasBetaTag() {
+        return versionDescriptionProvider.getVersionDescription().contains("beta");
+    }
+
     private boolean isRelease() {
         return getVersionDescriptionComponents().length == 1;
     }
 
-    private boolean isBeta() {
-        return versionDescriptionProvider.getVersionDescription().contains("beta");
+    private boolean isBetaRelease() {
+        return hasBetaTag() && getVersionDescriptionComponents().length == 2;
     }
 
     @NotNull

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/MainMenuViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/MainMenuViewModelTest.java
@@ -17,13 +17,31 @@ public class MainMenuViewModelTest {
     }
 
     @Test
-    public void version_whenBeta_returnsSemanticVersionWithPrefix_andBetaVersion() {
+    public void version_whenDirtyRelease_returnsSemanticVersionWithPrefix() {
+        MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.1.7-dirty");
+        assertThat(viewModel.getVersion(), equalTo("v1.1.7"));
+    }
+
+    @Test
+    public void version_whenBetaRelease_returnsSemanticVersionWithPrefix_andBetaVersion() {
+        MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.23.0-beta.1");
+        assertThat(viewModel.getVersion(), equalTo("v1.23.0 Beta 1"));
+    }
+
+    @Test
+    public void version_whenDirtyBetaRelease_returnsSemanticVersionWithPrefix_andBetaVersion() {
+        MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.23.0-beta.1-dirty");
+        assertThat(viewModel.getVersion(), equalTo("v1.23.0 Beta 1"));
+    }
+
+    @Test
+    public void version_whenBetaTag_returnsSemanticVersionWithPrefix_andBetaVersion() {
         MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.23.0-beta.1-181-ge51d004d4");
         assertThat(viewModel.getVersion(), equalTo("v1.23.0 Beta 1"));
     }
 
     @Test
-    public void version_whenNormalCommit_returnsSemanticVersionWithPrefix() {
+    public void version_whenReleaseTag_returnsSemanticVersionWithPrefix() {
         MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.23.0-181-ge51d004d4");
         assertThat(viewModel.getVersion(), equalTo("v1.23.0"));
     }
@@ -35,13 +53,31 @@ public class MainMenuViewModelTest {
     }
 
     @Test
-    public void versionCommitDescription_whenBeta_returnsCommitCountAndSHA() {
+    public void versionCommitDescription_whenDirtyRelease_returnsDirty() {
+        MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.1.7-dirty");
+        assertThat(viewModel.getVersionCommitDescription(), equalTo("dirty"));
+    }
+
+    @Test
+    public void versionCommitDescription_whenBetaRelease_returnsNull() {
+        MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.1.7-beta.7");
+        assertThat(viewModel.getVersionCommitDescription(), equalTo(null));
+    }
+
+    @Test
+    public void versionCommitDescription_whenDirtyBetaRelease_returnsNull() {
+        MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.1.7-beta.7-dirty");
+        assertThat(viewModel.getVersionCommitDescription(), equalTo("dirty"));
+    }
+
+    @Test
+    public void versionCommitDescription_whenBetaTag_returnsCommitCountAndSHA() {
         MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.23.0-beta.1-181-ge51d004d4");
         assertThat(viewModel.getVersionCommitDescription(), equalTo("181-ge51d004d4"));
     }
 
     @Test
-    public void versionCommitDescription_whenNormalCommit_returnsCommitCountAndSHA() {
+    public void versionCommitDescription_whenReleaseTag_returnsCommitCountAndSHA() {
         MainMenuViewModel viewModel = new MainMenuViewModel(() -> "v1.23.0-181-ge51d004d4");
         assertThat(viewModel.getVersionCommitDescription(), equalTo("181-ge51d004d4"));
     }


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Run automated tests, manually tried `v1.26.0-beta.1` and `v1.26.0-beta.1-dirty` tags.

#### Why is this the best possible solution? Were any other approaches considered?
I think this is now pretty difficult to understand. I considered restructuring the code so that the beta tag suffix is dealt with before any of the rest of the decision making. I also considered using a regular expression to identified the different components of the version string. Ultimately, I figured that it would be easier to review a simpler diff for now since my goal is to get a beta out today.

I also considered catching exceptions and falling back in case we change our tag structure and/or a fork wants to use different tags but I figure that can be dealt with when it comes up. It is a little strange that a tag can now prevent app launch.

I also considered allowing beta numbers above 9 or documenting that with a test because it's also an unexpected limitation but again, I figured it was safer to keep the diff small for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It prevents the application from crashing on launch on a version tagged with our tagging scheme. There's a chance I didn't think of all missing cases and that there are still possible crashes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
I have added a line to the README to document the mandatory tag structure.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)