### PR TITLE
Added margin in Label Widget

### DIFF
--- a/collect_app/src/main/res/layout/label_widget.xml
+++ b/collect_app/src/main/res/layout/label_widget.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/question_widget_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_marginTop="@dimen/margin_small">
 
     <org.odk.collect.android.formentry.questions.AudioVideoImageTextLabel
         android:id="@+id/question_label"


### PR DESCRIPTION
Closes #3709

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it on Android 9.0.

Before adding margin           |     After adding margin
:-------------------------:|:-------------------------:
![WhatsApp Image 2020-03-17 at 20 17 45](https://user-images.githubusercontent.com/35730054/76868390-d7981580-688c-11ea-868d-0785189bae59.jpeg)  |  ![WhatsApp Image 2020-03-17 at 20 17 13](https://user-images.githubusercontent.com/35730054/76868331-be8f6480-688c-11ea-801c-df6ff01ea566.jpeg)



#### Why is this the best possible solution? Were any other approaches considered?
I added the same top margin in the `label_widget.xml` file, as in `question_widget.xml`. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
A form with a grid of questions [as this one](https://docs.google.com/spreadsheets/d/1CWjrWnneTAl1Gs8-BaT-VwJV8TgrbKlYXPMK5HjGVrU/edit#gid=0).

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)