### PR TITLE
Make sure dialog fragments aren't shown for destroyed Activity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -152,6 +152,10 @@ public final class DialogUtils {
     }
 
     public static <T extends DialogFragment> T showIfNotShowing(T newDialog, FragmentManager fragmentManager) {
+        if (fragmentManager.isStateSaved()) {
+            return newDialog;
+        }
+
         String tag = newDialog.getClass().getName();
         T existingDialog = (T) fragmentManager.findFragmentByTag(tag);
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
@@ -1,23 +1,27 @@
 package org.odk.collect.android.utilities;
 
+import android.os.Bundle;
+
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.odk.collect.android.support.RobolectricHelpers.buildThemedActivity;
+import static org.odk.collect.android.support.RobolectricHelpers.createThemedActivity;
 
 @RunWith(RobolectricTestRunner.class)
 public class DialogUtilsTest {
 
     @Test
-    public void show_onlyEverOpensOneDialog() {
-        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class);
+    public void showIfNotShowing_onlyEverOpensOneDialog() {
+        FragmentActivity activity = createThemedActivity(FragmentActivity.class);
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
 
         DialogFragment dialog1 = new DialogFragment();
@@ -28,5 +32,25 @@ public class DialogUtilsTest {
 
         assertThat(fragmentManager.getFragments().size(), equalTo(1));
         assertThat(fragmentManager.getFragments().get(0), equalTo(dialog1));
+    }
+
+    @Test
+    public void showIfNotShowing_whenActivitySavedState_doesNotShowDialog() {
+        ActivityController<FragmentActivity> activityController = buildThemedActivity(FragmentActivity.class).setup();
+        activityController.pause().stop().saveInstanceState(new Bundle());
+
+        FragmentManager fragmentManager = activityController.get().getSupportFragmentManager();
+        DialogUtils.showIfNotShowing(new DialogFragment(), fragmentManager);
+        assertThat(fragmentManager.getFragments().size(), equalTo(0));
+    }
+
+    @Test
+    public void showIfNotShowing_whenActivityDestroyed_doesNotShowDialog() {
+        ActivityController<FragmentActivity> activityController = buildThemedActivity(FragmentActivity.class).setup();
+        activityController.pause().stop().destroy();
+
+        FragmentManager fragmentManager = activityController.get().getSupportFragmentManager();
+        DialogUtils.showIfNotShowing(new DialogFragment(), fragmentManager);
+        assertThat(fragmentManager.getFragments().size(), equalTo(0));
     }
 }


### PR DESCRIPTION
Closes #3716

From investigating this it seems likely to me that this bug was cooperating on creating crashes with #3702. I'd recommend merging both and doing a patch release.

#### What has been done to verify that this works as intended?

I wasn't able to get to reproduction steps but I did create a test that (when failing) produced the same exception.

#### Why is this the best possible solution? Were any other approaches considered?

It looks we were previously catching `IllegalStateException` for some [similar code](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/GoogleSheetsUploaderProgressDialog.java#L70). My thinking is that with this solution we have tests that are (hopefully) identifying the issue and preventing regressions. Totally understand if others disagree!

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue but it's hard to test. I'd say it's best to test form loading and check nothing is wrong.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)