### PR TITLE
Use md5 hash to detect changes in search()/pulldata files

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/tasks/FormLoaderTaskTest.java
@@ -58,9 +58,8 @@ public class FormLoaderTaskTest {
         assertThat(wrapper, notNullValue());
     }
 
-    // Validate the side effects of importing external data for search/pulldata
     @Test
-    public void loadSearchFromExternalCSVrenamesFiles() throws Exception {
+    public void loadSearchFromexternalCsvLeavesFileUnchanged() throws Exception {
         final String formPath = storagePathProvider.getDirPath(StorageSubdirectory.FORMS) + File.separator + SIMPLE_SEARCH_EXTERNAL_CSV_FORM;
         FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null);
         FormLoaderTask.FECWrapper wrapper = formLoaderTask.execute(formPath).get();

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalDataUtil.java
@@ -61,7 +61,7 @@ public final class ExternalDataUtil {
     public static final String EXTERNAL_METADATA_TABLE_NAME = "externalMetadata";
     public static final String SORT_COLUMN_NAME = "c_sortby";
     public static final String COLUMN_DATASET_FILENAME = "dataSetFilename";
-    public static final String COLUMN_LAST_MODIFIED = "lastModified";
+    public static final String COLUMN_MD5_HASH = "md5Hash";
 
     public static final Pattern SEARCH_FUNCTION_REGEX = Pattern.compile("search\\(.+\\)");
     private static final String COLUMN_SEPARATOR = ",";


### PR DESCRIPTION
Closes #3694

#### What has been done to verify that this works as intended?
Ran automated tests. Manually tried the forms from https://github.com/opendatakit/collect/pull/3666.

#### Why is this the best possible solution? Were any other approaches considered?
This is the simplest conversion from timestamps to md5. Neither the code nor the tests had to change much and I think give us high confidence that the change is safe or at least no worse than #3666.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
New CSV files should be ingested regardless of whether the system time changes or not. Additionally, if the same file is downloaded multiple times, it won't be re-ingested. Regression risks are only in the search()/pulldata() features and external secondary CSV instances.

#### Do we need any specific form for testing your changes? If so, please attach one.
See #3666.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)