### PR TITLE
Add try again helpers to tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DeletingRepeatGroupsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DeletingRepeatGroupsTest.java
@@ -49,7 +49,7 @@ public class DeletingRepeatGroupsTest {
         new FormEntryPage("repeatGroups", activityTestRule)
                 .swipeToNextQuestion()
                 .deleteGroup("text1")
-                .assertText("3");
+                .waitForText("3");
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/preferences/qr/ConfigureWithQRCodeTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/preferences/qr/ConfigureWithQRCodeTest.java
@@ -18,6 +18,7 @@ import com.google.zxing.WriterException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -114,6 +115,7 @@ public class ConfigureWithQRCodeTest {
     }
 
     @Test
+    @Ignore("Should be replaced at Robolectric level")
     public void onMainMenu_clickConfigureQRCode_andClickingOnImportQRCode_startsExternalImagePickerIntent() {
         new MainMenuPage(rule)
                 .assertOnPage()
@@ -127,6 +129,7 @@ public class ConfigureWithQRCodeTest {
     }
 
     @Test
+    @Ignore("Should be replaced at Robolectric level")
     public void onMainMenu_clickConfigureQRCode_andClickingOnShareQRCode_startsExternalShareIntent() {
         String path = new StubQRCodeGenerator().getQrCodeFilepath();
         Uri expected = FileProvider.getUriForFile(getApplicationContext(),

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -219,7 +219,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public AddNewRepeatDialog swipeToNextQuestionWithRepeatGroup(String repeatName) {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
-        return new AddNewRepeatDialog(repeatName, rule).assertOnPage();
+        tryAgainOnFail(() -> {
+            onView(withId(R.id.questionholder)).perform(swipeLeft());
+            new AddNewRepeatDialog(repeatName, rule).assertOnPage();
+        });
+
+        return new AddNewRepeatDialog(repeatName, rule);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -299,8 +299,10 @@ abstract class Page<T extends Page<T>> {
         }
     }
 
-    void waitForText(String text) {
-        while (true) {
+    public void waitForText(String text) {
+        int counter = 0;
+
+        while (counter < 20) {
             try {
                 assertText(text);
                 break;
@@ -313,6 +315,8 @@ abstract class Page<T extends Page<T>> {
             } catch (InterruptedException ignored) {
                 // ignored
             }
+
+            counter++;
         }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -301,13 +301,14 @@ abstract class Page<T extends Page<T>> {
 
     public void waitForText(String text) {
         int counter = 0;
+        NoMatchingViewException failure = null;
 
         while (counter < 20) {
             try {
                 assertText(text);
-                break;
-            } catch (NoMatchingViewException ignored) {
-                // ignored
+                return;
+            } catch (NoMatchingViewException exception) {
+                failure = exception;
             }
 
             try {
@@ -317,6 +318,10 @@ abstract class Page<T extends Page<T>> {
             }
 
             counter++;
+        }
+
+        if (failure != null) {
+            throw failure;
         }
     }
 }


### PR DESCRIPTION
This adds try again (or wait) helpers to a couple of tests that seem to need it. It also ignores some tests we added recently that seem to be using an overflow helper and intent assertions. Both of which are not behaving. We'll replace these tests at the Robolectric level.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)