### PR TITLE
Support calculations in field-lists

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/FieldListUpdateTest.java
@@ -183,25 +183,23 @@ public class FieldListUpdateTest {
         onView(withText("Please don't use your calculator, !")).check(matches(isDisplayed()));
     }
 
-    /**
-     * TODO: calculation doesn't seem to be updated whether or not there's a fieldlist.
-     *
-     * @Test public void changeInValueUsedInOtherField_ShouldChangeValue() {
-     * onView(withId(R.id.menu_goto)).perform(click());
-     * onView(withId(R.id.menu_go_up)).perform(click());
-     * onView(allOf(withText("Value change"), isDisplayed())).perform(click());
-     * onView(withText(startsWith("What is your"))).perform(click());
-     * <p>
-     * String name = UUID.randomUUID().toString();
-     * <p>
-     * onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
-     * onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
-     * onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(name));
-     * onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText(name.length())));
-     * onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
-     * onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
-     * }
-     **/
+
+    @Test
+    public void changeInValueUsedInOtherField_ShouldChangeValue() {
+        onView(withId(R.id.menu_goto)).perform(click());
+        onView(withId(R.id.menu_go_up)).perform(click());
+        onView(allOf(withText("Value change"), isDisplayed())).perform(click());
+        onView(withText(startsWith("What is your"))).perform(click());
+
+        String name = UUID.randomUUID().toString();
+
+        onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
+        onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
+        onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(name));
+        onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText(String.valueOf(name.length()))));
+        onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
+        onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
+    }
 
     @Test
     public void selectionChangeAtFirstCascadeLevel_ShouldUpdateNextLevels() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2871,7 +2871,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         for (Map.Entry<FormIndex, IAnswerData> answer : currentView.getAnswers().entrySet()) {
             if (isQuestionNotRecalculated(mutableQuestionsBeforeSave[index], immutableQuestionsBeforeSave.get(index))) {
                 try {
-                    formController.saveOneScreenAnswers(answer.getKey(), answer.getValue(), false);
+                    formController.saveOneScreenAnswer(answer.getKey(), answer.getValue(), false);
                 } catch (JavaRosaException e) {
                     Timber.w(e);
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -803,23 +803,27 @@ public class FormController {
                                                  boolean evaluateConstraints) throws JavaRosaException {
         if (currentPromptIsQuestion()) {
             for (FormIndex index : answers.keySet()) {
-                // Within a group, you can only save for question events
-                if (getEvent(index) == FormEntryController.EVENT_QUESTION) {
-                    int saveStatus;
-                    IAnswerData answer = answers.get(index);
-                    if (evaluateConstraints) {
-                        saveStatus = answerQuestion(index, answer);
-                        if (saveStatus != FormEntryController.ANSWER_OK) {
-                            return new FailedConstraint(index, saveStatus);
-                        }
-                    } else {
-                        saveAnswer(index, answer);
-                    }
-                } else {
-                    Timber.w("Attempted to save an index referencing something other than a question: %s",
-                            index.getReference().toString());
-                }
+                saveOneScreenAnswers(index, answers.get(index), evaluateConstraints);
             }
+        }
+        return null;
+    }
+
+    public FailedConstraint saveOneScreenAnswers(FormIndex index, IAnswerData answer, boolean evaluateConstraints) throws JavaRosaException {
+        // Within a group, you can only save for question events
+        if (getEvent(index) == FormEntryController.EVENT_QUESTION) {
+            int saveStatus;
+            if (evaluateConstraints) {
+                saveStatus = answerQuestion(index, answer);
+                if (saveStatus != FormEntryController.ANSWER_OK) {
+                    return new FailedConstraint(index, saveStatus);
+                }
+            } else {
+                saveAnswer(index, answer);
+            }
+        } else {
+            Timber.w("Attempted to save an index referencing something other than a question: %s",
+                    index.getReference().toString());
         }
         return null;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -803,18 +803,17 @@ public class FormController {
                                                  boolean evaluateConstraints) throws JavaRosaException {
         if (currentPromptIsQuestion()) {
             for (FormIndex index : answers.keySet()) {
-                saveOneScreenAnswers(index, answers.get(index), evaluateConstraints);
+                saveOneScreenAnswer(index, answers.get(index), evaluateConstraints);
             }
         }
         return null;
     }
 
-    public FailedConstraint saveOneScreenAnswers(FormIndex index, IAnswerData answer, boolean evaluateConstraints) throws JavaRosaException {
+    public FailedConstraint saveOneScreenAnswer(FormIndex index, IAnswerData answer, boolean evaluateConstraints) throws JavaRosaException {
         // Within a group, you can only save for question events
         if (getEvent(index) == FormEntryController.EVENT_QUESTION) {
-            int saveStatus;
             if (evaluateConstraints) {
-                saveStatus = answerQuestion(index, answer);
+                int saveStatus = answerQuestion(index, answer);
                 if (saveStatus != FormEntryController.ANSWER_OK) {
                     return new FailedConstraint(index, saveStatus);
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/ImmutableDisplayableQuestion.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/ImmutableDisplayableQuestion.java
@@ -90,6 +90,10 @@ public class ImmutableDisplayableQuestion {
         return index;
     }
 
+    public Object getAnswerText() {
+        return answerText;
+    }
+
     /**
      * Returns {@code true} if the provided {@link FormEntryPrompt} has the same user-visible
      * aspects, {@code false} otherwise.


### PR DESCRIPTION
Closes #3211 

#### What has been done to verify that this works as intended?
I tested implemented changes manually and there is also an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
I'l try to explain what was wrong with our code:
The form we are using has two questions on the same screen where the answer of the second question is based on the answer of the first question (calculated)
| type  | name | label | appearance | calculation |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| begin group | my-group | My group | field-list | |
| text  | foo  | Foo | | |
| integer | foo-length | Foo length | | string-length(${foo}) |
| end group | my-group | | | |

When we open the form the first answer is `null` and the second answer is `0`. We expect the second answer to be updated every time we edit the first one so 
if we type `q` it should be updated fro `0`->`1`
then if we type `w` (`qw`) it should be updated from `1`->`2`
then if we type `e` (`qwe`) it should be updated from `2`->`3` etc

The problem with the current implementation was that we were trying to save all answers from the screen at the same time so analyzing the same scenario as above:
if we type `q` we are trying to save answers `q` and `0` because it is what we have on the screen,
First we save `q` an the value of the element is changed from `null` to `q` that triggers calculations and the value of the second element is changed from `0` to `1` (it takes place in javarosa automatically) and then we try to save the second question from the screen `0` ignoring that calculations took place what changes the answer back from `1` -> `0`

The only solution I can come up with is to save questions one by one and check whether the answer of the questions we are trying to save changed after saving a previous answer if it changed we do nothing because that mean it was recalculated  otherwise we save the answer from the screen.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test field-list especially with calculations/hiding questions to ensure there is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
I'm not sure... was the limitation (bug) mentioned anywhere?

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)