### PR TITLE
Catch exceptions that might take place while customizing a toast

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.java
@@ -51,10 +51,14 @@ public class ToastUtils {
 
     private static void showToastInMiddle(String message, int duration) {
         Toast toast = Toast.makeText(Collect.getInstance(), message, duration);
-        ViewGroup group = (ViewGroup) toast.getView();
-        TextView messageTextView = (TextView) group.getChildAt(0);
-        messageTextView.setTextSize(21);
-        messageTextView.setGravity(Gravity.CENTER);
+        try {
+            ViewGroup group = (ViewGroup) toast.getView();
+            TextView messageTextView = (TextView) group.getChildAt(0);
+            messageTextView.setTextSize(21);
+            messageTextView.setGravity(Gravity.CENTER);
+        } catch (Exception ignored) {
+            // ignored
+        }
 
         toast.setGravity(Gravity.CENTER, 0, 0);
         toast.show();


### PR DESCRIPTION
Closes #3874 

#### What has been done to verify that this works as intended?
Just reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
Looks like on some devices the approach we use to customize toasts might cause exceptions  when we try to change font size because `group.getChildAt(0);` doesn't return TextView but LinearLayout. Since it''s rare case we can just catch it and keep the default font size when it happens.

Another possible solution would be to create our custom toasts https://medium.com/@francis4dblues/custom-toast-views-in-android-1e1e7352351c
but I think it doesn't make sense in this case because:
1. The issue is rare
2. Even if the exception takes place and we catch it, it will work but with default font size so not a big problem.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)