### PR TITLE
Check for null map field

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -317,7 +317,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity {
     }
 
     @Override public void onBackPressed() {
-        if (!formatPoints(map.getPolyPoints(featureId)).equals(originalAnswerString)) {
+        if (map != null && !formatPoints(map.getPolyPoints(featureId)).equals(originalAnswerString)) {
             showBackDialog();
         } else {
             finish();


### PR DESCRIPTION
Closes #3868 

Steps to reproduce the issue:
1. Install the app without internet connection.
2. Select mapbox in General Settings -> Maps.
3. Go to All widgets for and open GeoShape/GeoTrace widget
4. Click on back button.

#### What has been done to verify that this works as intended?
I tested the fix manually and confirmed it works.

#### Why is this the best possible solution? Were any other approaches considered?
It's the only solution. The issue takes place when mapbox is not initialized due to no internet connection and then such NPE might occur.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix. Reproducing the mentioned steps and confirming it fixes the issue would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with GeoShape/GeoTrace widget.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)