### PR TITLE
Close form cursor when getting count

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -208,7 +208,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         downloadButton.setEnabled(listView.getCheckedItemCount() > 0);
         downloadButton.setOnClickListener(v -> {
             ArrayList<FormDetails> filesToDownload = getFilesToDownload();
-            viewModel.logDownloadAnalyticsEvent(formsDao.getFormsCursor().getCount(),
+            viewModel.logDownloadAnalyticsEvent(formsDao.getCount(),
                     webCredentialsUtils.getServerUrlFromPreferences());
             startFormsDownload(filesToDownload);
         });

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -21,6 +21,8 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
+import androidx.loader.content.CursorLoader;
+
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
@@ -28,8 +30,6 @@ import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.loader.content.CursorLoader;
 
 /**
  * This class is used to encapsulate all access to the {@link org.odk.collect.android.database.helpers.FormsDatabaseHelper#DATABASE_NAME}
@@ -230,6 +230,12 @@ public class FormsDao {
 
     public int updateForm(ContentValues values, String where, String[] whereArgs) {
         return Collect.getInstance().getContentResolver().update(FormsColumns.CONTENT_URI, values, where, whereArgs);
+    }
+
+    public int getCount() {
+        try (Cursor c = getFormsCursor()) {
+            return c.getCount();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes cursor leak when logging form download analytics

#### What has been done to verify that this works as intended?
Visual code inspection only since this is so simple and only affects analytics.

#### Why is this the best possible solution? Were any other approaches considered?
I put the count method in `FormsDao` because the class already exists. If there were something like a higher-level `FormsRepository` I might have put it there.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No intended behavior change other than lowering the risk of running out of memory.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)