### PR TITLE
Downgrade GCloud SDK version for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,17 +181,17 @@ jobs:
               --directories-to-pull /sdcard --timeout 30m
             fi
           no_output_timeout: 60m
-#       - run:
-#           name: Copy integration test results
-#           command: |
-#             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
-#               mkdir firebase
-#               gsutil -m cp -r -U "`gsutil ls gs://opendatakit-collect-test-results | tail -1`*" /root/work/firebase/ | true
-#             fi
-#       - *persist_firebase_workspace
-#       - store_test_results:
-#           path: firebase/
-#           destination: /firebase/
+       - run:
+           name: Copy integration test results
+           command: |
+             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+               mkdir firebase
+               gsutil -m cp -r -U "`gsutil ls gs://opendatakit-collect-test-results | tail -1`*" /root/work/firebase/ | true
+             fi
+       - *persist_firebase_workspace
+       - store_test_results:
+           path: firebase/
+           destination: /firebase/
 
   ## Submit JaCoCo coverage report
 
@@ -243,11 +243,11 @@ workflows:
           filters:
             branches:
               only: master
-#       - report_coverage:
-#           requires:
-#             - test_unit
-#             - test_instrumented
-#           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-#           filters:
-#             branches:
-#               only: master
+       - report_coverage:
+           requires:
+             - test_unit
+             - test_instrumented
+           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
+           filters:
+             branches:
+               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ references:
       <<: *cache_tests_key
       <<: *cache_paths
 
-  accept_licenses : &accept_licenses
+  accept_licenses: &accept_licenses
     run:
       name: Accept licenses
       command: yes | sdkmanager --licenses || true
@@ -41,7 +41,7 @@ references:
   ## Workspace
 
   workspace: &workspace
-    ~/work
+               ~/work
   attach_debug_workspace: &attach_debug_workspace
     attach_workspace:
       at: *workspace
@@ -82,75 +82,75 @@ jobs:
   build_debug:
     <<: *android_config
     environment:
-#       Runtime configuration build tests
-#       ./gradlew clean assembleDebug
-#       Xms128 - the default on most systems is 256m but gradle spawns some java subprocesses during build that don't need 256m
-#       Xmx512m 1m30s
-#       Xmx768m 1m17s
-#       Xmx1024m ~1min
-#       Xmx1536m ~1min
-#       -XX:+HeapDumpOnOutOfMemoryError in case of an out of memory the java process will dump a heap file on the file system.
-#       The heap file can be analyzed to figure out the root cause or the memory leak.
-#       -DpreDexEnable=false disables pre-dexing step. Pre-dexing is good for local incremental builds during development,
-#       But on a build machine, the performance impact is not worthy because on a CI, every build should be clean.
+      #       Runtime configuration build tests
+      #       ./gradlew clean assembleDebug
+      #       Xms128 - the default on most systems is 256m but gradle spawns some java subprocesses during build that don't need 256m
+      #       Xmx512m 1m30s
+      #       Xmx768m 1m17s
+      #       Xmx1024m ~1min
+      #       Xmx1536m ~1min
+      #       -XX:+HeapDumpOnOutOfMemoryError in case of an out of memory the java process will dump a heap file on the file system.
+      #       The heap file can be analyzed to figure out the root cause or the memory leak.
+      #       -DpreDexEnable=false disables pre-dexing step. Pre-dexing is good for local incremental builds during development,
+      #       But on a build machine, the performance impact is not worthy because on a CI, every build should be clean.
 
-        GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xms128m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError" -DpreDexEnable=false'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xms128m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError" -DpreDexEnable=false'
     steps:
-        - checkout
-        - *restore_cache
-        - *accept_licenses
-        - run:
-            name: Download dependencies
-            command: ./gradlew androidDependencies
-        - *save_cache
-#       It's faster if we build before running the quality checks, because quality checks depend on build output anyway.
-#       Also, while running gradle on daemon mode, we can even run build targets individually without impacting runtime ramp-up time.
-#       This also implies that we can also observe per-target build timings, instead of just the total execution time from a single command.
-        - run:
-            name: Assemble debug build
-            command: |
-                ./gradlew assembleDebug -PdisablePreDex
-        - run:
-            name: Assemble test build
-            command: |
-                ./gradlew assembleDebugAndroidTest -PdisablePreDex
-        - run:
-            name: Run code quality checks
-#           When running the plain lint target, it will execute by default for all flavors.
-#           This implies building the release and test flavors as well, which are out of scope for this job.
-#           Instead, using lintDebug it's running only once, for the 'debug' flavor that we are building here
-#           This means ~3x faster for the lint task.
-            command: ./gradlew checkCode
-        - store_artifacts:
-            path: collect_app/build/reports
-            destination: reports
-#         Since the other workflow are only triggered after this job is successful, caching the build outputs for them can be the last task.
-#         Otherwise we only persist something that will never be used.
-        - *persist_debug_workspace
+      - checkout
+      - *restore_cache
+      - *accept_licenses
+      - run:
+          name: Download dependencies
+          command: ./gradlew androidDependencies
+      - *save_cache
+      #       It's faster if we build before running the quality checks, because quality checks depend on build output anyway.
+      #       Also, while running gradle on daemon mode, we can even run build targets individually without impacting runtime ramp-up time.
+      #       This also implies that we can also observe per-target build timings, instead of just the total execution time from a single command.
+      - run:
+          name: Assemble debug build
+          command: |
+            ./gradlew assembleDebug -PdisablePreDex
+      - run:
+          name: Assemble test build
+          command: |
+            ./gradlew assembleDebugAndroidTest -PdisablePreDex
+      - run:
+          name: Run code quality checks
+          #           When running the plain lint target, it will execute by default for all flavors.
+          #           This implies building the release and test flavors as well, which are out of scope for this job.
+          #           Instead, using lintDebug it's running only once, for the 'debug' flavor that we are building here
+          #           This means ~3x faster for the lint task.
+          command: ./gradlew checkCode
+      - store_artifacts:
+          path: collect_app/build/reports
+          destination: reports
+      #         Since the other workflow are only triggered after this job is successful, caching the build outputs for them can be the last task.
+      #         Otherwise we only persist something that will never be used.
+      - *persist_debug_workspace
 
   ## Run unit tests
 
   test_unit:
     <<: *android_config
     steps:
-        - checkout
-##        - *restore_cache
-##      Depending on actual usage, we could toggle the above cache restoration (the step below includes it.)
-        - *restore_tests_cache
-        - *accept_licenses
-        - run:
-            name: Download dependencies
-            command: ./gradlew androidDependencies
-        - run:
-            name: Run unit tests
-            command: ./gradlew testDebugUnitTest
-        - *save_tests_cache
-        - *persist_debug_workspace
-        - store_artifacts:
-            path: collect_app/build/reports
-            destination: reports
-        - store_test_results:
-            path: collect_app/build/test-results
+      - checkout
+      ##        - *restore_cache
+      ##      Depending on actual usage, we could toggle the above cache restoration (the step below includes it.)
+      - *restore_tests_cache
+      - *accept_licenses
+      - run:
+          name: Download dependencies
+          command: ./gradlew androidDependencies
+      - run:
+          name: Run unit tests
+          command: ./gradlew testDebugUnitTest
+      - *save_tests_cache
+      - *persist_debug_workspace
+      - store_artifacts:
+          path: collect_app/build/reports
+          destination: reports
+      - store_test_results:
+          path: collect_app/build/test-results
 
   ## Run instrumented tests
 
@@ -181,17 +181,17 @@ jobs:
               --directories-to-pull /sdcard --timeout 30m
             fi
           no_output_timeout: 60m
-       - run:
-           name: Copy integration test results
-           command: |
-             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
-               mkdir firebase
-               gsutil -m cp -r -U "`gsutil ls gs://opendatakit-collect-test-results | tail -1`*" /root/work/firebase/ | true
-             fi
-       - *persist_firebase_workspace
-       - store_test_results:
-           path: firebase/
-           destination: /firebase/
+      - run:
+          name: Copy integration test results
+          command: |
+            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+              mkdir firebase
+              gsutil -m cp -r -U "`gsutil ls gs://opendatakit-collect-test-results | tail -1`*" /root/work/firebase/ | true
+            fi
+      - *persist_firebase_workspace
+      - store_test_results:
+          path: firebase/
+          destination: /firebase/
 
   ## Submit JaCoCo coverage report
 
@@ -225,14 +225,14 @@ workflows:
   version: 2
   workflow:
     jobs:
-#       This job will run on every commit on any branch
+      #       This job will run on every commit on any branch
       - build_debug
-#       Unit tests should only start after a successful build. Or vice versa?
+      #       Unit tests should only start after a successful build. Or vice versa?
       - test_unit:
-#         Although the unit testing task could run in parallel with build task,
-#         in such case, it would not benefit from the previous caching in the event of
-#         any change in the .gradle script files.
-#         Hence,
+          #         Although the unit testing task could run in parallel with build task,
+          #         in such case, it would not benefit from the previous caching in the event of
+          #         any change in the .gradle script files.
+          #         Hence,
           requires:
             - build_debug
       # Instrumentation tests should only start after unit tests complete gracefully. Or vice versa?
@@ -243,11 +243,11 @@ workflows:
           filters:
             branches:
               only: master
-       - report_coverage:
-           requires:
-             - test_unit
-             - test_instrumented
-           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-           filters:
-             branches:
-               only: master
+      - report_coverage:
+          requires:
+            - test_unit
+            - test_instrumented
+          # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ references:
   gcloud_config: &gcloud_config
     working_directory: *workspace
     docker:
-      - image: google/cloud-sdk:289.0.0
+      - image: google/cloud-sdk:273.0.0
 
 jobs:
 


### PR DESCRIPTION
This downgrades the GCloud SDK docker image back to one that includes the Crcmod tool. Without this we get errors as when downloading test results for our coverage steps.