### PR TITLE
Don't drain help_layout to register its children for context menu

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -32,6 +32,7 @@ import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
@@ -114,7 +115,10 @@ public class StringWidget extends QuestionWidget {
     protected void registerToClearAnswerOnLongPress(FormEntryActivity activity, ViewGroup viewGroup) {
         for (int i = 0; i < viewGroup.getChildCount(); i++) {
             View child = viewGroup.getChildAt(i);
-            if (child instanceof ViewGroup) {
+            if (child.getId() == R.id.help_layout) {
+                child.setId(getId());
+                activity.registerForContextMenu(child);
+            } else if (child instanceof ViewGroup) {
                 registerToClearAnswerOnLongPress(activity, (ViewGroup) child);
             } else if (!(child instanceof EditText)) {
                 child.setId(getId());

--- a/collect_app/src/main/res/layout/help_layout.xml
+++ b/collect_app/src/main/res/layout/help_layout.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/help_layout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I ran tests that failed on master and tested a form with guidance manually.

#### Why is this the best possible solution? Were any other approaches considered?
In order to support removing answers in #3755 I had to set view Ids what broke guidance. The solution is not to drain the layout which contains guidance. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It would be good to test a form with guidance like the one used in GuidanceHintFormTest to confirm that everything is fine.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with guidance hints like the one used in GuidanceHintFormTest.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)