### PR TITLE
Use JavaRosa 2.17.1 release

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -231,7 +231,7 @@ dependencies {
     implementation "com.rarepebble:colorpicker:3.0.1"
     implementation "commons-io:commons-io:2.6"
     implementation "net.sf.opencsv:opencsv:2.4"
-    implementation("org.opendatakit:opendatakit-javarosa:2.17.1-SNAPSHOT") {
+    implementation("org.opendatakit:opendatakit-javarosa:2.17.1") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
This is a follow-up to #3753 to use the JavaRosa 2.17.1 release rather than the snapshot.

For the v2.17.1 release, I added a commit to update the version to v2.17.1 to the [JavaRosa `v2.17.x` branch](https://github.com/getodk/javarosa/tree/v2.17.x) that the snapshot was off of. Then I tagged the tip so there should be no behavior change. 

I did a sanity check with the form from [this forum post](https://forum.getodk.org/t/infinite-loop-and-dynamically-delete-already-selected-options-from-list/25902).

It would be good to double check that I put the tag in the right place.