### PR TITLE
Fix classes path for code coverage plugin

### DIFF
--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -22,7 +22,7 @@ tasks.register("jacocoTestReport", JacocoReport) {
     }
 
     classDirectories = fileTree(
-            dir: "${buildDir}/intermediates/classes/debug",
+            dir: "${buildDir}/intermediates/javac/debug/classes",
             excludes: ['**/R.class',
                        '**/R$*.class',
                        '**/*$ViewInjector*.*',


### PR DESCRIPTION
Fixes #3730

Codecov reporting is broken as jacoco plugin can't find source classes for generating reports.
See https://codecov.io/github/opendatakit/collect

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Screenshots attached at the bottom

#### Why is this the best possible solution? Were any other approaches considered?
This is the only viable solution to the problem

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Non-user facing change

#### Do we need any specific form for testing your changes? If so, please attach one.
Not needed. Just running `./gradlew jacocoTestReport` should suffice

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)

###Screenshots of reports generated
Before:
![image](https://user-images.githubusercontent.com/8918023/77245163-8a2bf780-6c42-11ea-95a9-13b26cd2f4a0.png)

After:
![image](https://user-images.githubusercontent.com/8918023/77245132-5650d200-6c42-11ea-9fee-7a5bcc7f8f5d.png)
