### PR TITLE
Avoid updating instance lastStatusChaneDate during migration

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrator.java
@@ -29,6 +29,7 @@ import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.FOR
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.FORM_MEDIA_PATH;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.JRCACHE_FILE_PATH;
 import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.INSTANCE_FILE_PATH;
+import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.LAST_STATUS_CHANGE_DATE;
 
 public class StorageMigrator {
     private static final String WHERE_ID = _ID + "=?";
@@ -146,10 +147,12 @@ public class StorageMigrator {
         if (cursor != null && cursor.moveToFirst()) {
             do {
                 int idColumnIndex = cursor.getColumnIndex(_ID);
-                int instanceFilePathIndex = cursor.getColumnIndex(INSTANCE_FILE_PATH);
+                int instanceFilePathColumnIndex = cursor.getColumnIndex(INSTANCE_FILE_PATH);
+                int lastStatusChangeDateColumnIndex = cursor.getColumnIndex(LAST_STATUS_CHANGE_DATE);
 
                 ContentValues values = new ContentValues();
-                values.put(INSTANCE_FILE_PATH, getRelativeInstanceDbPath(cursor.getString(instanceFilePathIndex)));
+                values.put(INSTANCE_FILE_PATH, getRelativeInstanceDbPath(cursor.getString(instanceFilePathColumnIndex)));
+                values.put(LAST_STATUS_CHANGE_DATE, cursor.getLong(lastStatusChangeDateColumnIndex));
 
                 String[] whereArgs = {String.valueOf(cursor.getLong(idColumnIndex))};
                 instancesDao.updateInstance(values, WHERE_ID, whereArgs);


### PR DESCRIPTION
Closes #3687 

#### What has been done to verify that this works as intended?
I tested the change manually to confirm the bug no longer exist.

#### Why is this the best possible solution? Were any other approaches considered?
The bug is not serious but still it's something unexpected what we should fix.
We need to include `LAST_STATUS_CHANGE_DATE` to `ContentValues` we want to update because otherwise if it's not present it's updated with the current date:  https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java#L358
that's the way `InstanceProvider.update()` works.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)