### PR TITLE
Make sure MapBox init fails silently

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -29,12 +29,16 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProviders;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.Style;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
@@ -157,6 +161,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
         viewModel = ViewModelProviders.of(this, new MainMenuViewModel.Factory(versionInformation)).get(MainMenuViewModel.class);
 
         initToolbar();
+        initMapBox();
         DaggerUtils.getComponent(this).inject(this);
 
         disableSmsIfNeeded();
@@ -391,6 +396,19 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void initMapBox() {
+        // This "one weird trick" lets us initialize MapBox at app start when the internet is
+        // most likely to be available. This is annoyingly needed for offline tiles to work.
+        try {
+            MapView mapView = new MapView(this);
+            FrameLayout mapboxContainer = findViewById(R.id.mapbox_container);
+            mapboxContainer.addView(mapView);
+            mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
+        } catch (Exception | Error ignored) {
+            // This will crash on devices where the arch for MapBox is not included
+        }
     }
 
     private void initToolbar() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -231,7 +231,13 @@ public class SplashScreenActivity extends Activity {
     }
 
     private void initMapBox() {
-        MapView mapView = findViewById(R.id.mapView);
-        mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
+        // This "one weird trick" lets us initialize MapBox at app start when the internet is
+        // most likely to be available. This is annoyingly needed for offline tiles to work.
+        try {
+            MapView mapView = getLayoutInflater().inflate(R.layout.mapbox_init, null).findViewById(R.id.mapView);
+            mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
+        } catch (Exception ignored) {
+            // This will crash on devices where the arch for MapBox is not included
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -29,9 +29,6 @@ import android.view.Window;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
-
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
@@ -86,7 +83,6 @@ public class SplashScreenActivity extends Activity {
                 }
 
                 init();
-                initMapBox();
             }
 
             @Override
@@ -228,16 +224,5 @@ public class SplashScreenActivity extends Activity {
             }
         };
         t.start();
-    }
-
-    private void initMapBox() {
-        // This "one weird trick" lets us initialize MapBox at app start when the internet is
-        // most likely to be available. This is annoyingly needed for offline tiles to work.
-        try {
-            MapView mapView = getLayoutInflater().inflate(R.layout.mapbox_init, null).findViewById(R.id.mapView);
-            mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
-        } catch (Exception | Error ignored) {
-            // This will crash on devices where the arch for MapBox is not included
-        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -236,7 +236,7 @@ public class SplashScreenActivity extends Activity {
         try {
             MapView mapView = getLayoutInflater().inflate(R.layout.mapbox_init, null).findViewById(R.id.mapView);
             mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
-        } catch (Exception ignored) {
+        } catch (Exception | Error ignored) {
             // This will crash on devices where the arch for MapBox is not included
         }
     }

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -30,6 +30,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
+            <FrameLayout
+                android:id="@+id/mapbox_container"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:visibility="invisible">
+            </FrameLayout>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/collect_app/src/main/res/layout/mapbox_init.xml
+++ b/collect_app/src/main/res/layout/mapbox_init.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<com.mapbox.mapboxsdk.maps.MapView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/mapView"
-    android:layout_width="match_parent"
-    android:layout_height="1dp"
-    android:visibility="invisible" />

--- a/collect_app/src/main/res/layout/mapbox_init.xml
+++ b/collect_app/src/main/res/layout/mapbox_init.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.mapbox.mapboxsdk.maps.MapView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mapView"
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:visibility="invisible" />

--- a/collect_app/src/main/res/layout/splash_screen.xml
+++ b/collect_app/src/main/res/layout/splash_screen.xml
@@ -7,12 +7,6 @@
     android:orientation="vertical"
     android:padding="10dip">
 
-    <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@+id/mapView"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:visibility="invisible"/>
-
     <ImageView
         android:id="@+id/splash"
         android:layout_width="wrap_content"


### PR DESCRIPTION
This stops the app crashing on launch in the emulator (and on other devices where Mapbox native code isn't included).

#### What has been done to verify that this works as intended?

Ran tests and launched app.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We should double check that this hasn't caused any regressions on the fixes #3804 introduced. I think if the reviewer could double check that we won't need QA for this.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)