### PR TITLE
Add analytics that will help shape changes to the onboarding experience

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -205,10 +205,10 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
             public void onClick(View v) {
                 downloadButton.setEnabled(toggleChecked(listView));
                 toggleButtonLabel(toggleButton, listView);
-                viewModel.clearSelectedForms();
+                viewModel.clearSelectedFormIds();
                 if (listView.getCheckedItemCount() == listView.getCount()) {
                     for (HashMap<String, String> map : viewModel.getFormList()) {
-                        viewModel.addSelectedForm(map.get(FORMDETAIL_KEY));
+                        viewModel.addSelectedFormId(map.get(FORMDETAIL_KEY));
                     }
                 }
             }
@@ -262,7 +262,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
                 }
                 downloadFormsTask = null;
             }
-        } else if (viewModel.getFormNamesAndURLs().isEmpty()
+        } else if (viewModel.getFormDetailsByFormId().isEmpty()
                 && getLastCustomNonConfigurationInstance() == null
                 && !viewModel.wasLoadingCanceled()) {
             // first time, so get the formlist
@@ -288,9 +288,9 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
 
         if (listView.isItemChecked(position)) {
-            viewModel.addSelectedForm(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
+            viewModel.addSelectedFormId(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
         } else {
-            viewModel.removeSelectedForm(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
+            viewModel.removeSelectedFormId(((HashMap<String, String>) listView.getAdapter().getItem(position)).get(FORMDETAIL_KEY));
         }
     }
 
@@ -306,7 +306,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
                 finish();
             }
         } else {
-            viewModel.clearFormNamesAndURLs();
+            viewModel.clearFormDetailsByFormId();
             if (progressDialog != null) {
                 // This is needed because onPrepareDialog() is broken in 1.6.
                 progressDialog.setMessage(viewModel.getProgressDialogMsg());
@@ -368,10 +368,10 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         }
         sortList();
         if (listView.getAdapter() == null) {
-            listView.setAdapter(new FormDownloadListAdapter(this, filteredFormList, viewModel.getFormNamesAndURLs()));
+            listView.setAdapter(new FormDownloadListAdapter(this, filteredFormList, viewModel.getFormDetailsByFormId()));
         } else {
             FormDownloadListAdapter formDownloadListAdapter = (FormDownloadListAdapter) listView.getAdapter();
-            formDownloadListAdapter.setFromIdsToDetails(viewModel.getFormNamesAndURLs());
+            formDownloadListAdapter.setFromIdsToDetails(viewModel.getFormDetailsByFormId());
             formDownloadListAdapter.notifyDataSetChanged();
         }
         toggleButton.setEnabled(!filteredFormList.isEmpty());
@@ -385,7 +385,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         for (int i = 0; i < listView.getCount(); i++) {
             HashMap<String, String> item =
                     (HashMap<String, String>) listView.getAdapter().getItem(i);
-            if (viewModel.getSelectedForms().contains(item.get(FORMDETAIL_KEY))) {
+            if (viewModel.getSelectedFormIds().contains(item.get(FORMDETAIL_KEY))) {
                 listView.setItemChecked(i, true);
             }
         }
@@ -415,7 +415,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
             if (sba.get(i, false)) {
                 HashMap<String, String> item =
                         (HashMap<String, String>) listView.getAdapter().getItem(i);
-                filesToDownload.add(viewModel.getFormNamesAndURLs().get(item.get(FORMDETAIL_KEY)));
+                filesToDownload.add(viewModel.getFormDetailsByFormId().get(item.get(FORMDETAIL_KEY)));
             }
         }
 
@@ -502,8 +502,8 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
         try (Cursor formCursor = new FormsDao().getFormsCursorForFormId(formId)) {
             return formCursor != null && formCursor.getCount() == 0 // form does not already exist locally
-                    || viewModel.getFormNamesAndURLs().get(formId).isNewerFormVersionAvailable() // or a newer version of this form is available
-                    || viewModel.getFormNamesAndURLs().get(formId).areNewerMediaFilesAvailable(); // or newer versions of media files are available
+                    || viewModel.getFormDetailsByFormId().get(formId).isNewerFormVersionAvailable() // or a newer version of this form is available
+                    || viewModel.getFormDetailsByFormId().get(formId).areNewerMediaFilesAvailable(); // or newer versions of media files are available
         }
     }
 
@@ -519,14 +519,14 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
             HashMap<String, String> item = filteredFormList.get(idx);
             if (isLocalFormSuperseded(item.get(FORM_ID_KEY))) {
                 ls.setItemChecked(idx, true);
-                viewModel.addSelectedForm(item.get(FORMDETAIL_KEY));
+                viewModel.addSelectedFormId(item.get(FORMDETAIL_KEY));
             }
         }
     }
 
     /*
      * Called when the form list has finished downloading. results will either contain a set of
-     * <formname, formdetails> tuples, or one tuple of DL.ERROR.MSG and the associated message.
+     * <form_id, formdetails> tuples, or one tuple of DL.ERROR.MSG and the associated message.
      */
     public void formListDownloadingComplete(HashMap<String, FormDetails> result) {
         progressDialog.dismiss();
@@ -563,14 +563,14 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
             createAlertDialog(dialogTitle, dialogMessage, DO_NOT_EXIT);
         } else {
             // Everything worked. Clear the list and add the results.
-            viewModel.setFormNamesAndURLs(result);
+            viewModel.setFormDetailsByFormId(result);
 
             viewModel.clearFormList();
 
-            ArrayList<String> ids = new ArrayList<>(viewModel.getFormNamesAndURLs().keySet());
+            ArrayList<String> ids = new ArrayList<>(viewModel.getFormDetailsByFormId().keySet());
             for (int i = 0; i < result.size(); i++) {
                 String formDetailsKey = ids.get(i);
-                FormDetails details = viewModel.getFormNamesAndURLs().get(formDetailsKey);
+                FormDetails details = viewModel.getFormDetailsByFormId().get(formDetailsKey);
 
                 if (!displayOnlyUpdatedForms || (details.isNewerFormVersionAvailable() || details.areNewerMediaFilesAvailable())) {
                     HashMap<String, String> item = new HashMap<>();
@@ -590,7 +590,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
                         for (j = 0; j < viewModel.getFormList().size(); j++) {
                             HashMap<String, String> compareMe = viewModel.getFormList().get(j);
                             String name = compareMe.get(FORMNAME);
-                            if (name.compareTo(viewModel.getFormNamesAndURLs().get(ids.get(i)).getFormName()) > 0) {
+                            if (name.compareTo(viewModel.getFormDetailsByFormId().get(ids.get(i)).getFormName()) > 0) {
                                 break;
                             }
                         }
@@ -614,7 +614,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
                 ArrayList<FormDetails> filesToDownload  = new ArrayList<>();
 
-                for (FormDetails formDetails: viewModel.getFormNamesAndURLs().values()) {
+                for (FormDetails formDetails: viewModel.getFormDetailsByFormId().values()) {
                     String formId = formDetails.getFormId();
 
                     if (viewModel.getFormResults().containsKey(formId)) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -16,18 +16,28 @@
 
 package org.odk.collect.android.activities.viewmodels;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.FormDetails;
+import org.odk.collect.android.utilities.FileUtils;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 
+import static org.odk.collect.android.analytics.AnalyticsEvents.FIRST_FORM_DOWNLOAD;
+import static org.odk.collect.android.analytics.AnalyticsEvents.SUBSEQUENT_FORM_DOWNLOAD;
+
 public class FormDownloadListViewModel extends ViewModel {
+    private final Analytics analytics;
+
     private HashMap<String, FormDetails> formDetailsByFormId = new HashMap<>();
 
     /**
@@ -56,6 +66,10 @@ public class FormDownloadListViewModel extends ViewModel {
     private String username;
     private String password;
     private final HashMap<String, Boolean> formResults = new HashMap<>();
+
+    FormDownloadListViewModel(Analytics analytics) {
+        this.analytics = analytics;
+    }
 
     public HashMap<String, FormDetails> getFormDetailsByFormId() {
         return formDetailsByFormId;
@@ -211,5 +225,38 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setLoadingCanceled(boolean loadingCanceled) {
         this.loadingCanceled = loadingCanceled;
+    }
+
+    public void logDownloadAnalyticsEvent(int downloadedFormCount, String serverUrl) {
+        String analyticsEvent = getDownloadAnalyticsEvent(downloadedFormCount);
+        String analyticsDesc = getDownloadAnalyticsDescription(serverUrl);
+        analytics.logEvent(analyticsEvent, analyticsDesc);
+    }
+
+    private String getDownloadAnalyticsEvent(int downloadedFormCount) {
+        return downloadedFormCount == 0 ? FIRST_FORM_DOWNLOAD : SUBSEQUENT_FORM_DOWNLOAD;
+    }
+
+    private String getDownloadAnalyticsDescription(String serverUrl) {
+        // If a URL was set by intent, use that
+        serverUrl = getUrl() != null ? getUrl() : serverUrl;
+
+        String serverHash = FileUtils.getMd5Hash(new ByteArrayInputStream(serverUrl.getBytes()));
+        return getSelectedFormIds().size() + "/" + getFormList().size() + "-" + serverHash;
+    }
+
+    public static class Factory implements ViewModelProvider.Factory {
+        private final Analytics analytics;
+
+        public Factory(Analytics analytics) {
+            this.analytics = analytics;
+        }
+
+        @SuppressWarnings("unchecked")
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            return (T) new FormDownloadListViewModel(analytics);
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -28,11 +28,16 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 
 public class FormDownloadListViewModel extends ViewModel {
-    private HashMap<String, FormDetails> formNamesAndURLs = new HashMap<>();
+    private HashMap<String, FormDetails> formDetailsByFormId = new HashMap<>();
 
+    /**
+     * List of forms from the formList response. The map acts like a DisplayableForm object with
+     * values for each component that shows up in the form list UI. See
+     * FormDownloadListActivity.formListDownloadingComplete for keys.
+     */
     private final ArrayList<HashMap<String, String>> formList = new ArrayList<>();
 
-    private final LinkedHashSet<String> selectedForms = new LinkedHashSet<>();
+    private final LinkedHashSet<String> selectedFormIds = new LinkedHashSet<>();
 
     private String alertTitle;
     private String progressDialogMsg;
@@ -52,16 +57,16 @@ public class FormDownloadListViewModel extends ViewModel {
     private String password;
     private final HashMap<String, Boolean> formResults = new HashMap<>();
 
-    public HashMap<String, FormDetails> getFormNamesAndURLs() {
-        return formNamesAndURLs;
+    public HashMap<String, FormDetails> getFormDetailsByFormId() {
+        return formDetailsByFormId;
     }
 
-    public void setFormNamesAndURLs(HashMap<String, FormDetails> formNamesAndURLs) {
-        this.formNamesAndURLs = formNamesAndURLs;
+    public void setFormDetailsByFormId(HashMap<String, FormDetails> formDetailsByFormId) {
+        this.formDetailsByFormId = formDetailsByFormId;
     }
 
-    public void clearFormNamesAndURLs() {
-        formNamesAndURLs.clear();
+    public void clearFormDetailsByFormId() {
+        formDetailsByFormId.clear();
     }
 
     public String getAlertTitle() {
@@ -120,20 +125,20 @@ public class FormDownloadListViewModel extends ViewModel {
         formList.add(index, item);
     }
 
-    public LinkedHashSet<String> getSelectedForms() {
-        return selectedForms;
+    public LinkedHashSet<String> getSelectedFormIds() {
+        return selectedFormIds;
     }
 
-    public void addSelectedForm(String form) {
-        selectedForms.add(form);
+    public void addSelectedFormId(String selectedFormId) {
+        selectedFormIds.add(selectedFormId);
     }
 
-    public void removeSelectedForm(String form) {
-        selectedForms.remove(form);
+    public void removeSelectedFormId(String selectedFormId) {
+        selectedFormIds.remove(selectedFormId);
     }
 
-    public void clearSelectedForms() {
-        selectedForms.clear();
+    public void clearSelectedFormIds() {
+        selectedFormIds.clear();
     }
 
     public boolean isDownloadOnlyMode() {

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -118,4 +118,23 @@ public class AnalyticsEvents {
      * The action should be the password removed/added.
      */
     public static final String CONFIGURE_QR_CODE = "ConfigureQRCode";
+
+    /**
+     * Track downloads initiated when there are no downloaded forms on the device. The action should
+     * be in the format: {number of downloaded forms}/{total forms}-{form server hash}
+     *
+     * Questions to answer to help shape new on-boarding and multi-tenancy experience:
+     *      - Does it look like some projects instruct data collectors to download all forms on
+     *      first launch and others to download a subset?
+     *      - If it looks like there's a clear process split, which of the two processes is most
+     *      common? Is project scale or number of forms hosted on server relevant to the process?
+     *      - Are subsequent manual downloads common? Are all forms downloaded or a subset?
+     */
+    public static final String FIRST_FORM_DOWNLOAD = "FirstFormDownload";
+
+    /**
+     * Download a subset of available forms. The action should be in the format:
+     * {number of downloaded forms}/{total forms}-{form server hash}
+     */
+    public static final String SUBSEQUENT_FORM_DOWNLOAD = "SubsequentFormDownload";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -37,6 +37,7 @@ import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.IdentityPreferences;
 import org.odk.collect.android.preferences.ServerPreferencesFragment;
 import org.odk.collect.android.preferences.UserInterfacePreferencesFragment;
+import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.migration.StorageMigrationDialog;
 import org.odk.collect.android.storage.migration.StorageMigrationService;
 import org.odk.collect.android.tasks.InstanceServerUploaderTask;
@@ -154,6 +155,8 @@ public interface AppDependencyComponent {
     void inject(QRCodeTabsActivity qrCodeTabsActivity);
 
     void inject(ShowQRCodeFragment showQRCodeFragment);
+
+    void inject(StorageInitializer storageInitializer);
 
     void inject(StorageMigrationService storageMigrationService);
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.MetaSharedPreferencesProvider;
 import org.odk.collect.android.preferences.qr.ObservableQRCodeGenerator;
 import org.odk.collect.android.preferences.qr.QRCodeGenerator;
+import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageStateProvider;
 import org.odk.collect.android.storage.migration.StorageEraser;
@@ -175,6 +176,12 @@ public class AppDependencyModule {
     @Singleton
     public StorageMigrationRepository providesStorageMigrationRepository() {
         return new StorageMigrationRepository();
+    }
+
+    @Provides
+    @Singleton
+    public StorageInitializer providesStorageInitializer() {
+        return new StorageInitializer();
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormDownloadListActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormDownloadListActivityTest.java
@@ -1,0 +1,104 @@
+package org.odk.collect.android.activities;
+
+import android.app.Activity;
+import android.app.Application;
+import android.database.Cursor;
+
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.listeners.PermissionListener;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.storage.StorageInitializer;
+import org.odk.collect.android.utilities.PermissionUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.support.RobolectricHelpers.overrideAppDependencyModule;
+
+@RunWith(AndroidJUnit4.class)
+public class FormDownloadListActivityTest {
+    @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock Analytics analytics;
+
+    @Mock FormsDao formsDao;
+
+    private ActivityScenario<FormDownloadListActivity> downloadActivity;
+
+    @Before public void setup() {
+        overrideAppDependencyModule(new AppDependencyModule(analytics, formsDao));
+        downloadActivity = ActivityScenario.launch(FormDownloadListActivity.class);
+    }
+
+    @Test public void tappingDownloadButton_logsAnalytics() {
+        Cursor cursor = mock(Cursor.class);
+        when(cursor.getCount()).thenReturn(0);
+        when(formsDao.getFormsCursor()).thenReturn(cursor);
+
+        downloadActivity.onActivity(activity -> {
+            activity.findViewById(R.id.add_button).setEnabled(true);
+            activity.findViewById(R.id.add_button).performClick();
+            verify(analytics).logEvent(eq(AnalyticsEvents.FIRST_FORM_DOWNLOAD), any());
+        });
+    }
+
+    private static class AppDependencyModule extends org.odk.collect.android.injection.config.AppDependencyModule {
+        Analytics analytics;
+        FormsDao formsDao;
+
+        AppDependencyModule(Analytics analytics, FormsDao formsDao) {
+            this.analytics = analytics;
+            this.formsDao = formsDao;
+        }
+
+        @Override
+        public Analytics providesAnalytics(Application application, GeneralSharedPreferences generalSharedPreferences) {
+            return analytics;
+        }
+
+        @Override
+        public FormsDao provideFormsDao() {
+            return formsDao;
+        }
+
+        @Override
+        public PermissionUtils providesPermissionUtils() {
+            return new AlwaysGrantStoragePermissionsPermissionUtils();
+        }
+
+        @Override
+        public StorageInitializer providesStorageInitializer() {
+            return new AlwaysSuccessfullyCreateOdkDirsStorageInitializer();
+        }
+    }
+
+    private static class AlwaysGrantStoragePermissionsPermissionUtils extends PermissionUtils {
+        @Override
+        public void requestStoragePermissions(Activity activity, @NonNull PermissionListener action) {
+            action.granted();
+        }
+    }
+
+    private static class AlwaysSuccessfullyCreateOdkDirsStorageInitializer extends StorageInitializer {
+        @Override
+        public void createOdkDirsOnStorage() {
+            // do nothing
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModelTest.java
@@ -1,0 +1,53 @@
+package org.odk.collect.android.activities.viewmodels;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
+
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+
+public class FormDownloadListViewModelTest {
+
+    private final Analytics analytics = mock(Analytics.class);
+
+    private FormDownloadListViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        viewModel = new FormDownloadListViewModel(analytics);
+    }
+
+    @Test
+    public void logDownloadAnalyticsEvent_whenNoFormsAreOnDevice_logsFirstDownload() {
+        viewModel.logDownloadAnalyticsEvent(0, "https://server.example.com");
+        verify(analytics).logEvent(eq(AnalyticsEvents.FIRST_FORM_DOWNLOAD), anyString());
+    }
+
+    @Test
+    public void logDownloadAnalyticsEvent_whenFormsAreOnDevice_logsSubsequentDownload() {
+        viewModel.logDownloadAnalyticsEvent(1, "https://server.example.com");
+        verify(analytics).logEvent(eq(AnalyticsEvents.SUBSEQUENT_FORM_DOWNLOAD), anyString());
+    }
+
+    @Test
+    public void logDownloadAnalyticsEvent_logsSelectedFormAndTotalFormCountsAndServerHashAsAction() {
+        viewModel.addForm(new HashMap<>());
+        viewModel.addForm(new HashMap<>());
+        viewModel.addForm(new HashMap<>());
+
+        viewModel.addSelectedFormId("foo");
+        viewModel.addSelectedFormId("bar");
+
+        viewModel.logDownloadAnalyticsEvent(0, "https://server.example.com");
+        verify(analytics).logEvent(anyString(), eq(
+                "2/3-e4534130b01d6707a431adbec4e03912" // Ends with hash of server URL
+        ));
+    }
+}


### PR DESCRIPTION
Adds analytics for form downloads triggered from Get Blank Form. I also verified that we already track usage of the automatic form update settings.

#### What has been done to verify that this works as intended?
Wrote and ran tests.

#### Why is this the best possible solution? Were any other approaches considered?
I had trouble deciding how to structure the download analytics because that area of the code doesn't have patterns to follow. There's a viewmodel but it's just holding state that was pulled out to support rotation. I felt there was enough logic involved in the analytics that I wanted the support of tests and I ended up putting that logic in the view model and testing it there. I put the analytics call in the activity and wrote a Robolectric test for that. If any of the tests seem superfluous, you're uncomfortable with the code changes, or you have a better structure to propose, let me know.

A long time ago now, @shobhitagarwal1612 had put in a PR to add some testing here and it turned into a risky refactor with some behavior regressions. I feel badly that no one had the cycles to work with him on that at the time because there are a ton of challenges that would be good to address in this area of the code.

Particularly dangerous is that the naming in both `FormDownloadListActivity` and `FormDownloadListViewModel` is  misleading. I tried to improve it for things I was touching but I think there are still some possibly problematic cases. For example, the viewmodel keeps track of `url` which seems like it could be the URL for the server that is currently configured. It is, but it's only set if the activity is launched from an external intent. In general, the external intent path seems hard to understand and brittle. There are other examples of fields that seem like they should have certain meaning but don't or are often null. Because there are no domain concepts, everything is very low level and some information is duplicated making the data flow hard to follow.

Other things that may need follow-up and/or just bothered me:
- Why is a homegrown insertion sort used to order form definitions in `formListDownloadingComplete` rather than putting them in a list as they come in and then sorting?
- The `item` hashmap built in `formListDownloadingComplete` is hard to understand and should be replaceable by the `Form` domain object, possibly with methods added.
- I really wanted to have a higher level `FormsRepository` rather than using the "dao" abstraction but held back since it was just to get a form count.
- I think `InstanceUploaderListActivity` is missing a call to create the ODK storage directory. Since that class can be launched via intent, that could be a problem if Collect was never launched another way.
- The method naming in `AppDependencyModule` is not consistent. Sometimes the prefix is `provide` and sometimes it's `provides`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There should be no change to behavior. There is some risk to form download behavior since I did do some refactoring there but I tried to keep it as minimal as possible.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)