### PR TITLE
Disable coverage reporting on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,11 +243,11 @@ workflows:
           filters:
             branches:
               only: master
-      - report_coverage:
-          requires:
-            - test_unit
-            - test_instrumented
-          # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-          filters:
-            branches:
-              only: master
+#      - report_coverage:
+#          requires:
+#            - test_unit
+#            - test_instrumented
+#          # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
+#          filters:
+#            branches:
+#              only: master


### PR DESCRIPTION
And again...

It looks like we're going to need to rework how coverage reports work now that we're sharding our tests. Disabling the upload step makes the most sense for the moment I think!