### PR TITLE
Allow null select one values

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -112,7 +112,9 @@ public class SelectOneListAdapter extends AbstractSelectListAdapter
         radioButton.setOnClickListener(this);
         radioButton.setOnCheckedChangeListener(this);
 
-        if (filteredItems.get(index).getValue().equals(selectedValue)) {
+        String value = filteredItems.get(index).getValue();
+
+        if (value != null && value.equals(selectedValue)) {
             radioButton.setChecked(true);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AbstractSelectOneWidget.java
@@ -18,6 +18,8 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.view.ViewGroup;
 import android.widget.RadioButton;
 
 import org.javarosa.core.model.FormIndex;
@@ -53,6 +55,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
     private String selectedValue;
     private final boolean autoAdvance;
     SelectOneListAdapter adapter;
+    private RecyclerView recyclerView;
 
     public AbstractSelectOneWidget(Context context, QuestionDetails questionDetails, boolean autoAdvance) {
         super(context, questionDetails);
@@ -96,7 +99,7 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
         adapter = new SelectOneListAdapter(items, selectedValue, this, numColumns, this.getFormEntryPrompt(), this.getReferenceManager(), this.getAnswerFontSize(), this.getAudioHelper(), getPlayColor(getFormEntryPrompt(), themeUtils), this.getContext(), autoAdvance);
 
         if (items != null) {
-            RecyclerView recyclerView = setUpRecyclerView();
+            recyclerView = setUpRecyclerView();
             recyclerView.setAdapter(adapter);
             answerLayout.addView(recyclerView);
             adjustRecyclerViewSize(adapter, recyclerView);
@@ -154,5 +157,9 @@ public abstract class AbstractSelectOneWidget extends SelectTextWidget implement
         button.setChecked(isSelected);
 
         adapter.onCheckedChanged(button, isSelected);
+    }
+
+    public ViewGroup getChoicesList() {
+        return recyclerView;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -87,9 +87,9 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().captureButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().chooseButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().annotateButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().captureButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().chooseButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().annotateButton.getVisibility(), is(View.GONE));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -92,7 +92,7 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().chooseFileButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().chooseFileButton.getVisibility(), is(View.GONE));
     }
 
     public void prepareForSetAnswer() {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -110,7 +110,7 @@ public class AudioWidgetTest extends FileWidgetTest<AudioWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().captureButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().chooseButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().captureButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().chooseButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BarcodeWidgetTest.java
@@ -75,7 +75,7 @@ public class BarcodeWidgetTest extends BinaryWidgetTest<BarcodeWidget, StringDat
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().getBarcodeButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().getBarcodeButton.getVisibility(), is(View.GONE));
     }
   
     public void stripInvalidCharacters() {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/BearingWidgetTest.java
@@ -55,6 +55,6 @@ public class BearingWidgetTest extends BinaryWidgetTest<BearingWidget, StringDat
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().getBearingButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().getBearingButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DateTimeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DateTimeWidgetTest.java
@@ -51,7 +51,7 @@ public class DateTimeWidgetTest extends GeneralDateTimeWidgetTest<DateTimeWidget
 
     @Test
     public void setData() {
-        DateTimeWidget widget = getWidget();
+        DateTimeWidget widget = getSpyWidget();
         LocalDateTime date = new LocalDateTime().withYear(2010).withMonthOfYear(5).withDayOfMonth(12);
         widget.setBinaryData(date);
         assertFalse(widget.isWaitingForData());
@@ -63,7 +63,7 @@ public class DateTimeWidgetTest extends GeneralDateTimeWidgetTest<DateTimeWidget
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().dateWidget.dateButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().timeWidget.timeButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().dateWidget.dateButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().timeWidget.timeButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DateWidgetTest.java
@@ -50,7 +50,7 @@ public class DateWidgetTest extends GeneralDateTimeWidgetTest<DateWidget, DateDa
 
     @Test
     public void setData() {
-        DateWidget widget = getWidget();
+        DateWidget widget = getSpyWidget();
         LocalDateTime date = new LocalDateTime().withYear(2010).withMonthOfYear(5).withDayOfMonth(12);
         widget.setBinaryData(date);
         assertFalse(widget.isWaitingForData());
@@ -62,6 +62,6 @@ public class DateWidgetTest extends GeneralDateTimeWidgetTest<DateWidget, DateDa
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().dateButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().dateButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DecimalWidgetTest.java
@@ -199,7 +199,7 @@ public class DecimalWidgetTest extends GeneralStringWidgetTest<DecimalWidget, De
     @Test
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
-        getActualWidget().answerText.setText("123456789.54");
-        assertEquals("123,456,789.54", getActualWidget().answerText.getText().toString());
+        getWidget().answerText.setText("123456789.54");
+        assertEquals("123,456,789.54", getWidget().answerText.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -89,7 +89,7 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().drawButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().drawButton.getVisibility(), is(View.GONE));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExDecimalWidgetTest.java
@@ -77,7 +77,7 @@ public class ExDecimalWidgetTest extends GeneralExStringWidgetTest<ExDecimalWidg
     @Test
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
-        getActualWidget().answerText.setText("123456789.54");
-        assertEquals("123,456,789.54", getActualWidget().answerText.getText().toString());
+        getWidget().answerText.setText("123456789.54");
+        assertEquals("123,456,789.54", getWidget().answerText.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExIntegerWidgetTest.java
@@ -41,14 +41,14 @@ public class ExIntegerWidgetTest extends GeneralExStringWidgetTest<ExIntegerWidg
 
     @Test
     public void digitsAboveLimitOfNineShouldBeTruncatedFromRight() {
-        getActualWidget().answerText.setText("123456789123");
-        assertEquals("123456789", getActualWidget().getAnswerText());
+        getWidget().answerText.setText("123456789123");
+        assertEquals("123456789", getWidget().getAnswerText());
     }
 
     @Test
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
-        getActualWidget().answerText.setText("123456789");
-        assertEquals("123,456,789", getActualWidget().answerText.getText().toString());
+        getWidget().answerText.setText("123456789");
+        assertEquals("123,456,789", getWidget().answerText.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExPrinterWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExPrinterWidgetTest.java
@@ -39,7 +39,7 @@ public class ExPrinterWidgetTest extends QuestionWidgetTest<ExPrinterWidget, IAn
     @Override
     // ExPrintWidget is and exceptional widget that doesn't return any answer
     public void getAnswerShouldReturnExistingAnswerIfPromptHasExistingAnswer() {
-        IAnswerData newAnswer = getWidget().getAnswer();
+        IAnswerData newAnswer = getSpyWidget().getAnswer();
         assertNull(newAnswer);
     }
 
@@ -47,6 +47,6 @@ public class ExPrinterWidgetTest extends QuestionWidgetTest<ExPrinterWidget, IAn
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().launchIntentButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().launchIntentButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GridMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GridMultiWidgetTest.java
@@ -101,7 +101,7 @@ public class GridMultiWidgetTest extends GeneralSelectMultiWidgetTest<GridMultiW
                 ))
                 .build();
 
-        GridMultiWidget widget = getActualWidget();
+        GridMultiWidget widget = getWidget();
 
         widget.onItemClick(0);
         verify(audioHelper).play(new Clip("i am index 0", REFERENCES.get(0).second));
@@ -125,7 +125,7 @@ public class GridMultiWidgetTest extends GeneralSelectMultiWidgetTest<GridMultiW
                 ))
                 .build();
 
-        getActualWidget();
+        getWidget();
 
         verify(analytics).logEvent("Prompt", "AudioChoiceGrid", "formAnalyticsID");
     }
@@ -144,7 +144,7 @@ public class GridMultiWidgetTest extends GeneralSelectMultiWidgetTest<GridMultiW
                 ))
                 .build();
 
-        GridMultiWidget widget = getActualWidget();
+        GridMultiWidget widget = getWidget();
         widget.onItemClick(0);
 
         verify(audioHelper, never()).play(any());
@@ -152,7 +152,7 @@ public class GridMultiWidgetTest extends GeneralSelectMultiWidgetTest<GridMultiW
 
     @Test
     public void getAnswerShouldReflectWhichSelectionsWereMade() {
-        GridMultiWidget widget = getWidget();
+        GridMultiWidget widget = getSpyWidget();
         assertNull(widget.getAnswer());
 
         List<SelectChoice> selectChoices = getSelectChoices();
@@ -208,7 +208,7 @@ public class GridMultiWidgetTest extends GeneralSelectMultiWidgetTest<GridMultiW
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        for (View view : getWidget().itemViews) {
+        for (View view : getSpyWidget().itemViews) {
             assertThat(view.getVisibility(), is(View.VISIBLE));
             assertThat(view.isEnabled(), is(Boolean.FALSE));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GridWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GridWidgetTest.java
@@ -90,7 +90,7 @@ public class GridWidgetTest extends GeneralSelectOneWidgetTest<GridWidget> {
                 ))
                 .build();
 
-        GridWidget widget = getActualWidget();
+        GridWidget widget = getWidget();
 
         widget.onItemClick(0);
         verify(audioHelper).play(new Clip("i am index 0", REFERENCES.get(0).second));
@@ -114,7 +114,7 @@ public class GridWidgetTest extends GeneralSelectOneWidgetTest<GridWidget> {
                 ))
                 .build();
 
-        getActualWidget();
+        getWidget();
         verify(analytics).logEvent("Prompt", "AudioChoiceGrid", "formAnalyticsID");
     }
 
@@ -132,7 +132,7 @@ public class GridWidgetTest extends GeneralSelectOneWidgetTest<GridWidget> {
                 ))
                 .build();
 
-        GridWidget widget = getActualWidget();
+        GridWidget widget = getWidget();
         widget.onItemClick(0);
 
         verify(audioHelper, never()).play(any());
@@ -148,7 +148,7 @@ public class GridWidgetTest extends GeneralSelectOneWidgetTest<GridWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        for (View view : getWidget().itemViews) {
+        for (View view : getSpyWidget().itemViews) {
             assertThat(view.getVisibility(), is(View.VISIBLE));
             assertThat(view.isEnabled(), is(Boolean.FALSE));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -92,8 +92,8 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().captureButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().chooseButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().captureButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().chooseButton.getVisibility(), is(View.GONE));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/IntegerWidgetTest.java
@@ -34,14 +34,14 @@ public class IntegerWidgetTest extends GeneralStringWidgetTest<IntegerWidget, In
 
     @Test
     public void digitsAboveLimitOfNineShouldBeTruncatedFromRight() {
-        getActualWidget().answerText.setText("123456789123");
-        assertEquals("123456789", getActualWidget().getAnswerText());
+        getWidget().answerText.setText("123456789123");
+        assertEquals("123456789", getWidget().getAnswerText());
     }
 
     @Test
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
-        getActualWidget().answerText.setText("123456789");
-        assertEquals("123,456,789", getActualWidget().answerText.getText().toString());
+        getWidget().answerText.setText("123456789");
+        assertEquals("123,456,789", getWidget().answerText.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ItemsetWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ItemsetWidgetTest.java
@@ -152,7 +152,7 @@ public class ItemsetWidgetTest extends QuestionWidgetTest<ItemsetWidget, StringD
 
     @Test
     public void getAnswerShouldReflectWhichSelectionWasMade() {
-        ItemsetWidget widget = getWidget();
+        ItemsetWidget widget = getSpyWidget();
         assertNull(widget.getAnswer());
 
         int randomIndex = Math.abs(random.nextInt()) % widget.getChoiceCount();
@@ -167,9 +167,9 @@ public class ItemsetWidgetTest extends QuestionWidgetTest<ItemsetWidget, StringD
     @Test
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
 
-        AudioVideoImageTextLabel avitLabel = (AudioVideoImageTextLabel) ((LinearLayout) ((RecyclerView) getWidget().answerLayout.getChildAt(0)).getLayoutManager().getChildAt(0)).getChildAt(0);
+        AudioVideoImageTextLabel avitLabel = (AudioVideoImageTextLabel) ((LinearLayout) ((RecyclerView) getSpyWidget().answerLayout.getChildAt(0)).getLayoutManager().getChildAt(0)).getChildAt(0);
         assertThat(avitLabel.isEnabled(), is(Boolean.FALSE));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/LikertWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/LikertWidgetTest.java
@@ -58,13 +58,13 @@ public class LikertWidgetTest extends QuestionWidgetTest<LikertWidget, SelectOne
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        for (int i = 0; i < getWidget().view.getChildCount(); i++) {
-            LinearLayout optionView = (LinearLayout) getWidget().view.getChildAt(0);
+        for (int i = 0; i < getSpyWidget().view.getChildCount(); i++) {
+            LinearLayout optionView = (LinearLayout) getSpyWidget().view.getChildAt(0);
             assertThat(optionView.getVisibility(), is(View.VISIBLE));
             assertThat(optionView.isEnabled(), is(Boolean.FALSE));
         }
 
-        for (Map.Entry<RadioButton, String> radioButtonStringEntry : getWidget().buttonsToName.entrySet()) {
+        for (Map.Entry<RadioButton, String> radioButtonStringEntry : getSpyWidget().buttonsToName.entrySet()) {
             assertThat(((RadioButton) ((Map.Entry) radioButtonStringEntry).getKey()).getVisibility(), is(View.VISIBLE));
             assertThat(((RadioButton) ((Map.Entry) radioButtonStringEntry).getKey()).isEnabled(), is(Boolean.FALSE));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ListMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ListMultiWidgetTest.java
@@ -28,7 +28,7 @@ public class ListMultiWidgetTest extends GeneralSelectMultiWidgetTest<ListMultiW
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        for (CheckBox checkBox : getWidget().checkBoxes) {
+        for (CheckBox checkBox : getSpyWidget().checkBoxes) {
             assertThat(checkBox.getVisibility(), is(View.VISIBLE));
             assertThat(checkBox.isEnabled(), is(Boolean.FALSE));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ListWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ListWidgetTest.java
@@ -28,7 +28,7 @@ public class ListWidgetTest extends GeneralSelectOneWidgetTest<ListWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        for (RadioButton radioButton : getWidget().buttons) {
+        for (RadioButton radioButton : getSpyWidget().buttons) {
             assertThat(radioButton.getVisibility(), is(View.VISIBLE));
             assertThat(radioButton.isEnabled(), is(Boolean.FALSE));
         }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -98,6 +98,6 @@ public class OSMWidgetTest extends BinaryWidgetTest<OSMWidget, StringData> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().launchOpenMapKitButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().launchOpenMapKitButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/RankingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/RankingWidgetTest.java
@@ -44,6 +44,6 @@ public class RankingWidgetTest extends SelectWidgetTest<RankingWidget, MultipleI
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().showRankingDialogButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().showRankingDialogButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/RatingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/RatingWidgetTest.java
@@ -45,7 +45,7 @@ public class RatingWidgetTest extends QuestionWidgetTest<RatingWidget, IntegerDa
 
     @Override
     public void getAnswerShouldReturnExistingAnswerIfPromptHasExistingAnswer() {
-        getWidget().answer = (Integer) answer.getValue();
+        getSpyWidget().answer = (Integer) answer.getValue();
         super.getAnswerShouldReturnExistingAnswerIfPromptHasExistingAnswer();
     }
 
@@ -53,9 +53,9 @@ public class RatingWidgetTest extends QuestionWidgetTest<RatingWidget, IntegerDa
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        for (int i = 0; i < getWidget().gridLayout.getChildCount(); i++) {
-            assertThat(getWidget().gridLayout.getChildAt(i).getVisibility(), is(View.VISIBLE));
-            assertThat(getWidget().gridLayout.getChildAt(i).isEnabled(), is(Boolean.FALSE));
+        for (int i = 0; i < getSpyWidget().gridLayout.getChildCount(); i++) {
+            assertThat(getSpyWidget().gridLayout.getChildAt(i).getVisibility(), is(View.VISIBLE));
+            assertThat(getSpyWidget().gridLayout.getChildAt(i).isEnabled(), is(Boolean.FALSE));
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectImageMapWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectImageMapWidgetTest.java
@@ -53,7 +53,7 @@ public abstract class SelectImageMapWidgetTest<W extends SelectImageMapWidget, A
         MotionEvent motionEvent = mock(MotionEvent.class);
         when(motionEvent.getAction()).thenReturn(MotionEvent.ACTION_DOWN);
 
-        assertThat(getWidget().webView.getVisibility(), is(View.VISIBLE));
-        assertThat(getWidget().webView.isClickable(), is(Boolean.FALSE));
+        assertThat(getSpyWidget().webView.getVisibility(), is(View.VISIBLE));
+        assertThat(getSpyWidget().webView.isClickable(), is(Boolean.FALSE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectMultiWidgetTest.java
@@ -84,7 +84,7 @@ public class SelectMultiWidgetTest extends GeneralSelectMultiWidgetTest<SelectMu
                 ))
                 .build();
 
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
         verify(audioHelper).setAudio(any(AudioButton.class), eq(new Clip("i am index 0", REFERENCES.get(0).second)));
         verify(audioHelper).setAudio(any(AudioButton.class), eq(new Clip("i am index 1", REFERENCES.get(1).second)));
     }
@@ -103,7 +103,7 @@ public class SelectMultiWidgetTest extends GeneralSelectMultiWidgetTest<SelectMu
                 ))
                 .build();
 
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
         verify(analytics).logEvent("Prompt", "AudioChoice", "formAnalyticsID");
     }
 
@@ -140,9 +140,9 @@ public class SelectMultiWidgetTest extends GeneralSelectMultiWidgetTest<SelectMu
                 .withReadOnly(true)
                 .build();
 
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
 
-        AudioVideoImageTextLabel avitLabel = (AudioVideoImageTextLabel) (((RecyclerView) getWidget().answerLayout.getChildAt(0)).getLayoutManager().getChildAt(0));
+        AudioVideoImageTextLabel avitLabel = (AudioVideoImageTextLabel) (((RecyclerView) getSpyWidget().answerLayout.getChildAt(0)).getLayoutManager().getChildAt(0));
         assertThat(avitLabel.isEnabled(), is(Boolean.FALSE));
 
         resetWidget();
@@ -152,9 +152,9 @@ public class SelectMultiWidgetTest extends GeneralSelectMultiWidgetTest<SelectMu
                 .withAppearance(WidgetAppearanceUtils.NO_BUTTONS)
                 .build();
 
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
 
-        FrameLayout view = (FrameLayout) ((RecyclerView) getWidget().answerLayout.getChildAt(0)).getLayoutManager().getChildAt(0);
+        FrameLayout view = (FrameLayout) ((RecyclerView) getSpyWidget().answerLayout.getChildAt(0)).getLayoutManager().getChildAt(0);
         assertThat(view.isEnabled(), is(Boolean.FALSE));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneAutocompleteWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneAutocompleteWidgetTest.java
@@ -42,9 +42,9 @@ public class SelectOneAutocompleteWidgetTest extends GeneralSelectOneWidgetTest<
                 .withReadOnly(true)
                 .build();
 
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
 
-        AudioVideoImageTextLabel avitLabel = (AudioVideoImageTextLabel) ((LinearLayout) ((RecyclerView) getWidget().answerLayout.getChildAt(1)).getLayoutManager().getChildAt(0)).getChildAt(0);
+        AudioVideoImageTextLabel avitLabel = (AudioVideoImageTextLabel) ((LinearLayout) ((RecyclerView) getSpyWidget().answerLayout.getChildAt(1)).getLayoutManager().getChildAt(0)).getChildAt(0);
         assertThat(avitLabel.isEnabled(), is(Boolean.FALSE));
 
         resetWidget();
@@ -54,9 +54,9 @@ public class SelectOneAutocompleteWidgetTest extends GeneralSelectOneWidgetTest<
                 .withAppearance(WidgetAppearanceUtils.NO_BUTTONS)
                 .build();
 
-        populateRecyclerView(getActualWidget());
+        populateRecyclerView(getWidget());
 
-        FrameLayout view = (FrameLayout) ((RecyclerView) getWidget().answerLayout.getChildAt(1)).getLayoutManager().getChildAt(0);
+        FrameLayout view = (FrameLayout) ((RecyclerView) getSpyWidget().answerLayout.getChildAt(1)).getLayoutManager().getChildAt(0);
         assertThat(view.isEnabled(), is(Boolean.FALSE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneWidgetTest.java
@@ -111,10 +111,26 @@ public class SelectOneWidgetTest extends GeneralSelectOneWidgetTest<SelectOneWid
     }
 
     @Test
-    public void whenAChoiceIsBlank_itIsShownAsBlank() {
+    public void whenAChoiceValueIsBlank_itIsShownAsBlank() {
         formEntryPrompt = new MockFormEntryPromptBuilder()
                 .withSelectChoices(asList(
                         new SelectChoice("1", "")
+                ))
+                .build();
+
+        SelectOneWidget widget = getWidget();
+        populateRecyclerView(widget);
+        assertThat(innerText(widget.getChoicesList().getChildAt(0)), equalTo(""));
+    }
+
+    @Test
+    public void whenAChoiceValueIsNull_itIsShownAsBlank() {
+        SelectChoice selectChoice = new SelectChoice(); // The two arg constructor protects against null values
+        selectChoice.setTextID("1");
+
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(asList(
+                        selectChoice
                 ))
                 .build();
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SelectOneWidgetTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.widgets;
 
 import android.app.Application;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
@@ -36,15 +37,14 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.support.CollectHelpers.setupFakeReferenceManager;
 import static org.odk.collect.android.support.RobolectricHelpers.populateRecyclerView;
-import static org.robolectric.shadows.ShadowView.innerText;
 
 /**
  * @author James Knight
@@ -111,32 +111,19 @@ public class SelectOneWidgetTest extends GeneralSelectOneWidgetTest<SelectOneWid
     }
 
     @Test
-    public void whenAChoiceValueIsBlank_itIsShownAsBlank() {
-        formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(asList(
-                        new SelectChoice("1", "")
-                ))
-                .build();
-
-        SelectOneWidget widget = getWidget();
-        populateRecyclerView(widget);
-        assertThat(innerText(widget.getChoicesList().getChildAt(0)), equalTo(""));
-    }
-
-    @Test
-    public void whenAChoiceValueIsNull_itIsShownAsBlank() {
+    public void whenAChoiceValueIsNull_selecting_doesNotSetAnswer() {
         SelectChoice selectChoice = new SelectChoice(); // The two arg constructor protects against null values
         selectChoice.setTextID("1");
 
         formEntryPrompt = new MockFormEntryPromptBuilder()
-                .withSelectChoices(asList(
-                        selectChoice
-                ))
+                .withSelectChoices(asList(selectChoice))
                 .build();
 
         SelectOneWidget widget = getWidget();
         populateRecyclerView(widget);
-        assertThat(innerText(widget.getChoicesList().getChildAt(0)), equalTo(""));
+
+        clickChoice(widget, 0);
+        assertThat(widget.getAnswer(), nullValue());
     }
 
     @Test
@@ -188,6 +175,14 @@ public class SelectOneWidgetTest extends GeneralSelectOneWidgetTest<SelectOneWid
                 return analytics;
             }
         });
+    }
+
+    private static void clickChoice(SelectOneWidget widget, int index) {
+        ((AudioVideoImageTextLabel) getChoiceView(widget, index).getChildAt(0)).getLabelTextView().performClick();
+    }
+
+    private static ViewGroup getChoiceView(SelectOneWidget widget, int index) {
+        return (ViewGroup) widget.getChoicesList().getChildAt(index);
     }
 
     private static final List<Pair<String, String>> REFERENCES = asList(

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -85,7 +85,7 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().signButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().signButton.getVisibility(), is(View.GONE));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SpinnerMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SpinnerMultiWidgetTest.java
@@ -41,6 +41,6 @@ public class SpinnerMultiWidgetTest extends GeneralSelectMultiWidgetTest<Spinner
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().button.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().button.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SpinnerWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SpinnerWidgetTest.java
@@ -27,7 +27,7 @@ public class SpinnerWidgetTest extends GeneralSelectOneWidgetTest<SpinnerWidget>
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().spinner.getVisibility(), is(View.VISIBLE));
-        assertThat(getWidget().spinner.isEnabled(), is(Boolean.FALSE));
+        assertThat(getSpyWidget().spinner.getVisibility(), is(View.VISIBLE));
+        assertThat(getSpyWidget().spinner.isEnabled(), is(Boolean.FALSE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/StringNumberWidgetTest.java
@@ -32,14 +32,14 @@ public class StringNumberWidgetTest extends GeneralStringWidgetTest<StringNumber
 
     @Test
     public void digitsNumberShouldNotBeLimited() {
-        getActualWidget().answerText.setText("123456789123456789123456789123456789");
-        assertEquals("123456789123456789123456789123456789", getActualWidget().getAnswerText());
+        getWidget().answerText.setText("123456789123456789123456789123456789");
+        assertEquals("123456789123456789123456789123456789", getWidget().getAnswerText());
     }
 
     @Test
     public void separatorsShouldBeAddedWhenEnabled() {
         when(formEntryPrompt.getAppearanceHint()).thenReturn(THOUSANDS_SEP);
-        getActualWidget().answerText.setText("123456789123456789123456789123456789");
-        assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getActualWidget().answerText.getText().toString());
+        getWidget().answerText.setText("123456789123456789123456789123456789");
+        assertEquals("123,456,789,123,456,789,123,456,789,123,456,789", getWidget().answerText.getText().toString());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/TimeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/TimeWidgetTest.java
@@ -45,7 +45,7 @@ public class TimeWidgetTest extends GeneralDateTimeWidgetTest<TimeWidget, TimeDa
 
     @Test
     public void updatingTheDateAndTimeWidgetsShouldUpdateTheAnswer() {
-        TimeWidget widget = getWidget();
+        TimeWidget widget = getSpyWidget();
 
         DateTime dateTime = getNextDateTime();
         widget.updateTime(dateTime);
@@ -60,6 +60,6 @@ public class TimeWidgetTest extends GeneralDateTimeWidgetTest<TimeWidget, TimeDa
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().timeButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().timeButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/UrlWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/UrlWidgetTest.java
@@ -41,6 +41,6 @@ public class UrlWidgetTest extends QuestionWidgetTest<UrlWidget, StringData> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().openUrlButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().openUrlButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -129,8 +129,8 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().captureButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().chooseButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().playButton.getVisibility(), is(View.VISIBLE));
+        assertThat(getSpyWidget().captureButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().chooseButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().playButton.getVisibility(), is(View.VISIBLE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/BaseGeoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/BaseGeoWidgetTest.java
@@ -25,6 +25,6 @@ public abstract class BaseGeoWidgetTest<W extends BaseGeoWidget, A extends IAnsw
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().startGeoButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().startGeoButton.getVisibility(), is(View.GONE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/BinaryWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/BinaryWidgetTest.java
@@ -19,7 +19,7 @@ public abstract class BinaryWidgetTest<W extends BinaryWidget, A extends IAnswer
 
     @Test
     public void getAnswerShouldReturnCorrectAnswerAfterBeingSet() {
-        W widget = getWidget();
+        W widget = getSpyWidget();
         assertNull(widget.getAnswer());
 
         A answer = getNextAnswer();
@@ -38,7 +38,7 @@ public abstract class BinaryWidgetTest<W extends BinaryWidget, A extends IAnswer
         A answer = getInitialAnswer();
         when(formEntryPrompt.getAnswerText()).thenReturn(answer.getDisplayText());
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
 
         A newAnswer = getNextAnswer();
         Object binaryData = createBinaryData(newAnswer);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/ButtonWidgetTest.java
@@ -29,11 +29,11 @@ public abstract class ButtonWidgetTest<W extends ButtonWidget, A extends IAnswer
 
     protected void stubAllRuntimePermissionsGranted(boolean isGranted) {
         permissionUtils.setPermissionGranted(isGranted);
-        ((QuestionWidget) getActualWidget()).setPermissionUtils(permissionUtils);
+        ((QuestionWidget) getWidget()).setPermissionUtils(permissionUtils);
     }
 
     protected Intent getIntentLaunchedByClick(int buttonId) {
-        ((QuestionWidget) getWidget()).findViewById(buttonId).performClick();
+        ((QuestionWidget) getSpyWidget()).findViewById(buttonId).performClick();
         return shadowOf(activity).getNextStartedActivity();
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/FileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/FileWidgetTest.java
@@ -39,7 +39,7 @@ public abstract class FileWidgetTest<W extends FileWidget> extends BinaryWidgetT
 
         super.settingANewAnswerShouldRemoveTheOldAnswer();
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
         verify(widget).deleteFile();
     }
 
@@ -47,7 +47,7 @@ public abstract class FileWidgetTest<W extends FileWidget> extends BinaryWidgetT
     public void callingClearAnswerShouldCallDeleteMediaAndRemoveTheExistingAnswer() {
         super.callingClearShouldRemoveTheExistingAnswer();
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
         verify(widget).deleteFile();
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
@@ -25,8 +25,8 @@ public abstract class GeneralExStringWidgetTest<W extends ExStringWidget, A exte
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().launchIntentButton.getVisibility(), is(View.GONE));
-        assertThat(getWidget().answerText.getVisibility(), is(View.VISIBLE));
-        assertThat(getWidget().answerText.isEnabled(), is(Boolean.FALSE));
+        assertThat(getSpyWidget().launchIntentButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().answerText.getVisibility(), is(View.VISIBLE));
+        assertThat(getSpyWidget().answerText.isEnabled(), is(Boolean.FALSE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralSelectMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralSelectMultiWidgetTest.java
@@ -45,7 +45,7 @@ public abstract class GeneralSelectMultiWidgetTest<W extends MultiChoiceWidget>
 
     @Test
     public void getAnswerShouldReflectWhichSelectionsWereMade() {
-        W widget = getWidget();
+        W widget = getSpyWidget();
         assertNull(widget.getAnswer());
 
         List<SelectChoice> selectChoices = getSelectChoices();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralSelectOneWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralSelectOneWidgetTest.java
@@ -41,7 +41,7 @@ public abstract class GeneralSelectOneWidgetTest<W extends MultiChoiceWidget>
 
     @Test
     public void getAnswerShouldReflectTheCurrentlySelectedChoice() {
-        W widget = getWidget();
+        W widget = getSpyWidget();
         assertNull(widget.getAnswer());
 
         List<SelectChoice> selectChoices = getSelectChoices();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
@@ -32,7 +32,7 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
     public void callingClearShouldRemoveTheExistingAnswer() {
         super.callingClearShouldRemoveTheExistingAnswer();
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
         assertEquals(widget.getAnswerText(), "");
     }
 
@@ -41,7 +41,7 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
     public void getAnswerShouldReturnExistingAnswerIfPromptHasExistingAnswer() {
         super.getAnswerShouldReturnExistingAnswerIfPromptHasExistingAnswer();
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
         IAnswerData answer = widget.getAnswer();
 
         assertEquals(widget.getAnswerText(), answer.getDisplayText());
@@ -52,7 +52,7 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
         // Make sure it starts null:
         super.getAnswerShouldReturnNullIfPromptDoesNotHaveExistingAnswer();
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
         IAnswerData answer = getNextAnswer();
 
         when(widget.getAnswerText()).thenReturn(answer.getDisplayText());
@@ -65,7 +65,7 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().answerText.getVisibility(), is(View.VISIBLE));
-        assertThat(getWidget().answerText.isEnabled(), is(Boolean.FALSE));
+        assertThat(getSpyWidget().answerText.getVisibility(), is(View.VISIBLE));
+        assertThat(getSpyWidget().answerText.isEnabled(), is(Boolean.FALSE));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
@@ -54,7 +54,7 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
      * <p>
      * This should be used for mutating the {@link org.odk.collect.android.widgets.QuestionWidget}
      */
-    public W getActualWidget() {
+    public W getWidget() {
         if (actualWidget == null) {
             actualWidget = createWidget();
         }
@@ -68,9 +68,9 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
      * This should be unless we want to mutate {@link org.odk.collect.android.widgets.QuestionWidget}
      * This is because a spy is not the real object and changing it won't have any effect on the real object
      */
-    public W getWidget() {
+    public W getSpyWidget() {
         if (widget == null) {
-            widget = spy(getActualWidget());
+            widget = spy(getWidget());
         }
 
         return widget;
@@ -93,7 +93,7 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
 
     @Test
     public void getAnswerShouldReturnNullIfPromptDoesNotHaveExistingAnswer() {
-        W widget = getWidget();
+        W widget = getSpyWidget();
         assertNull(widget.getAnswer());
     }
 
@@ -106,7 +106,7 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
             when(formEntryPrompt.getAnswerValue()).thenReturn(answer);
         }
 
-        W widget = getWidget();
+        W widget = getSpyWidget();
         IAnswerData newAnswer = widget.getAnswer();
 
         assertNotNull(newAnswer);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/RangeWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/RangeWidgetTest.java
@@ -44,7 +44,7 @@ public abstract class RangeWidgetTest<W extends RangeWidget, A extends IAnswerDa
 
     @Test
     public void getAnswerShouldReflectActualValueSetViaSeekBar() {
-        W widget = getWidget();
+        W widget = getSpyWidget();
         assertNull(widget.getAnswer());
 
         int progress = Math.abs(random.nextInt()) % widget.getElementCount();
@@ -73,14 +73,14 @@ public abstract class RangeWidgetTest<W extends RangeWidget, A extends IAnswerDa
         // Picker appearance
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getWidget().pickerButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().pickerButton.getVisibility(), is(View.GONE));
 
         resetWidget();
 
         // No appearance
         when(rangeQuestion.getAppearanceAttr()).thenReturn(null);
 
-        assertThat(getWidget().seekBar.getVisibility(), is(View.VISIBLE));
-        assertThat(getWidget().seekBar.isEnabled(), is(Boolean.FALSE));
+        assertThat(getSpyWidget().seekBar.getVisibility(), is(View.VISIBLE));
+        assertThat(getSpyWidget().seekBar.isEnabled(), is(Boolean.FALSE));
     }
 }


### PR DESCRIPTION
Closes #3142

This makes it possible to have null select choice values in select one. This not working was causing a crash. While it's not common it is possible for JavaRosa's `SelectChoice#getValue()` to return `null`. 

The behaviour we now expect is as follows:
1. Enumerator selects choice that has no underlying value
2. Choice looks selected
3. Enumerator swipes to another question and swipes back
4. There is no choice selected

This is a bit confusing but really a result of strange/bad form design so we're going to go with it for the moment.

#### What has been done to verify that this works as intended?

Wrote tests for `null` case for `SelectChoice` values. 

#### Why is this the best possible solution? Were any other approaches considered?

We initially considered hiding the value but it felt like the simplest thing to do was to let this kind of form exist as-is but make sure it wouldn't crash.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the crash. Good to have a play around with selects.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)