### PR TITLE
Updated work manager dependency to androidx

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -202,6 +202,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation "androidx.work:work-runtime:2.3.4"
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.1.0'
@@ -283,15 +284,6 @@ dependencies {
     // Better "Subjects" for Rx:
     implementation "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 
-    // WorkManager for specifying deferrable, asynchronous tasks
-    implementation("android.arch.work:work-runtime:1.0.1") {
-        exclude group: 'com.google.guava', module: 'listenablefuture'
-    }
-    // Optional JobDispatcher support so devices with Play Services do better than AlarmManager
-    implementation("android.arch.work:work-firebase:1.0.0-alpha11") {
-        exclude group: 'com.google.guava', module: 'listenablefuture'
-    }
-
     implementation project(':nbi-stubs')
     implementation project(':material')
 
@@ -321,8 +313,6 @@ dependencies {
     testImplementation "org.powermock:powermock-module-junit4:2.0.5"
     testImplementation "org.powermock:powermock-api-mockito2:2.0.5"
 
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-
     testImplementation "org.json:json:20190722"
 
     androidTestImplementation "org.mockito:mockito-android:3.3.3"
@@ -336,7 +326,7 @@ dependencies {
 
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:${rootProject.okhttp3Version}"
 
-    androidTestImplementation "android.arch.work:work-testing:1.0.1"
+    androidTestImplementation "androidx.work:work-testing:2.3.4"
 }
 
 // Must be at bottom to prevent dependency collisions


### PR DESCRIPTION
Closes #3881 

#### What has been done to verify that this works as intended?
Not much since it's something I can't reproduce. I just reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
I think it's a bug fixed in [version 2.2.0-rc01](https://developer.android.com/jetpack/androidx/releases/work#2.2.0-rc01) I don't know why we kept arch (Pre-AndroidX) dependencies. If I had forgotten about something @lognaturel @seadowg please let me know but I guess we just missed it. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It would be good to check auto-send option for example to confirm that there is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)