### PR TITLE
Fixed navigation buttons in form entry in Magenta theme

### DIFF
--- a/collect_app/src/main/res/drawable/ic_navigate_back.xml
+++ b/collect_app/src/main/res/drawable/ic_navigate_back.xml
@@ -4,8 +4,8 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="?iconColor"
+        android:fillColor="?colorOnPrimary"
         android:strokeWidth="0.5"
-        android:strokeColor="?iconColor"
+        android:strokeColor="?colorOnPrimary"
         android:pathData="M15.41,16.09l-4.58,-4.59 4.58,-4.59L14,5.5l-6,6 6,6z"/>
 </vector>

--- a/collect_app/src/main/res/drawable/ic_navigate_forward.xml
+++ b/collect_app/src/main/res/drawable/ic_navigate_forward.xml
@@ -4,8 +4,8 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="?iconColor"
+        android:fillColor="?colorOnPrimary"
         android:strokeWidth="0.5"
-        android:strokeColor="?iconColor"
+        android:strokeColor="?colorOnPrimary"
         android:pathData="M8.59,16.34l4.58,-4.59 -4.58,-4.59L10,5.75l6,6 -6,6z"/>
 </vector>

--- a/collect_app/src/main/res/layout/form_entry.xml
+++ b/collect_app/src/main/res/layout/form_entry.xml
@@ -49,10 +49,11 @@ the License.
             android:background="?colorPrimary"
             android:orientation="horizontal">
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/form_back_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:textColor="?colorOnPrimary"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:clickable="true"
                 android:focusable="true"
@@ -70,10 +71,11 @@ the License.
                 android:layout_height="match_parent"
                 android:layout_weight="1" />
 
-            <TextView
+            <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/form_forward_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:textColor="?colorOnPrimary"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:clickable="true"
                 android:focusable="true"


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested the navigation buttons with all three themes.

#### Why is this the best possible solution? Were any other approaches considered?
The text and images in Magenta theme should be white not black because black doesn't look good.
The table contains screenshots **before** and **after**:

| Magenta theme  | Light theme | Dark theme |
| ------------- | ------------- | ------------- |
| ![Screenshot_1591914488](https://user-images.githubusercontent.com/3276264/84472839-43b9c800-ac88-11ea-9e57-260f9cc5c9bd.png)  | ![Screenshot_1591914329](https://user-images.githubusercontent.com/3276264/84472836-43213180-ac88-11ea-9194-d13fed62d032.png)  | ![Screenshot_1591914300](https://user-images.githubusercontent.com/3276264/84472833-41f00480-ac88-11ea-9d4b-c855e4a9ce12.png)  |
| ![Screenshot_1591914239](https://user-images.githubusercontent.com/3276264/84472830-40264100-ac88-11ea-81d0-bb16d50b2699.png)  | No changes | No changes  |

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue and have no side effects. Checking the buttons using all three themes would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)