### PR TITLE
Assert overflow menu open before clicking

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QRCodeTabsActivityPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QRCodeTabsActivityPage.java
@@ -6,18 +6,19 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.widget.ImageView;
 
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.matcher.BoundedMatcher;
+import androidx.test.rule.ActivityTestRule;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.ActivityHelpers;
 
-import androidx.test.espresso.Espresso;
-import androidx.test.espresso.matcher.BoundedMatcher;
-import androidx.test.rule.ActivityTestRule;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
@@ -49,6 +50,7 @@ public class QRCodeTabsActivityPage extends Page<QRCodeTabsActivityPage> {
 
     public QRCodeTabsActivityPage clickOnMenu() {
         Espresso.openActionBarOverflowOrOptionsMenu(ActivityHelpers.getActivity());
+        onView(withText(R.string.import_qrcode_sd)).check(matches(isDisplayed()));
         return this;
     }
 


### PR DESCRIPTION
Attempts to fix `onMainMenu_clickConfigureQRCode_andClickingOnImportQRCode_startsExternalImagePickerIntent()` which has been failing systematically on Test Lab.

#### What has been done to verify that this works as intended?
Ran build on Test Lab.

#### Why is this the best possible solution? Were any other approaches considered?
The failure is always that the "Import QR Code" text is not displayed. The only things I can think of to try to address that is to add an assertion after clicking on the overflow menu.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Test-only change.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)