### PR TITLE
Remove explicit colorSurface background from main menu

### DIFF
--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -11,9 +11,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="?colorSurface">
-
+    android:orientation="vertical">
+    
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
This makes the main menu screen have the same background color as the rest of the app.

#### What has been done to verify that this works as intended?

Eyeballed it locally.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No risks to users just tweaks the color. Can be merged after accepting.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)