### PR TITLE
Fix regression tests that fail because of permission

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/AboutPageTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/AboutPageTest.java
@@ -24,7 +24,7 @@ import static org.odk.collect.android.support.matchers.RecyclerViewMatcher.withR
 public class AboutPageTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/AdminSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/AdminSettingsTest.java
@@ -1,8 +1,13 @@
 package org.odk.collect.android.regression;
 
+import android.Manifest;
+
+import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.support.pages.AdminSettingsPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
@@ -10,6 +15,12 @@ import org.odk.collect.android.support.pages.MainMenuPage;
 //Issue NODK-239
 @RunWith(AndroidJUnit4.class)
 public class AdminSettingsTest extends BaseRegressionTest {
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE));
 
     @Test
     public void when_openAdminSettings_should_notCrash() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/AdminSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/AdminSettingsTest.java
@@ -17,7 +17,7 @@ import org.odk.collect.android.support.pages.MainMenuPage;
 public class AdminSettingsTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/BaseRegressionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/BaseRegressionTest.java
@@ -3,10 +3,10 @@ package org.odk.collect.android.regression;
 import androidx.test.rule.ActivityTestRule;
 
 import org.junit.Rule;
-import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.activities.SplashScreenActivity;
 
 public class BaseRegressionTest {
 
     @Rule
-    public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
+    public ActivityTestRule<SplashScreenActivity> rule = new ActivityTestRule<>(SplashScreenActivity.class);
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
@@ -23,7 +23,7 @@ import org.odk.collect.android.support.ScreenshotOnFailureTestRule;
 public class DrawWidgetTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -40,8 +40,9 @@ import static org.odk.collect.android.support.matchers.RecyclerViewMatcher.withR
 //Issue NODK-244
 @RunWith(AndroidJUnit4.class)
 public class FillBlankFormTest extends BaseRegressionTest {
+
         @Rule
-        public RuleChain copyFormChain = RuleChain
+        public RuleChain ruleChain = RuleChain
                 .outerRule(GrantPermissionRule.grant(
                         Manifest.permission.READ_EXTERNAL_STORAGE,
                         Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormWithRepeatGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormWithRepeatGroupTest.java
@@ -20,7 +20,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankInvalidFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankInvalidFormTest.java
@@ -16,8 +16,9 @@ import org.odk.collect.android.support.pages.MainMenuPage;
 //Issue NODK-244
 @RunWith(AndroidJUnit4.class)
 public class FillBlankInvalidFormTest extends BaseRegressionTest {
+
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormEntrySettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormEntrySettingsTest.java
@@ -17,9 +17,6 @@ import org.odk.collect.android.support.ResetStateRule;
 
 //Issue NODK-243
 public class FormEntrySettingsTest extends BaseRegressionTest {
-    @Rule
-    public RuleChain ruleChain = RuleChain
-            .outerRule(new ResetStateRule());
 
     @Rule
     public RuleChain copyFormChain = RuleChain

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormManagementTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormManagementTest.java
@@ -21,7 +21,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class FormManagementTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -21,7 +21,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class FormValidationTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/RequiredQuestionTest.java
@@ -20,7 +20,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class RequiredQuestionTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
@@ -23,7 +23,7 @@ public class ResetApplicationTest {
     public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
@@ -2,14 +2,12 @@ package org.odk.collect.android.regression;
 
 import android.Manifest;
 
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.MainMenuActivity;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.pages.AdminSettingsPage;
@@ -18,9 +16,7 @@ import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.ResetApplicationDialog;
 
 //Issue NODK-240
-public class ResetApplicationTest {
-
-    public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
+public class ResetApplicationTest extends BaseRegressionTest {
 
     @Rule
     public RuleChain ruleChain = RuleChain

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
@@ -19,6 +19,8 @@ public class ServerOtherTest extends BaseRegressionTest {
     @Rule
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
                     Manifest.permission.READ_PHONE_STATE)
             )
             .around(new ResetStateRule());

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ServerOtherTest.java
@@ -17,7 +17,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class ServerOtherTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
@@ -23,7 +23,7 @@ import org.odk.collect.android.support.ScreenshotOnFailureTestRule;
 public class SignatureWidgetTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SpinnerWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SpinnerWidgetTest.java
@@ -20,7 +20,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class SpinnerWidgetTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/TriggerWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/TriggerWidgetTest.java
@@ -19,7 +19,7 @@ import org.odk.collect.android.support.ResetStateRule;
 @RunWith(AndroidJUnit4.class)
 public class TriggerWidgetTest extends BaseRegressionTest {
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserAndDeviceIdentityTest.java
@@ -21,7 +21,7 @@ import org.odk.collect.android.support.ResetStateRule;
 public class UserAndDeviceIdentityTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserSettingsTest.java
@@ -1,5 +1,8 @@
 package org.odk.collect.android.regression;
 
+import android.Manifest;
+
+import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Rule;
@@ -18,7 +21,11 @@ public class UserSettingsTest extends BaseRegressionTest {
 
     @Rule
     public RuleChain ruleChain = RuleChain
-            .outerRule(new ResetStateRule());
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            )
+            .around(new ResetStateRule());
 
     @Test
     public void typeOption_ShouldNotBeVisible() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/CascadingSelectWithNumberInHeaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/CascadingSelectWithNumberInHeaderTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 public class CascadingSelectWithNumberInHeaderTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/ExternalSecondaryInstancesTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/formfilling/ExternalSecondaryInstancesTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 public class ExternalSecondaryInstancesTest extends BaseRegressionTest {
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
+    public RuleChain ruleChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE)


### PR DESCRIPTION
Closes #3700

I added some improvements firs. The fix itself is in the last commit https://github.com/opendatakit/collect/commit/23e0545400e4765cd7a3f96a4162026f9fb0eece

#### What has been done to verify that this works as intended?
I tested the solution on emulators.

#### Why is this the best possible solution? Were any other approaches considered?
I have no idea why it might fix the problem... On an emulator I noticed that the first test is failing every time because permissions are not granted. I even tried to remove:
`android:configChanges="locale|orientation|screenSize` from the manifest file (from the `MainMenuActivity` of course) but to no avail.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need just test it on the real device that the QA team uses. @mmarciniak90 please do that.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)