### PR TITLE
Fix code coverage integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,11 +244,11 @@ workflows:
           filters:
             branches:
               only: master
-#      - report_coverage:
-#          requires:
-#            - test_unit
-#            - test_instrumented
-#          # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
-#          filters:
-#            branches:
-#              only: master
+      - report_coverage:
+          requires:
+            - test_unit
+            - test_instrumented
+          # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,8 @@ jobs:
           name: Move Firebase coverage report
           command: |
             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
-              mkdir -p collect_app/build/outputs/code-coverage/connected && cp firebase/Pixel2-27-en-portrait/artifacts/coverage.ec collect_app/build/outputs/code-coverage/connected/coverage.ec
+            mkdir -p collect_app/build/outputs/code-coverage/connected
+            find firebase -iname 'coverage.ec' | cpio -pdm collect_app/build/outputs/code-coverage/connected
             fi
       - run:
           name: Generate JaCoCo report


### PR DESCRIPTION
Closes #3796 

Copy all code coverage files from each sharded output dir. 

`jacoco.gradle` already includes `outputs/code-coverage/connected/*coverage.ec` so we don't have to change anything in the plugin config.

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I was unable to test the changes locally. For that, I need atleast 2-3 `coverage.ec` from the shards.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only solution I considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I noticed that the coverage files are not getting generated in the latest master build. Even if that is the case, then this won't fail the build.

#### Do we need any specific form for testing your changes? If so, please attach one.
n/a

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
n/a

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)