### PR TITLE
Avoid crashes that might occur while initializing map providers

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -154,6 +154,8 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
 
     private MainMenuViewModel viewModel;
 
+    private MapView mapView;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -315,6 +317,14 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     @Override
+    protected void onStart() {
+        super.onStart();
+        if (mapView != null) {
+            mapView.onStart();
+        }
+    }
+
+    @Override
     protected void onResume() {
         super.onResume();
 
@@ -327,6 +337,9 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
         setButtonsVisibility();
         invalidateOptionsMenu();
         setUpStorageMigrationBanner();
+        if (mapView != null) {
+            mapView.onResume();
+        }
     }
 
     private void setButtonsVisibility() {
@@ -344,11 +357,41 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             alertDialog.dismiss();
         }
         getContentResolver().unregisterContentObserver(contentObserver);
+        if (mapView != null) {
+            mapView.onPause();
+        }
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if (mapView != null) {
+            mapView.onStop();
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (mapView != null) {
+            mapView.onSaveInstanceState(outState);
+        }
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        if (mapView != null) {
+            mapView.onLowMemory();
+        }
     }
 
     @Override
     public void onDestroy() {
         storageMigrationRepository.clearResult();
+        if (mapView != null) {
+            mapView.onDestroy();
+        }
         super.onDestroy();
     }
 
@@ -404,7 +447,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             // This "one weird trick" lets us initialize MapBox at app start when the internet is
             // most likely to be available. This is annoyingly needed for offline tiles to work.
             try {
-                MapView mapView = new MapView(this);
+                mapView = new MapView(this);
                 FrameLayout mapboxContainer = findViewById(R.id.mapbox_container);
                 mapboxContainer.addView(mapView);
                 mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -28,16 +28,12 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.ViewModelProviders;
-
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.Style;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
@@ -46,8 +42,6 @@ import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.injection.DaggerUtils;
-import org.odk.collect.android.network.NetworkStateProvider;
-import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.material.MaterialBanner;
 import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
@@ -89,7 +83,6 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import timber.log.Timber;
 
-import static org.odk.collect.android.preferences.MetaKeys.KEY_MAPBOX_INITIALIZED;
 import static org.odk.collect.android.utilities.DialogUtils.getDialog;
 import static org.odk.collect.android.utilities.DialogUtils.showIfNotShowing;
 
@@ -144,17 +137,9 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     VersionInformation versionInformation;
 
     @Inject
-    NetworkStateProvider connectivityProvider;
-
-    @Inject
     GeneralSharedPreferences generalSharedPreferences;
 
-    @Inject
-    PreferencesProvider preferencesProvider;
-
     private MainMenuViewModel viewModel;
-
-    private MapView mapView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -165,7 +150,6 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
         viewModel = ViewModelProviders.of(this, new MainMenuViewModel.Factory(versionInformation)).get(MainMenuViewModel.class);
 
         initToolbar();
-        initMapBox();
         DaggerUtils.getComponent(this).inject(this);
 
         storageMigrationRepository.getResult().observe(this, this::onStorageMigrationFinish);
@@ -317,14 +301,6 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        if (mapView != null) {
-            mapView.onStart();
-        }
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
 
@@ -337,9 +313,6 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
         setButtonsVisibility();
         invalidateOptionsMenu();
         setUpStorageMigrationBanner();
-        if (mapView != null) {
-            mapView.onResume();
-        }
     }
 
     private void setButtonsVisibility() {
@@ -357,41 +330,11 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             alertDialog.dismiss();
         }
         getContentResolver().unregisterContentObserver(contentObserver);
-        if (mapView != null) {
-            mapView.onPause();
-        }
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
-        if (mapView != null) {
-            mapView.onStop();
-        }
-    }
-
-    @Override
-    protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        if (mapView != null) {
-            mapView.onSaveInstanceState(outState);
-        }
-    }
-
-    @Override
-    public void onLowMemory() {
-        super.onLowMemory();
-        if (mapView != null) {
-            mapView.onLowMemory();
-        }
     }
 
     @Override
     public void onDestroy() {
         storageMigrationRepository.clearResult();
-        if (mapView != null) {
-            mapView.onDestroy();
-        }
         super.onDestroy();
     }
 
@@ -439,24 +382,6 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
                 return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    private void initMapBox() {
-        SharedPreferences metaSharedPreferences = preferencesProvider.getMetaSharedPreferences();
-        if (!metaSharedPreferences.getBoolean(KEY_MAPBOX_INITIALIZED, false) && connectivityProvider.isDeviceOnline()) {
-            // This "one weird trick" lets us initialize MapBox at app start when the internet is
-            // most likely to be available. This is annoyingly needed for offline tiles to work.
-            try {
-                mapView = new MapView(this);
-                FrameLayout mapboxContainer = findViewById(R.id.mapbox_container);
-                mapboxContainer.addView(mapView);
-                mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> {
-                    metaSharedPreferences.edit().putBoolean(KEY_MAPBOX_INITIALIZED, true).apply();
-                }));
-            } catch (Exception | Error ignored) {
-                // This will crash on devices where the arch for MapBox is not included
-            }
-        }
     }
 
     private void initToolbar() {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -99,9 +99,13 @@ public class ApplicationInitializer {
     }
 
     private void initializeMapFrameworks() {
-        new com.google.android.gms.maps.MapView(context).onCreate(null);
-        org.osmdroid.config.Configuration.getInstance().setUserAgentValue(userAgentProvider.getUserAgent());
-        MapboxUtils.initMapbox();
+        try {
+            new com.google.android.gms.maps.MapView(context).onCreate(null);
+            org.osmdroid.config.Configuration.getInstance().setUserAgentValue(userAgentProvider.getUserAgent());
+            MapboxUtils.initMapbox();
+        } catch (Exception | Error ignore) {
+            // ignored
+        }
     }
 
     private static class CrashReportingTree extends Timber.Tree {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/MapBoxInitializationFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/MapBoxInitializationFragment.java
@@ -1,0 +1,121 @@
+package org.odk.collect.android.fragments;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.network.NetworkStateProvider;
+import org.odk.collect.android.preferences.PreferencesProvider;
+
+import javax.inject.Inject;
+
+import static org.odk.collect.android.preferences.MetaKeys.KEY_MAPBOX_INITIALIZED;
+
+public class MapBoxInitializationFragment extends Fragment {
+
+    @Inject
+    PreferencesProvider preferencesProvider;
+
+    @Inject
+    NetworkStateProvider connectivityProvider;
+
+    private MapView mapView;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        DaggerUtils.getComponent(getActivity()).inject(this);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.mapbox_fragment_layout, container, false);
+        initMapBox(rootView);
+        return rootView;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (mapView != null) {
+            mapView.onStart();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mapView != null) {
+            mapView.onResume();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (mapView != null) {
+            mapView.onPause();
+        }
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        if (mapView != null) {
+            mapView.onStop();
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (mapView != null) {
+            mapView.onSaveInstanceState(outState);
+        }
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        if (mapView != null) {
+            mapView.onLowMemory();
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        if (mapView != null) {
+            mapView.onDestroy();
+        }
+    }
+
+    private void initMapBox(View rootView) {
+        SharedPreferences metaSharedPreferences = preferencesProvider.getMetaSharedPreferences();
+        if (!metaSharedPreferences.getBoolean(KEY_MAPBOX_INITIALIZED, false) && connectivityProvider.isDeviceOnline()) {
+            // This "one weird trick" lets us initialize MapBox at app start when the internet is
+            // most likely to be available. This is annoyingly needed for offline tiles to work.
+            try {
+                mapView = new MapView(getContext());
+                FrameLayout mapBoxContainer = rootView.findViewById(R.id.map_box_container);
+                mapBoxContainer.addView(mapView);
+                mapView.getMapAsync(mapBoxMap -> mapBoxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+                    metaSharedPreferences.edit().putBoolean(KEY_MAPBOX_INITIALIZED, true).apply();
+                }));
+            } catch (Exception | Error ignored) {
+                // This will crash on devices where the arch for MapBox is not included
+            }
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -22,6 +22,7 @@ import org.odk.collect.android.formentry.ODKView;
 import org.odk.collect.android.formentry.QuitFormDialogFragment;
 import org.odk.collect.android.formentry.saving.SaveFormProgressDialogFragment;
 import org.odk.collect.android.fragments.DataManagerList;
+import org.odk.collect.android.fragments.MapBoxInitializationFragment;
 import org.odk.collect.android.geo.GoogleMapFragment;
 import org.odk.collect.android.geo.MapboxMapFragment;
 import org.odk.collect.android.geo.OsmDroidMapFragment;
@@ -167,6 +168,8 @@ public interface AppDependencyComponent {
     void inject(SaveFormProgressDialogFragment saveFormProgressDialogFragment);
 
     void inject(QuitFormDialogFragment quitFormDialogFragment);
+
+    void inject(MapBoxInitializationFragment mapBoxInitializationFragment);
 
     RxEventBus rxEventBus();
 

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -34,13 +34,13 @@
                 android:visibility="gone"
                 custom:text="blah"
                 custom:secondaryActionColor="true" />
-
-            <FrameLayout
-                android:id="@+id/mapbox_container"
+            
+            <fragment
+                android:name="org.odk.collect.android.fragments.MapBoxInitializationFragment"
+                android:id="@+id/map_box_initialization_fragment"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:visibility="invisible">
-            </FrameLayout>
+                android:layout_height="1dp">
+            </fragment>
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/collect_app/src/main/res/layout/mapbox_fragment_layout.xml
+++ b/collect_app/src/main/res/layout/mapbox_fragment_layout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/map_box_container"
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:visibility="invisible">
+
+</FrameLayout>


### PR DESCRIPTION
Closes #3846 

#### What has been done to verify that this works as intended?
I reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
The first commit is not strictly a fix for the issue but should catch possible exceptions like:
https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/45c613c546aa3cea42be7d9fa55c286d?time=last-seven-days&sessionId=5EF99A4C0180000114A81ED19C1D1285_DNE_0_v2

The second commit I prepared based on:
https://github.com/mapbox/mapbox-gl-native-android/issues/126#issuecomment-650708237
and
https://docs.mapbox.com/android/maps/overview/#5-lifecycle-methods

@lognaturel you said that we should at least handle on destroy but in bot cases (links) they say that we should handle all lifecycle methods so just in case I think it's a good idea to do that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It shouldn't change anything in behavior. It should just prevent from crashes so i'm not even sure if this pr requires testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)