### PR TITLE
Retain Input Setting Dialog on GeoPolyActivity on orientation change

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -1,7 +1,13 @@
 package org.odk.collect.android.geo;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.RadioGroup;
+import android.widget.Spinner;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -12,14 +18,84 @@ import org.odk.collect.android.R;
 
 public class SettingsDialogFragment extends DialogFragment {
 
+    private static final int[] INTERVAL_OPTIONS = {
+            1, 5, 10, 20, 30, 60, 300, 600, 1200, 1800
+    };
+
+    private static final int[] ACCURACY_THRESHOLD_OPTIONS = {
+            0, 3, 5, 10, 15, 20
+    };
+
+    private View autoOptions;
+    private RadioGroup radioGroup;
+    private Spinner autoInterval;
+    private Spinner accuracyThreshold;
+
+    protected SettingsDialogCallback callback;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+
+        if (context instanceof SettingsDialogCallback) {
+            callback = (SettingsDialogCallback) context;
+        }
+    }
+
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         super.onCreateDialog(savedInstanceState);
 
+        View settingsView = getActivity().getLayoutInflater().inflate(R.layout.geopoly_dialog, null);
+        radioGroup = settingsView.findViewById(R.id.radio_group);
+        radioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup group, int checkedId) {
+                callback.updateRecordingMode(group, checkedId);
+                updateSettingsDialog();
+            }
+        });
+
+        autoOptions = settingsView.findViewById(R.id.auto_options);
+        autoInterval = settingsView.findViewById(R.id.auto_interval);
+        autoInterval.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                callback.setIntervalIndex(position);
+            }
+
+            @Override public void onNothingSelected(AdapterView<?> parent) { }
+        });
+
+        String[] options = new String[INTERVAL_OPTIONS.length];
+        for (int i = 0; i < INTERVAL_OPTIONS.length; i++) {
+            options[i] = formatInterval(INTERVAL_OPTIONS[i]);
+        }
+        populateSpinner(autoInterval, options);
+
+        accuracyThreshold = settingsView.findViewById(R.id.accuracy_threshold);
+        accuracyThreshold.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                callback.setAccuracyThresholdIndex(position);
+            }
+
+            @Override public void onNothingSelected(AdapterView<?> parent) { }
+        });
+
+        options = new String[ACCURACY_THRESHOLD_OPTIONS.length];
+        for (int i = 0; i < ACCURACY_THRESHOLD_OPTIONS.length; i++) {
+            options[i] = formatAccuracyThreshold(ACCURACY_THRESHOLD_OPTIONS[i]);
+        }
+        populateSpinner(accuracyThreshold, options);
+
+        radioGroup.check(callback.getCheckedId());
+        updateSettingsDialog();
+
         return new AlertDialog.Builder(getActivity())
                 .setTitle(getString(R.string.input_method))
+                .setView(settingsView)
                 .setPositiveButton(getString(R.string.start), (dialog, id) -> {
+                    callback.startInput();
                     dialog.cancel();
                     dismiss();
                 })
@@ -28,5 +104,47 @@ public class SettingsDialogFragment extends DialogFragment {
                     dismiss();
                 })
                 .create();
+    }
+
+    private void updateSettingsDialog() {
+        autoOptions.setVisibility(radioGroup.getCheckedRadioButtonId() == R.id.automatic_mode ? View.VISIBLE : View.GONE);
+        autoInterval.setSelection(callback.getIntervalIndex());
+        accuracyThreshold.setSelection(callback.getAccuracyThresholdIndex());
+    }
+
+    /** Formats a time interval as a whole number of seconds or minutes. */
+    private String formatInterval(int seconds) {
+        int minutes = seconds / 60;
+        return minutes > 0 ?
+                getResources().getQuantityString(R.plurals.number_of_minutes, minutes, minutes) :
+                getResources().getQuantityString(R.plurals.number_of_seconds, seconds, seconds);
+    }
+
+    /** Populates a Spinner with the option labels in the given array. */
+    private void populateSpinner(Spinner spinner, String[] options) {
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                getActivity(), android.R.layout.simple_spinner_item, options);
+        adapter.setDropDownViewResource(R.layout.simple_spinner_dropdown_item);
+        spinner.setAdapter(adapter);
+    }
+
+    /** Formats an entry in the accuracy threshold dropdown. */
+    private String formatAccuracyThreshold(int meters) {
+        return meters > 0 ?
+                getResources().getQuantityString(R.plurals.number_of_meters, meters, meters) :
+                getString(R.string.none);
+    }
+
+    public interface SettingsDialogCallback {
+
+        void startInput();
+        void updateRecordingMode(RadioGroup group, int checkedId);
+
+        int getCheckedId();
+        int getIntervalIndex();
+        int getAccuracyThresholdIndex();
+
+        void setIntervalIndex(int intervalIndex);
+        void setAccuracyThresholdIndex(int accuracyThresholdIndex);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -1,6 +1,32 @@
 package org.odk.collect.android.geo;
 
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
+import org.odk.collect.android.R;
+
 public class SettingsDialogFragment extends DialogFragment {
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        super.onCreateDialog(savedInstanceState);
+
+        return new AlertDialog.Builder(getActivity())
+                .setTitle(getString(R.string.input_method))
+                .setPositiveButton(getString(R.string.start), (dialog, id) -> {
+                    dialog.cancel();
+                    dismiss();
+                })
+                .setNegativeButton(R.string.cancel, (dialog, id) -> {
+                    dialog.cancel();
+                    dismiss();
+                })
+                .create();
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -28,8 +28,6 @@ public class SettingsDialogFragment extends DialogFragment {
 
     private View autoOptions;
     private RadioGroup radioGroup;
-    private Spinner autoInterval;
-    private Spinner accuracyThreshold;
     protected SettingsDialogCallback callback;
 
     private int checkedRadioButtonId = -1;
@@ -65,7 +63,7 @@ public class SettingsDialogFragment extends DialogFragment {
         });
 
         autoOptions = settingsView.findViewById(R.id.auto_options);
-        autoInterval = settingsView.findViewById(R.id.auto_interval);
+        Spinner autoInterval = settingsView.findViewById(R.id.auto_interval);
         autoInterval.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -84,7 +82,7 @@ public class SettingsDialogFragment extends DialogFragment {
         }
         populateSpinner(autoInterval, options);
 
-        accuracyThreshold = settingsView.findViewById(R.id.accuracy_threshold);
+        Spinner accuracyThreshold = settingsView.findViewById(R.id.accuracy_threshold);
         accuracyThreshold.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 accuracyThresholdIndex = position;

--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -1,0 +1,6 @@
+package org.odk.collect.android.geo;
+
+import androidx.fragment.app.DialogFragment;
+
+public class SettingsDialogFragment extends DialogFragment {
+}

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -1,0 +1,48 @@
+package org.odk.collect.android.geo;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class SettingsDialogFragmentTest {
+
+    private ActivityController<FragmentActivity> activity;
+    private FragmentManager fragmentManager;
+    private SettingsDialogFragment dialogFragment;
+
+    @Before
+    public void setup() {
+        activity = RobolectricHelpers.buildThemedActivity(FragmentActivity.class);
+        activity.setup();
+
+        fragmentManager = activity.get().getSupportFragmentManager();
+        dialogFragment = new SettingsDialogFragment();
+    }
+
+    @Test
+    public void dialogIsCancellable() {
+
+    }
+
+    @Test
+    public void shouldShowCorrectButtons() {
+
+    }
+
+    @Test
+    public void clickingStart_shouldDismissTheDialog() {
+
+    }
+
+    @Test
+    public void clickingCancel_shouldDismissTheDialog() {
+
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -1,14 +1,26 @@
 package org.odk.collect.android.geo;
 
+import android.content.DialogInterface;
+
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowDialog;
+
+import static android.view.View.VISIBLE;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 public class SettingsDialogFragmentTest {
@@ -28,21 +40,42 @@ public class SettingsDialogFragmentTest {
 
     @Test
     public void dialogIsCancellable() {
-
+        dialogFragment.show(fragmentManager, "TAG");
+        assertThat(shadowOf(dialogFragment.getDialog()).isCancelable(), equalTo(true));
     }
 
     @Test
     public void shouldShowCorrectButtons() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
 
+        assertThat(dialog.getButton(DialogInterface.BUTTON_POSITIVE).getVisibility(), equalTo(VISIBLE));
+        assertThat(dialog.getButton(DialogInterface.BUTTON_POSITIVE).getText(),
+                equalTo(activity.get().getString(R.string.start)));
+        assertThat(dialog.getButton(DialogInterface.BUTTON_NEGATIVE).getVisibility(), equalTo(VISIBLE));
+        assertThat(dialog.getButton(DialogInterface.BUTTON_NEGATIVE).getText(),
+                equalTo(activity.get().getString(R.string.cancel)));
     }
 
     @Test
     public void clickingStart_shouldDismissTheDialog() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        assertTrue(dialog.isShowing());
 
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
+        assertFalse(dialog.isShowing());
+        assertTrue(shadowOf(dialog).hasBeenDismissed());
     }
 
     @Test
     public void clickingCancel_shouldDismissTheDialog() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        assertTrue(dialog.isShowing());
 
+        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
+        assertFalse(dialog.isShowing());
+        assertTrue(shadowOf(dialog).hasBeenDismissed());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -121,7 +121,6 @@ public class SettingsDialogFragmentTest {
         assertThat(((Spinner) dialog.findViewById(R.id.accuracy_threshold)).getSelectedItemPosition(), equalTo(2));
     }
 
-
     @Test
     public void onDismissingDialog_callsCorrectMethods() {
         dialogFragment.show(fragmentManager, "TAG");

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -35,7 +35,7 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricTestRunner.class)
 public class SettingsDialogFragmentTest {
 
-    private int sampleId = R.id.automatic_mode;
+    private final int sampleId = R.id.automatic_mode;
 
     private ActivityController<FragmentActivity> activity;
     private FragmentManager fragmentManager;

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -1,7 +1,6 @@
 package org.odk.collect.android.geo;
 
 import android.content.DialogInterface;
-import android.content.res.Configuration;
 import android.view.View;
 import android.widget.RadioGroup;
 import android.widget.Spinner;
@@ -16,7 +15,6 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowDialog;
 
@@ -37,15 +35,13 @@ public class SettingsDialogFragmentTest {
 
     private final int sampleId = R.id.automatic_mode;
 
-    private ActivityController<FragmentActivity> activity;
     private FragmentManager fragmentManager;
     private SettingsDialogFragment dialogFragment;
-
     private SettingsDialogFragment.SettingsDialogCallback callback;
 
     @Before
     public void setup() {
-        activity = RobolectricHelpers.buildThemedActivity(FragmentActivity.class);
+        ActivityController<FragmentActivity> activity = RobolectricHelpers.buildThemedActivity(FragmentActivity.class);
         activity.setup();
 
         fragmentManager = activity.get().getSupportFragmentManager();
@@ -114,31 +110,6 @@ public class SettingsDialogFragmentTest {
         radioGroup.check(sampleId);
         fragmentManager.executePendingTransactions();
         assertThat(autoOptions.getVisibility(), equalTo(VISIBLE));
-    }
-
-    @Test
-    public void retainsIntervalAndSpinnerValueOnScreenOrientation() {
-        dialogFragment.show(fragmentManager, "TAG");
-        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
-        RadioGroup radioGroup = dialog.findViewById(R.id.radio_group);
-        Spinner autoInterval = dialog.findViewById(R.id.auto_interval);
-        Spinner accuracyThreshold = dialog.findViewById(R.id.accuracy_threshold);
-
-        radioGroup.check(sampleId);
-        autoInterval.setSelection(2);
-        accuracyThreshold.setSelection(2);
-
-        assertThat(activity.get().getResources().getConfiguration().orientation, equalTo(Configuration.ORIENTATION_PORTRAIT));
-        RuntimeEnvironment.setQualifiers("+land");
-        activity.configurationChange();
-        assertThat(activity.get().getResources().getConfiguration().orientation, equalTo(Configuration.ORIENTATION_LANDSCAPE));
-
-        SettingsDialogFragment restoredFragment = (SettingsDialogFragment) activity.get().getSupportFragmentManager().findFragmentByTag("TAG");
-        AlertDialog restoredDialog = (AlertDialog) restoredFragment.getDialog();
-
-        assertThat(((RadioGroup) restoredDialog.findViewById(R.id.radio_group)).getCheckedRadioButtonId(), equalTo(sampleId));
-        assertThat(((Spinner) restoredDialog.findViewById(R.id.auto_interval)).getSelectedItemPosition(), equalTo(2));
-        assertThat(((Spinner) restoredDialog.findViewById(R.id.accuracy_threshold)).getSelectedItemPosition(), equalTo(2));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -62,19 +62,6 @@ public class SettingsDialogFragmentTest {
     }
 
     @Test
-    public void shouldShowCorrectButtons() {
-        dialogFragment.show(fragmentManager, "TAG");
-        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
-
-        assertThat(dialog.getButton(DialogInterface.BUTTON_POSITIVE).getVisibility(), equalTo(VISIBLE));
-        assertThat(dialog.getButton(DialogInterface.BUTTON_POSITIVE).getText(),
-                equalTo(activity.get().getString(R.string.start)));
-        assertThat(dialog.getButton(DialogInterface.BUTTON_NEGATIVE).getVisibility(), equalTo(VISIBLE));
-        assertThat(dialog.getButton(DialogInterface.BUTTON_NEGATIVE).getText(),
-                equalTo(activity.get().getString(R.string.cancel)));
-    }
-
-    @Test
     public void clickingStart_shouldDismissTheDialog() {
         dialogFragment.show(fragmentManager, "TAG");
         AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();

--- a/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/SettingsDialogFragmentTest.java
@@ -1,6 +1,10 @@
 package org.odk.collect.android.geo;
 
 import android.content.DialogInterface;
+import android.content.res.Configuration;
+import android.view.View;
+import android.widget.RadioGroup;
+import android.widget.Spinner;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
@@ -12,14 +16,19 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowDialog;
 
+import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
@@ -36,6 +45,8 @@ public class SettingsDialogFragmentTest {
 
         fragmentManager = activity.get().getSupportFragmentManager();
         dialogFragment = new SettingsDialogFragment();
+
+        dialogFragment.callback = mock(SettingsDialogFragment.SettingsDialogCallback.class);
     }
 
     @Test
@@ -77,5 +88,53 @@ public class SettingsDialogFragmentTest {
         dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
         assertFalse(dialog.isShowing());
         assertTrue(shadowOf(dialog).hasBeenDismissed());
+    }
+
+    @Test
+    public void clickingStart_shouldCallStartInputMethod() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
+
+        verify(dialogFragment.callback, times(1)).startInput();
+    }
+
+    @Test
+    public void selectingAutomaticMode_shouldDisplayIntervalAndAccuracyOptions() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+
+        RadioGroup radioGroup = dialog.findViewById(R.id.radio_group);
+        View autoOptions = dialog.findViewById(R.id.auto_options);
+        assertThat(autoOptions.getVisibility(), equalTo(GONE));
+
+        radioGroup.check(R.id.automatic_mode);
+        fragmentManager.executePendingTransactions();
+        assertThat(autoOptions.getVisibility(), equalTo(VISIBLE));
+    }
+
+    @Test
+    public void retainsIntervalAndSpinnerValueOnScreenOrientation() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        RadioGroup radioGroup = dialog.findViewById(R.id.radio_group);
+        Spinner autoInterval = dialog.findViewById(R.id.auto_interval);
+        Spinner accuracyThreshold = dialog.findViewById(R.id.accuracy_threshold);
+
+        radioGroup.check(R.id.automatic_mode);
+        autoInterval.setSelection(2);
+        accuracyThreshold.setSelection(2);
+
+        assertThat(activity.get().getResources().getConfiguration().orientation, equalTo(Configuration.ORIENTATION_PORTRAIT));
+        RuntimeEnvironment.setQualifiers("+land");
+        activity.configurationChange();
+        assertThat(activity.get().getResources().getConfiguration().orientation, equalTo(Configuration.ORIENTATION_LANDSCAPE));
+
+        SettingsDialogFragment restoredFragment = (SettingsDialogFragment) activity.get().getSupportFragmentManager().findFragmentByTag("TAG");
+        AlertDialog restoredDialog = (AlertDialog) restoredFragment.getDialog();
+
+        assertThat(((RadioGroup) restoredDialog.findViewById(R.id.radio_group)).getCheckedRadioButtonId(), equalTo(R.id.automatic_mode));
+        assertThat(((Spinner) restoredDialog.findViewById(R.id.auto_interval)).getSelectedItemPosition(), equalTo(2));
+        assertThat(((Spinner) restoredDialog.findViewById(R.id.accuracy_threshold)).getSelectedItemPosition(), equalTo(2));
     }
 }


### PR DESCRIPTION
Work towards #3612 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it.

#### Why is this the best possible solution? Were any other approaches considered?
I used a separate variable `IS_SETTINGS_DIALOG_ACTIVE` to check whether the dialog is active or not, and if the dialog was active last when the activity was destroyed on configuration change, then the dialog is displayed again in `onCreate`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks

#### Do we need any specific form for testing your changes? If so, please attach one.
All Widgets form or any form with Geo widgets 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)