### PR TITLE
Fix crash when user removes all repeat groups and presses back button

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1200,19 +1200,19 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case FormEntryController.EVENT_REPEAT:
                 // should only be a group here if the event_group is a field-list
                 try {
-                    AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), System.currentTimeMillis());
-
                     FormEntryCaption[] groups = formController
                             .getGroupsForCurrentIndex();
                     FormEntryPrompt[] prompts = formController.getQuestionPrompts();
 
-                    TreeElement treeElement = formController.getFormDef().getInstance().
-                            resolveReference(prompts[0].getIndex().getReference());
-                    if(treeElement == null) {
+                    TreeElement treeElement = formController.getFormDef().getInstance()
+                            .resolveReference(prompts[0].getIndex().getReference());
+                    if (treeElement == null) {
                         formController.getAuditEventLogger().flush();
                         formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
                         return createViewForFormBeginning(formController);
                     }
+
+                    AuditUtils.logCurrentScreen(formController, formController.getAuditEventLogger(), System.currentTimeMillis());
 
                     odkView = createODKView(advancingPage, prompts, groups);
                     odkView.setWidgetValueChangedListener(this);
@@ -1660,18 +1660,17 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     .getQuestionPrompts();
             for (FormEntryPrompt p : prompts) {
 
-                TreeElement treeElement = formController.getFormDef().getInstance().
-                        resolveReference(p.getIndex().getReference());
-                if (treeElement == null) {
-                    break;
-                }
-                List<TreeElement> attrs = p.getBindAttributes();
-                for (int i = 0; i < attrs.size(); i++) {
-                    if (!autoSaved && "saveIncomplete".equals(attrs.get(i).getName())) {
-                        analytics.logEvent(SAVE_INCOMPLETE, "saveIncomplete", Collect.getCurrentFormIdentifierHash());
+                TreeElement treeElement = formController.getFormDef().getInstance()
+                        .resolveReference(p.getIndex().getReference());
+                if (treeElement != null) {
+                    List<TreeElement> attrs = p.getBindAttributes();
+                    for (int i = 0; i < attrs.size(); i++) {
+                        if (!autoSaved && "saveIncomplete".equals(attrs.get(i).getName())) {
+                            analytics.logEvent(SAVE_INCOMPLETE, "saveIncomplete", Collect.getCurrentFormIdentifierHash());
 
-                        saveForm(false, false, null, false);
-                        autoSaved = true;
+                            saveForm(false, false, null, false);
+                            autoSaved = true;
+                        }
                     }
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1206,6 +1206,14 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             .getGroupsForCurrentIndex();
                     FormEntryPrompt[] prompts = formController.getQuestionPrompts();
 
+                    TreeElement treeElement = formController.getFormDef().getInstance().
+                            resolveReference(prompts[0].getIndex().getReference());
+                    if(treeElement == null) {
+                        formController.getAuditEventLogger().flush();
+                        formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+                        return createViewForFormBeginning(formController);
+                    }
+
                     odkView = createODKView(advancingPage, prompts, groups);
                     odkView.setWidgetValueChangedListener(this);
                     Timber.i("Created view for group %s %s",
@@ -1651,6 +1659,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             FormEntryPrompt[] prompts = getFormController()
                     .getQuestionPrompts();
             for (FormEntryPrompt p : prompts) {
+
+                TreeElement treeElement = formController.getFormDef().getInstance().
+                        resolveReference(p.getIndex().getReference());
+                if (treeElement == null) {
+                    break;
+                }
                 List<TreeElement> attrs = p.getBindAttributes();
                 for (int i = 0; i < attrs.size(); i++) {
                     if (!autoSaved && "saveIncomplete".equals(attrs.get(i).getName())) {


### PR DESCRIPTION
Closes #3799 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it for both the cases mentioned in the issue.

#### Why is this the best possible solution? Were any other approaches considered?
When the tree element of the form is null, the user is directed to the beginning of the form to create a new repeat.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risks, as such now.

#### Do we need any specific form for testing your changes? If so, please attach one.
[nested-repeats.xml.txt](https://github.com/getodk/collect/files/4667376/nested-repeats.xml.txt)
[repeatTest.xml.txt](https://github.com/getodk/collect/files/4667377/repeatTest.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)