### PR TITLE
Fixed Dialog Button for Experimental Magenta Theme

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -27,6 +27,7 @@ import android.view.View.OnClickListener;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -102,7 +103,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     private static final String FORM_VERSION_KEY = "formversion";
 
     private AlertDialog alertDialog;
-    private ProgressDialog progressDialog;
+    private AlertDialog progressDialog;
     private ProgressDialog cancelDialog;
     private Button downloadButton;
 
@@ -683,7 +684,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     }
 
     private void createProgressDialog() {
-        progressDialog = new ProgressDialog(this);
+        progressDialog = new AlertDialog.Builder(this).create();
         DialogInterface.OnClickListener loadingButtonListener =
                 new DialogInterface.OnClickListener() {
                     @Override
@@ -713,12 +714,17 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
                         viewModel.setProgressDialogShowing(false);
                     }
                 };
+
         progressDialog.setTitle(getString(R.string.downloading_data));
-        progressDialog.setMessage(viewModel.getProgressDialogMsg());
+
+        View dialogView = this.getLayoutInflater().inflate(R.layout.progress_dialog, null, false);
+        TextView textView = dialogView.findViewById(R.id.message);
+        textView.setText(viewModel.getProgressDialogMsg());
+
+        progressDialog.setView(dialogView);
         progressDialog.setIcon(android.R.drawable.ic_dialog_info);
-        progressDialog.setIndeterminate(true);
         progressDialog.setCancelable(false);
-        progressDialog.setButton(getString(R.string.cancel), loadingButtonListener);
+        progressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.cancel), loadingButtonListener);
         viewModel.setProgressDialogShowing(true);
         DialogUtils.showDialog(progressDialog, this);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -31,8 +31,6 @@ import android.widget.ListView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.odk.collect.android.R;
@@ -42,7 +40,6 @@ import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.formentry.RefreshFormListDialogFragment;
-import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.DownloadFormsTaskListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
@@ -258,19 +255,13 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         if (getLastCustomNonConfigurationInstance() instanceof DownloadFormListTask) {
             downloadFormListTask = (DownloadFormListTask) getLastCustomNonConfigurationInstance();
             if (downloadFormListTask.getStatus() == AsyncTask.Status.FINISHED) {
-                Fragment dialogFragment = getSupportFragmentManager().findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
-                if (dialogFragment != null) {
-                    ((DialogFragment) dialogFragment).dismiss();
-                }
+                DialogUtils.dismissDialog(RefreshFormListDialogFragment.class, getSupportFragmentManager());
                 downloadFormsTask = null;
             }
         } else if (getLastCustomNonConfigurationInstance() instanceof DownloadFormsTask) {
             downloadFormsTask = (DownloadFormsTask) getLastCustomNonConfigurationInstance();
             if (downloadFormsTask.getStatus() == AsyncTask.Status.FINISHED) {
-                Fragment dialogFragment = getSupportFragmentManager().findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
-                if (dialogFragment != null) {
-                    ((DialogFragment) dialogFragment).dismiss();
-                }
+                DialogUtils.dismissDialog(RefreshFormListDialogFragment.class, getSupportFragmentManager());
                 downloadFormsTask = null;
             }
         } else if (viewModel.getFormDetailsByFormId().isEmpty()
@@ -319,7 +310,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         } else {
             viewModel.clearFormDetailsByFormId();
             refreshFormListDialogFragment = new RefreshFormListDialogFragment();
-            refreshFormListDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+            refreshFormListDialogFragment.show(getSupportFragmentManager(), RefreshFormListDialogFragment.class.getName());
 
             if (downloadFormListTask != null
                     && downloadFormListTask.getStatus() != AsyncTask.Status.FINISHED) {
@@ -435,7 +426,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         if (totalCount > 0) {
             // show dialog box
             refreshFormListDialogFragment = new RefreshFormListDialogFragment();
-            refreshFormListDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+            refreshFormListDialogFragment.show(getSupportFragmentManager(), RefreshFormListDialogFragment.class.getName());
 
             downloadFormsTask = new DownloadFormsTask();
             downloadFormsTask.setDownloaderListener(this);
@@ -534,10 +525,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
      * <form_id, formdetails> tuples, or one tuple of DL.ERROR.MSG and the associated message.
      */
     public void formListDownloadingComplete(HashMap<String, FormDetails> result) {
-        Fragment dialogFragment = getSupportFragmentManager().findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
-        if (dialogFragment != null) {
-            ((DialogFragment) dialogFragment).dismiss();
-        }
+        DialogUtils.dismissDialog(RefreshFormListDialogFragment.class, getSupportFragmentManager());
         downloadFormListTask.setDownloaderListener(null);
         downloadFormListTask = null;
 
@@ -701,7 +689,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     @Override
     public void progressUpdate(String currentFile, int progress, int total) {
         refreshFormListDialogFragment = (RefreshFormListDialogFragment) getSupportFragmentManager()
-                .findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+                .findFragmentByTag(RefreshFormListDialogFragment.class.getName());
         refreshFormListDialogFragment.setMessage(getString(R.string.fetching_file, currentFile,
                 String.valueOf(progress), String.valueOf(total)));
     }
@@ -714,11 +702,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
         cleanUpWebCredentials();
 
-        Fragment dialogFragment = getSupportFragmentManager().findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
-        if (dialogFragment != null) {
-            ((DialogFragment) dialogFragment).dismiss();
-        }
-
+        DialogUtils.dismissDialog(RefreshFormListDialogFragment.class, getSupportFragmentManager());
         createAlertDialog(getString(R.string.download_forms_result), getDownloadResultMessage(result), EXIT);
 
         // Set result to true for forms which were downloaded

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -107,7 +107,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     private ProgressDialog cancelDialog;
     private Button downloadButton;
 
-    private RefreshFormListDialogFragment refreshFormListDialogFragment;
     private DownloadFormListTask downloadFormListTask;
     private DownloadFormsTask downloadFormsTask;
     private Button toggleButton;
@@ -309,8 +308,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
             }
         } else {
             viewModel.clearFormDetailsByFormId();
-            refreshFormListDialogFragment = new RefreshFormListDialogFragment();
-            refreshFormListDialogFragment.show(getSupportFragmentManager(), RefreshFormListDialogFragment.class.getName());
+            DialogUtils.showIfNotShowing(RefreshFormListDialogFragment.class, getSupportFragmentManager());
 
             if (downloadFormListTask != null
                     && downloadFormListTask.getStatus() != AsyncTask.Status.FINISHED) {
@@ -425,8 +423,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         int totalCount = filesToDownload.size();
         if (totalCount > 0) {
             // show dialog box
-            refreshFormListDialogFragment = new RefreshFormListDialogFragment();
-            refreshFormListDialogFragment.show(getSupportFragmentManager(), RefreshFormListDialogFragment.class.getName());
+            DialogUtils.showIfNotShowing(RefreshFormListDialogFragment.class, getSupportFragmentManager());
 
             downloadFormsTask = new DownloadFormsTask();
             downloadFormsTask.setDownloaderListener(this);
@@ -688,9 +685,9 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
     @Override
     public void progressUpdate(String currentFile, int progress, int total) {
-        refreshFormListDialogFragment = (RefreshFormListDialogFragment) getSupportFragmentManager()
+        RefreshFormListDialogFragment fragment = (RefreshFormListDialogFragment) getSupportFragmentManager()
                 .findFragmentByTag(RefreshFormListDialogFragment.class.getName());
-        refreshFormListDialogFragment.setMessage(getString(R.string.fetching_file, currentFile,
+        fragment.setMessage(getString(R.string.fetching_file, currentFile,
                 String.valueOf(progress), String.valueOf(total)));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -700,8 +700,10 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
     @Override
     public void progressUpdate(String currentFile, int progress, int total) {
-        viewModel.setProgressDialogMsg(getString(R.string.fetching_file, currentFile, String.valueOf(progress), String.valueOf(total)));
-//        progressDialog.setMessage(viewModel.getProgressDialogMsg());
+        refreshFormListDialogFragment = (RefreshFormListDialogFragment) getSupportFragmentManager()
+                .findFragmentByTag(ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+        refreshFormListDialogFragment.setMessage(getString(R.string.fetching_file, currentFile,
+                String.valueOf(progress), String.valueOf(total)));
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormDownloadListViewModel.java
@@ -53,7 +53,6 @@ public class FormDownloadListViewModel extends ViewModel {
     private String progressDialogMsg;
     private String alertDialogMsg;
 
-    private boolean progressDialogShowing;
     private boolean alertShowing;
     private boolean cancelDialogShowing;
     private boolean shouldExit;
@@ -201,14 +200,6 @@ public class FormDownloadListViewModel extends ViewModel {
 
     public void setFormIdsToDownload(String[] formIdsToDownload) {
         this.formIdsToDownload = formIdsToDownload;
-    }
-
-    public boolean isProgressDialogShowing() {
-        return progressDialogShowing;
-    }
-
-    public void setProgressDialogShowing(boolean progressDialogShowing) {
-        this.progressDialogShowing = progressDialogShowing;
     }
 
     public boolean isCancelDialogShowing() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
@@ -1,0 +1,19 @@
+package org.odk.collect.android.formentry;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
+
+public class RefreshFormListDialogFragment extends ProgressDialogFragment {
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        setTitle(getString(R.string.downloading_data));
+        setMessage(Collect.getInstance().getString(R.string.please_wait));
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
@@ -12,7 +12,7 @@ import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 
 public class RefreshFormListDialogFragment extends ProgressDialogFragment {
 
-    private RefreshFormListDialogFragmentListener listener;
+    protected RefreshFormListDialogFragmentListener listener;
 
     @Override
     public void onAttach(@NonNull Context context) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
@@ -1,8 +1,10 @@
 package org.odk.collect.android.formentry;
 
+import android.app.Dialog;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
@@ -10,10 +12,40 @@ import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 
 public class RefreshFormListDialogFragment extends ProgressDialogFragment {
 
+    private RefreshFormListDialogFragmentListener listener;
+
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
+
+        if (context instanceof RefreshFormListDialogFragmentListener) {
+            listener = (RefreshFormListDialogFragmentListener) context;
+        }
         setTitle(getString(R.string.downloading_data));
         setMessage(Collect.getInstance().getString(R.string.please_wait));
+        setCancelable(false);
+    }
+
+    @Override
+    public void setupDialog(@NonNull Dialog dialog, int style) {
+        ((AlertDialog) dialog).setIcon(android.R.drawable.ic_dialog_info);
+    }
+
+    @Override
+    protected String getCancelButtonText() {
+        return getString(R.string.cancel_loading_form);
+    }
+
+    @Override
+    protected Cancellable getCancellable() {
+        return () -> {
+            listener.onCancelFormLoading();
+            dismiss();
+            return true;
+        };
+    }
+
+    public interface RefreshFormListDialogFragmentListener {
+            void onCancelFormLoading();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
@@ -101,7 +101,6 @@ public class ProgressDialogFragment extends DialogFragment {
         }
 
         if (getArguments() != null && getArguments().getString(MESSAGE) != null) {
-            ((TextView) dialogView.findViewById(R.id.message)).setTextAppearance(getActivity(), R.style.TextAppearance_Collect_Body1);
             ((TextView) dialogView.findViewById(R.id.message)).setText(getArguments().getString(MESSAGE));
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
@@ -101,6 +101,7 @@ public class ProgressDialogFragment extends DialogFragment {
         }
 
         if (getArguments() != null && getArguments().getString(MESSAGE) != null) {
+            ((TextView) dialogView.findViewById(R.id.message)).setTextAppearance(getActivity(), R.style.TextAppearance_Collect_Body1);
             ((TextView) dialogView.findViewById(R.id.message)).setText(getArguments().getString(MESSAGE));
         }
 

--- a/collect_app/src/main/res/layout/progress_dialog.xml
+++ b/collect_app/src/main/res/layout/progress_dialog.xml
@@ -18,11 +18,11 @@
 
     <TextView
         android:layout_marginStart="@dimen/margin_standard"
-        android:textAppearance="@style/TextAppearance.Collect.Body1"
         android:id="@+id/message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toEndOf="@id/progress_bar"
+        android:layout_centerVertical="true"
         tools:text="Loading..." />
 
 </RelativeLayout>

--- a/collect_app/src/main/res/layout/progress_dialog.xml
+++ b/collect_app/src/main/res/layout/progress_dialog.xml
@@ -18,6 +18,7 @@
 
     <TextView
         android:layout_marginStart="@dimen/margin_standard"
+        android:textAppearance="@style/TextAppearance.Collect.Body1"
         android:id="@+id/message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/RefreshFormListDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/RefreshFormListDialogFragmentTest.java
@@ -1,0 +1,33 @@
+package org.odk.collect.android.formentry;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class RefreshFormListDialogFragmentTest {
+
+    private FragmentManager fragmentManager;
+
+    @Before
+    public void setup() {
+        FragmentActivity activity = Robolectric.setupActivity(FragmentActivity.class);
+        fragmentManager = activity.getSupportFragmentManager();
+    }
+
+    @Test
+    public void dialogIsNotCancellable() {
+        FormLoadingDialogFragment fragment = new FormLoadingDialogFragment();
+        fragment.show(fragmentManager, "TAG");
+        assertThat(shadowOf(fragment.getDialog()).isCancelable(), equalTo(false));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/RefreshFormListDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/RefreshFormListDialogFragmentTest.java
@@ -1,33 +1,50 @@
 package org.odk.collect.android.formentry;
 
+
+import android.content.DialogInterface;
+
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
+import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowDialog;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 public class RefreshFormListDialogFragmentTest {
 
     private FragmentManager fragmentManager;
+    private RefreshFormListDialogFragment fragment;
 
     @Before
     public void setup() {
-        FragmentActivity activity = Robolectric.setupActivity(FragmentActivity.class);
+        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class);
         fragmentManager = activity.getSupportFragmentManager();
+        fragment = new RefreshFormListDialogFragment();
+        fragment.listener = mock(RefreshFormListDialogFragment.RefreshFormListDialogFragmentListener.class);
     }
 
     @Test
     public void dialogIsNotCancellable() {
-        FormLoadingDialogFragment fragment = new FormLoadingDialogFragment();
         fragment.show(fragmentManager, "TAG");
         assertThat(shadowOf(fragment.getDialog()).isCancelable(), equalTo(false));
+    }
+
+    @Test
+    public void clickingCancel_calls_onCancelFormLoading() {
+        fragment.show(fragmentManager, "TAG");
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick();
+        verify(fragment.listener).onCancelFormLoading();
     }
 }


### PR DESCRIPTION
Work towards #3849

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it.

Light Theme           |     Magenta Theme
:-------------------------:|:-------------------------:
![WhatsApp Image 2020-05-31 at 18 24 49 (1)](https://user-images.githubusercontent.com/35730054/83352891-6684dc00-a36c-11ea-8aed-6192bb5bd9c2.jpeg)  |  ![WhatsApp Image 2020-05-31 at 18 24 49](https://user-images.githubusercontent.com/35730054/83352900-6f75ad80-a36c-11ea-9c4a-810480b138ba.jpeg)
  

#### Why is this the best possible solution? Were any other approaches considered?
I replaced Progress dialog with Alert dialog, and inflated the view with `progress_dialog.xml` file.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)