### PR TITLE
Fixed readonly option in SelectImageMapWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/views/CustomWebView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/CustomWebView.java
@@ -42,9 +42,9 @@ public class CustomWebView extends WebView {
         return super.onTouchEvent(event);
     }
 
-    public void setEnabled(boolean enabled) {
+    public void setClickable(boolean enabled) {
         setOnTouchListener((v, event) -> !enabled);
-        super.setEnabled(enabled);
+        super.setClickable(enabled);
     }
 
     public boolean suppressFlingGesture() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/SelectImageMapWidget.java
@@ -149,7 +149,7 @@ public abstract class SelectImageMapWidget extends SelectWidget {
             webView.getSettings().setUseWideViewPort(true);
             int height = (int) (getResources().getDisplayMetrics().heightPixels / 1.7); // about 60% of a screen
             webView.setLayoutParams(new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height));
-            webView.setEnabled(!getFormEntryPrompt().isReadOnly());
+            webView.setClickable(!getFormEntryPrompt().isReadOnly());
             webView.setWebViewClient(new WebViewClient() {
                 @Override
                 public void onPageFinished(WebView view, String url) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectImageMapWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectImageMapWidgetTest.java
@@ -54,6 +54,6 @@ public abstract class SelectImageMapWidgetTest<W extends SelectImageMapWidget, A
         when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_DOWN);
 
         assertThat(getWidget().webView.getVisibility(), is(View.VISIBLE));
-        assertThat(getWidget().webView.isEnabled(), is(Boolean.FALSE));
+        assertThat(getWidget().webView.isClickable(), is(Boolean.FALSE));
     }
 }


### PR DESCRIPTION
Closes #3692

#### What has been done to verify that this works as intended?
I tested the form attached to the issue and the original `All widgets` form.

#### Why is this the best possible solution? Were any other approaches considered?
It was a bit strange bug that I don't fully understand.
[setEnabled()](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3692?expand=1#diff-3608867347eed7955275e361adec2a75L45)
existed just for tests (in fact I just need `setOnTouchListener((v, event) -> !enabled);` to disable clicking but in order to test it easily I wraped it using that method) https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3692?expand=1#diff-4cc3ee7caf6dcf8168614fbe9c351935L57
but turns out that [super.setEnabled(enabled)](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3692?expand=1#diff-3608867347eed7955275e361adec2a75L47) breakes [setOnTouchListener((v, event) -> !enabled);](https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3692?expand=1#diff-3608867347eed7955275e361adec2a75R46) I tried changing the order but to no avail. However using setClickable instead works fine so I just did that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is a small and safe fix, shouldn't affect anything else. Testing the attached form should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
The form attached to the issue.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)