### PR TITLE
Fixed search view colors

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
@@ -25,6 +25,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.CursorAdapter;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.ProgressBar;
@@ -175,6 +176,8 @@ abstract class AppListActivity extends CollectAbstractActivity {
         final MenuItem sortItem = menu.findItem(R.id.menu_sort);
         final MenuItem searchItem = menu.findItem(R.id.menu_filter);
         searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
+        EditText searchEditText = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
+        searchEditText.setTextColor(themeUtils.getColorOnPrimary());
         searchView.setQueryHint(getResources().getString(R.string.search));
         searchView.setMaxWidth(Integer.MAX_VALUE);
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
@@ -22,6 +22,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.SimpleCursorAdapter;
 
@@ -117,6 +118,8 @@ abstract class AppListFragment extends ListFragment {
         final MenuItem sortItem = menu.findItem(R.id.menu_sort);
         final MenuItem searchItem = menu.findItem(R.id.menu_filter);
         final SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
+        EditText searchEditText = searchView.findViewById(androidx.appcompat.R.id.search_src_text);
+        searchEditText.setTextColor(new ThemeUtils(getContext()).getColorOnPrimary());
         searchView.setQueryHint(getResources().getString(R.string.search));
         searchView.setMaxWidth(Integer.MAX_VALUE);
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -142,6 +142,11 @@ public final class ThemeUtils {
     }
 
     @ColorInt
+    public int getColorOnPrimary() {
+        return getAttributeValue(R.attr.colorOnPrimary);
+    }
+
+    @ColorInt
     public int getColorSecondary() {
         return getAttributeValue(R.attr.colorSecondary);
     }

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -16,6 +16,7 @@
         <item name="colorOnBackground">#000000</item>
         <item name="colorOnError">#FFFFFF</item>
         <item name="colorOnSurface">#000000</item>
+        <item name="android:textColorHint">#E3E3E3</item>
         <item name="scrimBackground">@color/mtrl_scrim_color</item>
 
         <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -16,7 +16,7 @@
         <item name="colorOnBackground">#000000</item>
         <item name="colorOnError">#FFFFFF</item>
         <item name="colorOnSurface">#000000</item>
-        <item name="android:textColorHint">#E3E3E3</item>
+        <item name="android:textColorHint">#E3E3E3</item> // defines the hint color for search
         <item name="scrimBackground">@color/mtrl_scrim_color</item>
 
         <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1


### PR DESCRIPTION
Work towards #3849 

#### What has been done to verify that this works as intended?
I checked the search view in all three themes:

|  |  |
| ------------- | ------------- |
| ![Screenshot_1592571326](https://user-images.githubusercontent.com/3276264/85134658-2a42ee00-b23d-11ea-9942-4c40f6c59ad3.png) | ![Screenshot_1592571338](https://user-images.githubusercontent.com/3276264/85134659-2b741b00-b23d-11ea-9fb3-5df2e92b97a0.png)  |

#### Why is this the best possible solution? Were any other approaches considered?
I tried adapting colors in themes but it didn't work so I had to do that problematically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's not a risky change but requires testing the search view in all three themes.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)