### PR TITLE
Add assertions to swipe helpers

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DeletingRepeatGroupsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DeletingRepeatGroupsTest.java
@@ -5,7 +5,6 @@ import android.Manifest;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.rule.GrantPermissionRule;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -22,7 +21,6 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
-@Ignore("https://github.com/getodk/collect/issues/3903")
 public class DeletingRepeatGroupsTest {
     private static final String TEST_FORM = "repeat_groups.xml";
 
@@ -49,7 +47,7 @@ public class DeletingRepeatGroupsTest {
     @Test
     public void requestingDeletionOfMiddleRepeat_deletesMiddleRepeat() {
         new FormEntryPage("repeatGroups", activityTestRule)
-                .swipeToNextRepeat("repeat", 2)
+                .swipeToNextRepeat("repeatGroup", 2)
                 .deleteGroup("text1")
                 .assertText("3");
     }
@@ -57,9 +55,9 @@ public class DeletingRepeatGroupsTest {
     @Test
     public void requestingDeletionOfLastRepeat_deletesLastRepeat() {
         new FormEntryPage("repeatGroups", activityTestRule)
-                .swipeToNextRepeat("repeat", 2)
-                .swipeToNextRepeat("repeat", 3)
-                .swipeToNextRepeat("repeat", 4)
+                .swipeToNextRepeat("repeatGroup", 2)
+                .swipeToNextRepeat("repeatGroup", 3)
+                .swipeToNextRepeat("repeatGroup", 4)
                 .deleteGroup("text1")
                 .assertText("number1");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormHierarchyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormHierarchyTest.java
@@ -12,6 +12,8 @@ import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
+import org.odk.collect.android.support.pages.AddNewRepeatDialog;
+import org.odk.collect.android.support.pages.FormEntryPage;
 import org.odk.collect.android.support.pages.FormHierarchyPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 
@@ -104,18 +106,18 @@ public class FormHierarchyTest {
     public void repeatGroupsShouldBeVisibleAsAppropriate() {
         FormHierarchyPage page = new MainMenuPage(rule)
                 .startBlankForm("formHierarchy3")
-                .swipeToNextQuestion()
-                .swipeToNextQuestion()
-                .swipeToNextQuestion()
-                .swipeToNextQuestion()
-                .swipeToNextQuestion()
-                .swipeToNextQuestion()
-                .clickOnString(R.string.add_repeat)
-                .swipeToNextQuestion()
-                .clickOnString(R.string.add_repeat)
-                .swipeToNextQuestion()
-                .clickOnDoNotAddGroup()
-                .clickOnDoNotAddGroup()
+                .swipeToNextQuestion("Text")
+                .swipeToNextQuestion("Integer 1_1")
+                .swipeToNextQuestion("Integer 1_2")
+                .swipeToNextQuestion("Integer 2_1")
+                .swipeToNextQuestion("Integer 2_2")
+                .swipeToNextQuestionWithRepeatGroup("Repeat Group 1")
+                .clickOnAdd(new FormEntryPage("formHierarchy3", rule))
+                .swipeToNextQuestionWithRepeatGroup("Repeat Group 1_1")
+                .clickOnAdd(new FormEntryPage("formHierarchy3", rule))
+                .swipeToNextQuestionWithRepeatGroup("Repeat Group 1_1")
+                .clickOnDoNotAdd(new AddNewRepeatDialog("Repeat Group 1", rule))
+                .clickOnDoNotAdd(new FormEntryPage("formHierarchy3", rule))
                 .clickGoToArrow();
 
         onView(withId(R.id.list)).check(matches(RecyclerViewMatcher.withListSize(3)));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AddNewRepeatDialog.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AddNewRepeatDialog.java
@@ -13,7 +13,7 @@ public class AddNewRepeatDialog extends Page<AddNewRepeatDialog> {
 
     private final String repeatName;
 
-    AddNewRepeatDialog(String repeatName, ActivityTestRule rule) {
+    public AddNewRepeatDialog(String repeatName, ActivityTestRule rule) {
         super(rule);
         this.repeatName = repeatName;
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -47,6 +47,12 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    public FormEntryPage swipeToNextQuestion(String questionText) {
+        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        assertText(questionText);
+        return this;
+    }
+
     public FormEntryPage swipeToNextQuestion(int repetitions) {
         for (int i = 0; i < repetitions; i++) {
             swipeToNextQuestion();
@@ -55,9 +61,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEntryPage swipeToNextRepeat(String repeatLabel, int repeatNumber) {
+        assertText(repeatLabel + " > " + (repeatNumber - 1));
+
         tryAgainOnFail(() -> {
             onView(withId(R.id.questionholder)).perform(swipeLeft());
-            onView(withText(repeatLabel + " > " + repeatNumber));
+            assertText(repeatLabel + " > " + repeatNumber);
         });
 
         return this;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -114,8 +114,17 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    /**
+     * @deprecated use {@link #swipeToPreviousQuestion(String)} instead
+     */
     public FormEntryPage swipeToPreviousQuestion() {
         onView(withId(R.id.questionholder)).perform(swipeRight());
+        return this;
+    }
+
+    public FormEntryPage swipeToPreviousQuestion(String questionText) {
+        onView(withId(R.id.questionholder)).perform(swipeRight());
+        assertText(questionText);
         return this;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -42,6 +42,10 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    /**
+     * @deprecated use {@link #swipeToNextQuestion(String)} instead
+     */
+    @Deprecated
     public FormEntryPage swipeToNextQuestion() {
         onView(withId(R.id.questionholder)).perform(swipeLeft());
         return this;
@@ -53,6 +57,10 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
+    /**
+     * @deprecated use {@link #swipeToNextQuestion(String)} instead
+     */
+    @Deprecated
     public FormEntryPage swipeToNextQuestion(int repetitions) {
         for (int i = 0; i < repetitions; i++) {
             swipeToNextQuestion();


### PR DESCRIPTION
Closes #3903.

This adds new swipe helpers that assert on the questions they're landing on and deprecates the old helpers.

#### What has been done to verify that this works as intended?

Ran test lab a whole bunch of times.

#### Why is this the best possible solution? Were any other approaches considered?

Basically it seems like one of the core problems we're facing in our tests is that the `question_holder` view that the `swipeToNextQuestion` uses is always available (during form entry) and so swipes can happen earlier/later than we want them to which means our tests can end up in unexpected states.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This can merge straight in without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)