### PR TITLE
Rebuild the mappable instance list when the map view is shown to reflect deleted geopoint

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -57,13 +57,9 @@ public class FormMapViewModel extends ViewModel {
     private void initializeFormInstances() {
         List<Instance> instances = instancesRepository.getAllBy(form.getJrFormId());
 
-        // Note: there is currently no way to delete instances from FormMapActivity so this works
-        // because a change in size means a refresh is needed. Compromise because we don't currently
-        // have an easy way to observe database changes.
-        if (mappableFormInstances == null || instances.size() != totalInstanceCount) {
-            totalInstanceCount = instances.size();
-            mappableFormInstances = getMappableFormInstances(instances);
-        }
+        // Ideally we could observe database changes instead of re-computing this every time.
+        totalInstanceCount = instances.size();
+        mappableFormInstances = getMappableFormInstances(instances);
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -133,6 +133,30 @@ public class FormMapViewModelTest {
         assertThat(instances.get(6).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
+    @Test public void clearingInstanceGeometry_isReflectedInInstanceCountsAndList() {
+        FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
+
+        List<FormMapViewModel.MappableFormInstance> mappableInstances = viewModel.getMappableFormInstances();
+        assertThat(viewModel.getTotalInstanceCount(), is(7));
+        assertThat(mappableInstances.size(), is(6));
+
+        assertThat(mappableInstances.get(5).getClickAction(), is(FormMapViewModel.ClickAction.NOT_VIEWABLE_TOAST));
+        ((TestInstancesRepository) testInstancesRepository).removeInstanceById(6L);
+
+        ((TestInstancesRepository) testInstancesRepository).addInstance(new Instance.Builder().databaseId(6L)
+                .jrFormId("formId1")
+                .jrVersion("2019103101")
+                .geometryType("")
+                .geometry("")
+                .canEditWhenComplete(false)
+                .status(InstanceProviderAPI.STATUS_SUBMISSION_FAILED).build());
+
+        mappableInstances = viewModel.getMappableFormInstances();
+        assertThat(viewModel.getTotalInstanceCount(), is(7));
+        assertThat(mappableInstances.size(), is(5));
+        assertThat(mappableInstances.get(4).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_READ_ONLY));
+    }
+
     static final Form TEST_FORM_1 = new Form.Builder().id(0L)
             .jrFormId("formId1")
             .jrVersion("2019103104")

--- a/collect_app/src/test/java/org/odk/collect/android/instances/TestInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/instances/TestInstancesRepository.java
@@ -55,9 +55,9 @@ public final class TestInstancesRepository implements InstancesRepository {
         instances.add(instance);
     }
 
-    public void removeInstanceById(int databaseId) {
+    public void removeInstanceById(Long databaseId) {
         for (int i = 0; i < instances.size(); i++) {
-            if (instances.get(i).getDatabaseId() == databaseId) {
+            if (instances.get(i).getDatabaseId().equals(databaseId)) {
                 instances.remove(i);
                 return;
             }


### PR DESCRIPTION
Closes #3696

#### What has been done to verify that this works as intended?
Manually verified case from issue. Added and ran automated test.

#### Why is this the best possible solution? Were any other approaches considered?

I went to the trouble of commenting that we could skip rebuilding the mappable instance list unless the instance count changed but that is not accurate. When geometry is removed, the instance count is the same. I considered trying to do something more clever like keeping track of which instance was opened since that's the only one that could change but I don't think it's worth it for now given the complexity it would add. If folks have a lot of submissions, this code will become a performance problem, I think, since it has to do some json parsing for each point. We can revisit it if we have evidence of users having problems.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This now rebuilds the mappable instance list each time the form map activity is displayed. The intentional change is fixing the bug. There's also likely a performance hit for very large numbers of submissions. Risk is only in the map view.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with a geopoint such as All Widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)