### PR TITLE
Update GCloud tooling on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ references:
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:
-      - image: google/cloud-sdk:216.0.0
+      - image: google/cloud-sdk:289.0.0
 
 jobs:
 


### PR DESCRIPTION
This hopefully fixes the build errors that are happening  due to unrecognized GCloud args