### PR TITLE
Save current screen answers when quitting form

### DIFF
--- a/collect_app/src/androidTest/assets/forms/two-question.xml
+++ b/collect_app/src/androidTest/assets/forms/two-question.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Two Question</h:title>
+        <model>
+            <instance>
+                <data id="two_question">
+                    <name/>
+                    <age/>
+                </data>
+            </instance>
+            <bind nodeset="name" type="string"/>
+            <bind nodeset="age" type="int"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/name">
+            <label>What is your name?</label>
+        </input>
+        <input ref="/data/age">
+            <label>What is your age?</label>
+        </input>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AddRepeatTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AddRepeatTest.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.formentry;
+package org.odk.collect.android.feature.formentry;
 
 import android.Manifest;
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -45,4 +45,14 @@ public class QuittingFormTest {
                 .assertText("Reuben") // Previous answers are saved
                 .assertText("10"); // Current screen answers are saved
     }
+
+    @Test
+    public void partiallyFillingForm_andPressingBack_andClickingIgnoreChanges_doesNotSaveForm() {
+        rule.mainMenu()
+                .startBlankForm("Two Question")
+                .answerQuestion("What is your name?", "Reuben")
+                .pressBack(new SaveOrIgnoreDialog<>("Two Question", new MainMenuPage(rule), rule))
+                .clickIgnoreChanges()
+                .assertNumberOfEditableForms(0);
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -1,0 +1,48 @@
+package org.odk.collect.android.feature.formentry;
+
+import android.Manifest;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.pages.MainMenuPage;
+import org.odk.collect.android.support.pages.SaveOrIgnoreDialog;
+
+@RunWith(AndroidJUnit4.class)
+public class QuittingFormTest {
+
+    public CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE
+            ))
+            .around(new ResetStateRule())
+            .around(new CopyFormRule("two-question.xml"))
+            .around(rule);
+
+    @Test
+    public void partiallyFillingForm_andPressingBack_andClickingSaveChanges_savesCurrentAnswers() {
+        rule.mainMenu()
+                .startBlankForm("Two Question")
+                .answerQuestion("What is your name?", "Reuben")
+                .swipeToNextQuestion()
+                .answerQuestion("What is your age?", "10")
+                .pressBack(new SaveOrIgnoreDialog<>("Two Question", new MainMenuPage(rule), rule))
+                .clickSaveChanges()
+                .clickEditSavedForm()
+                .clickOnForm("Two Question")
+                .assertText("Reuben") // Previous answers are saved
+                .assertText("10"); // Current screen answers are saved
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -235,4 +235,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
 
         return new AddNewRepeatDialog(repeatName, rule);
     }
+
+    public FormEntryPage answerQuestion(String question, String answer) {
+        assertText(question);
+        inputText(answer);
+        closeSoftKeyboard();
+        return this;
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -97,6 +97,16 @@ public class MainMenuPage extends Page<MainMenuPage> {
         return this;
     }
 
+    public MainMenuPage assertNumberOfEditableForms(int number) {
+        if (number == 0) {
+            onView(withText(getTranslatedString(R.string.review_data))).check(matches(isDisplayed()));
+        } else {
+            onView(withText(getTranslatedString(R.string.review_data, String.valueOf(number)))).check(matches(isDisplayed()));
+        }
+
+        return this;
+    }
+
     public MainMenuPage assertStorageMigrationBannerIsDisplayed() {
         onView(withText(R.string.scoped_storage_banner_text)).check(matches(isDisplayed()));
         onView(withText(R.string.scoped_storage_learn_more)).check(matches(isDisplayed()));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -201,7 +201,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         SaveFormIndexTask.SaveFormIndexListener, WidgetValueChangedListener,
         ScreenContext, FormLoadingDialogFragment.FormLoadingDialogFragmentListener,
         AudioControllerView.SwipableParent,
-        FormIndexAnimationHandler.Listener {
+        FormIndexAnimationHandler.Listener,
+        QuitFormDialogFragment.Listener {
 
     // Defines for FormEntryActivity
     private static final boolean EXIT = true;
@@ -1026,7 +1027,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             case R.id.menu_save:
                 // don't exit
-                saveForm(DO_NOT_EXIT, InstancesDaoHelper.isInstanceComplete(false), null);
+                saveForm(DO_NOT_EXIT, InstancesDaoHelper.isInstanceComplete(false), null, true);
                 return true;
 
             case R.id.menu_goto:
@@ -1398,7 +1399,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         } else {
                             saveForm(EXIT, instanceComplete
                                     .isChecked(), saveAs.getText()
-                                    .toString());
+                                    .toString(), true);
                         }
                     }
                 });
@@ -1807,12 +1808,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * isntancs as complete. If updatedSaveName is non-null, the instances
      * content provider is updated with the new name
      */
-    // by default, save the current screen
-    private boolean saveForm(boolean exit, boolean complete, String updatedSaveName) {
-        return saveForm(exit, complete, updatedSaveName, true);
-    }
-
-    // but if you want save in the background, can't be current screen
     private boolean saveForm(boolean exit, boolean complete, String updatedSaveName,
                              boolean current) {
         // save current answer
@@ -1914,6 +1909,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      */
     private void createQuitDialog() {
         showIfNotShowing(QuitFormDialogFragment.class, getSupportFragmentManager());
+    }
+
+    @Override
+    public void onSaveChangesClicked() {
+        saveForm(EXIT, InstancesDaoHelper.isInstanceComplete(false), null, true);
     }
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
@@ -42,6 +42,7 @@ public class QuitFormDialogFragment extends DialogFragment {
     Analytics analytics;
 
     private FormSaveViewModel viewModel;
+    private Listener listener;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -50,6 +51,10 @@ public class QuitFormDialogFragment extends DialogFragment {
 
         viewModel = new ViewModelProvider(requireActivity(), new FormSaveViewModel.Factory(analytics))
                 .get(FormSaveViewModel.class);
+
+        if (context instanceof Listener) {
+            listener = (Listener) context;
+        }
     }
 
     @NonNull
@@ -76,9 +81,9 @@ public class QuitFormDialogFragment extends DialogFragment {
             IconMenuItem item = (IconMenuItem) adapter.getItem(position);
 
             if (item.getTextResId() == R.string.keep_changes) {
-                viewModel.saveForm(getActivity().getIntent().getData(), InstancesDaoHelper.isInstanceComplete(false),
-                        null, true);
-
+                if (listener != null) {
+                    listener.onSaveChangesClicked();
+                }
             } else {
                 ExternalDataManager manager = Collect.getInstance().getExternalDataManager();
                 if (manager != null) {
@@ -116,5 +121,9 @@ public class QuitFormDialogFragment extends DialogFragment {
                 })
                 .setView(listView)
                 .create();
+    }
+
+    public interface Listener {
+        void onSaveChangesClicked();
     }
 }


### PR DESCRIPTION
This was the reason the Track Changes Reason tests were failing.

#### What has been done to verify that this works as intended?

Added new tests to make a bug in this area a little more obvious (hopefully) and ran tests to check we're now green.

#### Why is this the best possible solution? Were any other approaches considered?

I think really we need to look at moving the screen answer saving out of the FormEntryActivity and into the FormSaveViewModel. I didn't want to get into that to get green again so just used a listener on QuitFormDialogFragment to call the FormEntryActivity's save logic. 

I think it's a good step forward to have some Espresso tests covering this flow a little better however.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think it's best to do a straight merge on this as it is mostly a step backwards and gets us green again. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)