### PR TITLE
Correct typo in circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,7 @@ jobs:
 
       - run:
           name: Assemble test build
-          command: |
-            ./gradlew ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug assembleDebugAndroidTest
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |


### PR DESCRIPTION
Tried this out locally using the `circleci` CLI tool and the crashing step went through ok.