### PR TITLE
Fixed bug in GeoPolyActivity.clear()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -445,7 +445,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
 
     private void clear() {
         map.clearFeatures();
-        featureId = map.addDraggablePoly(new ArrayList<>(), false);
+        featureId = map.addDraggablePoly(new ArrayList<>(), outputMode == OutputMode.GEOSHAPE);
         inputActive = false;
         updateUi();
     }


### PR DESCRIPTION
Closes #3860 

#### What has been done to verify that this works as intended?
I reproduced the scenario mentioned i the issue and confirmed this fix works.

#### Why is this the best possible solution? Were any other approaches considered?
It is just a bug fix the problem was that in GeoPolyActivity.clear() we always passed false as `closedPolygon` parameter not matter what type of geowidget we used.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix so testing the scenario from the issue would be enough to confirm that everything is fine.

#### Do we need any specific form for testing your changes? If so, please attach one.
All widgets form would be good.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)