### PR TITLE
Revise `DialogUtils.showIfNotShowing` helper

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/storage/StorageMigrationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/storage/StorageMigrationTest.java
@@ -11,7 +11,10 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.storage.migration.StorageMigrationService;
 import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.IdlingResourceRule;
+import org.odk.collect.android.support.IntentServiceIdlingResource;
 import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.StorageMigrationDialogPage;
@@ -31,6 +34,7 @@ public class StorageMigrationTest {
             ))
             .around(new ResetStateRule(false))
             .around(new CopyFormRule("formWithExternalFiles.xml", Arrays.asList("formWithExternalFiles-media/itemsets.csv", "formWithExternalFiles-media/fruits.xml", "formWithExternalFiles-media/fruits.csv", "formWithExternalFiles-media/last-saved.xml"), true))
+            .around(new IdlingResourceRule(new IntentServiceIdlingResource(StorageMigrationService.SERVICE_NAME)))
             .around(rule);
 
     @Test
@@ -144,3 +148,4 @@ public class StorageMigrationTest {
                 .rotateToPortrait(new StorageMigrationDialogPage(rule));
     }
 }
+

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/IdlingResourceRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/IdlingResourceRule.java
@@ -1,0 +1,44 @@
+package org.odk.collect.android.support;
+
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResource;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class IdlingResourceRule implements TestRule {
+
+    private final IdlingResource idlingResource;
+
+    public IdlingResourceRule(IdlingResource idlingResource) {
+        this.idlingResource = idlingResource;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new IdlingResourceStatement(idlingResource, base);
+    }
+
+    private static class IdlingResourceStatement extends Statement {
+
+        private final IdlingResource idlingResource;
+        private final Statement base;
+
+        IdlingResourceStatement(IdlingResource idlingResource, Statement base) {
+            this.idlingResource = idlingResource;
+            this.base = base;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            IdlingRegistry.getInstance().register(idlingResource);
+
+            try {
+                base.evaluate();
+            } finally {
+                IdlingRegistry.getInstance().unregister(idlingResource);
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/IntentServiceIdlingResource.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/IntentServiceIdlingResource.java
@@ -1,0 +1,47 @@
+package org.odk.collect.android.support;
+
+import android.app.ActivityManager;
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.IdlingResource;
+
+public class IntentServiceIdlingResource implements IdlingResource {
+
+    private ResourceCallback resourceCallback;
+    private final String serviceName;
+
+    public IntentServiceIdlingResource(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
+    public String getName() {
+        return IntentServiceIdlingResource.class.getName();
+    }
+
+    @Override
+    public boolean isIdleNow() {
+        boolean idle = !isMigrationRunning();
+        if (idle && resourceCallback != null) {
+            resourceCallback.onTransitionToIdle();
+        }
+        return idle;
+    }
+
+    @Override
+    public void registerIdleTransitionCallback(ResourceCallback resourceCallback) {
+        this.resourceCallback = resourceCallback;
+    }
+
+    private boolean isMigrationRunning() {
+        ActivityManager manager = (ActivityManager) ApplicationProvider.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
+        for (ActivityManager.RunningServiceInfo info : manager.getRunningServices(Integer.MAX_VALUE)) {
+            if (info.service.getClassName().equals(serviceName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -93,7 +93,7 @@ the specific language governing permissions and limitations under the License.
 
         <activity
             android:name=".activities.MainMenuActivity"
-            android:configChanges="locale|orientation|screenSize" />
+            android:configChanges="locale" />
         <activity
             android:name=".activities.ScannerWithFlashlightActivity"
             android:screenOrientation="portrait"

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -93,7 +93,7 @@ the specific language governing permissions and limitations under the License.
 
         <activity
             android:name=".activities.MainMenuActivity"
-            android:configChanges="locale" />
+            android:configChanges="locale|orientation|screenSize" />
         <activity
             android:name=".activities.ScannerWithFlashlightActivity"
             android:screenOrientation="portrait"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -413,8 +413,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         identityPromptViewModel = ViewModelProviders.of(this).get(IdentityPromptViewModel.class);
         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
             if (requiresIdentity) {
-                IdentifyUserPromptDialogFragment dialog = IdentifyUserPromptDialogFragment.create(getFormController().getFormTitle());
-                DialogUtils.showIfNotShowing(dialog, getSupportFragmentManager());
+                DialogUtils.showIfNotShowing(IdentifyUserPromptDialogFragment.class, getSupportFragmentManager());
             }
         });
         identityPromptViewModel.isFormEntryCancelled().observe(this, isFormEntryCancelled -> {
@@ -486,13 +485,13 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             if (!newForm) {
                 if (getFormController() != null) {
                     FormController formController = getFormController();
-                    identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                    identityPromptViewModel.setFormController(formController);
                     formSaveViewModel.setFormController(formController);
                     refreshCurrentView();
                 } else {
                     Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath);
-                    DialogUtils.showIfNotShowing(FormLoadingDialogFragment.newInstance(), getSupportFragmentManager());
+                    DialogUtils.showIfNotShowing(FormLoadingDialogFragment.class, getSupportFragmentManager());
                     formLoaderTask.execute(formPath);
                 }
                 return;
@@ -627,7 +626,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
 
         formLoaderTask = new FormLoaderTask(instancePath, null, null);
-        DialogUtils.showIfNotShowing(FormLoadingDialogFragment.newInstance(), getSupportFragmentManager());
+        DialogUtils.showIfNotShowing(FormLoadingDialogFragment.class, getSupportFragmentManager());
         formLoaderTask.execute(formPath);
     }
 
@@ -667,6 +666,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     private FormController getFormController() {
         return Collect.getInstance().getFormController();
     }
+
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -1836,15 +1836,14 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
         switch (result.getState()) {
             case CHANGE_REASON_REQUIRED:
-                ChangesReasonPromptDialogFragment dialog = ChangesReasonPromptDialogFragment.create(getFormController().getFormTitle());
-                DialogUtils.showIfNotShowing(dialog, getSupportFragmentManager());
+                DialogUtils.showIfNotShowing(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
                 break;
 
             case SAVING:
                 autoSaved = true;
 
                 SaveFormProgressDialogFragment progressDialog = DialogUtils.showIfNotShowing(
-                        new SaveFormProgressDialogFragment(),
+                        SaveFormProgressDialogFragment.class,
                         getSupportFragmentManager()
                 );
 
@@ -2399,7 +2398,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
                 if (formController.getInstanceFile() == null) {
                     createInstanceDirectory(formController);
-                    identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                    identityPromptViewModel.setFormController(formController);
                     formSaveViewModel.setFormController(formController);
 
                     identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
@@ -2416,7 +2415,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         // we've just loaded a saved form, so start in the hierarchy view
                         String formMode = reqIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
                         if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
-                            identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                            identityPromptViewModel.setFormController(formController);
                             formSaveViewModel.setFormController(formController);
 
                             identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
@@ -2449,7 +2448,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             finish();
                         }
                     } else {
-                        identityPromptViewModel.setAuditEventLogger(formController.getAuditEventLogger());
+                        identityPromptViewModel.setFormController(formController);
                         formSaveViewModel.setFormController(formController);
 
                         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
@@ -2520,7 +2519,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     public void onProgressStep(String stepMessage) {
         DialogUtils.showIfNotShowing(
-                new FormLoadingDialogFragment(),
+                FormLoadingDialogFragment.class,
                 getSupportFragmentManager()
         ).setMessage(getString(R.string.please_wait) + "\n\n" + stepMessage);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -32,6 +32,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProviders;
 
@@ -82,6 +83,7 @@ import butterknife.ButterKnife;
 import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
+import static org.odk.collect.android.utilities.DialogUtils.getDialog;
 import static org.odk.collect.android.utilities.DialogUtils.showIfNotShowing;
 
 /**
@@ -543,8 +545,11 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
                 startActivity(new Intent(this, AdminPreferencesActivity.class));
                 break;
             case STORAGE_MIGRATION:
-                showStorageMigrationDialog()
-                        .startStorageMigration();
+                StorageMigrationDialog dialog = showStorageMigrationDialog();
+                if (dialog != null) {
+                    dialog.startStorageMigration();
+                }
+
                 break;
             case SCAN_QR_CODE:
                 startActivity(new Intent(this, ScanQRCodeActivity.class));
@@ -628,16 +633,21 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             DialogUtils.dismissDialog(StorageMigrationDialog.class, getSupportFragmentManager());
             displayBannerWithSuccessStorageMigrationResult();
         } else {
-            showStorageMigrationDialog()
-                    .handleMigrationError(result);
+            StorageMigrationDialog dialog = showStorageMigrationDialog();
+
+            if (dialog != null) {
+                dialog.handleMigrationError(result);
+            }
         }
     }
 
+    @Nullable
     private StorageMigrationDialog showStorageMigrationDialog() {
         Bundle args = new Bundle();
         args.putInt(StorageMigrationDialog.ARG_UNSENT_INSTANCES, savedCount);
 
-        return showIfNotShowing(StorageMigrationDialog.class, args, getSupportFragmentManager());
+        showIfNotShowing(StorageMigrationDialog.class, args, getSupportFragmentManager());
+        return getDialog(StorageMigrationDialog.class, getSupportFragmentManager());
     }
 
     private void setUpStorageMigrationBanner() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -40,9 +40,9 @@ import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
-import org.odk.collect.android.fragments.dialogs.AdminPasswordDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.AdminKeys;
+import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
 import org.odk.collect.android.preferences.AdminPreferencesActivity;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.AutoSendPreferenceMigrator;
@@ -89,7 +89,7 @@ import static org.odk.collect.android.preferences.GeneralKeys.KEY_SUBMISSION_TRA
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
-public class MainMenuActivity extends CollectAbstractActivity implements AdminPasswordDialog.AdminPasswordDialogCallback {
+public class MainMenuActivity extends CollectAbstractActivity implements AdminPasswordDialogFragment.AdminPasswordDialogCallback {
     private static final boolean EXIT = true;
     // buttons
     private Button manageFilesButton;
@@ -359,7 +359,8 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
                 analytics.logEvent(SCAN_QR_CODE, "MainMenu");
 
                 if (adminPasswordProvider.isAdminPasswordSet()) {
-                    DialogUtils.showIfNotShowing(AdminPasswordDialog.create(adminPasswordProvider, AdminPasswordDialog.Action.SCAN_QR_CODE), getSupportFragmentManager());
+                    DialogUtils.showIfNotShowing(AdminPasswordDialogFragment.class, getSupportFragmentManager())
+                            .setAction(AdminPasswordDialogFragment.Action.SCAN_QR_CODE);
                 } else {
                     startActivity(new Intent(this, ScanQRCodeActivity.class));
                 }
@@ -372,7 +373,8 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
                 return true;
             case R.id.menu_admin_preferences:
                 if (adminPasswordProvider.isAdminPasswordSet()) {
-                    DialogUtils.showIfNotShowing(AdminPasswordDialog.create(adminPasswordProvider, AdminPasswordDialog.Action.ADMIN_SETTINGS), getSupportFragmentManager());
+                    DialogUtils.showIfNotShowing(AdminPasswordDialogFragment.class, getSupportFragmentManager())
+                            .setAction(AdminPasswordDialogFragment.Action.ADMIN_SETTINGS);
                 } else {
                     startActivity(new Intent(this, AdminPreferencesActivity.class));
                 }
@@ -531,7 +533,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     @Override
-    public void onCorrectAdminPassword(AdminPasswordDialog.Action action) {
+    public void onCorrectAdminPassword(AdminPasswordDialogFragment.Action action) {
         switch (action) {
             case ADMIN_SETTINGS:
                 startActivity(new Intent(this, AdminPreferencesActivity.class));

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormLoadingDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormLoadingDialogFragment.java
@@ -35,10 +35,6 @@ public class FormLoadingDialogFragment extends ProgressDialogFragment {
     @Deprecated
     private FormLoadingDialogFragmentListener listener;
 
-    public static FormLoadingDialogFragment newInstance() {
-        return new FormLoadingDialogFragment();
-    }
-
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/SaveFormProgressDialogFragment.java
@@ -9,21 +9,34 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 
+import static org.odk.collect.android.formentry.saving.FormSaveViewModel.SaveResult.State.SAVING;
+
 public class SaveFormProgressDialogFragment extends ProgressDialogFragment {
+
+    private FormSaveViewModel viewModel;
 
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
+        viewModel = ViewModelProviders
+                .of(requireActivity(), new FormSaveViewModel.Factory())
+                .get(FormSaveViewModel.class);
+
         setCancelable(false);
         setTitle(getString(R.string.saving_form));
-        setMessage(getString(R.string.please_wait));
+
+        viewModel.getSaveResult().observe(this, result -> {
+            if (result != null && result.getState() == SAVING && result.getMessage() != null) {
+                setMessage(getString(R.string.please_wait) + "\n\n" + result.getMessage());
+            } else {
+                setMessage(getString(R.string.please_wait));
+            }
+        });
     }
 
     @Override
     protected Cancellable getCancellable() {
-        return ViewModelProviders
-                .of(getActivity(), new FormSaveViewModel.Factory())
-                .get(FormSaveViewModel.class);
+        return viewModel;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -21,18 +21,9 @@ import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 
 public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogFragment {
 
-    private static final String ARG_FORM_NAME = "ArgFormName";
     private FormSaveViewModel viewModel;
 
     public ViewModelProvider.Factory viewModelFactory = new FormSaveViewModel.Factory();
-
-    public static ChangesReasonPromptDialogFragment create(String formName) {
-        ChangesReasonPromptDialogFragment fragment = new ChangesReasonPromptDialogFragment();
-        Bundle bundle = new Bundle();
-        bundle.putString(ChangesReasonPromptDialogFragment.ARG_FORM_NAME, formName);
-        fragment.setArguments(bundle);
-        return fragment;
-    }
 
     @Nullable
     @Override
@@ -45,7 +36,7 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
         super.onViewCreated(view, savedInstanceState);
 
         Toolbar toolbar = getToolbar();
-        toolbar.setTitle(getArguments().getString(ARG_FORM_NAME));
+        toolbar.setTitle(viewModel.getFormName());
         toolbar.inflateMenu(R.menu.changes_reason_dialog);
 
         EditText reasonField = view.findViewById(R.id.reason);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
@@ -17,19 +17,7 @@ import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 
 public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFragment {
 
-    private static final String ARG_FORM_NAME = "ArgFormName";
-
     private IdentityPromptViewModel viewModel;
-
-    public static IdentifyUserPromptDialogFragment create(String formName) {
-        IdentifyUserPromptDialogFragment dialog = new IdentifyUserPromptDialogFragment();
-
-        Bundle bundle = new Bundle();
-        bundle.putString(IdentifyUserPromptDialogFragment.ARG_FORM_NAME, formName);
-        dialog.setArguments(bundle);
-
-        return dialog;
-    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -40,7 +28,7 @@ public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFr
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        getToolbar().setTitle(getArguments().getString(ARG_FORM_NAME));
+        getToolbar().setTitle(viewModel.getFormName());
 
         EditText identityField = view.findViewById(R.id.identity);
         identityField.setText(viewModel.getUser());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentifyUserPromptDialogFragment.java
@@ -28,7 +28,7 @@ public class IdentifyUserPromptDialogFragment extends MaterialFullScreenDialogFr
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        getToolbar().setTitle(viewModel.getFormName());
+        getToolbar().setTitle(viewModel.getFormTitle());
 
         EditText identityField = view.findViewById(R.id.identity);
         identityField.setText(viewModel.getUser());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
@@ -5,6 +5,8 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
+import org.odk.collect.android.logic.FormController;
+
 import static org.odk.collect.android.utilities.StringUtils.isBlank;
 
 public class IdentityPromptViewModel extends ViewModel {
@@ -15,6 +17,7 @@ public class IdentityPromptViewModel extends ViewModel {
     @Nullable
     private AuditEventLogger auditEventLogger;
     private String identity = "";
+    private String formName;
 
     public IdentityPromptViewModel() {
         updateRequiresIdentity();
@@ -32,8 +35,9 @@ public class IdentityPromptViewModel extends ViewModel {
         return identity;
     }
 
-    public void setAuditEventLogger(AuditEventLogger auditEventLogger) {
-        this.auditEventLogger = auditEventLogger;
+    public void setFormController(FormController formController) {
+        this.formName = formController.getFormTitle();
+        this.auditEventLogger = formController.getAuditEventLogger();
         updateRequiresIdentity();
     }
 
@@ -58,5 +62,9 @@ public class IdentityPromptViewModel extends ViewModel {
 
     private static boolean userIsValid(String user) {
         return user != null && !user.isEmpty() && !isBlank(user);
+    }
+
+    public String getFormName() {
+        return formName;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
@@ -64,7 +64,7 @@ public class IdentityPromptViewModel extends ViewModel {
         return user != null && !user.isEmpty() && !isBlank(user);
     }
 
-    public String getFormName() {
+    public String getFormTitle() {
         return formName;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -197,6 +197,10 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
                 && auditEventLogger.isChangesMade();
     }
 
+    public String getFormName() {
+        return formController.getFormTitle();
+    }
+
     public static class SaveResult {
 
         private final State state;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -182,7 +182,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
         }
     }
 
-    public LiveData<SaveResult> getSavedResult() {
+    public LiveData<SaveResult> getSaveResult() {
         return saveResult;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -27,6 +27,7 @@ import org.odk.collect.android.geo.OsmDroidMapFragment;
 import org.odk.collect.android.fragments.ShowQRCodeFragment;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.FormManagementPreferences;
 import org.odk.collect.android.preferences.FormMetadataFragment;
@@ -154,6 +155,8 @@ public interface AppDependencyComponent {
     void inject(AutoSendWorker autoSendWorker);
 
     void inject(StorageMigrationDialog storageMigrationDialog);
+
+    void inject(AdminPasswordDialogFragment adminPasswordDialogFragment);
 
     void inject(SplashScreenActivity splashScreenActivity);
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPasswordDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPasswordDialogFragment.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 
 public class AdminPasswordDialogFragment extends DialogFragment {
 
-    private static final String KEY_ACTION = "ACTION";
+    public static final String ARG_ACTION = "ACTION";
 
     public enum Action { ADMIN_SETTINGS, STORAGE_MIGRATION, SCAN_QR_CODE }
 
@@ -30,14 +30,6 @@ public class AdminPasswordDialogFragment extends DialogFragment {
 
     @Inject
     AdminPasswordProvider adminPasswordProvider;
-
-    public void setAction(Action action) {
-        if (getArguments() == null) {
-            setArguments(new Bundle());
-        }
-
-        getArguments().putSerializable(KEY_ACTION, action);
-    }
 
     @Override
     public void onAttach(@NotNull Context context) {

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
@@ -17,6 +17,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
+import org.odk.collect.android.preferences.AdminPasswordDialogFragment.Action;
 import org.odk.collect.android.utilities.AdminPasswordProvider;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.MultiClickGuard;
@@ -28,7 +29,7 @@ import butterknife.ButterKnife;
 
 public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
 
-    private static final String UNSENT_INSTANCES = "unsentInstances";
+    public static final String ARG_UNSENT_INSTANCES = "unsentInstances";
 
     @BindView(R.id.cancelButton)
     Button cancelButton;
@@ -62,15 +63,6 @@ public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
 
     private int unsentInstancesNumber;
 
-    public static StorageMigrationDialog create(int unsentInstances) {
-        StorageMigrationDialog storageMigrationDialog = new StorageMigrationDialog();
-        Bundle bundle = new Bundle();
-        bundle.putInt(UNSENT_INSTANCES, unsentInstances);
-        storageMigrationDialog.setArguments(bundle);
-
-        return storageMigrationDialog;
-    }
-
     @Override
     public void onAttach(@NotNull Context context) {
         super.onAttach(context);
@@ -88,7 +80,7 @@ public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
         ButterKnife.bind(this, view);
 
         if (getArguments() != null) {
-            unsentInstancesNumber = getArguments().getInt(UNSENT_INSTANCES);
+            unsentInstancesNumber = getArguments().getInt(ARG_UNSENT_INSTANCES);
         }
 
         setUpToolbar();
@@ -108,8 +100,9 @@ public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
         migrateButton.setOnClickListener(v -> {
             if (MultiClickGuard.allowClick(getClass().getName())) {
                 if (adminPasswordProvider.isAdminPasswordSet()) {
-                    DialogUtils.showIfNotShowing(AdminPasswordDialogFragment.class, getActivity().getSupportFragmentManager())
-                            .setAction(AdminPasswordDialogFragment.Action.STORAGE_MIGRATION);
+                    Bundle args = new Bundle();
+                    args.putSerializable(AdminPasswordDialogFragment.ARG_ACTION, Action.STORAGE_MIGRATION);
+                    DialogUtils.showIfNotShowing(AdminPasswordDialogFragment.class, args, getActivity().getSupportFragmentManager());
                 } else {
                     startStorageMigration();
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
@@ -14,12 +14,12 @@ import android.widget.TextView;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
-import org.odk.collect.android.fragments.dialogs.AdminPasswordDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
+import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
 import org.odk.collect.android.utilities.AdminPasswordProvider;
-import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.MultiClickGuard;
 
 import javax.inject.Inject;
 
@@ -108,7 +108,8 @@ public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
         migrateButton.setOnClickListener(v -> {
             if (MultiClickGuard.allowClick(getClass().getName())) {
                 if (adminPasswordProvider.isAdminPasswordSet()) {
-                    DialogUtils.showIfNotShowing(AdminPasswordDialog.create(adminPasswordProvider, AdminPasswordDialog.Action.STORAGE_MIGRATION), getActivity().getSupportFragmentManager());
+                    DialogUtils.showIfNotShowing(AdminPasswordDialogFragment.class, getActivity().getSupportFragmentManager())
+                            .setAction(AdminPasswordDialogFragment.Action.STORAGE_MIGRATION);
                 } else {
                     startStorageMigration();
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationService.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationService.java
@@ -10,11 +10,14 @@ import org.odk.collect.android.application.Collect;
 import javax.inject.Inject;
 
 public class StorageMigrationService extends IntentService {
+
+    public static final String SERVICE_NAME = "StorageMigrationService";
+
     @Inject
     StorageMigrator storageMigrator;
 
     public StorageMigrationService() {
-        super("StorageMigrationService");
+        super(SERVICE_NAME);
         Collect.getInstance().getComponent().inject(this);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -154,13 +154,18 @@ public final class DialogUtils {
         return alertDialog;
     }
 
-    public static <T extends DialogFragment> T showIfNotShowing(Class<T> dialogClass, FragmentManager fragmentManager) {
-        return showIfNotShowing(dialogClass, null, fragmentManager);
+    @Nullable
+    public static <T extends DialogFragment> T getDialog(Class<T> dialogClass, FragmentManager fragmentManager) {
+        return (T) fragmentManager.findFragmentByTag(dialogClass.getName());
     }
 
-    public static <T extends DialogFragment> T showIfNotShowing(Class<T> dialogClass, @Nullable Bundle args, FragmentManager fragmentManager) {
+    public static <T extends DialogFragment> void showIfNotShowing(Class<T> dialogClass, FragmentManager fragmentManager) {
+        showIfNotShowing(dialogClass, null, fragmentManager);
+    }
+
+    public static <T extends DialogFragment> void showIfNotShowing(Class<T> dialogClass, @Nullable Bundle args, FragmentManager fragmentManager) {
         if (fragmentManager.isStateSaved()) {
-            return createNewInstance(dialogClass, args);
+            return;
         }
 
         String tag = dialogClass.getName();
@@ -174,10 +179,6 @@ public final class DialogUtils {
             // could happen before the Fragment exists in the Fragment Manager and so the
             // call to findFragmentByTag would return null and result in second dialog being show.
             fragmentManager.executePendingTransactions();
-
-            return newDialog;
-        } else {
-            return existingDialog;
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -154,6 +154,13 @@ public final class DialogUtils {
         return alertDialog;
     }
 
+    /**
+     * It can be a bad idea to interact with Fragment instances. As much as possible we
+     * should be using arguments (for static data the dialog needs), Dagger (for dependencies) or
+     * ViewModel (for non static data) to get things into fragments so as to avoid crashes or
+     * weirdness when they are recreated.
+     */
+    @Deprecated
     @Nullable
     public static <T extends DialogFragment> T getDialog(Class<T> dialogClass, FragmentManager fragmentManager) {
         return (T) fragmentManager.findFragmentByTag(dialogClass.getName());

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -70,7 +70,7 @@ public class FormSaveViewModelTest {
     @Test
     public void saveForm_returnsSaveResult_inSavingState() {
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        FormSaveViewModel.SaveResult saveResult1 = viewModel.getSavedResult().getValue();
+        FormSaveViewModel.SaveResult saveResult1 = viewModel.getSaveResult().getValue();
         assertThat(saveResult1.getState(), equalTo(SAVING));
     }
 
@@ -90,7 +90,7 @@ public class FormSaveViewModelTest {
     public void saveForm_whenReasonRequiredToSave_returnsSaveResult_inChangeReasonRequiredState() {
         whenReasonRequiredToSave();
 
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         assertThat(saveResult.getValue().getState(), equalTo(CHANGE_REASON_REQUIRED));
     }
@@ -98,7 +98,7 @@ public class FormSaveViewModelTest {
     @Test
     public void whenFormSaverFinishes_saved_setsSaveResultState_toSaved() {
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
         assertThat(saveResult.getValue().getState(), equalTo(SAVED));
@@ -227,7 +227,7 @@ public class FormSaveViewModelTest {
     @Test
     public void whenFormSaverFinishes_savedAndExit_setsSaveResultState_toSaved() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         whenFormSaverFinishes(SaveFormToDisk.SAVED_AND_EXIT);
         assertThat(saveResult.getValue().getState(), equalTo(SAVED));
@@ -236,7 +236,7 @@ public class FormSaveViewModelTest {
     @Test
     public void whenFormSaverFinishes_saveError_setSaveResultState_toSaveErrorWithMessage() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         whenFormSaverFinishes(SaveFormToDisk.SAVE_ERROR, "OH NO");
         assertThat(saveResult.getValue().getState(), equalTo(SAVE_ERROR));
@@ -257,7 +257,7 @@ public class FormSaveViewModelTest {
     @Test
     public void whenFormSaverFinishes_encryptionError_setSaveResultState_toFinalizeErrorWithMessage() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         whenFormSaverFinishes(SaveFormToDisk.ENCRYPTION_ERROR, "OH NO");
         assertThat(saveResult.getValue().getState(), equalTo(FINALIZE_ERROR));
@@ -278,7 +278,7 @@ public class FormSaveViewModelTest {
     @Test
     public void whenFormSaverFinishes_answerConstraintViolated_setSaveResultState_toConstraintError() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         whenFormSaverFinishes(FormEntryController.ANSWER_CONSTRAINT_VIOLATED);
         assertThat(saveResult.getValue().getState(), equalTo(CONSTRAINT_ERROR));
@@ -298,7 +298,7 @@ public class FormSaveViewModelTest {
     @Test
     public void whenFormSaverFinishes_answerRequiredButEmpty_setSaveResultState_toConstraintError() {
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         whenFormSaverFinishes(FormEntryController.ANSWER_REQUIRED_BUT_EMPTY);
         assertThat(saveResult.getValue().getState(), equalTo(CONSTRAINT_ERROR));
@@ -319,7 +319,7 @@ public class FormSaveViewModelTest {
     public void whenReasonRequiredToSave_saveReason_setsSaveResultState_toSaving() {
         whenReasonRequiredToSave();
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         viewModel.setReason("blah");
         viewModel.saveReason();
@@ -351,7 +351,7 @@ public class FormSaveViewModelTest {
 
     @Test
     public void resumeFormEntry_clearsSaveResult() {
-        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSavedResult();
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         viewModel.resumeFormEntry();
         assertThat(saveResult.getValue(), equalTo(null));

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModelTest.java
@@ -2,20 +2,24 @@ package org.odk.collect.android.formentry.audit;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.logic.FormController;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class IdentityPromptViewModelTest {
 
     @Test
     public void done_setsUserOnAuditEventLogger() {
+        FormController formController = mock(FormController.class);
         AuditEventLogger auditEventLogger = mock(AuditEventLogger.class);
+        when(formController.getAuditEventLogger()).thenReturn(auditEventLogger);
         IdentityPromptViewModel viewModel = new IdentityPromptViewModel();
 
-        viewModel.setAuditEventLogger(auditEventLogger);
+        viewModel.setFormController(formController);
         viewModel.setIdentity("Picard");
         viewModel.done();
         verify(auditEventLogger).setUser("Picard");

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
@@ -18,6 +18,7 @@ import org.robolectric.annotation.LooperMode;
 import static android.os.Looper.getMainLooper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.odk.collect.android.preferences.AdminPasswordDialogFragment.ARG_ACTION;
 import static org.odk.collect.android.preferences.AdminPasswordDialogFragment.Action.STORAGE_MIGRATION;
 import static org.robolectric.Shadows.shadowOf;
@@ -50,6 +51,24 @@ public class AdminPasswordDialogFragmentTest {
             shadowOf(getMainLooper()).idle();
 
             assertThat(activity.onCorrectAdminPasswordCalledWith, equalTo(STORAGE_MIGRATION));
+            assertThat(activity.onIncorrectAdminPasswordCalled, equalTo(false));
+        });
+    }
+
+    @Test
+    public void enteringIncorrectPassword_andClickingOK_callsOnInCorrectAdminPassword() {
+        TestActivityScenario<SpyAdminPasswordDialogCallbackActivity> activityScenario = TestActivityScenario.launch(SpyAdminPasswordDialogCallbackActivity.class);
+        activityScenario.onActivity(activity -> {
+            AdminPasswordDialogFragment fragment = createFragment();
+            fragment.show(activity.getSupportFragmentManager(), "tag");
+            shadowOf(getMainLooper()).idle();
+
+            fragment.getInput().setText("not the password");
+            ((AlertDialog) fragment.getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+            shadowOf(getMainLooper()).idle();
+
+            assertThat(activity.onCorrectAdminPasswordCalledWith, nullValue());
+            assertThat(activity.onIncorrectAdminPasswordCalled, equalTo(true));
         });
     }
 
@@ -71,6 +90,7 @@ public class AdminPasswordDialogFragmentTest {
             shadowOf(getMainLooper()).idle();
 
             assertThat(activity.onCorrectAdminPasswordCalledWith, equalTo(STORAGE_MIGRATION));
+            assertThat(activity.onIncorrectAdminPasswordCalled, equalTo(false));
         });
     }
 
@@ -102,6 +122,7 @@ public class AdminPasswordDialogFragmentTest {
     private static class SpyAdminPasswordDialogCallbackActivity extends FragmentActivity implements AdminPasswordDialogFragment.AdminPasswordDialogCallback  {
 
         private AdminPasswordDialogFragment.Action onCorrectAdminPasswordCalledWith;
+        private boolean onIncorrectAdminPasswordCalled;
 
         @Override
         public void onCorrectAdminPassword(AdminPasswordDialogFragment.Action action) {
@@ -110,7 +131,7 @@ public class AdminPasswordDialogFragmentTest {
 
         @Override
         public void onIncorrectAdminPassword() {
-
+            onIncorrectAdminPasswordCalled = true;
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
@@ -1,0 +1,108 @@
+package org.odk.collect.android.preferences;
+
+import android.app.AlertDialog;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.injection.config.AppDependencyModule;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.odk.collect.android.support.TestActivityScenario;
+import org.odk.collect.android.utilities.AdminPasswordProvider;
+import org.robolectric.annotation.LooperMode;
+
+import static android.os.Looper.getMainLooper;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.odk.collect.android.preferences.AdminPasswordDialogFragment.Action.STORAGE_MIGRATION;
+import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
+
+@RunWith(AndroidJUnit4.class)
+@LooperMode(PAUSED)
+public class AdminPasswordDialogFragmentTest {
+
+    @Before
+    public void setup() {
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public AdminPasswordProvider providesAdminPasswordProvider() {
+                return new StubAdminPasswordProvider();
+            }
+        });
+    }
+
+    @Test
+    public void enteringPassword_andClickingOK_callsOnCorrectAdminPasswordWithAction() {
+        TestActivityScenario<MockAdminPasswordDialogCallback> activityScenario = TestActivityScenario.launch(MockAdminPasswordDialogCallback.class);
+        activityScenario.onActivity(activity -> {
+            AdminPasswordDialogFragment fragment = new AdminPasswordDialogFragment();
+            fragment.setAction(STORAGE_MIGRATION);
+            fragment.show(activity.getSupportFragmentManager(), "tag");
+            shadowOf(getMainLooper()).idle();
+
+            fragment.getInput().setText("password");
+            ((AlertDialog) fragment.getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+            shadowOf(getMainLooper()).idle();
+
+            assertThat(activity.onCorrectAdminPasswordCalledWith, equalTo(STORAGE_MIGRATION));
+        });
+    }
+
+    @Test
+    public void afterRecreating_enteringPassword_andClickingOK_callsOnCorrectAdminPasswordWithAction() {
+        TestActivityScenario<MockAdminPasswordDialogCallback> activityScenario = TestActivityScenario.launch(MockAdminPasswordDialogCallback.class);
+        activityScenario.onActivity(activity -> {
+            AdminPasswordDialogFragment fragment = new AdminPasswordDialogFragment();
+            fragment.setAction(STORAGE_MIGRATION);
+            fragment.show(activity.getSupportFragmentManager(), "tag");
+            shadowOf(getMainLooper()).idle();
+        });
+
+        activityScenario.recreate();
+        activityScenario.onActivity(activity -> {
+            AdminPasswordDialogFragment fragment = (AdminPasswordDialogFragment) activity.getSupportFragmentManager().findFragmentByTag("tag");
+
+            fragment.getInput().setText("password");
+            ((AlertDialog) fragment.getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+            shadowOf(getMainLooper()).idle();
+
+            assertThat(activity.onCorrectAdminPasswordCalledWith, equalTo(STORAGE_MIGRATION));
+        });
+    }
+
+    private static class StubAdminPasswordProvider extends AdminPasswordProvider {
+
+        StubAdminPasswordProvider() {
+            super(null);
+        }
+
+        @Override
+        public boolean isAdminPasswordSet() {
+            return true;
+        }
+
+        @Override
+        public String getAdminPassword() {
+            return "password";
+        }
+    }
+
+    private static class MockAdminPasswordDialogCallback extends FragmentActivity implements AdminPasswordDialogFragment.AdminPasswordDialogCallback  {
+
+        private AdminPasswordDialogFragment.Action onCorrectAdminPasswordCalledWith;
+
+        @Override
+        public void onCorrectAdminPassword(AdminPasswordDialogFragment.Action action) {
+            onCorrectAdminPasswordCalledWith = action;
+        }
+
+        @Override
+        public void onIncorrectAdminPassword() {
+
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
@@ -39,7 +39,7 @@ public class AdminPasswordDialogFragmentTest {
 
     @Test
     public void enteringPassword_andClickingOK_callsOnCorrectAdminPasswordWithAction() {
-        TestActivityScenario<MockAdminPasswordDialogCallback> activityScenario = TestActivityScenario.launch(MockAdminPasswordDialogCallback.class);
+        TestActivityScenario<SpyAdminPasswordDialogCallbackActivity> activityScenario = TestActivityScenario.launch(SpyAdminPasswordDialogCallbackActivity.class);
         activityScenario.onActivity(activity -> {
             AdminPasswordDialogFragment fragment = createFragment();
             fragment.show(activity.getSupportFragmentManager(), "tag");
@@ -55,7 +55,7 @@ public class AdminPasswordDialogFragmentTest {
 
     @Test
     public void afterRecreating_enteringPassword_andClickingOK_callsOnCorrectAdminPasswordWithAction() {
-        TestActivityScenario<MockAdminPasswordDialogCallback> activityScenario = TestActivityScenario.launch(MockAdminPasswordDialogCallback.class);
+        TestActivityScenario<SpyAdminPasswordDialogCallbackActivity> activityScenario = TestActivityScenario.launch(SpyAdminPasswordDialogCallbackActivity.class);
         activityScenario.onActivity(activity -> {
             AdminPasswordDialogFragment fragment = createFragment();
             fragment.show(activity.getSupportFragmentManager(), "tag");
@@ -99,7 +99,7 @@ public class AdminPasswordDialogFragmentTest {
         }
     }
 
-    private static class MockAdminPasswordDialogCallback extends FragmentActivity implements AdminPasswordDialogFragment.AdminPasswordDialogCallback  {
+    private static class SpyAdminPasswordDialogCallbackActivity extends FragmentActivity implements AdminPasswordDialogFragment.AdminPasswordDialogCallback  {
 
         private AdminPasswordDialogFragment.Action onCorrectAdminPasswordCalledWith;
 

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/AdminPasswordDialogFragmentTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.preferences;
 
 import android.app.AlertDialog;
+import android.os.Bundle;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -17,6 +18,7 @@ import org.robolectric.annotation.LooperMode;
 import static android.os.Looper.getMainLooper;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.odk.collect.android.preferences.AdminPasswordDialogFragment.ARG_ACTION;
 import static org.odk.collect.android.preferences.AdminPasswordDialogFragment.Action.STORAGE_MIGRATION;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
@@ -39,8 +41,7 @@ public class AdminPasswordDialogFragmentTest {
     public void enteringPassword_andClickingOK_callsOnCorrectAdminPasswordWithAction() {
         TestActivityScenario<MockAdminPasswordDialogCallback> activityScenario = TestActivityScenario.launch(MockAdminPasswordDialogCallback.class);
         activityScenario.onActivity(activity -> {
-            AdminPasswordDialogFragment fragment = new AdminPasswordDialogFragment();
-            fragment.setAction(STORAGE_MIGRATION);
+            AdminPasswordDialogFragment fragment = createFragment();
             fragment.show(activity.getSupportFragmentManager(), "tag");
             shadowOf(getMainLooper()).idle();
 
@@ -56,8 +57,7 @@ public class AdminPasswordDialogFragmentTest {
     public void afterRecreating_enteringPassword_andClickingOK_callsOnCorrectAdminPasswordWithAction() {
         TestActivityScenario<MockAdminPasswordDialogCallback> activityScenario = TestActivityScenario.launch(MockAdminPasswordDialogCallback.class);
         activityScenario.onActivity(activity -> {
-            AdminPasswordDialogFragment fragment = new AdminPasswordDialogFragment();
-            fragment.setAction(STORAGE_MIGRATION);
+            AdminPasswordDialogFragment fragment = createFragment();
             fragment.show(activity.getSupportFragmentManager(), "tag");
             shadowOf(getMainLooper()).idle();
         });
@@ -72,6 +72,14 @@ public class AdminPasswordDialogFragmentTest {
 
             assertThat(activity.onCorrectAdminPasswordCalledWith, equalTo(STORAGE_MIGRATION));
         });
+    }
+
+    private AdminPasswordDialogFragment createFragment() {
+        AdminPasswordDialogFragment fragment = new AdminPasswordDialogFragment();
+        Bundle args = new Bundle();
+        args.putSerializable(ARG_ACTION, STORAGE_MIGRATION);
+        fragment.setArguments(args);
+        return fragment;
     }
 
     private static class StubAdminPasswordProvider extends AdminPasswordProvider {

--- a/collect_app/src/test/java/org/odk/collect/android/support/TestActivityScenario.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/TestActivityScenario.java
@@ -1,0 +1,40 @@
+package org.odk.collect.android.support;
+
+import android.app.Activity;
+
+import androidx.test.core.app.ActivityScenario;
+
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+
+/**
+ * Allows the use of an {@link androidx.test.core.app.ActivityScenario} like interface when
+ * using an Activity that isn't part of the manifest. This is useful when using a mock/fake/stub
+ * Activity as part of a test
+ */
+public class TestActivityScenario<T extends Activity> {
+
+    private final ActivityController<T> activityController;
+
+    public static <A extends Activity> TestActivityScenario<A> launch(Class<A> activityClass) {
+        TestActivityScenario<A> activityScenario = new TestActivityScenario<>(activityClass);
+        activityScenario.launchInternal();
+        return activityScenario;
+    }
+
+    private TestActivityScenario(Class<T> activityClass) {
+        activityController = Robolectric.buildActivity(activityClass);
+    }
+
+    private void launchInternal() {
+        activityController.setup();
+    }
+
+    public void onActivity(ActivityScenario.ActivityAction<T> activityAction) {
+        activityAction.perform(activityController.get());
+    }
+
+    public void recreate() {
+        activityController.recreate();
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.utilities;
 import android.os.Bundle;
 
 import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
@@ -24,9 +25,11 @@ public class DialogUtilsTest {
         FragmentActivity activity = createThemedActivity(FragmentActivity.class);
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
 
-        DialogFragment dialog1 = DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
         DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
+        assertThat(fragmentManager.getFragments().size(), equalTo(1));
+        Fragment dialog1 = fragmentManager.getFragments().get(0);
 
+        DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
         assertThat(fragmentManager.getFragments().size(), equalTo(1));
         assertThat(fragmentManager.getFragments().get(0), equalTo(dialog1));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DialogUtilsTest.java
@@ -24,11 +24,8 @@ public class DialogUtilsTest {
         FragmentActivity activity = createThemedActivity(FragmentActivity.class);
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
 
-        DialogFragment dialog1 = new DialogFragment();
-        DialogUtils.showIfNotShowing(dialog1, fragmentManager);
-
-        DialogFragment dialog2 = new DialogFragment();
-        DialogUtils.showIfNotShowing(dialog2, fragmentManager);
+        DialogFragment dialog1 = DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
+        DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
 
         assertThat(fragmentManager.getFragments().size(), equalTo(1));
         assertThat(fragmentManager.getFragments().get(0), equalTo(dialog1));
@@ -40,7 +37,7 @@ public class DialogUtilsTest {
         activityController.pause().stop().saveInstanceState(new Bundle());
 
         FragmentManager fragmentManager = activityController.get().getSupportFragmentManager();
-        DialogUtils.showIfNotShowing(new DialogFragment(), fragmentManager);
+        DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
         assertThat(fragmentManager.getFragments().size(), equalTo(0));
     }
 
@@ -50,7 +47,7 @@ public class DialogUtilsTest {
         activityController.pause().stop().destroy();
 
         FragmentManager fragmentManager = activityController.get().getSupportFragmentManager();
-        DialogUtils.showIfNotShowing(new DialogFragment(), fragmentManager);
+        DialogUtils.showIfNotShowing(DialogFragment.class, fragmentManager);
         assertThat(fragmentManager.getFragments().size(), equalTo(0));
     }
 }


### PR DESCRIPTION
This slightly revises our `DialogUtils.showIfNotShowing` helper based on some recent crashes related to it (fixed in another PR). The goal here was to make the helper a `void` method rather than returning a `DialogFragment`. This was becasue the returned dialog didn't make any sense in the case where a dialog wasn't actually shown (because the `FragmentManager` is in the wrong state). Changing it so the dialog instance isn't accessible to the caller has a couple of other advantages:

* It's stops there being any confusion around which dialog instance is actually shown
* It stops us having to create a new dialog instance for no reason

I've added a `getDialog` helper that returns the shown dialog for cases where we really need to call something on the dialog but as much as possible we should be using arguments (for static data the dialog needs), Dagger (for dependencies) or `ViewModel` (for non static data) to get things into fragments so as to avoid crashes or weirdness when they are recreated.

#### What has been done to verify that this works as intended?

Added some new tests for cases that weren't covered and played around with some dialogs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't be any change in behaviour. I'd recommend testing:

* The storage migration flow (with and without admin password set)
* Form loading and saving

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)