### PR TITLE
Add `waitFor` helper

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -53,7 +53,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
 
     public FormEntryPage swipeToNextQuestion(String questionText) {
         onView(withId(R.id.questionholder)).perform(swipeLeft());
-        assertText(questionText);
+        waitForText(questionText);
         return this;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -69,23 +69,15 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEntryPage swipeToNextRepeat(String repeatLabel, int repeatNumber) {
-        assertText(repeatLabel + " > " + (repeatNumber - 1));
-
-        tryAgainOnFail(() -> {
-            onView(withId(R.id.questionholder)).perform(swipeLeft());
-            assertText(repeatLabel + " > " + repeatNumber);
-        });
-
+        waitForText(repeatLabel + " > " + (repeatNumber - 1));
+        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        waitForText(repeatLabel + " > " + repeatNumber);
         return this;
     }
 
     public FormEndPage swipeToEndScreen() {
-        tryAgainOnFail(() -> {
-            onView(withId(R.id.questionholder)).perform(swipeLeft());
-            new FormEndPage(formName, rule).assertOnPage();
-        });
-
-        return new FormEndPage(formName, rule);
+        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        return waitFor(() -> new FormEndPage(formName, rule).assertOnPage());
     }
 
     public ErrorDialog swipeToNextQuestionWithError() {
@@ -253,12 +245,8 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public AddNewRepeatDialog swipeToNextQuestionWithRepeatGroup(String repeatName) {
-        tryAgainOnFail(() -> {
-            onView(withId(R.id.questionholder)).perform(swipeLeft());
-            new AddNewRepeatDialog(repeatName, rule).assertOnPage();
-        });
-
-        return new AddNewRepeatDialog(repeatName, rule);
+        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        return waitFor(() -> new AddNewRepeatDialog(repeatName, rule).assertOnPage());
     }
 
     public FormEntryPage answerQuestion(String question, String answer) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -16,6 +16,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.support.actions.RotateAction;
 import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
 
+import java.util.concurrent.Callable;
+
 import timber.log.Timber;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -299,20 +301,24 @@ abstract class Page<T extends Page<T>> {
         }
     }
 
-    public void waitForText(String text) {
-        int counter = 0;
-        NoMatchingViewException failure = null;
+    protected void waitForText(String text) {
+        waitFor(() -> assertText(text));
+    }
 
+    protected <T> T waitFor(Callable<T> callable) {
+        int counter = 0;
+        Exception failure = null;
+
+        // Try 20 times/for 5 seconds
         while (counter < 20) {
             try {
-                assertText(text);
-                return;
-            } catch (NoMatchingViewException exception) {
-                failure = exception;
+                return callable.call();
+            } catch (Exception throwable) {
+                failure = throwable;
             }
 
             try {
-                Thread.sleep(500);
+                Thread.sleep(250);
             } catch (InterruptedException ignored) {
                 // ignored
             }
@@ -320,9 +326,7 @@ abstract class Page<T extends Page<T>> {
             counter++;
         }
 
-        if (failure != null) {
-            throw failure;
-        }
+        throw new RuntimeException("waitFor failed", failure);
     }
 }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/StorageMigrationDialogPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/StorageMigrationDialogPage.java
@@ -40,7 +40,7 @@ public class StorageMigrationDialogPage extends Page<StorageMigrationDialogPage>
 
     public MainMenuPage clickMigrate() {
         onView(withId(R.id.migrateButton)).perform(click());
-        return new MainMenuPage(rule).assertOnPage();
+        return waitFor(() -> new MainMenuPage(rule).assertOnPage());
     }
 
     public StorageMigrationDialogPage assertForumPostOpen() {


### PR DESCRIPTION
This adds a (pretty common) `waitFor` helper for some tests that just don't seem to behave. Espresso makes claims that helpers like this aren't needed but event with Idling Resource and swapping out async dispatchers I think we may be running into some async behaviours that both ourselves and Espresso don't realize are there.

#### What has been done to verify that this works as intended?

Ran test lab a bunch of times!

#### Why is this the best possible solution? Were any other approaches considered?

There are probably "better" solutions to the handful of cases we're using `waitFor` on but I think it's a good compromise to have and use this helper in cases that are sucking up all our time. The only real drawback is that tests will take longer on failure (up to 5 seconds) but I think that's something we can live with.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change to users. This can merge straight in on acceptance.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)