### PR TITLE
Check if selected map layer file exists before using it

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -171,7 +171,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     @Override public void applyConfig(Bundle config) {
         mapType = config.getInt(KEY_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
         String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        referenceLayerFile = path != null ? new File(path) : null;
+        referenceLayerFile = (path != null && new File(path).exists()) ? new File(path) : null;
         if (map != null) {
             map.setMapType(mapType);
             loadReferenceOverlay();

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -51,7 +51,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
-import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
@@ -170,8 +169,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
 
     @Override public void applyConfig(Bundle config) {
         mapType = config.getInt(KEY_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
-        String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        referenceLayerFile = (path != null && new File(path).exists()) ? new File(path) : null;
+        referenceLayerFile = getReferenceLayerFile(config);
         if (map != null) {
             map.setMapType(mapType);
             loadReferenceOverlay();

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -51,6 +51,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.utilities.GeoUtils;
 import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
@@ -169,7 +171,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
 
     @Override public void applyConfig(Bundle config) {
         mapType = config.getInt(KEY_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
-        referenceLayerFile = getReferenceLayerFile(config);
+        referenceLayerFile = GeoUtils.getReferenceLayerFile(config, new StoragePathProvider());
         if (map != null) {
             map.setMapType(mapType);
             loadReferenceOverlay();

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapFragment.java
@@ -16,14 +16,11 @@ package org.odk.collect.android.geo;
 
 import android.os.Bundle;
 
-import java.io.File;
 import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
-
-import org.odk.collect.android.storage.StoragePathProvider;
 
 /**
  * Interface for a Fragment that renders a map view.  The plan is to have one
@@ -208,12 +205,5 @@ public interface MapFragment {
 
     interface FeatureListener {
         void onFeature(int featureId);
-    }
-
-    default File getReferenceLayerFile(Bundle config) {
-        String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        return path != null && new File(path).exists()
-                ? new File(path)
-                : null;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapFragment.java
@@ -16,11 +16,14 @@ package org.odk.collect.android.geo;
 
 import android.os.Bundle;
 
+import java.io.File;
 import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
+
+import org.odk.collect.android.storage.StoragePathProvider;
 
 /**
  * Interface for a Fragment that renders a map view.  The plan is to have one
@@ -205,5 +208,12 @@ public interface MapFragment {
 
     interface FeatureListener {
         void onFeature(int featureId);
+    }
+
+    default File getReferenceLayerFile(Bundle config) {
+        String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
+        return path != null && new File(path).exists()
+                ? new File(path)
+                : null;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -232,7 +232,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
     @Override public void applyConfig(Bundle config) {
         styleUrl = config.getString(KEY_STYLE_URL);
         String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        referenceLayerFile = path != null ? new File(path) : null;
+        referenceLayerFile = (path != null && new File(path).exists()) ? new File(path) : null;
         if (map != null) {
             map.setStyle(getStyleBuilder(), style -> {
                 // See addTo() above for why we add this placeholder layer.

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -56,6 +56,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.geo.MbtilesFile.LayerType;
 import org.odk.collect.android.geo.MbtilesFile.MbtilesException;
 import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.utilities.GeoUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -230,7 +232,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
 
     @Override public void applyConfig(Bundle config) {
         styleUrl = config.getString(KEY_STYLE_URL);
-        referenceLayerFile = getReferenceLayerFile(config);
+        referenceLayerFile = GeoUtils.getReferenceLayerFile(config, new StoragePathProvider());
         if (map != null) {
             map.setStyle(getStyleBuilder(), style -> {
                 // See addTo() above for why we add this placeholder layer.

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -56,7 +56,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.geo.MbtilesFile.LayerType;
 import org.odk.collect.android.geo.MbtilesFile.MbtilesException;
 import org.odk.collect.android.injection.DaggerUtils;
-import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.io.File;
 import java.io.IOException;
@@ -231,8 +230,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
 
     @Override public void applyConfig(Bundle config) {
         styleUrl = config.getString(KEY_STYLE_URL);
-        String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        referenceLayerFile = (path != null && new File(path).exists()) ? new File(path) : null;
+        referenceLayerFile = getReferenceLayerFile(config);
         if (map != null) {
             map.setStyle(getStyleBuilder(), style -> {
                 // See addTo() above for why we add this placeholder layer.

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -151,7 +151,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     @Override public void applyConfig(Bundle config) {
         webMapService = (WebMapService) config.getSerializable(KEY_WEB_MAP_SERVICE);
         String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        referenceLayerFile = path != null ? new File(path) : null;
+        referenceLayerFile = (path != null && new File(path).exists()) ? new File(path) : null;
         if (map != null) {
             map.setTileSource(webMapService.asOnlineTileSource());
             loadReferenceOverlay();

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -44,6 +44,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.utilities.GeoUtils;
 import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.osmdroid.api.IGeoPoint;
@@ -149,7 +151,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     @Override public void applyConfig(Bundle config) {
         webMapService = (WebMapService) config.getSerializable(KEY_WEB_MAP_SERVICE);
-        referenceLayerFile = getReferenceLayerFile(config);
+        referenceLayerFile = GeoUtils.getReferenceLayerFile(config, new StoragePathProvider());
         if (map != null) {
             map.setTileSource(webMapService.asOnlineTileSource());
             loadReferenceOverlay();

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -44,7 +44,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.location.client.LocationClient;
 import org.odk.collect.android.location.client.LocationClients;
-import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.osmdroid.api.IGeoPoint;
@@ -150,8 +149,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     @Override public void applyConfig(Bundle config) {
         webMapService = (WebMapService) config.getSerializable(KEY_WEB_MAP_SERVICE);
-        String path = new StoragePathProvider().getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
-        referenceLayerFile = (path != null && new File(path).exists()) ? new File(path) : null;
+        referenceLayerFile = getReferenceLayerFile(config);
         if (map != null) {
             map.setTileSource(webMapService.asOnlineTileSource());
             loadReferenceOverlay();

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -131,7 +131,13 @@ public class MapsPreferences extends BasePreferenceFragment {
             populateReferenceLayerPref();
             return false;
         });
-        updateReferenceLayerSummary(referenceLayerPref.getValue());
+        if (referenceLayerPref.getValue() == null
+                || new File(new StoragePathProvider().getAbsoluteOfflineMapLayerPath(referenceLayerPref.getValue())).exists()) {
+            updateReferenceLayerSummary(referenceLayerPref.getValue());
+        } else {
+            referenceLayerPref.setValue(null);
+            updateReferenceLayerSummary(null);
+        }
         referenceLayerPref.setOnPreferenceChangeListener((preference, newValue) -> {
             updateReferenceLayerSummary(newValue);
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/GeoUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/GeoUtils.java
@@ -1,6 +1,13 @@
 package org.odk.collect.android.utilities;
 
 import android.location.Location;
+import android.os.Bundle;
+
+import org.odk.collect.android.storage.StoragePathProvider;
+
+import java.io.File;
+
+import static org.odk.collect.android.geo.MapFragment.KEY_REFERENCE_LAYER;
 
 public class GeoUtils {
 
@@ -18,5 +25,12 @@ public class GeoUtils {
      */
     public static String capitalizeGps(String locationProvider) {
         return "gps".equals(locationProvider) ? "GPS" : locationProvider;
+    }
+
+    public static File getReferenceLayerFile(Bundle config, StoragePathProvider storagePathProvider) {
+        String path = storagePathProvider.getAbsoluteOfflineMapLayerPath(config.getString(KEY_REFERENCE_LAYER));
+        return path != null && new File(path).exists()
+                ? new File(path)
+                : null;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/GeoUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/GeoUtilsTest.java
@@ -1,10 +1,22 @@
 package org.odk.collect.android.utilities;
 
-import org.junit.Test;
+import android.os.Bundle;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@RunWith(RobolectricTestRunner.class)
 public class GeoUtilsTest {
     @Test
     public void capitalizesGps() {
@@ -16,5 +28,35 @@ public class GeoUtilsTest {
 
         String nullLocationProvider = null;
         assertNull(GeoUtils.capitalizeGps(nullLocationProvider));
+    }
+
+    @Test
+    public void whenPathIsNull_should_getReferenceLayerFileReturnNull() {
+        Bundle config = mock(Bundle.class);
+        StoragePathProvider storagePathProvider = mock(StoragePathProvider.class);
+        when(storagePathProvider.getAbsoluteOfflineMapLayerPath(any())).thenReturn(null);
+
+        assertNull(GeoUtils.getReferenceLayerFile(config, storagePathProvider));
+    }
+
+    @Test
+    public void whenOfflineLayerFileDoesNotExist_should_getReferenceLayerFileReturnNull() {
+        Bundle config = mock(Bundle.class);
+        StoragePathProvider storagePathProvider = mock(StoragePathProvider.class);
+        when(storagePathProvider.getAbsoluteOfflineMapLayerPath(any())).thenReturn("/storage/emulated/0/odk/layers/MapBox_Demo_Layer/demo_layers.mbtiles");
+
+        assertNull(GeoUtils.getReferenceLayerFile(config, storagePathProvider));
+    }
+
+    @Test
+    public void whenOfflineLayerFileExist_should_getReferenceLayerFileReturnThatFile() {
+        File file = new File(new StoragePathProvider().getAbsoluteOfflineMapLayerPath("MapBox_Demo_Layer/demo_layers.mbtiles"));
+        FileUtils.write(file, new byte[] {});
+
+        Bundle config = mock(Bundle.class);
+        StoragePathProvider storagePathProvider = mock(StoragePathProvider.class);
+        when(storagePathProvider.getAbsoluteOfflineMapLayerPath(any())).thenReturn(file.getAbsolutePath());
+
+        assertNotNull(GeoUtils.getReferenceLayerFile(config, storagePathProvider));
     }
 }


### PR DESCRIPTION
Closes #3771

#### What has been done to verify that this works as intended?
I was able to reproduce the issue following the steps described below and confirmed this pr fixes the issue.

#### Why is this the best possible solution? Were any other approaches considered?
I was able to reproduce the issue reported in #3771. Steps are:
1. Download any offline map layer and paste it to layers/ dir.
2. Select the downloaded layer in the map settings.
3. Go to any geo widget which uses maps.
4. Remove the offline map layer from layers dir
5. Open the map view from the geo widget.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is safe, we just need to confirm the crash mentioned in the issue doesn't exist anymore using the steps I described above.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with geo widgets.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)