### PR TITLE
Update storage migration banner for v1.28

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -654,7 +654,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
 
     private void displayStorageMigrationBanner() {
         storageMigrationBanner.setVisibility(View.VISIBLE);
-        storageMigrationBanner.setText(getString(R.string.scoped_storage_banner_text));
+        storageMigrationBanner.setText(getText(R.string.scoped_storage_banner_text));
         storageMigrationBanner.setActionText(getString(R.string.scoped_storage_learn_more));
         storageMigrationBanner.setAction(() -> {
             showStorageMigrationDialog();

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -24,7 +24,6 @@ import androidx.annotation.Nullable;
 import androidx.multidex.MultiDex;
 
 import org.odk.collect.android.BuildConfig;
-import org.odk.collect.android.R;
 import org.odk.collect.android.application.initialization.ApplicationInitializer;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.external.ExternalDataManager;
@@ -42,8 +41,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 
 import javax.inject.Inject;
-
-import timber.log.Timber;
 
 import static org.odk.collect.android.logic.PropertyManager.PROPMGR_USERNAME;
 import static org.odk.collect.android.logic.PropertyManager.SCHEME_USERNAME;
@@ -137,10 +134,6 @@ public class Collect extends Application {
 
         initializeJavaRosa();
         setupStrictMode();
-
-        // Force inclusion of scoped storage strings so they can be translated
-        Timber.i("%s %s", getString(R.string.scoped_storage_banner_text),
-                                   getString(R.string.scoped_storage_learn_more));
     }
 
     /**

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -683,7 +683,7 @@
     <string name="save_legacy_settings_warning">Will be removed in a future version. Please use the QR code above.</string>
     <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
 
-    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage by August 2020 to comply with Android requirements.</string>
+    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage to comply with Android requirements. In Collect v1.29, <b>the migration will be forced on install</b>.</string>
     <string name="scoped_storage_learn_more">Learn more and migrate</string>
     <string name="storage_migration_completed">Storage migration completed!</string>
     <string name="scoped_storage_dismiss">Dismiss</string>

--- a/material/src/main/java/org/odk/collect/material/MaterialBanner.java
+++ b/material/src/main/java/org/odk/collect/material/MaterialBanner.java
@@ -46,6 +46,11 @@ public class MaterialBanner extends FrameLayout {
         textView.setText(text);
     }
 
+    public void setText(CharSequence text) {
+        TextView textView = findViewById(R.id.text);
+        textView.setText(text);
+    }
+
     public void setActionText(String actionTitle) {
         Button button = findViewById(R.id.button);
         button.setText(actionTitle);


### PR DESCRIPTION
Closes #3936

#### What has been done to verify that this works as intended?
Ran it and verified that in particular the bold looks as expected.

#### Why is this the best possible solution? Were any other approaches considered?
We discussed the string in the issue. Adding the `setText(CharSequence)` method to `MaterialBanner` seems like the most straightforward way to add styling.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is only a text change so there should be no risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)