### PR TITLE
Fixed Failed to find configured root that contains on huawei devices

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/preferences/qr/ConfigureWithQRCodeTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/preferences/qr/ConfigureWithQRCodeTest.java
@@ -8,7 +8,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 
-import androidx.core.content.FileProvider;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -30,6 +29,7 @@ import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.RunnableRule;
 import org.odk.collect.android.support.pages.MainMenuPage;
+import org.odk.collect.android.utilities.ContentUriProvider;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -52,7 +52,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
-
 
 @RunWith(AndroidJUnit4.class)
 public class ConfigureWithQRCodeTest {
@@ -132,7 +131,7 @@ public class ConfigureWithQRCodeTest {
     @Ignore("Should be replaced at Robolectric level")
     public void onMainMenu_clickConfigureQRCode_andClickingOnShareQRCode_startsExternalShareIntent() {
         String path = new StubQRCodeGenerator().getQrCodeFilepath();
-        Uri expected = FileProvider.getUriForFile(getApplicationContext(),
+        Uri expected = ContentUriProvider.getUriForFile(getApplicationContext(),
                 BuildConfig.APPLICATION_ID + ".provider",
                 new File(path));
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -33,7 +33,6 @@ import android.widget.RadioButton;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import androidx.core.content.FileProvider;
 import androidx.lifecycle.LiveData;
 
 import com.google.android.material.button.MaterialButton;
@@ -46,6 +45,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.audio.AudioButton;
 import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.audio.Clip;
+import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.ScreenContext;
@@ -179,7 +179,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
         Intent intent = new Intent("android.intent.action.VIEW");
         Uri uri =
-                FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", videoFile);
+                ContentUriProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", videoFile);
         FileUtils.grantFileReadPermissions(intent, uri, getContext());
         intent.setDataAndType(uri, "video/*");
         if (intent.resolveActivity(getContext().getPackageManager()) != null) {
@@ -229,7 +229,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
             File bigImage = new File(referenceManager.deriveReference(bigImageURI).getLocalURI());
             Intent intent = new Intent("android.intent.action.VIEW");
             Uri uri =
-                    FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", bigImage);
+                    ContentUriProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", bigImage);
             FileUtils.grantFileReadPermissions(intent, uri, getContext());
             intent.setDataAndType(uri, "image/*");
             getContext().startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
@@ -15,7 +15,6 @@ import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.utilities.SettingsUtils;
-import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
@@ -57,9 +56,6 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
 
     @Inject
     QRCodeGenerator qrCodeGenerator;
-
-    @Inject
-    StoragePathProvider storagePathProvider;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -105,7 +101,7 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
         shareIntent = new Intent();
         shareIntent.setAction(Intent.ACTION_SEND);
         shareIntent.setType("image/*");
-        Uri uri = ContentUriProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".provider", new File(qrCodeGenerator.getQrCodeFilepath()), storagePathProvider);
+        Uri uri = ContentUriProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".provider", new File(qrCodeGenerator.getQrCodeFilepath()));
         FileUtils.grantFileReadPermissions(shareIntent, uri, this);
         shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/qr/QRCodeTabsActivity.java
@@ -15,6 +15,8 @@ import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.utilities.SettingsUtils;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.QRCodeUtils;
@@ -34,7 +36,6 @@ import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
 
 import androidx.appcompat.widget.Toolbar;
-import androidx.core.content.FileProvider;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.tabs.TabLayout;
@@ -56,6 +57,9 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
 
     @Inject
     QRCodeGenerator qrCodeGenerator;
+
+    @Inject
+    StoragePathProvider storagePathProvider;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -101,8 +105,7 @@ public class QRCodeTabsActivity extends CollectAbstractActivity {
         shareIntent = new Intent();
         shareIntent.setAction(Intent.ACTION_SEND);
         shareIntent.setType("image/*");
-        Uri uri =
-                FileProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".provider", new File(qrCodeGenerator.getQrCodeFilepath()));
+        Uri uri = ContentUriProvider.getUriForFile(this, BuildConfig.APPLICATION_ID + ".provider", new File(qrCodeGenerator.getQrCodeFilepath()), storagePathProvider);
         FileUtils.grantFileReadPermissions(shareIntent, uri, this);
         shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
@@ -1,0 +1,65 @@
+package org.odk.collect.android.utilities;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.FileProvider;
+
+import org.apache.commons.io.IOUtils;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageSubdirectory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import timber.log.Timber;
+
+public class ContentUriProvider {
+    private static final String HUAWEI_MANUFACTURER = "Huawei";
+
+    private ContentUriProvider() {
+    }
+
+    // https://stackoverflow.com/a/41309223/5479029
+    public static Uri getUriForFile(@NonNull Context context, @NonNull String authority, @NonNull File file, StoragePathProvider storagePathProvider) {
+        if (HUAWEI_MANUFACTURER.equalsIgnoreCase(Build.MANUFACTURER)) {
+            Timber.w(ContentUriProvider.class.getSimpleName(), "Using a Huawei device Increased likelihood of failure...");
+            try {
+                return FileProvider.getUriForFile(context, authority, file);
+            } catch (IllegalArgumentException e) {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                    Timber.w(e, ContentUriProvider.class.getSimpleName(), "Returning Uri.fromFile to avoid Huawei 'external-files-path' bug for pre-N devices");
+                    return Uri.fromFile(file);
+                } else {
+                    Timber.w(e, ContentUriProvider.class.getSimpleName(), "ANR Risk -- Copying the file the location cache to avoid Huawei 'external-files-path' bug for N+ devices");
+                    // Note: Periodically clear this cache
+                    final File cacheFolder = new File(storagePathProvider.getDirPath(StorageSubdirectory.CACHE), HUAWEI_MANUFACTURER);
+                    final File cacheLocation = new File(cacheFolder, file.getName());
+                    InputStream in = null;
+                    OutputStream out = null;
+                    try {
+                        in = new FileInputStream(file);
+                        out = new FileOutputStream(cacheLocation); // appending output stream
+                        IOUtils.copy(in, out);
+                        Timber.i(ContentUriProvider.class.getSimpleName(), "Completed Android N+ Huawei file copy. Attempting to return the cached file");
+                        return FileProvider.getUriForFile(context, authority, cacheLocation);
+                    } catch (IOException e1) {
+                        Timber.e(e1, ContentUriProvider.class.getSimpleName(), "Failed to copy the Huawei file. Re-throwing exception");
+                        throw new IllegalArgumentException("Huawei devices are unsupported for Android N", e1);
+                    } finally {
+                        IOUtils.closeQuietly(in);
+                        IOUtils.closeQuietly(out);
+                    }
+                }
+            }
+        } else {
+            return FileProvider.getUriForFile(context, authority, file);
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
@@ -27,7 +27,7 @@ public class ContentUriProvider {
     }
 
     // https://stackoverflow.com/a/41309223/5479029
-    public static Uri getUriForFile(@NonNull Context context, @NonNull String authority, @NonNull File file, StoragePathProvider storagePathProvider) {
+    public static Uri getUriForFile(@NonNull Context context, @NonNull String authority, @NonNull File file) {
         if (HUAWEI_MANUFACTURER.equalsIgnoreCase(Build.MANUFACTURER)) {
             Timber.w(ContentUriProvider.class.getSimpleName(), "Using a Huawei device Increased likelihood of failure...");
             try {
@@ -39,7 +39,7 @@ public class ContentUriProvider {
                 } else {
                     Timber.w(e, ContentUriProvider.class.getSimpleName(), "ANR Risk -- Copying the file the location cache to avoid Huawei 'external-files-path' bug for N+ devices");
                     // Note: Periodically clear this cache
-                    final File cacheFolder = new File(storagePathProvider.getDirPath(StorageSubdirectory.CACHE), HUAWEI_MANUFACTURER);
+                    final File cacheFolder = new File(new StoragePathProvider().getDirPath(StorageSubdirectory.CACHE), HUAWEI_MANUFACTURER);
                     final File cacheLocation = new File(cacheFolder, file.getName());
                     InputStream in = null;
                     OutputStream out = null;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -21,7 +21,6 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.net.Uri;
-import androidx.core.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
 
@@ -32,6 +31,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 
@@ -183,7 +183,7 @@ public class AnnotateWidget extends BaseImageWidget {
         // the size. boo.
 
         try {
-            Uri uri = FileProvider.getUriForFile(getContext(),
+            Uri uri = ContentUriProvider.getUriForFile(getContext(),
                     BuildConfig.APPLICATION_ID + ".provider",
                     new File(new StoragePathProvider().getTmpFilePath()));
             // if this gets modified, the onActivityResult in

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -22,7 +22,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.provider.MediaStore;
 import androidx.annotation.NonNull;
-import androidx.core.content.FileProvider;
 import android.view.Gravity;
 import android.webkit.MimeTypeMap;
 import android.widget.Button;
@@ -38,6 +37,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaManager;
@@ -197,7 +197,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget {
     private void openFile() {
 
         Uri fileUri = Uri.fromFile(new File(getInstanceFolder() + File.separator + binaryName));
-        Uri contentUri = FileProvider.getUriForFile(getContext(),
+        Uri contentUri = ContentUriProvider.getUriForFile(getContext(),
                 BuildConfig.APPLICATION_ID + ".provider",
                 new File(getInstanceFolder() + File.separator + binaryName));
         Intent intent = new Intent();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -18,7 +18,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import androidx.core.content.FileProvider;
 import android.view.View;
 import android.widget.Button;
 
@@ -30,6 +29,7 @@ import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.CameraUtils;
+import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 
@@ -166,7 +166,7 @@ public class ImageWidget extends BaseImageWidget {
             // the size. boo.
 
             try {
-                Uri uri = FileProvider.getUriForFile(getContext(),
+                Uri uri = ContentUriProvider.getUriForFile(getContext(),
                         BuildConfig.APPLICATION_ID + ".provider",
                         new File(new StoragePathProvider().getTmpFilePath()));
                 // if this gets modified, the onActivityResult in

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -30,7 +30,6 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.core.content.FileProvider;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -43,6 +42,7 @@ import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.utilities.CameraUtils;
+import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaManager;
@@ -345,7 +345,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget {
 
         Uri uri = null;
         try {
-            uri = FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", file);
+            uri = ContentUriProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".provider", file);
             FileUtils.grantFileReadPermissions(intent, uri, getContext());
         } catch (IllegalArgumentException e) {
             Timber.e(e);


### PR DESCRIPTION
Closes #3887 

#### What has been done to verify that this works as intended?
Not much because I 'm not able to reproduce the issue. I just confirmed there is no regression on devices I have.

#### Why is this the best possible solution? Were any other approaches considered?
It's a bug that occurs on huawei devices. I implemented a fix according to: https://stackoverflow.com/a/41309223/5479029

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
it might be difficult to test becuase we might reproduce the bug only on Huawei devices. If we are not able to reproduce we need just confirm that nothing wrong happens when we click `Configure via QE code` and we can scane/share codes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)