### PR TITLE
Disable Jacoco in debug build (by default)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,11 +109,11 @@ jobs:
       - run:
           name: Assemble debug build
           command: |
-            ./gradlew assembleDebug -PdisablePreDex
+            ./gradlew -PenableJacoco=true assembleDebug -PdisablePreDex
       - run:
           name: Assemble test build
           command: |
-            ./gradlew assembleDebugAndroidTest -PdisablePreDex
+            ./gradlew -PenableJacoco=true assembleDebugAndroidTest -PdisablePreDex
       - run:
           name: Run code quality checks
           #           When running the plain lint target, it will execute by default for all flavors.
@@ -143,7 +143,7 @@ jobs:
           command: ./gradlew androidDependencies
       - run:
           name: Run unit tests
-          command: ./gradlew testDebugUnitTest
+          command: ./gradlew -PenableJacoco=true testDebugUnitTest
       - *save_tests_cache
       - *persist_debug_workspace
       - store_artifacts:
@@ -213,7 +213,7 @@ jobs:
             fi
       - run:
           name: Generate JaCoCo report
-          command: ./gradlew -PciBuild=true jacocoTestReport
+          command: ./gradlew -PciBuild=true -PenableJacoco=true jacocoTestReport
       - run:
           name: Upload coverage report to CodeCov
           command: bash <(curl -s https://codecov.io/bash)

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -94,6 +94,7 @@ android {
     }
 
     buildTypes {
+
         // Release build for all forks
         release {
             if (secrets.getProperty('RELEASE_STORE_FILE')) {
@@ -105,6 +106,7 @@ android {
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             buildConfigField 'String', "MAPBOX_ACCESS_TOKEN", '"' + mapboxToken + '"'
         }
+
         // Release build for the official ODK Collect app
         odkCollectRelease {
             if (secrets.getProperty('RELEASE_STORE_FILE')) {
@@ -118,9 +120,10 @@ android {
 
             matchingFallbacks = ['release'] // So other modules use release build type for this
         }
+
         debug {
             debuggable(true)
-            testCoverageEnabled(true)
+            testCoverageEnabled((findProperty("enableJacoco") ?: "false").toBoolean())
             resValue("bool", "CRASHLYTICS_ENABLED", "false")
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             buildConfigField 'String', "MAPBOX_ACCESS_TOKEN", '"' + mapboxToken + '"'


### PR DESCRIPTION
Closes #3262.

This disables Jacoco by default in the `debug` build. It can still be enabled by passing `enableJacoco` to a task like so:

```
./gradlew -PenableJacoco=true myTask
```

#### What has been done to verify that this works as intended?

Ran different build types to check Jacoco is disabled without the flag and enabled with the flag. I also double checked that Android Studio's coverage tool still works (without the flag).

I considered writing docs but I felt that updating CI's config was better as it'd generally be the first place I looked to see how build tasks work for a project.

#### Why is this the best possible solution? Were any other approaches considered?

We could try and work out why the task was occasionally slow but this feels better as unless we want a coverage report it's always a waste of time to have Jacoco's build tasks running.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change to users. Should be a straight merge once approved.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)