### PR TITLE
Rework CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,6 @@ references:
       paths:
         - firebase
 
-  ## Docker image configurations
-
   android_config: &android_config
     working_directory: *workspace
     docker:
@@ -76,10 +74,7 @@ references:
       - image: google/cloud-sdk:273.0.0
 
 jobs:
-
-  ## Build debug APK and instrumented test APK
-
-  build_debug:
+  test_unit:
     <<: *android_config
     environment:
       #       Runtime configuration build tests
@@ -97,53 +92,25 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xms128m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError" -DpreDexEnable=false'
     steps:
       - checkout
-      - *restore_cache
-      - *accept_licenses
-      - run:
-          name: Download dependencies
-          command: ./gradlew androidDependencies
-      - *save_cache
-      #       It's faster if we build before running the quality checks, because quality checks depend on build output anyway.
-      #       Also, while running gradle on daemon mode, we can even run build targets individually without impacting runtime ramp-up time.
-      #       This also implies that we can also observe per-target build timings, instead of just the total execution time from a single command.
-      - run:
-          name: Assemble debug build
-          command: |
-            ./gradlew assembleDebug -PdisablePreDex
-      - run:
-          name: Assemble test build
-          command: |
-            ./gradlew assembleDebugAndroidTest -PdisablePreDex
-      - run:
-          name: Run code quality checks
-          #           When running the plain lint target, it will execute by default for all flavors.
-          #           This implies building the release and test flavors as well, which are out of scope for this job.
-          #           Instead, using lintDebug it's running only once, for the 'debug' flavor that we are building here
-          #           This means ~3x faster for the lint task.
-          command: ./gradlew checkCode
-      - store_artifacts:
-          path: collect_app/build/reports
-          destination: reports
-      #         Since the other workflow are only triggered after this job is successful, caching the build outputs for them can be the last task.
-      #         Otherwise we only persist something that will never be used.
-      - *persist_debug_workspace
-
-  ## Run unit tests
-
-  test_unit:
-    <<: *android_config
-    steps:
-      - checkout
-      ##        - *restore_cache
-      ##      Depending on actual usage, we could toggle the above cache restoration (the step below includes it.)
       - *restore_tests_cache
       - *accept_licenses
       - run:
           name: Download dependencies
           command: ./gradlew androidDependencies
       - run:
+          name: Assemble debug build
+          command: |
+            ./gradlew assembleDebug -PdisablePreDex
+      - run:
+          name: Run code quality checks
+          command: ./gradlew checkCode
+      - run:
           name: Run unit tests
           command: ./gradlew testDebugUnitTest
+      - run:
+          name: Assemble test build
+          command: |
+            ./gradlew assembleDebugAndroidTest -PdisablePreDex
       - *save_tests_cache
       - *persist_debug_workspace
       - store_artifacts:
@@ -151,8 +118,6 @@ jobs:
           destination: reports
       - store_test_results:
           path: collect_app/build/test-results
-
-  ## Run instrumented tests
 
   test_instrumented:
     <<: *gcloud_config
@@ -193,8 +158,6 @@ jobs:
           path: firebase/
           destination: /firebase/
 
-  ## Submit JaCoCo coverage report
-
   report_coverage:
     <<: *android_config
     steps:
@@ -225,17 +188,7 @@ workflows:
   version: 2
   workflow:
     jobs:
-      #       This job will run on every commit on any branch
-      - build_debug
-      #       Unit tests should only start after a successful build. Or vice versa?
-      - test_unit:
-          #         Although the unit testing task could run in parallel with build task,
-          #         in such case, it would not benefit from the previous caching in the event of
-          #         any change in the .gradle script files.
-          #         Hence,
-          requires:
-            - build_debug
-      # Instrumentation tests should only start after unit tests complete gracefully. Or vice versa?
+      - test_unit
       - test_instrumented:
           requires:
             - test_unit
@@ -243,6 +196,7 @@ workflows:
           filters:
             branches:
               only: master
+
 #      - report_coverage:
 #          requires:
 #            - test_unit


### PR DESCRIPTION
Circle CI often ends up downloading docker images if the container we're
running in doesn't already have the image. Combining build jobs will help
us avoid this!

Closes #

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)