### PR TITLE
Fixed not tappable map area

### DIFF
--- a/collect_app/src/main/res/layout/instance_map_layout.xml
+++ b/collect_app/src/main/res/layout/instance_map_layout.xml
@@ -49,7 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
             android:layout_below="@+id/form_title"
-            android:layout_above="@+id/new_instance">
+            android:layout_marginBottom="100dp">
 
             <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Closes #3829 

#### What has been done to verify that this works as intended?
I tested the fix manually on various devices.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix. Before we had a scroll view which consumed the whole space vertically so despite the fact it was empty it covered the map. I fixed it and now everything should be fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is related to `FormMapActivity` so it's the map view we can open from the Fill Blank Form list to show saved instances on the map. No other parts of the app can be affected by this pr. It's a safe change that should just fix the tappable area.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with geopoint widget.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)