### PR TITLE
Don't allow clicking on symbols/lines if the clicklistener is not set (in GeoWidgets)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -890,7 +890,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
         class SymbolClickListener implements OnSymbolClickListener {
             @Override public void onAnnotationClick(Symbol clickedSymbol) {
                 for (Symbol symbol : symbols) {
-                    if (clickedSymbol.getId() == symbol.getId()) {
+                    if (clickedSymbol.getId() == symbol.getId() && featureClickListener != null) {
                         featureClickListener.onFeature(featureId);
                         break;
                     }
@@ -900,7 +900,7 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
 
         class LineClickListener implements OnLineClickListener {
             @Override public void onAnnotationClick(Line clickedLine) {
-                if (clickedLine.getId() == line.getId()) {
+                if (clickedLine.getId() == line.getId() && featureClickListener != null) {
                     featureClickListener.onFeature(featureId);
                 }
             }


### PR DESCRIPTION
Closes #3879 

#### What has been done to verify that this works as intended?
I reproduced the issue and confirmed that this pr fixes it.

#### Why is this the best possible solution? Were any other approaches considered?
We just don't support clicking on lines or points in `GeoWidgets` it is only used in `FormMapActivity` to show submission summary, so only there the listener is set otherwise it's null and such an action should be ignored.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe change if it needs testing reproducing the steps and confirming that everything is fine will be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)