### PR TITLE
Get rid of configChanges flags in the manifest file

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationCompletedBannerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationCompletedBannerTest.java
@@ -44,18 +44,10 @@ public class StorageMigrationCompletedBannerTest {
             .around(rule);
 
     @Test
-    public void when_storageMigrationCompleted_should_bannerBeVisibleAndPersistScreenRotation() {
+    public void when_storageMigrationCompleted_should_bannerBeVisibleAndDisappearsAfterScreenRotation() {
         new MainMenuPage(rule)
                 .assertStorageMigrationCompletedBannerIsDisplayed()
                 .rotateToLandscape(new MainMenuPage(rule))
-                .assertStorageMigrationCompletedBannerIsDisplayed()
-                .rotateToPortrait(new MainMenuPage(rule))
-                .assertStorageMigrationCompletedBannerIsDisplayed()
-                .clickDismissButton()
-                .assertStorageMigrationCompletedBannerIsNotDisplayed()
-                .rotateToLandscape(new MainMenuPage(rule))
-                .assertStorageMigrationCompletedBannerIsNotDisplayed()
-                .rotateToPortrait(new MainMenuPage(rule))
                 .assertStorageMigrationCompletedBannerIsNotDisplayed();
     }
 

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -104,7 +104,6 @@ the specific language governing permissions and limitations under the License.
             />
         <activity
             android:name=".activities.FormEntryActivity"
-            android:configChanges="orientation"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".activities.NotificationActivity"
@@ -139,12 +138,8 @@ the specific language governing permissions and limitations under the License.
         <activity android:name=".activities.FormHierarchyActivity" />
         <activity android:name=".activities.ViewOnlyFormHierarchyActivity" />
         <activity android:name=".activities.GeoPointActivity" />
-        <activity
-            android:name=".activities.GeoPointMapActivity"
-            android:configChanges="orientation" />
-        <activity
-            android:name=".activities.GeoPolyActivity"
-            android:configChanges="orientation" />
+        <activity android:name=".activities.GeoPointMapActivity" />
+        <activity android:name=".activities.GeoPolyActivity" />
         <activity android:name=".activities.FormMapActivity" />
         <activity android:name=".activities.BearingActivity" />
         <activity

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -91,9 +91,7 @@ the specific language governing permissions and limitations under the License.
                 android:resource="@xml/provider_paths" />
         </provider>
 
-        <activity
-            android:name=".activities.MainMenuActivity"
-            android:configChanges="locale|orientation|screenSize" />
+        <activity android:name=".activities.MainMenuActivity" />
         <activity
             android:name=".activities.ScannerWithFlashlightActivity"
             android:screenOrientation="portrait"


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I investigated how `orientation|screenSize` work together and separately and reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
We agreed that blocking activity recreations is a bad approach so we decided to get rid of it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only risky change is the one made in `MainMenuActivity` take a look at this comment for example: https://github.com/opendatakit/collect/pull/3738#issuecomment-603193682
in other cases I removed single `orientation` flags and as we already agreed 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)