### PR TITLE
Don't try to initialize mapbox every time the main menu is displayed 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -89,6 +89,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import timber.log.Timber;
 
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_MAPBOX_INITIALIZED;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_SUBMISSION_TRANSPORT_TYPE;
 import static org.odk.collect.android.utilities.DialogUtils.getDialog;
 import static org.odk.collect.android.utilities.DialogUtils.showIfNotShowing;
@@ -145,6 +146,9 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
 
     @Inject
     NetworkStateProvider connectivityProvider;
+
+    @Inject
+    GeneralSharedPreferences generalSharedPreferences;
 
     private MainMenuViewModel viewModel;
 
@@ -395,14 +399,16 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     private void initMapBox() {
-        if (connectivityProvider.isDeviceOnline()) {
+        if (!generalSharedPreferences.getBoolean(KEY_MAPBOX_INITIALIZED, false) && connectivityProvider.isDeviceOnline()) {
             // This "one weird trick" lets us initialize MapBox at app start when the internet is
             // most likely to be available. This is annoyingly needed for offline tiles to work.
             try {
                 MapView mapView = new MapView(this);
                 FrameLayout mapboxContainer = findViewById(R.id.mapbox_container);
                 mapboxContainer.addView(mapView);
-                mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
+                mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+                    generalSharedPreferences.save(KEY_MAPBOX_INITIALIZED, true);
+                }));
             } catch (Exception | Error ignored) {
                 // This will crash on devices where the arch for MapBox is not included
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -542,7 +542,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             Map<String, Object> entries = (Map<String, Object>) input.readObject();
 
             AutoSendPreferenceMigrator.migrate(entries);
-            PreferenceSaver.saveGeneralPrefs(GeneralSharedPreferences.getInstance(), entries);
+            PreferenceSaver.saveGeneralPrefs(generalSharedPreferences, entries);
 
             // second object is admin options
             Map<String, Object> adminEntries = (Map<String, Object>) input.readObject();
@@ -624,8 +624,8 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     private void disableSmsIfNeeded() {
-        if (Transport.Internet != Transport.fromPreference(GeneralSharedPreferences.getInstance().get(KEY_SUBMISSION_TRANSPORT_TYPE))) {
-            GeneralSharedPreferences.getInstance().save(KEY_SUBMISSION_TRANSPORT_TYPE, getString(R.string.transport_type_value_internet));
+        if (Transport.Internet != Transport.fromPreference(generalSharedPreferences.get(KEY_SUBMISSION_TRANSPORT_TYPE))) {
+            generalSharedPreferences.save(KEY_SUBMISSION_TRANSPORT_TYPE, getString(R.string.transport_type_value_internet));
 
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -46,6 +46,7 @@ import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.network.NetworkStateProvider;
 import org.odk.collect.material.MaterialBanner;
 import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
@@ -141,6 +142,9 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
 
     @Inject
     VersionInformation versionInformation;
+
+    @Inject
+    NetworkStateProvider connectivityProvider;
 
     private MainMenuViewModel viewModel;
 
@@ -391,15 +395,17 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     private void initMapBox() {
-        // This "one weird trick" lets us initialize MapBox at app start when the internet is
-        // most likely to be available. This is annoyingly needed for offline tiles to work.
-        try {
-            MapView mapView = new MapView(this);
-            FrameLayout mapboxContainer = findViewById(R.id.mapbox_container);
-            mapboxContainer.addView(mapView);
-            mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
-        } catch (Exception | Error ignored) {
-            // This will crash on devices where the arch for MapBox is not included
+        if (connectivityProvider.isDeviceOnline()) {
+            // This "one weird trick" lets us initialize MapBox at app start when the internet is
+            // most likely to be available. This is annoyingly needed for offline tiles to work.
+            try {
+                MapView mapView = new MapView(this);
+                FrameLayout mapboxContainer = findViewById(R.id.mapbox_container);
+                mapboxContainer.addView(mapView);
+                mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> { }));
+            } catch (Exception | Error ignored) {
+                // This will crash on devices where the arch for MapBox is not included
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralKeys.java
@@ -71,6 +71,7 @@ public final class GeneralKeys {
     public static final String KEY_LAST_VERSION             = "lastVersion";
     public static final String KEY_FIRST_RUN                = "firstRun";
     public static final String KEY_SCOPED_STORAGE_USED      = "scoped_storage_used";
+    public static final String KEY_MAPBOX_INITIALIZED       = "mapbox_initialized";
 
     /** Whether any existing username and email values have been migrated to form metadata */
     static final String KEY_METADATA_MIGRATED               = "metadata_migrated";
@@ -157,7 +158,8 @@ public final class GeneralKeys {
             KEY_METADATA_MIGRATED,
             KEY_AUTOSEND_WIFI,
             KEY_AUTOSEND_NETWORK,
-            KEY_SCOPED_STORAGE_USED
+            KEY_SCOPED_STORAGE_USED,
+            KEY_MAPBOX_INITIALIZED
     );
 
     public static final HashMap<String, Object> DEFAULTS = getHashMap();


### PR DESCRIPTION
Closes #3846

#### What has been done to verify that this works as intended?
I tested the initialization manually.

#### Why is this the best possible solution? Were any other approaches considered?
The QA team is reporting that we have much more ANRs now and even the process of testing is difficult because of that fact. I investigated the issue and according to our reports most of the ANRs come from mapbox https://github.com/mapbox/mapbox-gl-native-android/issues/263.
Seems like it's not our fault but we can at least get rid of initializing mapbox every time the main menu is displayed and thanks to that eliminate those ANRs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is safe and shouldn't affect anything but we could just check if it really works and eliminates ANRs.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)