### PR TITLE
Handle exceptions that might occur when a user tries to open a browser

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationDialog.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.storage.migration;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -14,11 +15,13 @@ import android.widget.TextView;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
+import org.odk.collect.android.activities.WebViewActivity;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.material.MaterialFullScreenDialogFragment;
 import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
 import org.odk.collect.android.preferences.AdminPasswordDialogFragment.Action;
 import org.odk.collect.android.utilities.AdminPasswordProvider;
+import org.odk.collect.android.utilities.CustomTabHelper;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.MultiClickGuard;
 
@@ -133,7 +136,13 @@ public class StorageMigrationDialog extends MaterialFullScreenDialogFragment {
     private void showMoreDetails() {
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(Uri.parse("https://forum.opendatakit.org/t/25268"));
-        startActivity(intent);
+        try {
+            startActivity(intent);
+        } catch (ActivityNotFoundException | SecurityException e) {
+            intent = new Intent(getContext(), WebViewActivity.class);
+            intent.putExtra(CustomTabHelper.OPEN_URL, Uri.parse("https://forum.opendatakit.org/t/25268"));
+            startActivity(intent);
+        }
     }
 
     private void disableDialog() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
@@ -101,7 +101,7 @@ public class CustomTabHelper {
             try {
                 //open in external browser
                 context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
-            } catch (ActivityNotFoundException e) {
+            } catch (ActivityNotFoundException | SecurityException e) {
                 //open in webview
                 Intent intent = new Intent(context, WebViewActivity.class);
                 intent.putExtra(OPEN_URL, uri.toString());


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Reviewed and tested manually with hardcoded exceptions.

#### Why is this the best possible solution? Were any other approaches considered?
We agreed that the crash when opening the forum from `StorageMigrationDialog` is not serious but since we are about to have a point release and another similar crash came up:
https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/84debbdb9ff2c7dfb84c961e3b54bc61?time=last-seven-days&sessionId=5E8451ED02FE000123A7DE9A2D5016BF_DNE_7_v2
I think it's worki merging and adding to v1.26.2

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)