### PR TITLE
Fixed selecting elements in no-button widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
@@ -71,6 +71,7 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
         void bind(final int index) {
             super.bind(index);
             if (noButtonsMode) {
+                view.setBackground(null);
                 for (Selection selectedItem : selectedItems) {
                     if (filteredItems.get(index).getValue().equals(selectedItem.getValue())) {
                         view.setBackground(ContextCompat.getDrawable(view.getContext(), R.drawable.select_item_border));

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
@@ -73,7 +73,7 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
             if (noButtonsMode) {
                 for (Selection selectedItem : selectedItems) {
                     if (filteredItems.get(index).getValue().equals(selectedItem.getValue())) {
-                        view.getChildAt(0).setBackground(ContextCompat.getDrawable(view.getContext(), R.drawable.select_item_border));
+                        view.setBackground(ContextCompat.getDrawable(view.getContext(), R.drawable.select_item_border));
                         break;
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -99,8 +99,8 @@ public class SelectOneListAdapter extends AbstractSelectListAdapter
         void bind(final int index) {
             super.bind(index);
             if (noButtonsMode && filteredItems.get(index).getValue().equals(selectedValue)) {
-                view.getChildAt(0).setBackground(ContextCompat.getDrawable(view.getContext(), R.drawable.select_item_border));
-                selectedItem = view.getChildAt(0);
+                view.setBackground(ContextCompat.getDrawable(view.getContext(), R.drawable.select_item_border));
+                selectedItem = view;
             }
         }
     }


### PR DESCRIPTION
Closes #3926 

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that we have every single item wrapped in a FrameLayout and in our code sometimes we called:
view.getChildAt(0).setBackground (changing a child) but sometimes view.setBackground (changing a parent FrameLayout). Now we always add/remove the frame using the parent FrameLayout.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe change that should just fix the issue. Testing select no-button widgets would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
All widgets form would be enough.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)