### PR TITLE
Fixed copy/paste and removing answer in String widgets

### DIFF
--- a/collect_app/src/androidTest/assets/forms/string_widgets_in_field_list.xml
+++ b/collect_app/src/androidTest/assets/forms/string_widgets_in_field_list.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>fl</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="stringwidgets">
+                    <my-group>
+                        <question1 />
+                        <question2 />
+                    </my-group>
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/my-group/question1" type="string" />
+            <bind nodeset="/data/my-group/question2" type="int" />
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <group appearance="field-list" ref="/data/my-group">
+            <label>My group</label>
+            <input ref="/data/my-group/question1">
+                <label>Question1</label>
+            </input>
+            <input ref="/data/my-group/question2">
+                <label>Question2</label>
+            </input>
+        </group>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ContextMenuTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/formentry/ContextMenuTest.java
@@ -1,0 +1,58 @@
+package org.odk.collect.android.formentry;
+
+import android.Manifest;
+
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.test.FormLoadingUtils;
+
+public class ContextMenuTest {
+    private static final String STRING_WIDGETS_TEST_FORM = "string_widgets_in_field_list.xml";
+
+    @Rule
+    public IntentsTestRule<FormEntryActivity> activityTestRule = FormLoadingUtils.getFormActivityTestRuleFor(STRING_WIDGETS_TEST_FORM);
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            )
+            .around(new ResetStateRule())
+            .around(new CopyFormRule(STRING_WIDGETS_TEST_FORM, true));
+
+    @Test
+    public void whenRemoveStringAnswer_ShouldAppropriateQuestionBeCleared() {
+        new FormEntryPage("string_widgets", activityTestRule)
+                .putTextOnIndex(0, "TestString")
+                .putTextOnIndex(1, "1234")
+                .assertText("TestString")
+                .assertText("1234")
+                .longPressOnView("Question1")
+                .removeResponse()
+                .checkIfTextDoesNotExist("TestString")
+                .assertText("1234")
+                .putTextOnIndex(0, "TestString")
+                .assertText("TestString")
+                .longPressOnView("Question2")
+                .removeResponse()
+                .checkIfTextDoesNotExist("1234")
+                .assertText("TestString");
+    }
+
+    @Test
+    public void whenLongPressedOnEditText_ShouldNotRemoveAnswerOptionAppear() {
+        new FormEntryPage("string_widgets", activityTestRule)
+                .longPressOnView(R.id.answer_container, 0)
+                .checkIfTextDoesNotExist(R.string.clear_answer);
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -240,4 +240,20 @@ public class FormEntryPage extends Page<FormEntryPage> {
         onView(withText(R.string.quit_entry)).check(matches(isDisplayed()));
         return this;
     }
+
+    public FormEntryPage longPressOnView(int id, int index) {
+        onView(withIndex(withId(id), index)).perform(longClick());
+        return this;
+    }
+
+    public FormEntryPage longPressOnView(String text) {
+        onView(withText(text)).perform(longClick());
+        return this;
+    }
+
+    public FormEntryPage removeResponse() {
+        onView(withText(R.string.clear_answer)).perform(click());
+        onView(withText(R.string.discard_answer)).perform(click());
+        return this;
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -154,7 +154,6 @@ import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangeWidget;
-import org.odk.collect.android.widgets.StringWidget;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -1118,28 +1117,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         if (item.getItemId() == DELETE_REPEAT) {
             createDeleteRepeatConfirmDialog();
         } else {
-            /*
-             * We don't have the right view here, so we store the View's ID as the
-             * item ID and loop through the possible views to find the one the user
-             * clicked on.
-             */
-            boolean shouldClearDialogBeShown;
             ODKView odkView = getCurrentViewIfODKView();
             if (odkView != null) {
                 for (QuestionWidget qw : odkView.getWidgets()) {
-                    shouldClearDialogBeShown = false;
-                    if (qw instanceof StringWidget) {
-                        for (int i = 0; i < qw.getChildCount(); i++) {
-                            if (item.getItemId() == qw.getChildAt(i).getId()) {
-                                shouldClearDialogBeShown = true;
-                                break;
-                            }
-                        }
-                    } else if (item.getItemId() == qw.getId()) {
-                        shouldClearDialogBeShown = true;
-                    }
-
-                    if (shouldClearDialogBeShown) {
+                    if (item.getItemId() == qw.getId()) {
                         createClearDialog(qw);
                         break;
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -262,7 +262,6 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
         QuestionWidget qw = WidgetFactory.createWidgetFromPrompt(question, getContext(), readOnlyOverride);
         qw.setOnLongClickListener(this);
         qw.setValueChangedListener(this);
-        qw.setId(View.generateViewId());
 
         return qw;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -108,6 +108,7 @@ public abstract class QuestionWidget
     public QuestionWidget(Context context, QuestionDetails questionDetails) {
         super(context);
         getComponent(context).inject(this);
+        setId(View.generateViewId());
         this.audioHelper = audioHelperFactory.create(context);
 
         themeUtils = new ThemeUtils(context);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -139,7 +139,7 @@ public abstract class QuestionWidget
         }
 
         if (context instanceof FormEntryActivity && !getFormEntryPrompt().isReadOnly()) {
-            registerToClearAnswerOnLongPress((FormEntryActivity) context);
+            registerToClearAnswerOnLongPress((FormEntryActivity) context, this);
         }
     }
 
@@ -409,7 +409,7 @@ public abstract class QuestionWidget
      * user long presses on it. Widget subclasses may override this if some or all of their
      * components need to intercept long presses.
      */
-    protected void registerToClearAnswerOnLongPress(FormEntryActivity activity) {
+    protected void registerToClearAnswerOnLongPress(FormEntryActivity activity, ViewGroup viewGroup) {
         activity.registerForContextMenu(this);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -117,6 +117,7 @@ public class StringWidget extends QuestionWidget {
         for (int i = 0; i < questionWidgetContainer.getChildCount(); i++) {
             View child = questionWidgetContainer.getChildAt(i);
             if (child.getId() != R.id.answer_container) {
+                child.setId(getId());
                 activity.registerForContextMenu(child);
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -32,7 +32,6 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
@@ -112,11 +111,12 @@ public class StringWidget extends QuestionWidget {
      * to long-press to paste or perform other text editing functions.
      */
     @Override
-    protected void registerToClearAnswerOnLongPress(FormEntryActivity activity) {
-        ViewGroup questionWidgetContainer = (ViewGroup) getChildAt(0);
-        for (int i = 0; i < questionWidgetContainer.getChildCount(); i++) {
-            View child = questionWidgetContainer.getChildAt(i);
-            if (child.getId() != R.id.answer_container) {
+    protected void registerToClearAnswerOnLongPress(FormEntryActivity activity, ViewGroup viewGroup) {
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            View child = viewGroup.getChildAt(i);
+            if (child instanceof ViewGroup) {
+                registerToClearAnswerOnLongPress(activity, (ViewGroup) child);
+            } else if (!(child instanceof EditText)) {
                 child.setId(getId());
                 activity.registerForContextMenu(child);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -23,6 +23,7 @@ import android.text.method.TextKeyListener;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.EditText;
 
 import androidx.annotation.NonNull;
@@ -31,6 +32,7 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
@@ -111,9 +113,11 @@ public class StringWidget extends QuestionWidget {
      */
     @Override
     protected void registerToClearAnswerOnLongPress(FormEntryActivity activity) {
-        for (int i = 0; i < getChildCount(); i++) {
-            if (!(getChildAt(i) instanceof EditText)) {
-                activity.registerForContextMenu(getChildAt(i));
+        ViewGroup questionWidgetContainer = (ViewGroup) getChildAt(0);
+        for (int i = 0; i < questionWidgetContainer.getChildCount(); i++) {
+            View child = questionWidgetContainer.getChildAt(i);
+            if (child.getId() != R.id.answer_container) {
+                activity.registerForContextMenu(child);
             }
         }
     }


### PR DESCRIPTION
Closes #3751

#### What has been done to verify that this works as intended?
I tested implemented changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that recently we merged a pr with changes in widget layouts. That pr made them a bit more complex and the EditText in String widget is no longer a direct child of the main layout so we can't use the same approach to `registerToClearAnswerOnLongPress`
https://github.com/opendatakit/collect/compare/master...grzesiek2010:COLLECT-3751?expand=1#diff-40209772412b68a8a49448905bedd78aL115
Now the EditText has it's own parent layout so we need to drain it a bit more to find views we really need to register.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is related to String widgets only so testing copy/paste and removing answers using String widgets + field-lists would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)