### PR TITLE
Fixed quit dialog title

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
@@ -109,7 +109,7 @@ public class QuitFormDialogFragment extends DialogFragment {
         });
 
         return new AlertDialog.Builder(getActivity())
-                .setTitle(title)
+                .setTitle(getString(R.string.quit_application, title))
                 .setNegativeButton(getActivity().getString(R.string.do_not_exit), (dialog, id) -> {
                     dialog.cancel();
                     dismiss();


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I have ran failing tests from https://console.firebase.google.com/u/0/project/api-project-322300403941/testlab/histories/bh.f6f8331e5ae6e371/matrices/4896598627817279457

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix. The bug has been introduced in https://github.com/getodk/collect/pull/3782
The quit dialog title should start with `Exit` but now it's just a form name:
![Screenshot_1591140013](https://user-images.githubusercontent.com/3276264/83582652-5fafc200-a542-11ea-8a93-ca184b80a07f.png)


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)