### PR TITLE
Fixed calendar color

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -67,9 +67,9 @@ public final class ThemeUtils {
 
     @StyleRes
     public int getMaterialDialogTheme() {
-        return isDarkTheme() ?
-                android.R.style.Theme_Material_Dialog :
-                android.R.style.Theme_Material_Light_Dialog;
+        return isDarkTheme()
+                ? R.style.Theme_Collect_Dark_Dialog
+                : R.style.Theme_Collect_Light_Dialog;
     }
 
     @StyleRes

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -73,6 +73,6 @@
     </style>
 
     <style name="Theme.Collect.Dark.Dialog" parent="android:Theme.Material.Dialog">
-        <item name="android:colorAccent">#57C4C2</item>
+        <item name="android:colorAccent">?attr/colorSecondary</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -71,4 +71,8 @@
     <style name="Widget.Collect.SearchView.Dark" parent="Widget.AppCompat.SearchView">
         <item name="searchHintIcon">@null</item>
     </style>
+
+    <style name="Theme.Collect.Dark.Dialog" parent="android:Theme.Material.Dialog">
+        <item name="android:colorAccent">#57C4C2</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -64,7 +64,7 @@
     </style>
 
     <style name="Theme.Collect.BaseLight.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorAccent">@color/blue_500</item>
+        <item name="colorAccent">?attr/colorSecondary</item>
     </style>
 
     <style name="Widget.Collect.SearchView.Light" parent="Widget.AppCompat.Light.SearchView">
@@ -72,6 +72,6 @@
     </style>
 
     <style name="Theme.Collect.Light.Dialog" parent="android:Theme.Material.Light.Dialog">
-        <item name="android:colorAccent">@color/blue_500</item>
+        <item name="android:colorAccent">?attr/colorSecondary</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -71,4 +71,7 @@
         <item name="searchHintIcon">@null</item>
     </style>
 
+    <style name="Theme.Collect.Light.Dialog" parent="android:Theme.Material.Light.Dialog">
+        <item name="android:colorAccent">@color/blue_500</item>
+    </style>
 </resources>

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTests.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTests.java
@@ -67,7 +67,7 @@ public class ThemeUtilsTests {
         assertEquals(themeUtils.getAppTheme(), R.style.Theme_Collect_Light);
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Light);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Light);
-        assertEquals(themeUtils.getMaterialDialogTheme(), android.R.style.Theme_Material_Light_Dialog);
+        assertEquals(themeUtils.getMaterialDialogTheme(), R.style.Theme_Collect_Light_Dialog);
         assertEquals(themeUtils.getHoloDialogTheme(), android.R.style.Theme_Holo_Light_Dialog);
     }
 
@@ -77,7 +77,7 @@ public class ThemeUtilsTests {
         assertEquals(themeUtils.getAppTheme(), R.style.Theme_Collect_Dark);
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Dark);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Dark);
-        assertEquals(themeUtils.getMaterialDialogTheme(), android.R.style.Theme_Material_Dialog);
+        assertEquals(themeUtils.getMaterialDialogTheme(), R.style.Theme_Collect_Dark_Dialog);
         assertEquals(themeUtils.getHoloDialogTheme(), android.R.style.Theme_Holo_Dialog);
     }
 


### PR DESCRIPTION
Closes #3748

#### What has been done to verify that this works as intended?
I tested implemented changes manually to confirm the color changed.

#### Why is this the best possible solution? Were any other approaches considered?
We just should use our accent color for calendars to keep consistency.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe change so testing one form with calendars (in both light and dark mode) would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with dates like the All widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)