### PR TITLE
Retains Select Layer Dialog on changing the Orientation

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/CaptionedListPreference.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/CaptionedListPreference.java
@@ -4,7 +4,6 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Rect;
-import android.os.Parcelable;
 import android.preference.ListPreference;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -78,6 +77,14 @@ public class CaptionedListPreference extends ListPreference {
         updateContent();
     }
 
+    @Override
+    public void onActivityDestroy() {
+        super.onActivityDestroy();
+        if (getDialog() != null) {
+            getDialog().dismiss();
+        }
+    }
+
     /** Updates the contents of the dialog to show the items passed in by setItems etc. */
     public void updateContent() {
         CharSequence[] values = getEntryValues();
@@ -118,16 +125,6 @@ public class CaptionedListPreference extends ListPreference {
         clickedIndex = index;
         onClick(getDialog(), DialogInterface.BUTTON_POSITIVE);
         getDialog().dismiss();
-    }
-
-    /** Closes the dialog when the screen is rotated. */
-    public Parcelable onSaveInstanceState() {
-        // If the dialog is left open, it becomes empty when restored.  For now,
-        // instead of building all the save/restore machinery, just close it.
-        if (getDialog() != null) {
-            getDialog().dismiss();
-        }
-        return super.onSaveInstanceState();
     }
 
     /** Saves the selected value to the preferences when the dialog is closed. */

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -81,6 +81,20 @@ public class MapsPreferences extends BasePreferenceFragment {
         }
     }
 
+    @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        if (referenceLayerPref != null) {
+            populateReferenceLayerPref();
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        referenceLayerPref = null;
+    }
+
     /**
      * Creates the Basemap Source preference widget (but doesn't add it to
      * the screen; onBasemapSourceChanged will do that part).
@@ -151,6 +165,7 @@ public class MapsPreferences extends BasePreferenceFragment {
             referenceLayerPref.setSummary(summary);
         }
     }
+
 
     /** Sets up the contents of the reference layer selection dialog. */
     private void populateReferenceLayerPref() {


### PR DESCRIPTION
Work towards #3612 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
 I tested it.

#### Why is this the best possible solution? Were any other approaches considered?
I populated the reference layer in `onViewRestored`, to retain the layer after orientation change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks

#### Do we need any specific form for testing your changes? If so, please attach one.
AllWidgetsForm or any form with Geotrace or Geoshape widget

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)