### PR TITLE
Fixed downloading forms with media files

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -345,8 +345,7 @@ public class FormDownloader {
      * Takes the formName and the URL and attempts to download the specified file. Returns a file
      * object representing the downloaded file.
      */
-    FileResult downloadXform(String formName, String url)
-            throws IOException, TaskCancelledException, Exception {
+    FileResult downloadXform(String formName, String url) throws Exception {
         // clean up friendly form name...
         String rootName = FormNameUtils.formatFilenameFromFormName(formName);
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDownloader.java
@@ -173,8 +173,12 @@ public class FormDownloader {
             fileResult = null;
         }
 
+        if (fileResult == null) {
+            return message + "Downloading Xform failed.";
+        }
+
         Map<String, String> parsedFields = null;
-        if (fileResult != null) {
+        if (fileResult.isNew) {
             try {
                 final long start = System.currentTimeMillis();
                 Timber.w("Parsing document %s", fileResult.file.getAbsolutePath());
@@ -200,8 +204,8 @@ public class FormDownloader {
 
         boolean installed = false;
 
-        if ((stateListener == null || !stateListener.isTaskCanceled()) && message.isEmpty() && parsedFields != null) {
-            if (isSubmissionOk(parsedFields)) {
+        if ((stateListener == null || !stateListener.isTaskCanceled()) && message.isEmpty()) {
+            if (!fileResult.isNew || isSubmissionOk(parsedFields)) {
                 installed = installEverything(tempMediaPath, fileResult, parsedFields);
             } else {
                 message += Collect.getInstance().getString(R.string.xform_parse_error,


### PR DESCRIPTION
Closes #3682

#### What has been done to verify that this works as intended?
Reproduced the scenario mentioned in the issue and confirmed it seems to be fixed.

#### Why is this the best possible solution? Were any other approaches considered?
It's the solution we agreed in the issue. There is no need to build `FormDef` if the xml file is not changed.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It changes a bit the method responsible for downloading forms and media files so it would be good to perform some regression testings in this area.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)