### PR TITLE
Keep swiping blocked until AddRepeatDialog is closed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1701,6 +1701,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * repeat of the current group.
      */
     private void createRepeatDialog() {
+        beenSwiped = true;
+
         // In some cases dialog might be present twice because refreshView() is being called
         // from onResume(). This ensures that we do not preset this modal dialog if it's already
         // visible. Checking for shownAlertDialogIsGroupRepeat because the same field
@@ -1709,12 +1711,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             return;
         }
 
-        beenSwiped = false;
         shownAlertDialogIsGroupRepeat = true;
 
         AddRepeatDialog.show(this, getFormController().getLastGroupText(), new AddRepeatDialog.Listener() {
             @Override
             public void onAddRepeatClicked() {
+                beenSwiped = false;
                 shownAlertDialogIsGroupRepeat = false;
                 formEntryViewModel.addRepeat(true);
                 formIndexAnimationHandler.handle(formEntryViewModel.getCurrentIndex());
@@ -1722,6 +1724,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             @Override
             public void onCancelClicked() {
+                beenSwiped = false;
                 shownAlertDialogIsGroupRepeat = false;
 
                 // Make sure the error dialog will not disappear.


### PR DESCRIPTION
Closes #3897

#### What has been done to verify that this works as intended?
I was able to reproduce the issue so I also confirmed the fix works.

#### Why is this the best possible solution? Were any other approaches considered?
We released swiping to early and it was possible to swipe multiple times in a case when the AddRepeatDialog should appear and block it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a pretty safe and isolated fix so we can just verify the mentioned scenario.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used: 
[repeatGr.xlsx](https://github.com/getodk/collect/files/4722963/repeatGr.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)