### PR TITLE
Fixed Save button in Reason for changes page does not work after rotating device orientation

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -123,7 +123,9 @@ public class TrackChangesReasonTest {
                 .clickSaveAndExitWithChangesReasonPrompt()
                 .enterReason("Something")
                 .rotateToLandscape(new ChangesReasonPromptPage("Track Changes Reason", rule))
-                .assertText("Something");
+                .assertText("Something")
+                .rotateToPortrait(new ChangesReasonPromptPage("Track Changes Reason", rule))
+                .clickSave();
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/audit/TrackChangesReasonTest.java
@@ -124,7 +124,7 @@ public class TrackChangesReasonTest {
                 .enterReason("Something")
                 .rotateToLandscape(new ChangesReasonPromptPage("Track Changes Reason", rule))
                 .assertText("Something")
-                .rotateToPortrait(new ChangesReasonPromptPage("Track Changes Reason", rule))
+                .closeSoftKeyboard()
                 .clickSave();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1868,7 +1868,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
                     finishAndReturnInstance();
                 }
-
+                formSaveViewModel.consumeSavedResult();
                 break;
 
             case SAVE_ERROR:
@@ -1883,6 +1883,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
 
                 showLongToast(message);
+                formSaveViewModel.consumeSavedResult();
                 break;
 
             case FINALIZE_ERROR:
@@ -1890,6 +1891,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 showLongToast(String.format(getString(R.string.encryption_error_message),
                         result.getMessage()));
                 finishAndReturnInstance();
+                formSaveViewModel.consumeSavedResult();
                 break;
 
             case CONSTRAINT_ERROR: {
@@ -1909,11 +1911,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     // otherwise, we can get the proper toast(s) by saving with constraint check
                     saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS);
                 }
-
+                formSaveViewModel.consumeSavedResult();
                 break;
             }
         }
-        formSaveViewModel.consumeSavedResult();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -425,6 +425,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         formSaveViewModel = ViewModelProviders
                 .of(this, changesReasonViewModelFactory)
                 .get(FormSaveViewModel.class);
+
+        formSaveViewModel.getSavedResult().observe(this, this::handleSaveResult);
     }
 
     private void setupFields(Bundle savedInstanceState) {
@@ -1821,91 +1823,97 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         }
 
-        formSaveViewModel.saveForm(getIntent().getData(), complete, updatedSaveName, exit).observe(this, result -> {
-            switch (result.getState()) {
-                case CHANGE_REASON_REQUIRED:
-                    ChangesReasonPromptDialogFragment dialog = ChangesReasonPromptDialogFragment.create(getFormController().getFormTitle());
-                    DialogUtils.showIfNotShowing(dialog, getSupportFragmentManager());
-                    break;
-
-                case SAVING:
-                    autoSaved = true;
-
-                    SaveFormProgressDialogFragment progressDialog = DialogUtils.showIfNotShowing(
-                            new SaveFormProgressDialogFragment(),
-                            getSupportFragmentManager()
-                    );
-
-                    if (result.getMessage() != null) {
-                        progressDialog.setMessage(getString(R.string.please_wait) + "\n\n" + result.getMessage());
-                    }
-
-                    break;
-
-                case SAVED:
-                    DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
-                    showShortToast(R.string.data_saved_ok);
-
-                    if (exit) {
-                        if (complete) {
-                            // Request auto-send if app-wide auto-send is enabled or the form that was just
-                            // finalized specifies that it should always be auto-sent.
-                            String formId = getFormController().getFormDef().getMainInstance().getRoot().getAttributeValue("", "id");
-                            if (AutoSendWorker.formShouldBeAutoSent(formId, GeneralSharedPreferences.isAutoSendEnabled())) {
-                                requestAutoSend();
-                            }
-                        }
-
-                        finishAndReturnInstance();
-                    }
-
-                    break;
-
-                case SAVE_ERROR:
-                    DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
-                    String message;
-
-                    if (result.getMessage() != null) {
-                        message = getString(R.string.data_saved_error) + " "
-                                + result.getMessage();
-                    } else {
-                        message = getString(R.string.data_saved_error);
-                    }
-
-                    showLongToast(message);
-                    break;
-
-                case FINALIZE_ERROR:
-                    DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
-                    showLongToast(String.format(getString(R.string.encryption_error_message),
-                            result.getMessage()));
-                    finishAndReturnInstance();
-                    break;
-
-                case CONSTRAINT_ERROR: {
-                    DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
-                    refreshCurrentView();
-
-                    // get constraint behavior preference value with appropriate default
-                    String constraintBehavior = (String) GeneralSharedPreferences.getInstance()
-                            .get(GeneralKeys.KEY_CONSTRAINT_BEHAVIOR);
-
-                    // an answer constraint was violated, so we need to display the proper toast(s)
-                    // if constraint behavior is on_swipe, this will happen if we do a 'swipe' to the
-                    // next question
-                    if (constraintBehavior.equals(GeneralKeys.CONSTRAINT_BEHAVIOR_ON_SWIPE)) {
-                        next();
-                    } else {
-                        // otherwise, we can get the proper toast(s) by saving with constraint check
-                        saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS);
-                    }
-
-                    break;
-                }
-            }
-        });
+        formSaveViewModel.saveForm(getIntent().getData(), complete, updatedSaveName, exit);
 
         return true;
+    }
+
+    private void handleSaveResult(FormSaveViewModel.SaveResult result) {
+        if (result == null) {
+            return;
+        }
+        switch (result.getState()) {
+            case CHANGE_REASON_REQUIRED:
+                ChangesReasonPromptDialogFragment dialog = ChangesReasonPromptDialogFragment.create(getFormController().getFormTitle());
+                DialogUtils.showIfNotShowing(dialog, getSupportFragmentManager());
+                break;
+
+            case SAVING:
+                autoSaved = true;
+
+                SaveFormProgressDialogFragment progressDialog = DialogUtils.showIfNotShowing(
+                        new SaveFormProgressDialogFragment(),
+                        getSupportFragmentManager()
+                );
+
+                if (result.getMessage() != null) {
+                    progressDialog.setMessage(getString(R.string.please_wait) + "\n\n" + result.getMessage());
+                }
+
+                break;
+
+            case SAVED:
+                DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                showShortToast(R.string.data_saved_ok);
+
+                if (result.getRequest().viewExiting()) {
+                    if (result.getRequest().shouldFinalize()) {
+                        // Request auto-send if app-wide auto-send is enabled or the form that was just
+                        // finalized specifies that it should always be auto-sent.
+                        String formId = getFormController().getFormDef().getMainInstance().getRoot().getAttributeValue("", "id");
+                        if (AutoSendWorker.formShouldBeAutoSent(formId, GeneralSharedPreferences.isAutoSendEnabled())) {
+                            requestAutoSend();
+                        }
+                    }
+
+                    finishAndReturnInstance();
+                }
+
+                break;
+
+            case SAVE_ERROR:
+                DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                String message;
+
+                if (result.getMessage() != null) {
+                    message = getString(R.string.data_saved_error) + " "
+                            + result.getMessage();
+                } else {
+                    message = getString(R.string.data_saved_error);
+                }
+
+                showLongToast(message);
+                break;
+
+            case FINALIZE_ERROR:
+                DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                showLongToast(String.format(getString(R.string.encryption_error_message),
+                        result.getMessage()));
+                finishAndReturnInstance();
+                break;
+
+            case CONSTRAINT_ERROR: {
+                DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                refreshCurrentView();
+
+                // get constraint behavior preference value with appropriate default
+                String constraintBehavior = (String) GeneralSharedPreferences.getInstance()
+                        .get(GeneralKeys.KEY_CONSTRAINT_BEHAVIOR);
+
+                // an answer constraint was violated, so we need to display the proper toast(s)
+                // if constraint behavior is on_swipe, this will happen if we do a 'swipe' to the
+                // next question
+                if (constraintBehavior.equals(GeneralKeys.CONSTRAINT_BEHAVIOR_ON_SWIPE)) {
+                    next();
+                } else {
+                    // otherwise, we can get the proper toast(s) by saving with constraint check
+                    saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS);
+                }
+
+                break;
+            }
+        }
+        formSaveViewModel.consumeSavedResult();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1868,7 +1868,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
                     finishAndReturnInstance();
                 }
-                formSaveViewModel.consumeSavedResult();
+                formSaveViewModel.resumeFormEntry();
                 break;
 
             case SAVE_ERROR:
@@ -1883,7 +1883,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
 
                 showLongToast(message);
-                formSaveViewModel.consumeSavedResult();
+                formSaveViewModel.resumeFormEntry();
                 break;
 
             case FINALIZE_ERROR:
@@ -1891,7 +1891,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 showLongToast(String.format(getString(R.string.encryption_error_message),
                         result.getMessage()));
                 finishAndReturnInstance();
-                formSaveViewModel.consumeSavedResult();
+                formSaveViewModel.resumeFormEntry();
                 break;
 
             case CONSTRAINT_ERROR: {
@@ -1911,7 +1911,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     // otherwise, we can get the proper toast(s) by saving with constraint check
                     saveAnswersForCurrentScreen(EVALUATE_CONSTRAINTS);
                 }
-                formSaveViewModel.consumeSavedResult();
+                formSaveViewModel.resumeFormEntry();
                 break;
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -111,7 +111,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         return reason;
     }
 
-    public void saveToDisk(SaveRequest saveRequest) {
+    private void saveToDisk(SaveRequest saveRequest) {
         saveTask = new SaveTask(saveRequest, formSaver, formController, new SaveTask.Listener() {
             @Override
             public void onProgressPublished(String progress) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -30,7 +30,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
     private final FormSaver formSaver;
 
     private String reason = "";
-    private MutableLiveData<SaveResult> saveResult = new MutableLiveData<>(null);
+    private final MutableLiveData<SaveResult> saveResult = new MutableLiveData<>(null);
 
     @Nullable
     private AuditEventLogger auditEventLogger;
@@ -184,7 +184,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
     }
 
     public void resumeFormEntry() {
-        saveResult = new MutableLiveData<>(null);
+        saveResult.setValue(null);
     }
 
     private boolean requiresReasonToSave() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -59,7 +59,6 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
 
     public void saveForm(Uri instanceContentURI, boolean shouldFinalize, String updatedSaveName, boolean viewExiting) {
         if (isSaving()) {
-            saveResult.setValue(new SaveResult(SaveResult.State.ALREADY_SAVING, null));
             return;
         }
 
@@ -112,7 +111,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         return reason;
     }
 
-    private void saveToDisk(SaveRequest saveRequest) {
+    public void saveToDisk(SaveRequest saveRequest) {
         saveTask = new SaveTask(saveRequest, formSaver, formController, new SaveTask.Listener() {
             @Override
             public void onProgressPublished(String progress) {
@@ -224,8 +223,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             SAVED,
             SAVE_ERROR,
             FINALIZE_ERROR,
-            CONSTRAINT_ERROR,
-            ALREADY_SAVING
+            CONSTRAINT_ERROR
         }
 
         public SaveRequest getRequest() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -57,9 +57,10 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         }
     }
 
-    public LiveData<SaveResult> saveForm(Uri instanceContentURI, boolean shouldFinalize, String updatedSaveName, boolean viewExiting) {
+    public void saveForm(Uri instanceContentURI, boolean shouldFinalize, String updatedSaveName, boolean viewExiting) {
         if (isSaving()) {
-            return new MutableLiveData<>(new SaveResult(SaveResult.State.ALREADY_SAVING, null));
+            saveResult.setValue(new SaveResult(SaveResult.State.ALREADY_SAVING, null));
+            return;
         }
 
         if (auditEventLogger != null) {
@@ -67,7 +68,6 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         }
 
         SaveRequest saveRequest = new SaveRequest(instanceContentURI, viewExiting, updatedSaveName, shouldFinalize);
-        this.saveResult = new MutableLiveData<>(null);
 
         if (!requiresReasonToSave()) {
             this.saveResult.setValue(new SaveResult(SaveResult.State.SAVING, saveRequest));
@@ -75,8 +75,6 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         } else {
             this.saveResult.setValue(new SaveResult(SaveResult.State.CHANGE_REASON_REQUIRED, saveRequest));
         }
-
-        return this.saveResult;
     }
 
     public boolean isSaving() {
@@ -181,6 +179,14 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         }
     }
 
+    public LiveData<SaveResult> getSavedResult() {
+        return saveResult;
+    }
+
+    public void consumeSavedResult() {
+        saveResult = new MutableLiveData<>(null);
+    }
+
     private boolean requiresReasonToSave() {
         return auditEventLogger != null
                 && auditEventLogger.isEditing()
@@ -227,7 +233,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         }
     }
 
-    private static class SaveRequest {
+    public static class SaveRequest {
 
         private final boolean shouldFinalize;
         private final boolean viewExiting;
@@ -239,6 +245,14 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             this.viewExiting = viewExiting;
             this.updatedSaveName = updatedSaveName;
             this.uri = instanceContentURI;
+        }
+
+        public boolean shouldFinalize() {
+            return shouldFinalize;
+        }
+
+        public boolean viewExiting() {
+            return viewExiting;
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -183,7 +183,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         return saveResult;
     }
 
-    public void consumeSavedResult() {
+    public void resumeFormEntry() {
         saveResult = new MutableLiveData<>(null);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -68,38 +68,44 @@ public class FormSaveViewModelTest {
 
     @Test
     public void saveForm_returnsNewSaveResult_inSavingState() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult1 = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        assertThat(saveResult1.getValue().getState(), equalTo(SAVING));
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        FormSaveViewModel.SaveResult saveResult1 = viewModel.getSavedResult().getValue();
+        assertThat(saveResult1.getState(), equalTo(SAVING));
 
-        LiveData<FormSaveViewModel.SaveResult> saveResult2 = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        FormSaveViewModel.SaveResult saveResult2 = viewModel.getSavedResult().getValue();
         assertThat(saveResult2, not(equalTo(saveResult1)));
     }
 
     @Test
     public void saveForm_wontRunMultipleSavesAtOnce() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult1 = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult2 = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult1 = viewModel.getSavedResult();
         assertThat(saveResult1.getValue().getState(), equalTo(SAVING));
+
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult2 = viewModel.getSavedResult();
         assertThat(saveResult2.getValue().getState(), equalTo(ALREADY_SAVING));
+
         assertThat(Robolectric.getBackgroundThreadScheduler().size(), equalTo(1));
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
         assertThat(saveResult1.getValue().getState(), equalTo(SAVED));
-        assertThat(saveResult2.getValue().getState(), equalTo(ALREADY_SAVING));
     }
 
     @Test
     public void saveForm_whenReasonRequiredToSave_returnsSaveResult_inChangeReasonRequiredState() {
         whenReasonRequiredToSave();
 
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
         assertThat(saveResult.getValue().getState(), equalTo(CHANGE_REASON_REQUIRED));
     }
 
     @Test
     public void whenFormSaverFinishes_saved_setsSaveResultState_toSaved() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), true, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
         assertThat(saveResult.getValue().getState(), equalTo(SAVED));
@@ -227,7 +233,8 @@ public class FormSaveViewModelTest {
 
     @Test
     public void whenFormSaverFinishes_savedAndExit_setsSaveResultState_toSaved() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED_AND_EXIT);
         assertThat(saveResult.getValue().getState(), equalTo(SAVED));
@@ -235,7 +242,8 @@ public class FormSaveViewModelTest {
 
     @Test
     public void whenFormSaverFinishes_saveError_setSaveResultState_toSaveErrorWithMessage() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         whenFormSaverFinishes(SaveFormToDisk.SAVE_ERROR, "OH NO");
         assertThat(saveResult.getValue().getState(), equalTo(SAVE_ERROR));
@@ -255,7 +263,8 @@ public class FormSaveViewModelTest {
 
     @Test
     public void whenFormSaverFinishes_encryptionError_setSaveResultState_toFinalizeErrorWithMessage() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         whenFormSaverFinishes(SaveFormToDisk.ENCRYPTION_ERROR, "OH NO");
         assertThat(saveResult.getValue().getState(), equalTo(FINALIZE_ERROR));
@@ -275,7 +284,8 @@ public class FormSaveViewModelTest {
 
     @Test
     public void whenFormSaverFinishes_answerConstraintViolated_setSaveResultState_toConstraintError() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         whenFormSaverFinishes(FormEntryController.ANSWER_CONSTRAINT_VIOLATED);
         assertThat(saveResult.getValue().getState(), equalTo(CONSTRAINT_ERROR));
@@ -294,7 +304,8 @@ public class FormSaveViewModelTest {
 
     @Test
     public void whenFormSaverFinishes_answerRequiredButEmpty_setSaveResultState_toConstraintError() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         whenFormSaverFinishes(FormEntryController.ANSWER_REQUIRED_BUT_EMPTY);
         assertThat(saveResult.getValue().getState(), equalTo(CONSTRAINT_ERROR));
@@ -314,7 +325,8 @@ public class FormSaveViewModelTest {
     @Test
     public void whenReasonRequiredToSave_saveReason_setsSaveResultState_toSaving() {
         whenReasonRequiredToSave();
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
 
         viewModel.setReason("blah");
         viewModel.saveReason();

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -30,9 +30,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.ALREADY_SAVING;
 import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.CHANGE_REASON_REQUIRED;
 import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.CONSTRAINT_ERROR;
 import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.FINALIZE_ERROR;
@@ -61,7 +62,7 @@ public class FormSaveViewModelTest {
         when(formController.getAuditEventLogger()).thenReturn(logger);
         when(logger.isChangeReasonRequired()).thenReturn(false);
 
-        viewModel = new FormSaveViewModel(() -> CURRENT_TIME, formSaver);
+        viewModel = spy(new FormSaveViewModel(() -> CURRENT_TIME, formSaver));
         viewModel.setFormController(formController);
     }
 
@@ -79,8 +80,7 @@ public class FormSaveViewModelTest {
         assertThat(saveResult1.getState(), equalTo(SAVING));
 
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        FormSaveViewModel.SaveResult saveResult2 = viewModel.getSavedResult().getValue();
-        assertThat(saveResult2.getState(), equalTo(ALREADY_SAVING));
+        verify(viewModel, times(1)).saveToDisk(any());
     }
 
     @Test


### PR DESCRIPTION
Closes #3689

#### What has been done to verify that this works as intended?
I tested the changes manually and improved one of the automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's the only solution. The previous one was wrong because once `onDestroy()` was called the observation was killed, now it's resumed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change should just fix the problem and that's all. It shouldn't affect anything else. I think the risk here is not big. Testing the attached form seems enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)