### PR TITLE
Fixed camera permission required when opening QR code configuration screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BaseCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BaseCodeScannerFragment.java
@@ -38,8 +38,6 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
-import org.odk.collect.android.listeners.PermissionListener;
-import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 
 import java.io.IOException;
@@ -69,30 +67,20 @@ public abstract class BaseCodeScannerFragment extends Fragment implements Decora
             switchToFrontCamera();
         }
 
-        new PermissionUtils().requestCameraPermission(getActivity(), new PermissionListener() {
+        barcodeScannerView.decodeContinuous(new BarcodeCallback() {
             @Override
-            public void granted() {
-                barcodeScannerView.decodeContinuous(new BarcodeCallback() {
-                    @Override
-                    public void barcodeResult(BarcodeResult result) {
-                        beepManager.playBeepSoundAndVibrate();
-                        try {
-                            handleScanningResult(result);
-                        } catch (IOException | DataFormatException | IllegalArgumentException e) {
-                            Timber.e(e);
-                            ToastUtils.showShortToast(getString(R.string.invalid_qrcode));
-                        }
-                    }
-
-                    @Override
-                    public void possibleResultPoints(List<ResultPoint> resultPoints) {
-
-                    }
-                });
+            public void barcodeResult(BarcodeResult result) {
+                beepManager.playBeepSoundAndVibrate();
+                try {
+                    handleScanningResult(result);
+                } catch (IOException | DataFormatException | IllegalArgumentException e) {
+                    Timber.e(e);
+                    ToastUtils.showShortToast(getString(R.string.invalid_qrcode));
+                }
             }
 
             @Override
-            public void denied() {
+            public void possibleResultPoints(List<ResultPoint> resultPoints) {
 
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
@@ -73,6 +73,7 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
 
             @Override
             public void denied() {
+                finish();
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
@@ -33,7 +33,6 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.FileProvider;
 import androidx.viewpager2.widget.ViewPager2;
@@ -82,18 +81,13 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
         fragmentTitleList = new String[]{getString(R.string.scan_qr_code_fragment_title),
                 getString(R.string.view_qr_code_fragment_title)};
 
-        ViewPager2 viewPager = (ViewPager2) this.findViewById(R.id.viewPager);
-        TabLayout tabLayout = (TabLayout) this.findViewById(R.id.tabLayout);
+        ViewPager2 viewPager = findViewById(R.id.viewPager);
+        TabLayout tabLayout = findViewById(R.id.tabLayout);
         QRCodeTabsAdapter adapter = new QRCodeTabsAdapter(this);
         viewPager.setAdapter(adapter);
 
-        new TabLayoutMediator(tabLayout, viewPager, new TabLayoutMediator.TabConfigurationStrategy() {
-            @Override
-            public void onConfigureTab(@NonNull TabLayout.Tab tab, int position) {
-                tab.setText(fragmentTitleList[position]);
-            }
-        }).attach();
-        this.updateShareIntent();
+        new TabLayoutMediator(tabLayout, viewPager, (tab, position) -> tab.setText(fragmentTitleList[position])).attach();
+        updateShareIntent();
     }
 
     private void initToolbar() {
@@ -123,9 +117,7 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
             Disposable disposable = qrCodeGenerator.generateQRCode(keys)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(bitmap -> {
-                        startActivity(Intent.createChooser(shareIntent, getString(R.string.share_qrcode)));
-                    }, Timber::e);
+                    .subscribe(bitmap -> startActivity(Intent.createChooser(shareIntent, getString(R.string.share_qrcode))), Timber::e);
             compositeDisposable.add(disposable);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
@@ -13,8 +13,10 @@ import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.utilities.SettingsUtils;
 import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.QRCodeUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
@@ -63,6 +65,19 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
         setContentView(R.layout.qrcode_tab);
         initToolbar();
 
+        new PermissionUtils().requestCameraPermission(this, new PermissionListener() {
+            @Override
+            public void granted() {
+                setupViewPager();
+            }
+
+            @Override
+            public void denied() {
+            }
+        });
+    }
+
+    private void setupViewPager() {
         fragmentTitleList = new String[]{getString(R.string.scan_qr_code_fragment_title),
                 getString(R.string.view_qr_code_fragment_title)};
 


### PR DESCRIPTION
Closes #3867 

#### What has been done to verify that this works as intended?
I tested implemented changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
I'm not sure why but keeping the permission request on a fragment level caused some strange problems so I decided to ask for permission on activity level. Beside the problem described in the issue I noticed also a similar problem when a user denies the permission (the dialog was also duplicated and there was an additional exception).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test camera permission required for scanning QR codes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)