### PR TITLE
Fixed canceling form saving 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
@@ -15,6 +15,7 @@ public class SaveFormProgressDialogFragment extends ProgressDialogFragment {
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
+        setCancelable(false);
         setTitle(getString(R.string.saving_form));
         setMessage(getString(R.string.please_wait));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragmentTest.java
@@ -1,0 +1,33 @@
+package org.odk.collect.android.formentry;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class SaveFormProgressDialogFragmentTest {
+    private FragmentManager fragmentManager;
+
+    @Before
+    public void setup() {
+        FragmentActivity activity = Robolectric.setupActivity(FragmentActivity.class);
+        fragmentManager = activity.getSupportFragmentManager();
+    }
+
+    @Test
+    public void dialogIsNotCancellable() {
+        SaveFormProgressDialogFragment fragment = new SaveFormProgressDialogFragment();
+        fragment.show(fragmentManager, "TAG");
+
+        assertThat(shadowOf(fragment.getDialog()).isCancelable(), equalTo(false));
+    }
+}


### PR DESCRIPTION
Closes #3714 

#### What has been done to verify that this works as intended?
I tested the fix manual and added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that it was possible to cancel saving form. The issue is similar to #3702 and probably was introduced in the same pr by mistake. In both cases it shouldn't be possible to cancel the process after clicking the area out of the dialog.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe change. Testing the scenario described in the issue would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)