### PR TITLE
Fixed canceling form loading

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormLoadingDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormLoadingDialogFragment.java
@@ -45,6 +45,7 @@ public class FormLoadingDialogFragment extends ProgressDialogFragment {
 
         setTitle(getString(R.string.loading_form));
         setMessage(getString(R.string.please_wait));
+        setCancelable(false);
 
         if (context instanceof FormLoadingDialogFragmentListener) {
             listener = (FormLoadingDialogFragmentListener) context;

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormLoadingDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormLoadingDialogFragmentTest.java
@@ -1,0 +1,34 @@
+package org.odk.collect.android.formentry;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class FormLoadingDialogFragmentTest {
+
+    private FragmentManager fragmentManager;
+
+    @Before
+    public void setup() {
+        FragmentActivity activity = Robolectric.setupActivity(FragmentActivity.class);
+        fragmentManager = activity.getSupportFragmentManager();
+    }
+
+    @Test
+    public void dialogIsNotCancellable() {
+        FormLoadingDialogFragment fragment = new FormLoadingDialogFragment();
+        fragment.show(fragmentManager, "TAG");
+
+        assertThat(shadowOf(fragment.getDialog()).isCancelable(), equalTo(false));
+    }
+}


### PR DESCRIPTION
Closes #3638

#### What has been done to verify that this works as intended?
I tested canceling form loading and confirmed that now it's possible only by clicking on the `cancel` button.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was introduced in https://github.com/opendatakit/collect/pull/3592/ by mistake I guess.
Prior to that pr we were able to cancel form loading only by clicking the `cancel` button. The pr changed it and now we are able to do that clicking the area out of the dialog as well what might be misleading. It's not a problem but I think if there is a button it should be responsible for that.

It's a regression but I don't think it's that important to block the release and add it to v1.26.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The risk is low here. Testing canceling form loading would be enough. A big form and maybe an older device would help here because it will give more time to cancel the loading process.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)