### PR TITLE
 Make sure to check for failed constraints when saving screen answers 

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -123,9 +123,15 @@ abstract class Page<T extends Page<T>> {
     }
 
     public T checkIsToastWithMessageDisplayed(String message) {
-        onView(withText(message))
-                .inRoot(withDecorView(not(is(getCurrentActivity().getWindow().getDecorView()))))
-                .check(matches(isDisplayed()));
+        try {
+            onView(withText(message))
+                    .inRoot(withDecorView(not(is(getCurrentActivity().getWindow().getDecorView()))))
+                    .check(matches(isDisplayed()));
+        } catch (RuntimeException e) {
+            // The exception we get out of this is really misleading so cleaning it up here
+            throw new RuntimeException("No Toast with text \"" + message + "\" shown on screen!");
+        }
+
 
         return (T) this;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -803,9 +803,18 @@ public class FormController {
                                                  boolean evaluateConstraints) throws JavaRosaException {
         if (currentPromptIsQuestion()) {
             for (FormIndex index : answers.keySet()) {
-                saveOneScreenAnswer(index, answers.get(index), evaluateConstraints);
+                FailedConstraint failedConstraint = saveOneScreenAnswer(
+                        index,
+                        answers.get(index),
+                        evaluateConstraints
+                );
+
+                if (failedConstraint != null) {
+                    return failedConstraint;
+                }
             }
         }
+
         return null;
     }
 


### PR DESCRIPTION
Before when saving screen answers using `saveAllScreenAnswers` we weren't checking for non-null `FailedConstraint` return values so failures wouldn't show in the UI. This was cause 3 Espresso tests to fail.

I also changed the assertion we use to check for Toasts as the failure message was quite confusing.

#### What has been done to verify that this works as intended?

Failing tests now pass

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue. Probably good to check forms with constraints to see if there is anything that the tests aren't catching here. I'd lean towards merging this and then doing that QA on master however.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)