### PR TITLE
Prevent crash when adding repeat from hierarchy

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -138,13 +138,13 @@ import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DestroyableLifecyleOwner;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.android.utilities.QuestionFontSizeUtils;
 import org.odk.collect.android.utilities.FormNameUtils;
 import org.odk.collect.android.utilities.ImageConverter;
 import org.odk.collect.android.utilities.MediaManager;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.PlayServicesUtil;
+import org.odk.collect.android.utilities.QuestionFontSizeUtils;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.SnackbarUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
@@ -749,10 +749,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         // If we're coming back from the hierarchy view, the user has either tapped the back
         // button or another question to jump to so we need to rebuild the view.
         if (requestCode == RequestCodes.HIERARCHY_ACTIVITY) {
-            if (resultCode == FormHierarchyActivity.RESULT_ADD_REPEAT) {
-                formEntryViewModel.addRepeat(false);
-            }
-
             refreshCurrentView();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -14,7 +14,6 @@
 
 package org.odk.collect.android.activities;
 
-import androidx.appcompat.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.Menu;
@@ -23,8 +22,10 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -41,6 +42,7 @@ import org.odk.collect.android.adapters.HierarchyListAdapter;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.JavaRosaException;
+import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.formentry.ODKView;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.logic.HierarchyElement;
@@ -54,8 +56,8 @@ import javax.inject.Inject;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getPreviousLevel;
 import static org.odk.collect.android.analytics.AnalyticsEvents.NULL_FORM_CONTROLLER_EVENT;
+import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getPreviousLevel;
 
 public class FormHierarchyActivity extends CollectAbstractActivity {
 
@@ -115,6 +117,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     @Inject
     Analytics analytics;
 
+    private FormEntryViewModel formEntryViewModel;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -138,6 +142,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             analytics.logEvent(NULL_FORM_CONTROLLER_EVENT, "FormHierarchyActivity", null);
             return;
         }
+
+        formEntryViewModel = new ViewModelProvider(this, new FormEntryViewModel.Factory(analytics)).get(FormEntryViewModel.class);
+        formEntryViewModel.formLoaded(Collect.getInstance().getFormController());
 
         startIndex = formController.getFormIndex();
 
@@ -272,8 +279,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             case R.id.menu_add_repeat:
                 Collect.getInstance().getFormController().jumpToIndex(repeatGroupPickerIndex);
-                Collect.getInstance().getFormController().jumpToNewRepeatPrompt();
-                setResult(RESULT_ADD_REPEAT);
+                formEntryViewModel.jumpToNewRepeat();
+                formEntryViewModel.addRepeat(false);
+
                 finish();
                 return true;
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -19,7 +19,6 @@ import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getRepeatGr
 
 public class FormEntryViewModel extends ViewModel implements RequiresFormController {
 
-
     private final Analytics analytics;
     private final MutableLiveData<String> error = new MutableLiveData<>(null);
 
@@ -59,6 +58,10 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         }
 
         jumpBackIndex = formController.getFormIndex();
+        jumpToNewRepeat();
+    }
+
+    public void jumpToNewRepeat() {
         formController.jumpToNewRepeatPrompt();
     }
 


### PR DESCRIPTION
Closes #3844 

#### What has been done to verify that this works as intended?

Tests failed when running with "Don't keep activities" option so was able to verify that way.

#### Why is this the best possible solution? Were any other approaches considered?

I think using the `FormEntryViewModel` in the hierarchy activity seems a little strange but I think that's mainly because of the static state it relies on in the `FormController`. In the future it looks like really we'd want to be able to initialize the `FormEntryViewModel` with a form and a starting point ("index"). That or the hierarchy view would be a Fragment in the `FormEntryActivity`. I think for the moment it's nice that we can pull logic into "view actions" in the view model from the `FormHierarchyActivity`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the crash! Good to check repeats and creating them from the hierarchy view.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)