### PR TITLE
Stop using fixed port in https tests to avoid clean up issues

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/support/MockWebServerRule.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/support/MockWebServerRule.java
@@ -42,13 +42,13 @@ public class MockWebServerRule implements TestRule {
         mockWebServers.add(httpsMockWebServer);
 
         httpsMockWebServer.useHttps(TlsUtil.localhost().sslSocketFactory(), false);
-        httpsMockWebServer.start(8443);
+        httpsMockWebServer.start();
         return httpsMockWebServer;
     }
 
     public void teardown() throws IOException {
         for (MockWebServer mockWebServer : mockWebServers) {
-            mockWebServer.shutdown();
+            mockWebServer.close();
         }
     }
 }


### PR DESCRIPTION
Closes  #3453 

#### What has been done to verify that this works as intended?

I was unable to reproduce the test failure but we've tested the solution before. Just to be safe I ran the full suite and the particular tests a few times before and after to make sure everything was green.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)