### PR TITLE
Use DialogUtils.showDialog to avoid Exceptions diaplaying dialogs in GoogleSheetsUploaderActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GoogleSheetsUploaderActivity.java
@@ -43,6 +43,7 @@ import org.odk.collect.android.network.NetworkStateProvider;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.tasks.InstanceGoogleSheetsUploaderTask;
 import org.odk.collect.android.utilities.ArrayUtils;
+import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.ToastUtils;
@@ -304,7 +305,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.ok), quitListener);
         alertShowing = true;
         alertMsg = message;
-        alertDialog.show();
+        DialogUtils.showDialog(alertDialog, this);
     }
 
     @Override


### PR DESCRIPTION
Closes #3891

#### What has been done to verify that this works as intended?
I uploaded a form to google sheets to confirm that the dialog is displayed properly.

#### Why is this the best possible solution? Were any other approaches considered?
`DialogUtils.showDialog()` is a method specially paperer for such cases so we should use it to avoid exceptions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a small and safe fix so probably it doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)