### PR TITLE
Used Dialog Fragment to create Remove Group Dialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -368,7 +368,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         nextButton = findViewById(R.id.form_forward_button);
         nextButton.setOnClickListener(v -> {
             beenSwiped = true;
-            showNextView(getFormController());
+            showNextView();
         });
 
         backButton = findViewById(R.id.form_back_button);
@@ -1152,11 +1152,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void deleteGroup() {
         FormController formController = getFormController();
-        if (formController != null) {
-            formController.deleteRepeat();
-        }
         if (formController != null && !formController.indexIsInFieldList()) {
-            showNextView(formController);
+            showNextView();
         } else {
             refreshCurrentView();
         }
@@ -1446,10 +1443,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * a question, an ask repeat dialog, or the submit screen. Also saves
      * answers to the data model after checking constraints.
      */
-    private void showNextView(FormController formController) {
+    private void showNextView() {
         state = null;
         try {
-
+            FormController formController = getFormController();
             if (saveBeforeNextView(formController)) {
                 return;
             }
@@ -2173,7 +2170,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 if (event.isAltPressed() && !beenSwiped) {
                     beenSwiped = true;
-                    showNextView(getFormController());
+                    showNextView();
                     return true;
                 }
                 break;
@@ -2474,7 +2471,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     public void next() {
         if (!beenSwiped) {
             beenSwiped = true;
-            showNextView(getFormController());
+            showNextView();
         }
     }
 
@@ -2558,7 +2555,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 if (velocityX > 0) {
                     if (e1.getX() > e2.getX()) {
                         Timber.e("showNextView VelocityX is bogus! %f > %f", e1.getX(), e2.getX());
-                        showNextView(getFormController());
+                        showNextView();
                     } else {
                         showPreviousView();
                     }
@@ -2567,7 +2564,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         Timber.e("showPreviousView VelocityX is bogus! %f < %f", e1.getX(), e2.getX());
                         showPreviousView();
                     } else {
-                        showNextView(getFormController());
+                        showNextView();
                     }
                 }
                 return true;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1159,11 +1159,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
     }
 
-    @Override
-    public void onCancelled() {
-        refreshCurrentView();
-    }
-
     /**
      * If we're loading, then we pass the loading thread to our next instance.
      */

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -368,7 +368,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         nextButton = findViewById(R.id.form_forward_button);
         nextButton.setOnClickListener(v -> {
             beenSwiped = true;
-            showNextView();
+            showNextView(getFormController());
         });
 
         backButton = findViewById(R.id.form_back_button);
@@ -1152,8 +1152,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void deleteGroup() {
         FormController formController = getFormController();
+        if (formController != null) {
+            formController.deleteRepeat();
+        }
         if (formController != null && !formController.indexIsInFieldList()) {
-            showNextView();
+            showNextView(formController);
         } else {
             refreshCurrentView();
         }
@@ -1443,10 +1446,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * a question, an ask repeat dialog, or the submit screen. Also saves
      * answers to the data model after checking constraints.
      */
-    private void showNextView() {
+    private void showNextView(FormController formController) {
         state = null;
         try {
-            FormController formController = getFormController();
 
             if (saveBeforeNextView(formController)) {
                 return;
@@ -2171,7 +2173,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case KeyEvent.KEYCODE_DPAD_RIGHT:
                 if (event.isAltPressed() && !beenSwiped) {
                     beenSwiped = true;
-                    showNextView();
+                    showNextView(getFormController());
                     return true;
                 }
                 break;
@@ -2472,7 +2474,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     public void next() {
         if (!beenSwiped) {
             beenSwiped = true;
-            showNextView();
+            showNextView(getFormController());
         }
     }
 
@@ -2556,7 +2558,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 if (velocityX > 0) {
                     if (e1.getX() > e2.getX()) {
                         Timber.e("showNextView VelocityX is bogus! %f > %f", e1.getX(), e2.getX());
-                        showNextView();
+                        showNextView(getFormController());
                     } else {
                         showPreviousView();
                     }
@@ -2565,7 +2567,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         Timber.e("showPreviousView VelocityX is bogus! %f < %f", e1.getX(), e2.getX());
                         showPreviousView();
                     } else {
-                        showNextView();
+                        showNextView(getFormController());
                     }
                 }
                 return true;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -203,9 +203,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         CustomDatePickerDialog.CustomDatePickerDialogListener, RankingWidgetDialog.RankingListener,
         SaveFormIndexTask.SaveFormIndexListener, WidgetValueChangedListener,
         ScreenContext, FormLoadingDialogFragment.FormLoadingDialogFragmentListener,
-        AudioControllerView.SwipableParent,
-        FormIndexAnimationHandler.Listener,
-        QuitFormDialogFragment.Listener {
+        AudioControllerView.SwipableParent, FormIndexAnimationHandler.Listener,
+        QuitFormDialogFragment.Listener, DeleteRepeatDialogFragment.DeleteRepeatDialogCallback {
 
     // Defines for FormEntryActivity
     private static final boolean EXIT = true;
@@ -1148,6 +1147,21 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         }
 
         return super.onContextItemSelected(item);
+    }
+
+    @Override
+    public void deleteGroup() {
+        FormController formController = getFormController();
+        if (formController != null && !formController.indexIsInFieldList()) {
+            showNextView();
+        } else {
+            refreshCurrentView();
+        }
+    }
+
+    @Override
+    public void onCancelled() {
+        refreshCurrentView();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -102,6 +102,7 @@ import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationMa
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationViewModel;
 import org.odk.collect.android.formentry.loading.FormInstanceFileCreator;
 import org.odk.collect.android.formentry.repeats.AddRepeatDialog;
+import org.odk.collect.android.formentry.repeats.DeleteRepeatDialogFragment;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.formentry.saving.SaveFormProgressDialogFragment;
 import org.odk.collect.android.fragments.MediaLoadingFragment;
@@ -1133,7 +1134,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public boolean onContextItemSelected(MenuItem item) {
         if (item.getItemId() == DELETE_REPEAT) {
-            createDeleteRepeatConfirmDialog();
+            DialogUtils.showIfNotShowing(DeleteRepeatDialogFragment.class, getSupportFragmentManager());
         } else {
             ODKView odkView = getCurrentViewIfODKView();
             if (odkView != null) {
@@ -1791,20 +1792,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         alertDialog.setButton(BUTTON_POSITIVE, getString(R.string.ok), errorListener);
         beenSwiped = false;
         alertDialog.show();
-    }
-
-    /**
-     * Creates a confirm/cancel dialog for deleting repeats.
-     */
-    private void createDeleteRepeatConfirmDialog() {
-        DialogUtils.showDeleteRepeatConfirmDialog(this, () -> {
-            FormController formController = getFormController();
-            if (formController != null && !formController.indexIsInFieldList()) {
-                showNextView();
-            } else {
-                refreshCurrentView();
-            }
-        }, this::refreshCurrentView);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -45,7 +45,6 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.formentry.ODKView;
-import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.repeats.DeleteRepeatDialogFragment;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.logic.HierarchyElement;
@@ -787,10 +786,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
 
     @Override
     public void deleteGroup() {
-        FormController formController = Collect.getInstance().getFormController();
-        formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, true, System.currentTimeMillis());
-        formController.deleteRepeat();
-
         if (didDeleteLastRepeatItem()) {
             // goUpLevel would put us in a weird state after deleting the last item;
             // just go back one event instead.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -798,7 +798,4 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
             goUpLevel();
         }
     }
-
-    @Override
-    public void onCancelled() {}
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -45,6 +45,8 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.formentry.ODKView;
+import org.odk.collect.android.formentry.audit.AuditEvent;
+import org.odk.collect.android.formentry.repeats.DeleteRepeatDialogFragment;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.DialogUtils;
@@ -60,7 +62,7 @@ import timber.log.Timber;
 import static org.odk.collect.android.analytics.AnalyticsEvents.NULL_FORM_CONTROLLER_EVENT;
 import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getPreviousLevel;
 
-public class FormHierarchyActivity extends CollectAbstractActivity {
+public class FormHierarchyActivity extends CollectAbstractActivity implements DeleteRepeatDialogFragment.DeleteRepeatDialogCallback {
 
     public static final int RESULT_ADD_REPEAT = 2;
     /**
@@ -263,19 +265,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_delete_child:
-                DialogUtils.showDeleteRepeatConfirmDialog(this, () -> {
-                    if (didDeleteLastRepeatItem()) {
-                        // goUpLevel would put us in a weird state after deleting the last item;
-                        // just go back one event instead.
-                        //
-                        // TODO: This works well in most cases, but if there are 2 repeats in a row,
-                        //   and you delete an item from the second repeat, it will send you into the
-                        //   first repeat instead of going back a level as expected.
-                        goToPreviousEvent();
-                    } else {
-                        goUpLevel();
-                    }
-                }, null);
+                DialogUtils.showIfNotShowing(DeleteRepeatDialogFragment.class, getSupportFragmentManager());
                 return true;
 
             case R.id.menu_add_repeat:
@@ -794,4 +784,26 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.ok), errorListener);
         alertDialog.show();
     }
+
+    @Override
+    public void deleteGroup() {
+        FormController formController = Collect.getInstance().getFormController();
+        formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, true, System.currentTimeMillis());
+        formController.deleteRepeat();
+
+        if (didDeleteLastRepeatItem()) {
+            // goUpLevel would put us in a weird state after deleting the last item;
+            // just go back one event instead.
+            //
+            // TODO: This works well in most cases, but if there are 2 repeats in a row,
+            //   and you delete an item from the second repeat, it will send you into the
+            //   first repeat instead of going back a level as expected.
+            goToPreviousEvent();
+        } else {
+            goUpLevel();
+        }
+    }
+
+    @Override
+    public void onCancelled() {}
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -123,14 +123,6 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         }
     }
 
-    public String getLastRepeatedGroupName() {
-        return formController.getLastRepeatedGroupName();
-    }
-
-    public int getLastRepeatedGroupRepeatCount() {
-        return formController.getLastRepeatedGroupRepeatCount();
-    }
-
     public static class Factory implements ViewModelProvider.Factory {
 
         private final Analytics analytics;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -123,6 +123,14 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         }
     }
 
+    public String getLastRepeatedGroupName() {
+        return formController.getLastRepeatedGroupName();
+    }
+
+    public int getLastRepeatedGroupRepeatCount() {
+        return formController.getLastRepeatedGroupRepeatCount();
+    }
+
     public static class Factory implements ViewModelProvider.Factory {
 
         private final Analytics analytics;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -21,6 +21,7 @@ import static android.content.DialogInterface.BUTTON_POSITIVE;
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
     private DeleteRepeatDialogCallback callback;
+    FormController formController = Collect.getInstance().getFormController();
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -36,7 +37,6 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         super.onCreateDialog(savedInstanceState);
 
-        FormController formController = Collect.getInstance().getFormController();
         String name = formController.getLastRepeatedGroupName();
         int repeatCount = formController.getLastRepeatedGroupRepeatCount();
         if (repeatCount != -1) {
@@ -51,7 +51,6 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
                 case BUTTON_POSITIVE: // yes
                     formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, true, System.currentTimeMillis());
                     formController.deleteRepeat();
-
                     callback.deleteGroup();
                     break;
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -47,16 +47,10 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
         alertDialog.setTitle(getActivity().getString(R.string.delete_repeat_ask));
         alertDialog.setMessage(getActivity().getString(R.string.delete_repeat_confirm, name));
         DialogInterface.OnClickListener quitListener = (dialog, i) -> {
-            switch (i) {
-                case BUTTON_POSITIVE: // yes
-                    formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, true, System.currentTimeMillis());
-                    formController.deleteRepeat();
-                    callback.deleteGroup();
-                    break;
-
-                case BUTTON_NEGATIVE: // no
-                    callback.onCancelled();
-                    break;
+            if (i == BUTTON_POSITIVE) { // yes
+                formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, true, System.currentTimeMillis());
+                formController.deleteRepeat();
+                callback.deleteGroup();
             }
             alertDialog.cancel();
             dismiss();
@@ -71,6 +65,5 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
 
     public interface DeleteRepeatDialogCallback {
         void deleteGroup();
-        void onCancelled();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -1,0 +1,7 @@
+package org.odk.collect.android.formentry.repeats;
+
+import androidx.fragment.app.DialogFragment;
+
+public class DeleteRepeatDialogFragment extends DialogFragment {
+
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -12,7 +12,10 @@ import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.formentry.FormEntryViewModel;
+
+import javax.inject.Inject;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
@@ -22,11 +25,17 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
     private FormEntryViewModel viewModel;
     private DeleteRepeatDialogCallback callback;
 
+    @Inject
+    Analytics analytics;
+
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
-        viewModel = new ViewModelProvider(requireActivity()).get(FormEntryViewModel.class);
+        if (viewModel == null) {
+            viewModel = new ViewModelProvider(requireActivity(), new FormEntryViewModel.Factory(analytics)).get(FormEntryViewModel.class);
+        }
+
         if (context instanceof DeleteRepeatDialogCallback) {
             callback = (DeleteRepeatDialogCallback) context;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -9,7 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.FormEntryViewModel;
@@ -20,13 +20,13 @@ import static android.content.DialogInterface.BUTTON_POSITIVE;
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
     private FormEntryViewModel viewModel;
-    protected DeleteRepeatDialogCallback callback;
+    private DeleteRepeatDialogCallback callback;
 
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
-        viewModel = ViewModelProviders.of(requireActivity()).get(FormEntryViewModel.class);
+        viewModel = new ViewModelProvider(requireActivity()).get(FormEntryViewModel.class);
         if (context instanceof DeleteRepeatDialogCallback) {
             callback = (DeleteRepeatDialogCallback) context;
         }
@@ -38,9 +38,9 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
         super.onCreateDialog(savedInstanceState);
 
         String name = viewModel.getLastRepeatedGroupName();
-        int repeatcount = viewModel.getLastRepeatedGroupRepeatCount();
-        if (repeatcount != -1) {
-            name += " (" + (repeatcount + 1) + ")";
+        int repeatCount = viewModel.getLastRepeatedGroupRepeatCount();
+        if (repeatCount != -1) {
+            name += " (" + (repeatCount + 1) + ")";
         }
 
         AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.formentry.repeats;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 
@@ -18,7 +19,17 @@ import static android.content.DialogInterface.BUTTON_POSITIVE;
 
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
-    protected FormController formController = Collect.getInstance().getFormController();;
+    protected FormController formController = Collect.getInstance().getFormController();
+    protected DeleteRepeatDialogCallback callback;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        if (context instanceof DeleteRepeatDialogCallback) {
+            callback = (DeleteRepeatDialogCallback) context;
+        }
+    }
 
     @NonNull
     @Override
@@ -37,11 +48,11 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
         DialogInterface.OnClickListener quitListener = (dialog, i) -> {
             switch (i) {
                 case BUTTON_POSITIVE: // yes
-
+                    callback.deleteGroup();
                     break;
 
                 case BUTTON_NEGATIVE: // no
-
+                    callback.onCancelled();
                     break;
             }
             alertDialog.cancel();
@@ -52,5 +63,10 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
         alertDialog.setButton(BUTTON_NEGATIVE, getActivity().getString(R.string.delete_repeat_no), quitListener);
 
         return alertDialog;
+    }
+
+    public interface DeleteRepeatDialogCallback {
+        void deleteGroup();
+        void onCancelled();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -9,23 +9,24 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProviders;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.formentry.FormEntryViewModel;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
-    protected FormController formController = Collect.getInstance().getFormController();
+    private FormEntryViewModel viewModel;
     protected DeleteRepeatDialogCallback callback;
 
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
+        viewModel = ViewModelProviders.of(requireActivity()).get(FormEntryViewModel.class);
         if (context instanceof DeleteRepeatDialogCallback) {
             callback = (DeleteRepeatDialogCallback) context;
         }
@@ -36,8 +37,8 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         super.onCreateDialog(savedInstanceState);
 
-        String name = formController.getLastRepeatedGroupName();
-        int repeatcount = formController.getLastRepeatedGroupRepeatCount();
+        String name = viewModel.getLastRepeatedGroupName();
+        int repeatcount = viewModel.getLastRepeatedGroupRepeatCount();
         if (repeatcount != -1) {
             name += " (" + (repeatcount + 1) + ")";
         }
@@ -58,6 +59,7 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
             alertDialog.cancel();
             dismiss();
         };
+        setCancelable(false);
         alertDialog.setCancelable(false);
         alertDialog.setButton(BUTTON_POSITIVE, getActivity().getString(R.string.discard_group), quitListener);
         alertDialog.setButton(BUTTON_NEGATIVE, getActivity().getString(R.string.delete_repeat_no), quitListener);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -1,7 +1,46 @@
 package org.odk.collect.android.formentry.repeats;
 
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+
+import org.odk.collect.android.R;
+
+import static android.content.DialogInterface.BUTTON_NEGATIVE;
+import static android.content.DialogInterface.BUTTON_POSITIVE;
 
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        super.onCreateDialog(savedInstanceState);
+
+        AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();
+
+        alertDialog.setTitle(getActivity().getString(R.string.delete_repeat_ask));
+        DialogInterface.OnClickListener quitListener = (dialog, i) -> {
+            switch (i) {
+                case BUTTON_POSITIVE: // yes
+
+                    break;
+
+                case BUTTON_NEGATIVE: // no
+
+                    break;
+            }
+            alertDialog.cancel();
+            dismiss();
+        };
+        alertDialog.setCancelable(false);
+        alertDialog.setButton(BUTTON_POSITIVE, getActivity().getString(R.string.discard_group), quitListener);
+        alertDialog.setButton(BUTTON_NEGATIVE, getActivity().getString(R.string.delete_repeat_no), quitListener);
+
+        return alertDialog;
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -10,20 +10,30 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.javarosawrapper.FormController;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
+    protected FormController formController = Collect.getInstance().getFormController();;
+
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         super.onCreateDialog(savedInstanceState);
 
-        AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();
+        String name = formController.getLastRepeatedGroupName();
+        int repeatcount = formController.getLastRepeatedGroupRepeatCount();
+        if (repeatcount != -1) {
+            name += " (" + (repeatcount + 1) + ")";
+        }
 
+        AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();
         alertDialog.setTitle(getActivity().getString(R.string.delete_repeat_ask));
+        alertDialog.setMessage(getActivity().getString(R.string.delete_repeat_confirm, name));
         DialogInterface.OnClickListener quitListener = (dialog, i) -> {
             switch (i) {
                 case BUTTON_POSITIVE: // yes

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -17,7 +17,6 @@
 package org.odk.collect.android.utilities;
 
 import android.app.Activity;
-import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -28,18 +27,15 @@ import android.widget.ListView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.formentry.audit.AuditEvent;
-import org.odk.collect.android.javarosawrapper.FormController;
 
 import timber.log.Timber;
 
-import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 
 /**
@@ -88,45 +84,6 @@ public final class DialogUtils {
         } catch (Exception e) {
             Timber.e(e);
         }
-    }
-
-    /**
-     * Shows a confirm/cancel dialog for deleting the current repeat group.
-     */
-    public static void showDeleteRepeatConfirmDialog(Context context, Runnable onDeleted, Runnable onCanceled) {
-        FormController formController = Collect.getInstance().getFormController();
-        String name = formController.getLastRepeatedGroupName();
-        int repeatcount = formController.getLastRepeatedGroupRepeatCount();
-        if (repeatcount != -1) {
-            name += " (" + (repeatcount + 1) + ")";
-        }
-        androidx.appcompat.app.AlertDialog alertDialog = new androidx.appcompat.app.AlertDialog.Builder(context).create();
-        alertDialog.setTitle(context.getString(R.string.delete_repeat_ask));
-        alertDialog.setMessage(context.getString(R.string.delete_repeat_confirm, name));
-        DialogInterface.OnClickListener quitListener = (dialog, i) -> {
-            switch (i) {
-                case BUTTON_POSITIVE: // yes
-                    formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.DELETE_REPEAT, true, System.currentTimeMillis());
-                    formController.deleteRepeat();
-
-                    if (onDeleted != null) {
-                        onDeleted.run();
-                    }
-
-                    break;
-
-                case BUTTON_NEGATIVE: // no
-                    if (onCanceled != null) {
-                        onCanceled.run();
-                    }
-
-                    break;
-            }
-        };
-        alertDialog.setCancelable(false);
-        alertDialog.setButton(BUTTON_POSITIVE, context.getString(R.string.discard_group), quitListener);
-        alertDialog.setButton(BUTTON_NEGATIVE, context.getString(R.string.delete_repeat_no), quitListener);
-        alertDialog.show();
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -109,16 +109,4 @@ public class FormEntryViewModelTest {
         viewModel.cancelRepeatPrompt();
         assertThat(viewModel.getError().getValue(), equalTo("OH NO"));
     }
-
-    @Test
-    public void getLastRepeatedGroupName_returnsCorrectGroupName() {
-        when(formController.getLastRepeatedGroupName()).thenReturn("blah");
-        assertThat(viewModel.getLastRepeatedGroupName(), equalTo("blah"));
-    }
-
-    @Test
-    public void getLastRepeatedGroupRepeatCount_returnsCorrectGroupRepeatCount() {
-        when(formController.getLastRepeatedGroupRepeatCount()).thenReturn(1);
-        assertThat(viewModel.getLastRepeatedGroupRepeatCount(), equalTo(1));
-    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -109,4 +109,16 @@ public class FormEntryViewModelTest {
         viewModel.cancelRepeatPrompt();
         assertThat(viewModel.getError().getValue(), equalTo("OH NO"));
     }
+
+    @Test
+    public void getLastRepeatedGroupName_returnsCorrectGroupName() {
+        when(formController.getLastRepeatedGroupName()).thenReturn("blah");
+        assertThat(viewModel.getLastRepeatedGroupName(), equalTo("blah"));
+    }
+
+    @Test
+    public void getLastRepeatedGroupRepeatCount_returnsCorrectGroupRepeatCount() {
+        when(formController.getLastRepeatedGroupRepeatCount()).thenReturn(1);
+        assertThat(viewModel.getLastRepeatedGroupRepeatCount(), equalTo(1));
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -101,20 +101,9 @@ public class DeleteRepeatDialogFragmentTest {
         verify(dialogFragment.formController).deleteRepeat();
     }
 
-    @Test
-    public void clickingCancel_callsOnCancelled() {
-        dialogFragment.show(fragmentManager, "TAG");
-        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
-        assertThat(activity.onCancelledCalled, equalTo(false));
-
-        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
-        assertThat(activity.onCancelledCalled, equalTo(true));
-    }
-
     public static class TestActivity extends FragmentActivity implements DeleteRepeatDialogFragment.DeleteRepeatDialogCallback {
 
         private boolean deleteGroupCalled;
-        private boolean onCancelledCalled;
 
         TestActivity() {
         }
@@ -122,11 +111,6 @@ public class DeleteRepeatDialogFragmentTest {
         @Override
         public void deleteGroup() {
             deleteGroupCalled = true;
-        }
-
-        @Override
-        public void onCancelled() {
-            onCancelledCalled = true;
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
-import org.odk.collect.android.formentry.FormEntryViewModel;
+import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
@@ -22,8 +22,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.odk.collect.android.support.RobolectricHelpers.mockViewModelProvider;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
@@ -32,7 +34,6 @@ public class DeleteRepeatDialogFragmentTest {
     private TestActivity activity;
     private FragmentManager fragmentManager;
     private DeleteRepeatDialogFragment dialogFragment;
-    private FormEntryViewModel formEntryViewModel;
 
     @Before
     public void setup() {
@@ -40,7 +41,9 @@ public class DeleteRepeatDialogFragmentTest {
         fragmentManager = activity.getSupportFragmentManager();
         dialogFragment = new DeleteRepeatDialogFragment();
 
-        formEntryViewModel = mockViewModelProvider(activity, FormEntryViewModel.class).get(FormEntryViewModel.class);
+        dialogFragment.formController = mock(FormController.class, RETURNS_MOCKS);
+        when(dialogFragment.formController.getLastRepeatedGroupName()).thenReturn("blah");
+        when(dialogFragment.formController.getLastRepeatedGroupRepeatCount()).thenReturn(0);
     }
 
     @Test
@@ -57,8 +60,6 @@ public class DeleteRepeatDialogFragmentTest {
 
     @Test
     public void shouldShowCorrectMessage() {
-        when(formEntryViewModel.getLastRepeatedGroupName()).thenReturn("blah");
-        when(formEntryViewModel.getLastRepeatedGroupRepeatCount()).thenReturn(0);
         dialogFragment.show(fragmentManager, "TAG");
         AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
         String message = ((TextView) dialog.findViewById(android.R.id.message)).getText().toString();
@@ -96,6 +97,8 @@ public class DeleteRepeatDialogFragmentTest {
 
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
         assertThat(activity.deleteGroupCalled, equalTo(true));
+
+        verify(dialogFragment.formController).deleteRepeat();
     }
 
     @Test
@@ -114,8 +117,6 @@ public class DeleteRepeatDialogFragmentTest {
         private boolean onCancelledCalled;
 
         TestActivity() {
-            deleteGroupCalled = false;
-            onCancelledCalled = false;
         }
 
         @Override

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -24,6 +24,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -40,7 +42,9 @@ public class DeleteRepeatDialogFragmentTest {
         activity.setup();
         fragmentManager = activity.get().getSupportFragmentManager();
         dialogFragment = new DeleteRepeatDialogFragment();
+
         dialogFragment.formController = mock(FormController.class);
+        dialogFragment.callback = mock(DeleteRepeatDialogFragment.DeleteRepeatDialogCallback.class);
     }
 
     @Test
@@ -75,7 +79,6 @@ public class DeleteRepeatDialogFragmentTest {
 
         DeleteRepeatDialogFragment restoredFragment = (DeleteRepeatDialogFragment) activity.get().getSupportFragmentManager().findFragmentByTag("TAG");
         AlertDialog restoredDialog = (AlertDialog) restoredFragment.getDialog();
-
         assertThat(((TextView) restoredDialog.findViewById(android.R.id.message)).getText().toString(), equalTo(message));
     }
 
@@ -99,5 +102,21 @@ public class DeleteRepeatDialogFragmentTest {
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
         assertFalse(dialog.isShowing());
         assertTrue(shadowOf(dialog).hasBeenDismissed());
+    }
+
+    @Test
+    public void clickingRemoveGroup_callsDeleteGroup() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
+        verify(dialogFragment.callback, times(1)).deleteGroup();
+    }
+
+    @Test
+    public void clickingCancel_callsOnCancelled() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
+        verify(dialogFragment.callback, times(1)).onCancelled();
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android.formentry.repeats;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.widget.TextView;
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -11,11 +11,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
-import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowDialog;
 
 import static junit.framework.TestCase.assertTrue;
@@ -26,38 +25,36 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.support.RobolectricHelpers.mockViewModelProvider;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 public class DeleteRepeatDialogFragmentTest {
 
-    private ActivityController<FragmentActivity> activity;
     private FragmentManager fragmentManager;
     private DeleteRepeatDialogFragment dialogFragment;
+    private FormEntryViewModel formEntryViewModel;
 
     @Before
     public void setup() {
-        activity = RobolectricHelpers.buildThemedActivity(FragmentActivity.class);
-        activity.setup();
-        fragmentManager = activity.get().getSupportFragmentManager();
+        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class);
+        fragmentManager = activity.getSupportFragmentManager();
         dialogFragment = new DeleteRepeatDialogFragment();
 
-        dialogFragment.formController = mock(FormController.class);
         dialogFragment.callback = mock(DeleteRepeatDialogFragment.DeleteRepeatDialogCallback.class);
+        formEntryViewModel = mockViewModelProvider(activity, FormEntryViewModel.class).get(FormEntryViewModel.class);
     }
 
     @Test
     public void dialogIsNotCancellable() {
         dialogFragment.show(fragmentManager, "TAG");
-        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
-        activity.get().finish();
-        assertThat(dialog.isShowing(), equalTo(true));
+        assertThat(shadowOf(dialogFragment.getDialog()).isCancelable(), equalTo(false));
     }
 
     @Test
     public void shouldShowCorrectMessage() {
-        when(dialogFragment.formController.getLastRepeatedGroupName()).thenReturn("blah");
-        when(dialogFragment.formController.getLastRepeatedGroupRepeatCount()).thenReturn(0);
+        when(formEntryViewModel.getLastRepeatedGroupName()).thenReturn("blah");
+        when(formEntryViewModel.getLastRepeatedGroupRepeatCount()).thenReturn(0);
         dialogFragment.show(fragmentManager, "TAG");
         AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
         String message = ((TextView) dialog.findViewById(android.R.id.message)).getText().toString();

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -1,0 +1,72 @@
+package org.odk.collect.android.formentry.repeats;
+
+import android.content.DialogInterface;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowDialog;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class DeleteRepeatDialogFragmentTest {
+
+    private ActivityController<FragmentActivity> activity;
+    private FragmentManager fragmentManager;
+    private DeleteRepeatDialogFragment dialogFragment;
+
+    @Before
+    public void setup() {
+        activity = RobolectricHelpers.buildThemedActivity(FragmentActivity.class);
+        activity.setup();
+
+        fragmentManager = activity.get().getSupportFragmentManager();
+        dialogFragment = new DeleteRepeatDialogFragment();
+    }
+
+    @Test
+    public void dialogIsCancellable() {
+        dialogFragment.show(fragmentManager, "TAG");
+        assertThat(shadowOf(dialogFragment.getDialog()).isCancelable(), equalTo(true));
+    }
+
+    @Test
+    public void shouldShowCorrectMessage() {}
+
+    @Test
+    public void shouldRetainMessageOnScreenRotation() {}
+
+    @Test
+    public void clickingCancel_shouldDismissTheDialog() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        assertTrue(dialog.isShowing());
+
+        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
+        assertFalse(dialog.isShowing());
+        assertTrue(shadowOf(dialog).hasBeenDismissed());
+    }
+
+    @Test
+    public void clickingRemoveGroup_shouldDismissTheDialog() {
+        dialogFragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        assertTrue(dialog.isShowing());
+
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
+        assertFalse(dialog.isShowing());
+        assertTrue(shadowOf(dialog).hasBeenDismissed());
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -1,7 +1,6 @@
 package org.odk.collect.android.formentry.repeats;
 
 import android.content.DialogInterface;
-import android.content.res.Configuration;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
@@ -64,22 +63,6 @@ public class DeleteRepeatDialogFragmentTest {
         String message = ((TextView) dialog.findViewById(android.R.id.message)).getText().toString();
 
         assertThat(message, equalTo(RuntimeEnvironment.application.getString(R.string.delete_repeat_confirm, "blah (1)")));
-    }
-
-    @Test
-    public void shouldRetainMessageOnScreenRotation() {
-        dialogFragment.show(fragmentManager, "TAG");
-        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
-        String message = ((TextView) dialog.findViewById(android.R.id.message)).getText().toString();
-
-        assertThat(activity.get().getResources().getConfiguration().orientation, equalTo(Configuration.ORIENTATION_PORTRAIT));
-        RuntimeEnvironment.setQualifiers("+land");
-        activity.configurationChange();
-        assertThat(activity.get().getResources().getConfiguration().orientation, equalTo(Configuration.ORIENTATION_LANDSCAPE));
-
-        DeleteRepeatDialogFragment restoredFragment = (DeleteRepeatDialogFragment) activity.get().getSupportFragmentManager().findFragmentByTag("TAG");
-        AlertDialog restoredDialog = (AlertDialog) restoredFragment.getDialog();
-        assertThat(((TextView) restoredDialog.findViewById(android.R.id.message)).getText().toString(), equalTo(message));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -37,9 +37,11 @@ public class DeleteRepeatDialogFragmentTest {
     }
 
     @Test
-    public void dialogIsCancellable() {
+    public void dialogIsNotCancellable() {
         dialogFragment.show(fragmentManager, "TAG");
-        assertThat(shadowOf(dialogFragment.getDialog()).isCancelable(), equalTo(true));
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        activity.get().finish();
+        assertThat(dialog.isShowing(), equalTo(true));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragmentTest.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.formentry.repeats;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.widget.TextView;
 
@@ -22,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.support.RobolectricHelpers.mockViewModelProvider;
@@ -89,7 +89,7 @@ public class DeleteRepeatDialogFragmentTest {
         dialogFragment.show(fragmentManager, "TAG");
         AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
-        verify(dialogFragment.callback, times(1)).deleteGroup();
+        verify(dialogFragment.callback).deleteGroup();
     }
 
     @Test
@@ -97,6 +97,6 @@ public class DeleteRepeatDialogFragmentTest {
         dialogFragment.show(fragmentManager, "TAG");
         AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
         dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
-        verify(dialogFragment.callback, times(1)).onCancelled();
+        verify(dialogFragment.callback).onCancelled();
     }
 }


### PR DESCRIPTION
Work towards #3612

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
This PR contains the fix for Remove Response Dialog. I tested it.

#### Why is this the best possible solution? Were any other approaches considered?
I shifted the creating of Alert Dialog to Dialog Fragment and wrote tests for the same.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks.

#### Do we need any specific form for testing your changes? If so, please attach one.
nested-repeats.xml would work ([nested-repeats.xml.txt](https://github.com/getodk/collect/files/4640404/nested-repeats.xml.txt))

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)