### PR TITLE
Don't register DateWidget and TimeWidget separately if both are part of DateTimeWidget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateTimeWidget.java
@@ -42,8 +42,8 @@ public class DateTimeWidget extends QuestionWidget implements BinaryWidget, Widg
     public DateTimeWidget(Context context, QuestionDetails prompt) {
         super(context, prompt);
 
-        dateWidget = new DateWidget(context, prompt);
-        timeWidget = new TimeWidget(context, prompt);
+        dateWidget = new DateWidget(context, prompt, true);
+        timeWidget = new TimeWidget(context, prompt, true);
 
         dateWidget.getAudioVideoImageTextLabel().getLabelTextView().setVisibility(GONE);
         dateWidget.getHelpTextLayout().setVisibility(GONE);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/DateWidget.java
@@ -77,7 +77,11 @@ public class DateWidget extends QuestionWidget implements DatePickerDialog.OnDat
     private DatePickerDetails datePickerDetails;
 
     public DateWidget(Context context, QuestionDetails prompt) {
-        super(context, prompt);
+        this(context, prompt, false);
+    }
+
+    public DateWidget(Context context, QuestionDetails prompt, boolean isPartOfDateTimeWidget) {
+        super(context, prompt, !isPartOfDateTimeWidget);
         createWidget(context);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -106,6 +106,10 @@ public abstract class QuestionWidget
     public Analytics analytics;
 
     public QuestionWidget(Context context, QuestionDetails questionDetails) {
+        this(context, questionDetails, true);
+    }
+
+    public QuestionWidget(Context context, QuestionDetails questionDetails, boolean registerForContextMenu) {
         super(context);
         getComponent(context).inject(this);
         setId(View.generateViewId());
@@ -138,7 +142,7 @@ public abstract class QuestionWidget
             addAnswerView(answerView);
         }
 
-        if (context instanceof FormEntryActivity && !getFormEntryPrompt().isReadOnly()) {
+        if (registerForContextMenu && context instanceof FormEntryActivity && !getFormEntryPrompt().isReadOnly()) {
             registerToClearAnswerOnLongPress((FormEntryActivity) context, this);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/TimeWidget.java
@@ -64,8 +64,11 @@ public class TimeWidget extends QuestionWidget implements ButtonWidget, TimePick
     private boolean nullAnswer;
 
     public TimeWidget(Context context, final QuestionDetails prompt) {
-        super(context, prompt);
+        this(context, prompt, false);
+    }
 
+    public TimeWidget(Context context, QuestionDetails prompt, boolean isPartOfDateTimeWidget) {
+        super(context, prompt, !isPartOfDateTimeWidget);
         createTimeButton();
         timeTextView = createAnswerTextView(getContext(), getAnswerFontSize());
         createTimePickerDialog();


### PR DESCRIPTION
Closes #3761

#### What has been done to verify that this works as intended?
I tested the implemented changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix. `DateTimeWidget` consists of `DateWidget` and `TimeWidget` so `registerToClearAnswerOnLongPress()` was called multiple times.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test removing answers from: `DateTimeWidget`, `DateWidget` and `TimeWidget`, that would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
All widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)