### PR TITLE
Friendly error message when submissions closed.

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -205,8 +205,8 @@ public class InstanceServerUploader extends InstanceUploader {
                     if (messageParser.isValid()) {
                         exception = new UploadException(FAIL + messageParser.getMessageResponse());
                     } else {
-                        exception = new UploadException(FAIL + postResult.getReasonPhrase()
-                                + " (" + responseCode + ") at " + urlString);
+                        Timber.i(FAIL + postResult.getReasonPhrase() + " (" + responseCode + ") at " + urlString);
+                        exception = new UploadException("Failed to upload. Please make sure the form is configured to accept submissions on the server");
                     }
 
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -204,7 +204,7 @@ public class InstanceServerUploader extends InstanceUploader {
                 } else {
                     if (messageParser.isValid()) {
                         exception = new UploadException(FAIL + messageParser.getMessageResponse());
-                    } else if(responseCode == HttpsURLConnection.HTTP_BAD_REQUEST){
+                    } else if (responseCode == HttpsURLConnection.HTTP_BAD_REQUEST) {
                         Timber.w(FAIL + postResult.getReasonPhrase() + " (" + responseCode + ") at " + urlString);
                         exception = new UploadException("Failed to upload. Please make sure the form is configured to accept submissions on the server");
                     } else {

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -204,9 +204,11 @@ public class InstanceServerUploader extends InstanceUploader {
                 } else {
                     if (messageParser.isValid()) {
                         exception = new UploadException(FAIL + messageParser.getMessageResponse());
-                    } else {
-                        Timber.i(FAIL + postResult.getReasonPhrase() + " (" + responseCode + ") at " + urlString);
+                    } else if(responseCode == HttpsURLConnection.HTTP_BAD_REQUEST){
+                        Timber.w(FAIL + postResult.getReasonPhrase() + " (" + responseCode + ") at " + urlString);
                         exception = new UploadException("Failed to upload. Please make sure the form is configured to accept submissions on the server");
+                    } else {
+                        exception = new UploadException(FAIL + postResult.getReasonPhrase() + " (" + responseCode + ") at " + urlString);
                     }
 
                 }


### PR DESCRIPTION
Signed-off-by: Rajkumar S <rajkumaar2304@icloud.com>

Closes #3428 

#### What has been done to verify that this works as intended?
- A form was created on ODK aggregate and tried to submit from ODK collect, it works. 
- The same form was turned off for submissions, and then a friendly error message pops up. 

![image](https://user-images.githubusercontent.com/37476886/78535480-df9f0180-7809-11ea-88e1-03a4fc2be012.png)

#### Why is this the best possible solution? Were any other approaches considered?
- Changing the error message like this was the best solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- It lets the users get a more human-friendly feedback.

#### Do we need any specific form for testing your changes? If so, please attach one.
- No, any form that is turned off for submissions is good to test.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
- No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)