### PR TITLE
Fixed FormEntryActivity.isQuestionRecalculated() method

### DIFF
--- a/collect_app/src/androidTest/assets/forms/fieldlist-updates.xml
+++ b/collect_app/src/androidTest/assets/forms/fieldlist-updates.xml
@@ -87,6 +87,7 @@
           <value_change>
             <source6/>
             <target6/>
+            <target6_1/>
           </value_change>
           <cascading_select>
             <source7/>
@@ -271,6 +272,7 @@
       <bind nodeset="/fieldlist-updates/hint_change/target5" type="string"/>
       <bind nodeset="/fieldlist-updates/value_change/source6" type="string"/>
       <bind calculate="string-length( /fieldlist-updates/value_change/source6 )" nodeset="/fieldlist-updates/value_change/target6" type="int"/>
+      <bind calculate="substr( /fieldlist-updates/value_change/source6, 0, 1 )" nodeset="/fieldlist-updates/value_change/target6_1" type="string"/>
       <bind nodeset="/fieldlist-updates/cascading_select/source7" type="select1"/>
       <bind nodeset="/fieldlist-updates/cascading_select/target7" type="select1"/>
       <bind nodeset="/fieldlist-updates/cascading_select/target7-1" type="select1"/>
@@ -382,6 +384,9 @@
       </input>
       <input ref="/fieldlist-updates/value_change/target6">
         <label>Name length</label>
+      </input>
+      <input ref="/fieldlist-updates/value_change/target6_1">
+        <label>First name letter</label>
       </input>
     </group>
     <group appearance="field-list" ref="/fieldlist-updates/cascading_select">

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -195,10 +195,13 @@ public class FieldListUpdateTest {
 
         onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
         onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
+        onView(withIndex(withClassName(endsWith("EditText")), 2)).check(matches(withText("")));
         onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(name));
         onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText(String.valueOf(name.length()))));
+        onView(withIndex(withClassName(endsWith("EditText")), 2)).check(matches(withText(String.valueOf(name.charAt(0)))));
         onView(withIndex(withClassName(endsWith("EditText")), 0)).perform(replaceText(""));
         onView(withIndex(withClassName(endsWith("EditText")), 1)).check(matches(withText("0")));
+        onView(withIndex(withClassName(endsWith("EditText")), 2)).check(matches(withText("")));
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -159,6 +159,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -2825,8 +2826,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     // If an answer has changed after saving one of previous answers that means it has been recalculated automatically
     private boolean isQuestionRecalculated(FormEntryPrompt mutableQuestionBeforeSave, ImmutableDisplayableQuestion immutableQuestionBeforeSave) {
-        return !(mutableQuestionBeforeSave.getAnswerText() == null && immutableQuestionBeforeSave.getAnswerText() == null
-                || mutableQuestionBeforeSave.getAnswerText().equals(immutableQuestionBeforeSave.getAnswerText()));
+        return !Objects.equals(mutableQuestionBeforeSave.getAnswerText(), immutableQuestionBeforeSave.getAnswerText());
     }
 }
 


### PR DESCRIPTION
Closes #3902

#### What has been done to verify that this works as intended?
I tested the fix manually and added improved our automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It was just a bug, we tried to call equals on null what is cause NPE so I replaced it with Objects.equals() which is null safe.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a safe bug fix so it doesn't affect users at all it should just fix the bug.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)