### PR TITLE
Add FormEndPage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'org.ow2.asm:asm:7.3.1' // https://github.com/jacoco/jacoco/issues/639#issuecomment-355424756
         classpath 'org.jacoco:org.jacoco.core:0.8.5'

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -49,7 +49,7 @@ public class EncryptedFormTest {
     public void instanceOfEncryptedForm_cantBeEditedWhenFinalized() {
         rule.mainMenu()
                 .startBlankForm("encrypted")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok)
                 .clickEditSavedForm()
@@ -62,7 +62,7 @@ public class EncryptedFormTest {
     public void instanceOfEncryptedFormWithoutInstanceID_failsFinalizationWithMessage() {
         rule.mainMenu()
                 .startBlankForm("encrypted-no-instanceID")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed("This form does not specify an instanceID. You must specify one to enable encryption. Form has not been saved as finalized.")
                 .clickEditSavedForm()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.java
@@ -39,7 +39,7 @@ public class FormFinalizingTest {
         new MainMenuPage(rule)
                 .assertNumberOfFinalizedForms(0)
                 .startBlankForm("One Question")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .assertNumberOfFinalizedForms(1);
     }
@@ -49,7 +49,7 @@ public class FormFinalizingTest {
         new MainMenuPage(rule)
                 .assertNumberOfFinalizedForms(0)
                 .startBlankForm("One Question")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickMarkAsFinalized()
                 .assertMarkFinishedIsNotSelected()
                 .clickSaveAndExit()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/IdentifyUserTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/IdentifyUserTest.java
@@ -42,7 +42,7 @@ public class IdentifyUserTest {
                 .clickOnFormWithIdentityPrompt("Identify User")
                 .enterIdentity("Lucius")
                 .clickKeyboardEnter()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -53,7 +53,7 @@ public class IdentifyUserTest {
                 .clickOnFormWithIdentityPrompt("Identify User")
                 .enterIdentity("Lucius")
                 .clickKeyboardEnter()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .clickEditSavedForm()
                 .clickOnFormWithIdentityPrompt("Identify User");
@@ -100,7 +100,7 @@ public class IdentifyUserTest {
         new MainMenuPage(rule)
                 .clickFillBlankForm()
                 .clickOnForm("Identify User False")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.java
@@ -175,7 +175,7 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Track Changes Reason")
                 .clickGoToStart()
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -204,7 +204,7 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Normal Form")
                 .clickGoToStart()
                 .inputText("Nothing much!")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.java
@@ -79,7 +79,7 @@ public class FormMapTest {
                 .inputText("Foo")
                 .swipeToNextQuestion()
                 .clickWidgetButton()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExitBackToMap()
                 .assertText(oneInstanceString);
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationTest.java
@@ -59,7 +59,7 @@ public class StorageMigrationTest {
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .clickLearnMoreButton()
                 .clickMigrate()
@@ -79,7 +79,7 @@ public class StorageMigrationTest {
                 .assertText("Plum", "Cherry")
                 .swipeToNextQuestion()
                 .assertText("The fruit Cherry from pulldata function")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         // Fill another form
@@ -93,7 +93,7 @@ public class StorageMigrationTest {
                 .swipeToNextQuestion()
                 .clickOnText("Cherry")
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -112,7 +112,7 @@ public class StorageMigrationTest {
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .clickLearnMoreButton()
                 .assertStorageMigrationContentWithSavedFormsIsVisible();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/CascadingSelectWithNumberInHeaderTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/CascadingSelectWithNumberInHeaderTest.java
@@ -43,7 +43,7 @@ public class CascadingSelectWithNumberInHeaderTest extends BaseRegressionTest {
                 .clickOnText("Pensão")
                 .assertText("3a")
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ExternalSecondaryInstancesTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ExternalSecondaryInstancesTest.java
@@ -38,7 +38,7 @@ public class ExternalSecondaryInstancesTest extends BaseRegressionTest {
                 .clickOnText("b")
                 .swipeToNextQuestion()
                 .clickOnText("ba")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -51,7 +51,7 @@ public class ExternalSecondaryInstancesTest extends BaseRegressionTest {
                 .clickOnText("c")
                 .swipeToNextQuestion()
                 .clickOnText("ca")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -140,18 +140,18 @@ public class FillBlankFormTest extends BaseRegressionTest {
         new MainMenuPage(rule)
                 .startBlankForm("1560_DateData")
                 .checkIsTranslationDisplayed("Jan 01, 1900", "01 ene. 1900")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
 
                 .startBlankForm("1560_IntegerData")
                 .assertText("5")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .assertText("5")
                 .clickSaveAndExit()
 
                 .startBlankForm("1560_IntegerData_instanceID")
                 .assertText("5")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -254,7 +254,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .swipeToNextQuestion()
                 .clickOnText("No")
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
     }
@@ -273,7 +273,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .clickOnText("Gala")
                 .clickOnText("Granny Smith")
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
     }
@@ -349,7 +349,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .assertText("Oranges")
                 .clickOnText("Mango")
                 .clickOnText("Oranges")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
     }
@@ -366,8 +366,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
             firstQuestionAnswers.add(getQuestionText());
             formEntryPage.swipeToNextQuestion();
             secondQuestionAnswers.add(getQuestionText());
-            formEntryPage.swipeToNextQuestion();
-            formEntryPage.clickSaveAndExit();
+            formEntryPage.swipeToEndScreen().clickSaveAndExit();
         }
 
         assertNotSame(firstQuestionAnswers.get(0), firstQuestionAnswers.get(1));
@@ -385,8 +384,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
             formEntryPage.inputText("3");
             formEntryPage.swipeToNextQuestion();
             firstQuestionAnswers.add(getQuestionText());
-            formEntryPage.swipeToNextQuestion();
-            formEntryPage.clickSaveAndExit();
+            formEntryPage.swipeToEndScreen().clickSaveAndExit();
         }
 
         assertNotSame(firstQuestionAnswers.get(0), firstQuestionAnswers.get(1));
@@ -401,7 +399,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
         new MainMenuPage(rule)
                 .startBlankFormWithError("g6Error")
                 .clickOK(new FormEntryPage("g6Error", rule))
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
 
@@ -411,18 +409,19 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .clickOK(new FormEntryPage("g6Error2", rule))
                 .swipeToNextQuestion()
                 .inputText("ble")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
 
         new MainMenuPage(rule)
-                .startBlankForm("emptyGroupFieldList")
+                .clickFillBlankForm()
+                .clickOnEmptyForm("emptyGroupFieldList")
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
 
         new MainMenuPage(rule).startBlankForm("emptyGroupFieldList2")
                 .inputText("nana")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
     }
@@ -432,7 +431,8 @@ public class FillBlankFormTest extends BaseRegressionTest {
 
         //TestCase27
         new MainMenuPage(rule)
-                .startBlankForm("metadata2")
+                .clickFillBlankForm()
+                .clickOnEmptyForm("metadata2")
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok);
     }
@@ -466,7 +466,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .clickOnString(R.string.select_one)
                 .clickOnText("Jaggu")
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -560,7 +560,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .checkIsTextDisplayedOnDialog("The value \"-01-01\" can't be converted to a date.")
                 .clickOKOnDialog()
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -601,7 +601,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
-                .clickOnDoNotAddGroup()
+                .clickOnDoNotAddGroupEndingForm()
                 .clickSaveAndExit();
     }
 
@@ -616,7 +616,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .assertText("more cheese")
                 .swipeToNextQuestion()
                 .assertText("5")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -652,7 +652,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .startBlankForm("search_and_select")
                 .assertText("File: /storage/emulated/0/odk/forms/search_and_select-media/nombre.csv is missing.")
                 .assertText("File: /storage/emulated/0/odk/forms/search_and_select-media/nombre2.csv is missing.")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit()
 
                 .startBlankForm("cascading select test")
@@ -661,7 +661,8 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .assertText("File: /storage/emulated/0/odk/forms/select_one_external-media/itemsets.csv is missing.")
                 .swipeToNextQuestion()
                 .assertText("File: /storage/emulated/0/odk/forms/select_one_external-media/itemsets.csv is missing.")
-                .swipeToNextQuestion(4)
+                .swipeToNextQuestion(3)
+                .swipeToEndScreen()
                 .clickSaveAndExit()
 
                 .startBlankForm("fieldlist-updates")
@@ -670,7 +671,7 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .clickOnElementInHierarchy(14)
                 .clickOnText("Source15")
                 .assertText("File: /storage/emulated/0/odk/forms/fieldlist-updates_nocsv-media/fruits.csv is missing.")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -772,7 +773,6 @@ public class FillBlankFormTest extends BaseRegressionTest {
                 .clickOnDoNotAdd(new FormEntryPage("Repeat Group", rule))
                 .clickGoToArrow()
                 .clickJumpEndButton()
-                .checkIsFormEndScreenVisible()
                 .clickGoToArrow()
                 .checkIfElementInHierarchyMatchesToText("Group Name", 0);
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormWithRepeatGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormWithRepeatGroupTest.java
@@ -59,7 +59,7 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .clickForwardButton()
                 .clickOnDoNotAddGroup()
                 .clickOnDoNotAddGroup()
-                .clickForwardButton()
+                .clickForwardButtonToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -93,7 +93,7 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .clickOnText("Date")
                 .swipeToNextQuestion()
                 .swipeToNextQuestion()
-                .clickOnDoNotAddGroup()
+                .clickOnDoNotAddGroupEndingForm()
                 .clickSaveAndExit();
     }
 
@@ -104,19 +104,19 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
         new MainMenuPage(rule)
                 .startBlankForm("form1")
                 .swipeToNextQuestion()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
                 .startBlankForm("form2")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
                 .startBlankForm("form3")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
@@ -129,7 +129,7 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .swipeToNextQuestion()
                 .inputText("T3")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
@@ -142,7 +142,7 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .swipeToNextQuestion()
                 .inputText("T3")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
@@ -155,24 +155,24 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .swipeToNextQuestion()
                 .inputText("T3")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
                 .startBlankForm("form7")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
                 .startBlankForm("form8")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
         new MainMenuPage(rule)
                 .startBlankForm("form9")
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -194,7 +194,7 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .clickBackwardButton()
                 .clickOnDoNotAddGroup()
                 .closeSoftKeyboard()
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -229,7 +229,7 @@ public class FillBlankFormWithRepeatGroupTest extends BaseRegressionTest {
                 .swipeToPreviousQuestion()
                 .assertText("3")
                 .swipeToNextQuestion()
-                .clickOnDoNotAddGroup()
+                .clickOnDoNotAddGroupEndingForm()
                 .clickSaveAndExit();
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormManagementTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormManagementTest.java
@@ -48,6 +48,7 @@ public class FormManagementTest extends BaseRegressionTest {
                 .pressBack(new GeneralSettingsPage(rule))
                 .pressBack(new FormEntryPage("OnePageFormValid", rule))
                 .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExitWithError()
                 .checkIsToastWithMessageDisplayed("Response length must be between 5 and 15");
     }
@@ -65,7 +66,7 @@ public class FormManagementTest extends BaseRegressionTest {
                 .pressBack(new MainMenuPage(rule))
                 .startBlankForm("hints textq")
                 .assertText("1 very very very very very very very very very very long text")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 
@@ -84,7 +85,7 @@ public class FormManagementTest extends BaseRegressionTest {
                 .checkIsIdDisplayed(R.id.help_icon)
                 .clickOnText("Hint 1")
                 .assertText("1 very very very very very very very very very very long text")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -38,7 +38,7 @@ public class FormValidationTest extends BaseRegressionTest {
                 .putTextOnIndex(0, "A")
                 .clickGoToArrow()
                 .clickJumpEndButton()
-                .clickSaveAndExitWhenValidationErrorIsExpected()
+                .clickSaveAndExitWithError()
                 .checkIsToastWithMessageDisplayed("Response length must be between 5 and 15")
                 .assertText("Integer")
                 .putTextOnIndex(0, "Aaaaa")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SpinnerWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SpinnerWidgetTest.java
@@ -40,7 +40,7 @@ public class SpinnerWidgetTest extends BaseRegressionTest {
                 .checkIfTextDoesNotExist("a")
                 .checkIfTextDoesNotExist("b")
                 .pressBack(new FormEntryPage("selectOneMinimal", rule))
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/TriggerWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/TriggerWidgetTest.java
@@ -40,7 +40,7 @@ public class TriggerWidgetTest extends BaseRegressionTest {
                 .pressBack(new MainMenuPage(rule))
                 .startBlankForm("Guidance Form Sample")
                 .assertText("Guidance text")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
 
     }
@@ -59,7 +59,7 @@ public class TriggerWidgetTest extends BaseRegressionTest {
                 .checkIsIdDisplayed(R.id.help_icon)
                 .clickOnText("TriggerWidget")
                 .assertText("Guidance text")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExit();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
@@ -12,11 +12,10 @@ import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
-import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.CursorMatchers.withRowString;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -87,6 +86,11 @@ public class FillBlankFormPage extends Page<FillBlankFormPage> {
     }
 
     private void clickOnFormButton(String formName) {
-        onView(withText(formName)).perform(scrollTo(), click());
+        onData(withRowString(FormsColumns.DISPLAY_NAME, formName)).perform(click());
+    }
+
+    public FormEndPage clickOnEmptyForm(String formName) {
+        clickOnFormButton(formName);
+        return new FormEndPage(formName, rule).assertOnPage();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -1,0 +1,65 @@
+package org.odk.collect.android.support.pages;
+
+import androidx.test.rule.ActivityTestRule;
+
+import org.odk.collect.android.R;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+public class FormEndPage extends Page<FormEndPage> {
+
+    private final String formName;
+
+    FormEndPage(String formName, ActivityTestRule rule) {
+        super(rule);
+        this.formName = formName;
+    }
+
+    @Override
+    public FormEndPage assertOnPage() {
+        onView(withText(getTranslatedString(R.string.save_enter_data_description, formName))).check(matches(isDisplayed()));
+        return this;
+    }
+
+    public MainMenuPage clickSaveAndExit() {
+        onView(withId(R.id.save_exit_button)).perform(click());
+        return new MainMenuPage(rule).assertOnPage();
+    }
+
+    public FormMapPage clickSaveAndExitBackToMap() {
+        onView(withId(R.id.save_exit_button)).perform(click());
+        return new FormMapPage(rule).assertOnPage();
+    }
+
+    public FormEntryPage clickSaveAndExitWithError() {
+        onView(withId(R.id.save_exit_button)).perform(click());
+        return new FormEntryPage(formName, rule).assertOnPage();
+    }
+
+    public FormEndPage assertMarkFinishedIsSelected() {
+        onView(withId(R.id.mark_finished)).check(matches(isChecked()));
+        return this;
+    }
+
+    public FormEndPage assertMarkFinishedIsNotSelected() {
+        onView(withId(R.id.mark_finished)).check(matches(isNotChecked()));
+        return this;
+    }
+
+    public FormEndPage clickMarkAsFinalized() {
+        onView(withId(R.id.mark_finished)).perform(click());
+        return this;
+    }
+
+    public FormEntryPage clickGoToArrow() {
+        onView(withId(R.id.menu_goto)).perform(click());
+        return new FormEntryPage(formName, rule);
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -14,10 +14,8 @@ import static androidx.test.espresso.action.ViewActions.swipeLeft;
 import static androidx.test.espresso.action.ViewActions.swipeRight;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
@@ -44,24 +42,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage clickJumpEndButton() {
+    public FormEndPage clickJumpEndButton() {
         onView(withId(R.id.jumpEndButton)).perform(click());
-        return this;
-    }
-
-    public MainMenuPage clickSaveAndExit() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return new MainMenuPage(rule).assertOnPage();
-    }
-
-    public FormMapPage clickSaveAndExitBackToMap() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return new FormMapPage(rule).assertOnPage();
-    }
-
-    public FormEntryPage clickSaveAndExitWithError() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return this;
+        return new FormEndPage(formName, rule).assertOnPage();
     }
 
     public FormEntryPage swipeToNextQuestion() {
@@ -76,11 +59,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage swipeToEndScreen() {
+    public FormEndPage swipeToEndScreen() {
         onView(withId(R.id.questionholder)).perform(swipeLeft());
-        onView(withText(getTranslatedString(R.string.save_enter_data_description, formName))).check(matches(isDisplayed()));
-
-        return this;
+        return new FormEndPage(formName, rule).assertOnPage();
     }
 
     public ErrorDialog swipeToNextQuestionWithError() {
@@ -134,11 +115,6 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage clickSaveAndExitWhenValidationErrorIsExpected() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return this;
-    }
-
     public FormEntryPage deleteGroup(String questionText) {
         onView(withText(questionText)).perform(longClick());
         onView(withText(R.string.delete_repeat)).perform(click());
@@ -172,6 +148,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    public FormEndPage clickForwardButtonToEndScreen() {
+        onView(withText(getTranslatedString(R.string.form_forward))).perform(click());
+        return new FormEndPage(formName, rule).assertOnPage();
+    }
+
     public FormEntryPage clickBackwardButton() {
         onView(withText(getTranslatedString(R.string.form_backward))).perform(click());
         return this;
@@ -182,23 +163,13 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    public FormEndPage clickOnDoNotAddGroupEndingForm() {
+        clickOnString(R.string.dont_add_repeat);
+        return new FormEndPage(formName, rule).assertOnPage();
+    }
+
     public FormEntryPage clickOnAddGroup() {
         clickOnString(R.string.add_repeat);
-        return this;
-    }
-
-    public FormEntryPage assertMarkFinishedIsSelected() {
-        onView(withId(R.id.mark_finished)).check(matches(isChecked()));
-        return this;
-    }
-
-    public FormEntryPage assertMarkFinishedIsNotSelected() {
-        onView(withId(R.id.mark_finished)).check(matches(isNotChecked()));
-        return this;
-    }
-
-    public FormEntryPage clickMarkAsFinalized() {
-        onView(withId(R.id.mark_finished)).perform(click());
         return this;
     }
 
@@ -235,11 +206,6 @@ public class FormEntryPage extends Page<FormEntryPage> {
     public FormEntryPage checkAreNavigationButtonsNotDisplayed() {
         onView(withId(R.id.form_forward_button)).check(matches(not(isDisplayed())));
         onView(withId(R.id.form_back_button)).check(matches(not(isDisplayed())));
-        return this;
-    }
-
-    public FormEntryPage checkIsFormEndScreenVisible() {
-        onView(withText(R.string.quit_entry)).check(matches(isDisplayed()));
         return this;
     }
 


### PR DESCRIPTION
This adds a `FormEndPage` object that contains the helper methods for actions on that screen. This lets us make sure we're always making the right assertions when navigating to this screen in Espresso tests.