### PR TITLE
Allow tests to detect failed "fling" gestures

### DIFF
--- a/collect_app/src/androidTest/assets/forms/encrypted-no-instanceID.xml
+++ b/collect_app/src/androidTest/assets/forms/encrypted-no-instanceID.xml
@@ -14,7 +14,7 @@
     </h:head>
     <h:body>
         <input ref="/encrypted-no-instanceID/question">
-            <label>Question</label>
+            <label>Question 1</label>
         </input>
     </h:body>
 </h:html>

--- a/collect_app/src/androidTest/assets/forms/encrypted.xml
+++ b/collect_app/src/androidTest/assets/forms/encrypted.xml
@@ -18,7 +18,7 @@
     </h:head>
     <h:body>
         <input ref="/encrypted/question">
-            <label>Question</label>
+            <label>Question 1</label>
         </input>
     </h:body>
 </h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -49,6 +49,7 @@ public class EncryptedFormTest {
     public void instanceOfEncryptedForm_cantBeEditedWhenFinalized() {
         rule.mainMenu()
                 .startBlankForm("encrypted")
+                .assertQuestion("Question 1")
                 .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok)
@@ -62,6 +63,7 @@ public class EncryptedFormTest {
     public void instanceOfEncryptedFormWithoutInstanceID_failsFinalizationWithMessage() {
         rule.mainMenu()
                 .startBlankForm("encrypted-no-instanceID")
+                .assertQuestion("Question 1")
                 .swipeToEndScreen()
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed("This form does not specify an instanceID. You must specify one to enable encryption. Form has not been saved as finalized.")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormHierarchyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormHierarchyTest.java
@@ -106,6 +106,7 @@ public class FormHierarchyTest {
     public void repeatGroupsShouldBeVisibleAsAppropriate() {
         FormHierarchyPage page = new MainMenuPage(rule)
                 .startBlankForm("formHierarchy3")
+                .assertQuestion("Intro")
                 .swipeToNextQuestion("Text")
                 .swipeToNextQuestion("Integer 1_1")
                 .swipeToNextQuestion("Integer 1_2")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -458,19 +458,19 @@ public class FillBlankFormTest {
 
     @Test
     public void bigForm_ShouldBeFilledSuccessfully() {
-
         //TestCase18
         new MainMenuPage(rule)
                 .startBlankForm("Nigeria Wards")
+                .assertQuestion("State")
                 .clickOnString(R.string.select_one)
                 .clickOnText("Adamawa")
-                .swipeToNextQuestion()
+                .swipeToNextQuestion("LGA", true)
                 .clickOnString(R.string.select_one)
                 .clickOnText("Ganye")
-                .swipeToNextQuestion()
+                .swipeToNextQuestion("Ward", true)
                 .clickOnString(R.string.select_one)
                 .clickOnText("Jaggu")
-                .swipeToNextQuestion()
+                .swipeToNextQuestion("Comments")
                 .swipeToEndScreen()
                 .clickSaveAndExit();
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -255,4 +255,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
         closeSoftKeyboard();
         return this;
     }
+
+    public FormEntryPage assertQuestion(String text) {
+        waitForText(text);
+        return this;
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -5,6 +5,7 @@ import androidx.test.rule.ActivityTestRule;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.ActivityHelpers;
+import org.odk.collect.android.utilities.FlingRegister;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -47,7 +48,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
      */
     @Deprecated
     public FormEntryPage swipeToNextQuestion() {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        flingLeft();
         return this;
     }
 
@@ -56,7 +57,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEntryPage swipeToNextQuestion(String questionText, boolean isRequired) {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        flingLeft();
 
         if (isRequired) {
             waitForText("* " + questionText);
@@ -80,18 +81,18 @@ public class FormEntryPage extends Page<FormEntryPage> {
 
     public FormEntryPage swipeToNextRepeat(String repeatLabel, int repeatNumber) {
         waitForText(repeatLabel + " > " + (repeatNumber - 1));
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        flingLeft();
         waitForText(repeatLabel + " > " + repeatNumber);
         return this;
     }
 
     public FormEndPage swipeToEndScreen() {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        flingLeft();
         return waitFor(() -> new FormEndPage(formName, rule).assertOnPage());
     }
 
     public ErrorDialog swipeToNextQuestionWithError() {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        flingLeft();
         return new ErrorDialog(rule).assertOnPage();
     }
 
@@ -255,7 +256,7 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public AddNewRepeatDialog swipeToNextQuestionWithRepeatGroup(String repeatName) {
-        onView(withId(R.id.questionholder)).perform(swipeLeft());
+        flingLeft();
         return waitFor(() -> new AddNewRepeatDialog(repeatName, rule).assertOnPage());
     }
 
@@ -269,5 +270,20 @@ public class FormEntryPage extends Page<FormEntryPage> {
     public FormEntryPage assertQuestion(String text) {
         waitForText(text);
         return this;
+    }
+
+    private void flingLeft() {
+        tryAgainOnFail(() -> {
+            FlingRegister.attemptingFling();
+            onView(withId(R.id.questionholder)).perform(swipeLeft());
+
+            waitFor(() -> {
+                if (FlingRegister.isFlingDetected()) {
+                    return true;
+                } else {
+                    throw new RuntimeException("Fling never detected!");
+                }
+            });
+        }, 5);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -52,8 +52,18 @@ public class FormEntryPage extends Page<FormEntryPage> {
     }
 
     public FormEntryPage swipeToNextQuestion(String questionText) {
+        return swipeToNextQuestion(questionText, false);
+    }
+
+    public FormEntryPage swipeToNextQuestion(String questionText, boolean isRequired) {
         onView(withId(R.id.questionholder)).perform(swipeLeft());
-        waitForText(questionText);
+
+        if (isRequired) {
+            waitForText("* " + questionText);
+        } else {
+            waitForText(questionText);
+        }
+
         return this;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -293,12 +293,28 @@ abstract class Page<T extends Page<T>> {
     }
 
     void tryAgainOnFail(Runnable action) {
-        try {
-            action.run();
-        } catch (NoMatchingViewException e) {
-            assertOnPage();
-            action.run();
+        tryAgainOnFail(action, 2);
+    }
+
+    void tryAgainOnFail(Runnable action, int maxTimes) {
+        Exception failure = null;
+
+        for (int i = 0; i < maxTimes; i++) {
+            try {
+                action.run();
+                return;
+            } catch (Exception e) {
+                failure = e;
+
+                try {
+                    Thread.sleep(250);
+                } catch (InterruptedException ignored) {
+                    // ignored
+                }
+            }
         }
+
+        throw new RuntimeException("tryAgainOnFail failed", failure);
     }
 
     protected void waitForText(String text) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -136,6 +136,7 @@ import org.odk.collect.android.upload.AutoSendWorker;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DestroyableLifecyleOwner;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.FlingRegister;
 import org.odk.collect.android.utilities.FormNameUtils;
 import org.odk.collect.android.utilities.ImageConverter;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -2514,6 +2515,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX,
                            float velocityY) {
+        FlingRegister.flingDetected();
+
         // only check the swipe if it's enabled in preferences
         String navigation = (String) GeneralSharedPreferences.getInstance()
                 .get(GeneralKeys.KEY_NAVIGATION);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FlingRegister.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FlingRegister.java
@@ -1,0 +1,27 @@
+package org.odk.collect.android.utilities;
+
+/**
+ * Used to allow tests to understand whether fling gestures have been
+ * successfully detected or not
+ */
+
+public class FlingRegister {
+
+    private static boolean flingDetected;
+
+    private FlingRegister() {
+        
+    }
+
+    public static void attemptingFling() {
+        flingDetected = false;
+    }
+
+    public static void flingDetected() {
+        flingDetected = true;
+    }
+
+    public static boolean isFlingDetected() {
+        return flingDetected;
+    }
+}


### PR DESCRIPTION
A lot of our tests rely on `FormEntryActivity#onFling` being called to swipe from left to right during form entry. We've had **a lot** of flakiness around this and after chipping away at rewriting tests it seems that there is an underlying problem where `onFling` simply isn't always called when we expect it to be. As far as I can see this is not the fault of any of Collect's code but rather a problem in our test environment.

To account for this I've added a `FlingRegister` component that tests and `FormEntryActivity` can share to let the tests know when a fling gesture hasn't worked so the test can then try again. Interestingly there was still flakes after adding this but upping the amount of retries seems to fix it. I'm guessing that there might be a momentary stall/freeze on the test device that's causing this problem.

This doesn't mean that we can relax and just swipe as much as we want: we still need to write tests that assert what question more so that we don't end up with weird scenarios where we swipe from an earlier or later question than we meant to.

#### What has been done to verify that this works as intended?

Ran through test lab a lot of times.

#### Why is this the best possible solution? Were any other approaches considered?

It's a little weird but I think it's a good solution to the weirdness of the problem and although it means adding "test" code to the core app it doesn't feel intrusive enough to avoid given the benefit.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No risk to behaviour. Can just be merged after approval.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)