### PR TITLE
Update URL widget default

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-Please refer to the project-wide [ODK Code of Conduct](https://github.com/opendatakit/governance/blob/master/CODE-OF-CONDUCT.md).
+Please refer to the project-wide [ODK Code of Conduct](https://github.com/getodk/governance/blob/master/CODE-OF-CONDUCT.md).

--- a/collect_app/src/androidTest/assets/forms/all-widgets.xml
+++ b/collect_app/src/androidTest/assets/forms/all-widgets.xml
@@ -255,7 +255,7 @@
           <text_widgets>
             <string_widget/>
             <string_number_widget/>
-            <url_widget>http://opendatakit.org/</url_widget>
+            <url_widget>http://getodk.org/</url_widget>
             <ex_string_widget/>
             <ex_printer_widget/>
           </text_widgets>

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -263,7 +263,7 @@ public class InstanceServerUploader extends InstanceUploader {
      *
      * If the upload was triggered by an external app and specified an override URL, use that one.
      * Otherwise, use the submission URL configured in the form
-     * (https://opendatakit.github.io/xforms-spec/#submission-attributes). Finally, default to the
+     * (https://getodk.github.io/xforms-spec/#submission-attributes). Finally, default to the
      * URL configured at the app level.
      */
     @Override

--- a/docs/WIDGETS.md
+++ b/docs/WIDGETS.md
@@ -1,6 +1,6 @@
 # Question Widgets
 
-Collect forms are defined using [XForms](https://opendatakit.github.io/xforms-spec/) which in the most simple sense are just a list of questions (which can be of various [types](https://xlsform.org/en/#question-types)). To render the form and let the enumerator fill it out Collect needs to be able to deal with each of these different question types. To do this Collect has a series of different `QuestionWidget` implementations - usually one for each type of question. The exact mapping between question types and widgets happens in `WidgetFactory`.
+Collect forms are defined using [XForms](https://getodk.github.io/xforms-spec/) which in the most simple sense are just a list of questions (which can be of various [types](https://xlsform.org/en/#question-types)). To render the form and let the enumerator fill it out Collect needs to be able to deal with each of these different question types. To do this Collect has a series of different `QuestionWidget` implementations - usually one for each type of question. The exact mapping between question types and widgets happens in `WidgetFactory`.
 
 ## Implementing widgets
 


### PR DESCRIPTION
#3821 changed URLs to `getodk`. It changed the expected URL in the All Widgets test but not in the corresponding form. It also missed a few URLs.

#### What has been done to verify that this works as intended?
Ran instrumented tests.

#### Why is this the best possible solution? Were any other approaches considered?
I searched the project root for `https://opendatakit` and made sure that all instances that weren't `https://opendatakit.appspot.com` were updated.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No user-facing app changes in this one.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)