### PR TITLE
Disable Markup button if default image couldn't be loaded

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -65,7 +65,7 @@ public class AnnotateWidget extends BaseImageWidget {
         imageCaptureHandler = new ImageCaptureHandler();
         setUpLayout();
         addCurrentImageToLayout();
-        if (errorLoadingImage) {
+        if (binaryName == null || imageView == null || imageView.getVisibility() == GONE) {
             annotateButton.setEnabled(false);
         }
         addAnswerView(answerLayout, WidgetViewUtils.getStandardMargin(context));
@@ -79,9 +79,7 @@ public class AnnotateWidget extends BaseImageWidget {
         chooseButton = createSimpleButton(getContext(), R.id.choose_image, getFormEntryPrompt().isReadOnly(), getContext().getString(R.string.choose_image), getAnswerFontSize(), this);
 
         annotateButton = createSimpleButton(getContext(), R.id.markup_image, getFormEntryPrompt().isReadOnly(), getContext().getString(R.string.markup_image), getAnswerFontSize(), this);
-        if (binaryName == null) {
-            annotateButton.setEnabled(false);
-        }
+
         annotateButton.setOnClickListener(v -> imageClickHandler.clickImage("annotateButton"));
 
         answerLayout.addView(captureButton);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -65,6 +65,9 @@ public class AnnotateWidget extends BaseImageWidget {
         imageCaptureHandler = new ImageCaptureHandler();
         setUpLayout();
         addCurrentImageToLayout();
+        if (errorLoadingImage) {
+            annotateButton.setEnabled(false);
+        }
         addAnswerView(answerLayout, WidgetViewUtils.getStandardMargin(context));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -65,9 +65,7 @@ public class AnnotateWidget extends BaseImageWidget {
         imageCaptureHandler = new ImageCaptureHandler();
         setUpLayout();
         addCurrentImageToLayout();
-        if (binaryName == null || imageView == null || imageView.getVisibility() == GONE) {
-            annotateButton.setEnabled(false);
-        }
+        adjustAnnotateButtonAvailability();
         addAnswerView(answerLayout, WidgetViewUtils.getStandardMargin(context));
     }
 
@@ -147,6 +145,12 @@ public class AnnotateWidget extends BaseImageWidget {
             case R.id.choose_image:
                 imageCaptureHandler.chooseImage(R.string.annotate_image);
                 break;
+        }
+    }
+
+    private void adjustAnnotateButtonAvailability() {
+        if (binaryName == null || imageView == null || imageView.getVisibility() == GONE) {
+            annotateButton.setEnabled(false);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -61,7 +61,6 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
     protected String binaryName;
     protected TextView errorTextView;
     protected LinearLayout answerLayout;
-    protected boolean errorLoadingImage;
 
     protected ImageClickHandler imageClickHandler;
     protected ExternalImageCaptureHandler imageCaptureHandler;
@@ -163,7 +162,6 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
                 Bitmap bmp = FileUtils.getBitmapScaledToDisplay(f, screenHeight, screenWidth);
                 if (bmp == null) {
                     errorTextView.setVisibility(View.VISIBLE);
-                    errorLoadingImage = true;
                 } else {
                     imageView = createAnswerImageView(getContext(), bmp);
                     imageView.setOnClickListener(v -> {
@@ -174,8 +172,6 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
                     answerLayout.addView(imageView);
                 }
-            } else {
-                errorLoadingImage = true;
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -61,6 +61,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
     protected String binaryName;
     protected TextView errorTextView;
     protected LinearLayout answerLayout;
+    protected boolean errorLoadingImage;
 
     protected ImageClickHandler imageClickHandler;
     protected ExternalImageCaptureHandler imageCaptureHandler;
@@ -162,6 +163,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
                 Bitmap bmp = FileUtils.getBitmapScaledToDisplay(f, screenHeight, screenWidth);
                 if (bmp == null) {
                     errorTextView.setVisibility(View.VISIBLE);
+                    errorLoadingImage = true;
                 } else {
                     imageView = createAnswerImageView(getContext(), bmp);
                     imageView.setOnClickListener(v -> {
@@ -172,6 +174,8 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
                     answerLayout.addView(imageView);
                 }
+            } else {
+                errorLoadingImage = true;
             }
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -112,4 +112,18 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
         String loadedImagePath = shadowOf(((BitmapDrawable) drawable).getBitmap()).getCreatedFromPath();
         assertThat(loadedImagePath, equalTo(defaultImagePath));
     }
+
+    @Test
+    public void markupButtonShouldBeDisabledIfImageAbsent() throws Exception {
+        String wrongDefaultPath = "wrong_path";
+        overrideReferenceManager(setupFakeReferenceManager(asList(
+                new Pair<>("jr://images/referenceURI", wrongDefaultPath)
+        )));
+
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withAnswerDisplayText("jr://images/referenceURI")
+                .build();
+
+        assertThat(getWidget().annotateButton.isEnabled(), is(false));
+    }
 }


### PR DESCRIPTION
Closes #3634 

#### What has been done to verify that this works as intended?
Tested on android 9 device

#### Why is this the best possible solution? Were any other approaches considered?
This is a simple solution. Another option might be to call `setUpLayout()` after `addCurrentImageToLayout()` .

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form mentioned in the issue.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)