### PR TITLE
Exit form when instance file cannot be created/is null

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -101,6 +101,7 @@ import org.odk.collect.android.formentry.audit.IdentifyUserPromptDialogFragment;
 import org.odk.collect.android.formentry.audit.IdentityPromptViewModel;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationManager;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationViewModel;
+import org.odk.collect.android.formentry.loading.FormInstanceFileCreator;
 import org.odk.collect.android.formentry.repeats.AddRepeatDialog;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.formentry.saving.SaveFormProgressDialogFragment;
@@ -152,6 +153,7 @@ import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangeWidget;
+import org.odk.collect.utilities.Clock;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -315,6 +317,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     @Inject
     NetworkStateProvider connectivityProvider;
+
+    @Inject
+    StoragePathProvider storagePathProvider;
 
     private final LocationProvidersReceiver locationProvidersReceiver = new LocationProvidersReceiver();
 
@@ -616,7 +621,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         formPath.lastIndexOf('.'))
                         + "_";
                 final String fileSuffix = ".xml.save";
-                File cacheDir = new File(new StoragePathProvider().getDirPath(StorageSubdirectory.CACHE));
+                File cacheDir = new File(storagePathProvider.getDirPath(StorageSubdirectory.CACHE));
                 File[] files = cacheDir.listFiles(pathname -> {
                     String name = pathname.getName();
                     return name.startsWith(filePrefix)
@@ -634,7 +639,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                                     candidate.getName().length()
                                             - fileSuffix.length());
                     File instanceDir = new File(
-                            new StoragePathProvider().getDirPath(StorageSubdirectory.INSTANCES) + File.separator
+                            storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + File.separator
                                     + instanceDirName);
                     File instanceFile = new File(instanceDir,
                             instanceDirName + ".xml");
@@ -831,7 +836,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                  */
                 // The intent is empty, but we know we saved the image to the temp
                 // file
-                StoragePathProvider storagePathProvider = new StoragePathProvider();
                 ImageConverter.execute(storagePathProvider.getTmpFilePath(), getWidgetWaitingForBinaryData(), this);
                 File fi = new File(storagePathProvider.getTmpFilePath());
 
@@ -2045,7 +2049,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                                         languages[whichButton]);
                                 String selection = FormsColumns.FORM_FILE_PATH
                                         + "=?";
-                                String[] selectArgs = {new StoragePathProvider().getFormDbPath(formPath)};
+                                String[] selectArgs = {storagePathProvider.getFormDbPath(formPath)};
                                 int updated = new FormsDao().updateForm(values, selection, selectArgs);
                                 Timber.i("Updated language to: %s in %d rows",
                                         languages[whichButton],
@@ -2481,14 +2485,13 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     private void createInstanceDirectory(FormController formController) {
-        String time = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss",
-                Locale.ENGLISH).format(Calendar.getInstance().getTime());
-        String file = formPath.substring(formPath.lastIndexOf('/') + 1,
-                formPath.lastIndexOf('.'));
-        String path = new StoragePathProvider().getDirPath(StorageSubdirectory.INSTANCES) + File.separator + file + "_"
-                + time;
-        if (FileUtils.createFolder(path)) {
-            File instanceFile = new File(path + File.separator + file + "_" + time + ".xml");
+        FormInstanceFileCreator formInstanceFileCreator = new FormInstanceFileCreator(
+                storagePathProvider,
+                System::currentTimeMillis
+        );
+        
+        File instanceFile = formInstanceFileCreator.createInstanceFile(formPath);
+        if (instanceFile != null) {
             formController.setInstanceFile(instanceFile);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2399,7 +2399,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     if (instanceFile != null) {
                         formController.setInstanceFile(instanceFile);
                     } else {
-                        showFormLoadErrorAndExit(getString(R.string.form_instance_file_creation_error));
+                        showFormLoadErrorAndExit(getString(R.string.loading_form_failed));
                     }
 
                     formControllerAvailable(formController);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreator.java
@@ -1,0 +1,37 @@
+package org.odk.collect.android.formentry.loading;
+
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageSubdirectory;
+import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.utilities.Clock;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class FormInstanceFileCreator {
+
+    private final StoragePathProvider storagePathProvider;
+    private final Clock clock;
+
+    public FormInstanceFileCreator(StoragePathProvider storagePathProvider, Clock clock) {
+        this.storagePathProvider = storagePathProvider;
+        this.clock = clock;
+    }
+
+    public File createInstanceFile(String formDefinitionPath) {
+        String timestamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.ENGLISH)
+                .format(new Date(clock.getCurrentTime()));
+        String formFileName = formDefinitionPath.substring(formDefinitionPath.lastIndexOf('/') + 1,
+                formDefinitionPath.lastIndexOf('.'));
+        String instancesDir = storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES);
+        String instanceDir = instancesDir + File.separator + formFileName + "_" + timestamp;
+
+        if (FileUtils.createFolder(instanceDir)) {
+            return new File(instanceDir + File.separator + formFileName + "_" + timestamp + ".xml");
+        } else {
+            return null;
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreator.java
@@ -10,6 +10,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 public class FormInstanceFileCreator {
 
     private final StoragePathProvider storagePathProvider;
@@ -31,6 +33,7 @@ public class FormInstanceFileCreator {
         if (FileUtils.createFolder(instanceDir)) {
             return new File(instanceDir + File.separator + formFileName + "_" + timestamp + ".xml");
         } else {
+            Timber.e("Error creating form instance file");
             return null;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -195,21 +195,17 @@ public class FormController {
     }
 
     public AuditEventLogger getAuditEventLogger() {
-        if (auditEventLogger == null && instanceFile != null) {
+        if (auditEventLogger == null) {
             AuditConfig auditConfig = getSubmissionMetadata().auditConfig;
 
             if (auditConfig != null) {
-                setAuditEventLogger(new AuditEventLogger(auditConfig, new AsyncTaskAuditEventWriter(new File(instanceFile.getParentFile().getPath() + File.separator + AUDIT_FILE_NAME), auditConfig.isLocationEnabled(), auditConfig.isTrackingChangesEnabled(), auditConfig.isIdentifyUserEnabled(), auditConfig.isTrackChangesReasonEnabled()), this));
+                auditEventLogger = new AuditEventLogger(auditConfig, new AsyncTaskAuditEventWriter(new File(instanceFile.getParentFile().getPath() + File.separator + AUDIT_FILE_NAME), auditConfig.isLocationEnabled(), auditConfig.isTrackingChangesEnabled(), auditConfig.isIdentifyUserEnabled(), auditConfig.isTrackChangesReasonEnabled()), this);
             } else {
-                setAuditEventLogger(new AuditEventLogger(null, null, this));
+                auditEventLogger = new AuditEventLogger(null, null, this);
             }
         }
 
         return auditEventLogger;
-    }
-
-    private void setAuditEventLogger(AuditEventLogger logger) {
-        auditEventLogger = logger;
     }
 
     /**

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -743,5 +743,4 @@
 
     <string name="install_id">Install ID - will replace Device ID in August 2020</string>
     <string name="preference_not_available">Not available</string>
-    <string name="form_instance_file_creation_error">Form instance file could not be created!</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -743,4 +743,5 @@
 
     <string name="install_id">Install ID - will replace Device ID in August 2020</string>
     <string name="preference_not_available">Not available</string>
+    <string name="form_instance_file_creation_error">Form instance file could not be created!</string>
 </resources>

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreatorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreatorTest.java
@@ -1,0 +1,62 @@
+package org.odk.collect.android.formentry.loading;
+
+import com.google.common.io.Files;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageSubdirectory;
+import org.odk.collect.utilities.Clock;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FormInstanceFileCreatorTest {
+
+    private final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.ENGLISH);
+    private final StoragePathProvider pathProvider = mock(StoragePathProvider.class);
+    private final Clock clock = mock(Clock.class);
+
+    @Test
+    public void createsDirectory_basedOnDefinitionPathAndCurrentTime_inInstancesDirectory() throws Exception {
+        String instancesDir = Files.createTempDir().getAbsolutePath();
+        when(pathProvider.getDirPath(StorageSubdirectory.INSTANCES)).thenReturn(instancesDir);
+        when(clock.getCurrentTime()).thenReturn(simpleDateFormat.parse("1990-04-24_00-00-00").getTime());
+
+        FormInstanceFileCreator instanceFileCreator = new FormInstanceFileCreator(pathProvider, clock);
+        instanceFileCreator.createInstanceFile("/blah/blah/Cool form name.xml");
+
+        File instanceDir = new File(instancesDir + File.separator + "Cool form name_1990-04-24_00-00-00");
+        assertThat(instanceDir.exists(), is(true));
+        assertThat(instanceDir.isDirectory(), is(true));
+    }
+
+    @Test
+    public void returnsInstanceFile_inInstanceDirectory() throws Exception {
+        String instancesDir = Files.createTempDir().getAbsolutePath();
+        when(pathProvider.getDirPath(StorageSubdirectory.INSTANCES)).thenReturn(instancesDir);
+        when(clock.getCurrentTime()).thenReturn(simpleDateFormat.parse("1990-04-24_00-00-00").getTime());
+
+        FormInstanceFileCreator instanceFileCreator = new FormInstanceFileCreator(pathProvider, clock);
+        File instanceFile = instanceFileCreator.createInstanceFile("/blah/blah/Cool form name.xml");
+
+        String instanceDir = instancesDir + File.separator + "Cool form name_1990-04-24_00-00-00";
+        assertThat(instanceFile.getAbsolutePath(), is(instanceDir + File.separator + "Cool form name_1990-04-24_00-00-00.xml"));
+    }
+
+    @Test
+    public void whenCreatingDirFails_returnsNull() throws Exception {
+        when(pathProvider.getDirPath(StorageSubdirectory.INSTANCES)).thenReturn("/not-real");
+        when(clock.getCurrentTime()).thenReturn(simpleDateFormat.parse("1990-04-24_00-00-00").getTime());
+
+        FormInstanceFileCreator instanceFileCreator = new FormInstanceFileCreator(pathProvider, clock);
+        File instanceFile = instanceFileCreator.createInstanceFile("/blah/blah/Cool form name.xml");
+        assertThat(instanceFile, is(nullValue()));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreatorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreatorTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.formentry.loading;
 
 import com.google.common.io.Files;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -13,7 +12,8 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreatorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreatorTest.java
@@ -52,7 +52,8 @@ public class FormInstanceFileCreatorTest {
 
     @Test
     public void whenCreatingDirFails_returnsNull() throws Exception {
-        when(pathProvider.getDirPath(StorageSubdirectory.INSTANCES)).thenReturn("/not-real");
+        File tempFile = File.createTempFile("not-a", "dir"); // Create a file where it needs a dir
+        when(pathProvider.getDirPath(StorageSubdirectory.INSTANCES)).thenReturn(tempFile.getAbsolutePath());
         when(clock.getCurrentTime()).thenReturn(simpleDateFormat.parse("1990-04-24_00-00-00").getTime());
 
         FormInstanceFileCreator instanceFileCreator = new FormInstanceFileCreator(pathProvider, clock);

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
@@ -14,6 +14,9 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 public class FormControllerTest {
 
@@ -72,6 +75,18 @@ public class FormControllerTest {
 
         assertThat(formController.getEvent(), equalTo(FormEntryController.EVENT_PROMPT_NEW_REPEAT));
         assertThat(formController.getFormIndex().toString(), equalTo("0_0, 1_1, "));
+    }
+
+    @Test
+    public void whenInstanceFileAndAuditConfigNull_getAuditEventLogger_isNotNull() throws Exception {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(ONE_QUESTION_NESTED_REPEAT.getBytes());
+        final FormEntryModel fem = new FormEntryModel(XFormUtils.getFormFromInputStream(inputStream));
+        final FormEntryController formEntryController = new FormEntryController(fem);
+        FormController formController = new FormController(Files.createTempDir(), formEntryController, null);
+        assertThat(formController.getSubmissionMetadata().auditConfig, is(nullValue()));
+        assertThat(formController.getInstanceFile(), is(nullValue()));
+
+        assertThat(formController.getAuditEventLogger(), notNullValue());
     }
 
     @NotNull


### PR DESCRIPTION
Should fix crash found at https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/30fcda84f13db871dca574a1b2cba23f?time=last-seven-days&sessionId=5ECDE9E80054000132DF2A24E11F24F0_DNE_2_v2.

This also makes sure we never have a `null` `AuditEventLogger`.

#### What has been done to verify that this works as intended?

Verified we see the error and form entry exits if instance file can't be created. Had to hardcode the failure to reproduce the case.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed before (thanks to @grzesiek2010) for the pointers. I thought adding a specific error message might help us if someone posts this error on the forum.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I'm not sure of a way to reproduce this (which is why I didn't create an issue) but really this should just fix the crash. I think a quick pass on form loading would be good.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)