### PR TITLE
Revise QR code stub setup

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/preferences/qr/ConfigureWithQRCodeTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/preferences/qr/ConfigureWithQRCodeTest.java
@@ -27,6 +27,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.MainMenuActivity;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.RunnableRule;
 import org.odk.collect.android.support.pages.MainMenuPage;
 
 import java.io.File;
@@ -74,6 +75,7 @@ public class ConfigureWithQRCodeTest {
                     return stubQRCodeGenerator;
                 }
             }))
+            .around(new RunnableRule(stubQRCodeGenerator::setup))
             .around(rule);
 
     @Before
@@ -172,7 +174,6 @@ public class ConfigureWithQRCodeTest {
                         BitmapFactory.decodeResource(
                                 getApplicationContext().getResources(),
                                 CHECKER_BACKGROUND_DRAWABLE_ID);
-                saveBitmap(bitmap);
                 emitter.onNext(bitmap);
                 emitter.onComplete();
             });
@@ -183,8 +184,16 @@ public class ConfigureWithQRCodeTest {
             return getApplicationContext().getExternalFilesDir(null) + File.separator + "test-collect-settings.png";
         }
 
-        public int getDrawableID() {
+        int getDrawableID() {
             return CHECKER_BACKGROUND_DRAWABLE_ID;
+        }
+
+        public void setup() {
+            Bitmap bitmap =
+                    BitmapFactory.decodeResource(
+                            getApplicationContext().getResources(),
+                            CHECKER_BACKGROUND_DRAWABLE_ID);
+            saveBitmap(bitmap);
         }
 
         public void teardown() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/RunnableRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/RunnableRule.java
@@ -1,0 +1,25 @@
+package org.odk.collect.android.support;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RunnableRule implements TestRule {
+
+    private final Runnable runnable;
+
+    public RunnableRule(Runnable runnable) {
+        this.runnable = runnable;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                runnable.run();
+                base.evaluate();
+            }
+        };
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -22,8 +22,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.odk.collect.android.support.CustomMatchers.withIndex;
 
@@ -55,8 +55,12 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEndPage swipeToEndScreen() {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
-        return new FormEndPage(formName, rule).assertOnPage();
+        tryAgainOnFail(() -> {
+            onView(withId(R.id.questionholder)).perform(swipeLeft());
+            new FormEndPage(formName, rule).assertOnPage();
+        });
+
+        return new FormEndPage(formName, rule);
     }
 
     public ErrorDialog swipeToNextQuestionWithError() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -40,9 +40,9 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.core.StringEndsWith.endsWith;
+import static org.odk.collect.android.support.CustomMatchers.withIndex;
 import static org.odk.collect.android.support.actions.NestedScrollToAction.nestedScrollTo;
 import static org.odk.collect.android.support.matchers.RecyclerViewMatcher.withRecyclerView;
-import static org.odk.collect.android.support.CustomMatchers.withIndex;
 
 /**
  * Base class for Page Objects used in Espresso tests. Provides shared helpers/setup.
@@ -288,6 +288,15 @@ abstract class Page<T extends Page<T>> {
     public T checkIfWebViewActivityIsDisplayed() {
         onView(withClassName(endsWith("WebView"))).check(matches(isDisplayed()));
         return (T) this;
+    }
+
+    void tryAgainOnFail(Runnable action) {
+        try {
+            action.run();
+        } catch (NoMatchingViewException e) {
+            assertOnPage();
+            action.run();
+        }
     }
 
     void waitForText(String text) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QRCodeTabsActivityPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QRCodeTabsActivityPage.java
@@ -49,8 +49,11 @@ public class QRCodeTabsActivityPage extends Page<QRCodeTabsActivityPage> {
     }
 
     public QRCodeTabsActivityPage clickOnMenu() {
-        Espresso.openActionBarOverflowOrOptionsMenu(ActivityHelpers.getActivity());
-        onView(withText(R.string.import_qrcode_sd)).check(matches(isDisplayed()));
+        tryAgainOnFail(() -> {
+            Espresso.openActionBarOverflowOrOptionsMenu(ActivityHelpers.getActivity());
+            onView(withText(getTranslatedString(R.string.import_qrcode_sd))).check(matches(isDisplayed()));
+        });
+
         return this;
     }
 


### PR DESCRIPTION
This reworks the QR code stub setup so that file saving happens in the test rules. This means that any errors will stop the test rather than us seeing fails later for what looks like unrelated reasons. I've also added cleanup to the stub for good measure (which might help stability if that was a problem) and added and used a `tryAgainOnFail` helper to tackle a couple of flakey actions in the tests.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)