### PR TITLE
Update JavaRosa to v2.17.1

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation "com.rarepebble:colorpicker:3.0.1"
     implementation "commons-io:commons-io:2.6"
     implementation "net.sf.opencsv:opencsv:2.4"
-    implementation("org.opendatakit:opendatakit-javarosa:2.17.0") {
+    implementation("org.opendatakit:opendatakit-javarosa:2.17.1-SNAPSHOT") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
This PR fixes various bugs that were reported by users and recently addressed in JavaRosa. Several of these fixes came in just as the Collect release was getting prepared so it wasn't a good time to update. JavaRosa has gone through a lot of changes so instead of releasing off master, I'm proposing we do a point release with only low-risk bug fixes. 

Addresses opendatakit/javarosa#131, opendatakit/javarosa#509, opendatakit/javarosa#540, opendatakit/javarosa#498, opendatakit/javarosa#547

The branch this PR uses a JavaRosa snapshot. The sequence I propose here is:
- [x] @seadowg or @grzesiek2010 reviews [the JavaRosa diff](https://github.com/opendatakit/javarosa/compare/v2.17.x) with the notes I've made below
- [x] QA verifies the fixes and regression risks
- [x] We iterate on JavaRosa as needed
- [x] We release JR v2.17.1
- [ ] We update this PR to use the final release
- [ ] Someone does a quick sanity check to make sure that JR v2.17.1 matches the last snapshot code that was QAed and merges
- [ ] We do a Collect point release off a v1.26.x branch also including the fix for https://github.com/opendatakit/collect/issues/3751.

opendatakit/javarosa#131 / https://github.com/opendatakit/javarosa/commit/efe171f: exclusively an error message change so should pose no risk. It could help with troubleshooting so I figure it's good to get out.

opendatakit/javarosa#509 / https://github.com/opendatakit/javarosa/commit/5fc1012, https://github.com/opendatakit/javarosa/commit/6cb87e4, https://github.com/opendatakit/javarosa/commit/3f22f7e: only the first commit has a code change and it is limited to the `count-not-empty` function. The other two commits are tests. I see no regression risk with this one.

opendatakit/javarosa#540 / https://github.com/opendatakit/javarosa/commit/8bc3362: I cherry-picked https://github.com/opendatakit/javarosa/commit/26cdfa2838ce1768f301411eb365e880579a01aa and fixed spacing conflicts. Then I verified the diff against master. I didn't bring the tests in because the ones added in https://github.com/opendatakit/javarosa/pull/546 rely on new testing infrastructure. This one is riskier and there's a regression risk around any relative path expression with parenting steps (`../`) and multiplicities. However, I think the logic is straightforward enough to review. The only change is the addition of the `if (i + refLevel <= newRef.size())` condition. This means that the behavior only changes in the case where `i + refLevel > newRef.size()` in which case multiplicities aren't copied. I think the tests document this sufficiently. We know that this only affects forms with nested repeats which are relatively rare. However, this bug is a showstopper for those who want to use complex expressions in nested repeats.

opendatakit/javarosa#498 / https://github.com/opendatakit/javarosa/commit/0fe85cf: I cherry-picked https://github.com/opendatakit/javarosa/commit/eb8cfd1f because the tests added by https://github.com/opendatakit/javarosa/pull/551 rely on new testing infrastructure. It's similar in nature to the one above in that it will only affect relative references and these will only be generated by pyxform for nested repeats. I think the regression risk here is even lower because `contextualize` does nothing with absolute references. The tests are also comprehensive (https://github.com/opendatakit/javarosa/pull/551/files#diff-68d926706ca036914f632b04878da9ca). Still, there's a regression risk to the `indexed-repeat` function and it would be good to verify it in single repeats and nested repeats.

opendatakit/javarosa#547 / https://github.com/opendatakit/javarosa/commit/4fdc453, https://github.com/opendatakit/javarosa/commit/6b28fd5: only the first commit changes code. The second removes a test that relies on updated test infrastructure. This is like the `count-not-empty` change above. It only changes the `digest` function so that should be the only place where there's risk of regression.

I have run all tests and verified that they pass. I verified 
[dynamic-digest.xml 2.zip](https://github.com/opendatakit/collect/files/4417960/dynamic-digest.xml.2.zip) to make sure that the `digest` function works as expected.
