### PR TITLE
Remove broken test result download step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,16 +115,6 @@ jobs:
               --directories-to-pull /sdcard --timeout 20m
             fi
           no_output_timeout: 60m
-      - run:
-          name: Copy integration test results
-          command: |
-            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
-              mkdir firebase
-              gsutil -m cp -r -U "`gsutil ls gs://opendatakit-collect-test-results | tail -1`*" /root/work/firebase/ | true
-            fi
-      - store_test_results:
-          path: firebase/
-          destination: /firebase/
 
 workflows:
   version: 2


### PR DESCRIPTION
Hard to test locally without setting up service keys for `gcloud`. If we run into more problems we can back off and get that tooling setup.