### PR TITLE
Allow forms to be edited after blank form deletion

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -33,4 +33,28 @@ public class DeleteBlankFormTest {
                 .clickFillBlankForm()
                 .assertTextDoesNotExist("One Question");
     }
+
+    @Test
+    public void deletingAForm_whenThereFillForms_allowsEditing() {
+        rule.mainMenu()
+                .startBlankForm("One Question")
+                .answerQuestion("what is your age", "22")
+                .swipeToEndScreen()
+                .clickSaveAndExit()
+
+                .clickDeleteSavedForm()
+                .clickBlankForms()
+                .clickForm("One Question")
+                .clickDeleteSelected(1)
+                .clickDeleteForms()
+                .assertTextDoesNotExist("One Question")
+                .pressBack(new MainMenuPage(rule))
+
+                .clickEditSavedForm()
+                .clickOnForm("One Question")
+                .clickOnQuestion("what is your age")
+                .answerQuestion("what is your age", "30")
+                .swipeToEndScreen()
+                .clickSaveAndExit();
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -35,7 +35,7 @@ public class DeleteBlankFormTest {
     }
 
     @Test
-    public void deletingAForm_whenThereFillForms_allowsEditing() {
+    public void deletingAForm_whenThereFilledForms_allowsEditing() {
         rule.mainMenu()
                 .startBlankForm("One Question")
                 .answerQuestion("what is your age", "22")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -1,0 +1,36 @@
+package org.odk.collect.android.feature.formmanagement;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.TestRuleChain;
+import org.odk.collect.android.support.pages.MainMenuPage;
+
+@RunWith(AndroidJUnit4.class)
+public class DeleteBlankFormTest {
+
+    public final CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public final RuleChain chain = TestRuleChain.chain()
+            .around(new CopyFormRule("one-question.xml"))
+            .around(rule);
+
+    @Test
+    public void deletingAForm_removesFormFromBlankFormList() {
+        rule.mainMenu()
+                .clickDeleteSavedForm()
+                .clickBlankForms()
+                .clickForm("One Question")
+                .clickDeleteSelected(1)
+                .clickDeleteForms()
+                .pressBack(new MainMenuPage(rule))
+                .clickFillBlankForm()
+                .assertTextDoesNotExist("One Question");
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteFilledFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteFilledFormTest.java
@@ -22,7 +22,7 @@ public class DeleteFilledFormTest {
             .around(rule);
 
     @Test
-    public void deletingAForm_removesFormFromBlankFormList() {
+    public void deletingAForm_removesFormFromFinalizedForms() {
         rule.mainMenu()
                 .startBlankForm("One Question")
                 .answerQuestion("what is your age", "30")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteFilledFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/DeleteFilledFormTest.java
@@ -1,0 +1,39 @@
+package org.odk.collect.android.feature.instancemanagement;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.TestRuleChain;
+import org.odk.collect.android.support.pages.MainMenuPage;
+
+@RunWith(AndroidJUnit4.class)
+public class DeleteFilledFormTest {
+
+    public final CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public final RuleChain chain = TestRuleChain.chain()
+            .around(new CopyFormRule("one-question.xml"))
+            .around(rule);
+
+    @Test
+    public void deletingAForm_removesFormFromBlankFormList() {
+        rule.mainMenu()
+                .startBlankForm("One Question")
+                .answerQuestion("what is your age", "30")
+                .swipeToEndScreen()
+                .clickSaveAndExit()
+
+                .clickDeleteSavedForm()
+                .clickForm("One Question")
+                .clickDeleteSelected(1)
+                .clickDeleteForms()
+                .pressBack(new MainMenuPage(rule))
+                .assertNumberOfFinalizedForms(0);
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/DeleteSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/DeleteSavedFormPage.java
@@ -1,0 +1,38 @@
+package org.odk.collect.android.support.pages;
+
+import androidx.test.rule.ActivityTestRule;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.provider.FormsProviderAPI;
+
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.CursorMatchers.withRowString;
+
+public class DeleteSavedFormPage extends Page<DeleteSavedFormPage> {
+
+    public DeleteSavedFormPage(ActivityTestRule rule) {
+        super(rule);
+    }
+
+    @Override
+    public DeleteSavedFormPage assertOnPage() {
+        assertToolbarTitle(getTranslatedString(R.string.manage_files));
+        return this;
+    }
+
+    public DeleteSavedFormPage clickBlankForms() {
+        clickOnString(R.string.forms);
+        return this;
+    }
+
+    public DeleteSavedFormPage clickForm(String formName) {
+        onData(withRowString(FormsProviderAPI.FormsColumns.DISPLAY_NAME, formName)).perform(click());
+        return this;
+    }
+
+    public DeleteSelectedDialog clickDeleteSelected(int numberSelected) {
+        clickOnString(R.string.delete_file);
+        return new DeleteSelectedDialog(numberSelected, this, rule).assertOnPage();
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/DeleteSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/DeleteSavedFormPage.java
@@ -3,11 +3,11 @@ package org.odk.collect.android.support.pages;
 import androidx.test.rule.ActivityTestRule;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.provider.FormsProviderAPI;
 
-import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.matcher.CursorMatchers.withRowString;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 public class DeleteSavedFormPage extends Page<DeleteSavedFormPage> {
 
@@ -27,7 +27,7 @@ public class DeleteSavedFormPage extends Page<DeleteSavedFormPage> {
     }
 
     public DeleteSavedFormPage clickForm(String formName) {
-        onData(withRowString(FormsProviderAPI.FormsColumns.DISPLAY_NAME, formName)).perform(click());
+        onView(withText(formName)).perform(scrollTo(), click());
         return this;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/DeleteSelectedDialog.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/DeleteSelectedDialog.java
@@ -1,0 +1,28 @@
+package org.odk.collect.android.support.pages;
+
+import androidx.test.rule.ActivityTestRule;
+
+import org.odk.collect.android.R;
+
+public class DeleteSelectedDialog extends Page<DeleteSelectedDialog> {
+
+    private final int numberSelected;
+    private final DeleteSavedFormPage destination;
+
+    public DeleteSelectedDialog(int numberSelected, DeleteSavedFormPage destination, ActivityTestRule rule) {
+        super(rule);
+        this.numberSelected = numberSelected;
+        this.destination = destination;
+    }
+
+    @Override
+    public DeleteSelectedDialog assertOnPage() {
+        assertText(getTranslatedString(R.string.delete_confirm, numberSelected));
+        return this;
+    }
+
+    public DeleteSavedFormPage clickDeleteForms() {
+        clickOnString(R.string.delete_yes);
+        return destination.assertOnPage();
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
@@ -67,9 +67,9 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
         return new IdentifyUserPromptPage(formName, rule).assertOnPage();
     }
 
-    public FormEntryPage clickOnForm(String formName) {
+    public FormHierarchyPage clickOnForm(String formName) {
         scrollToAndClickOnForm(formName);
-        return new FormEntryPage(formName, rule);
+        return new FormHierarchyPage(formName, rule);
     }
 
     private void scrollToAndClickOnForm(String formName) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -20,6 +20,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.toPackage;
 import static androidx.test.espresso.matcher.CursorMatchers.withRowString;
+import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -247,7 +248,8 @@ public class MainMenuPage extends Page<MainMenuPage> {
     }
 
     public DeleteSavedFormPage clickDeleteSavedForm() {
-        onView(withText(getTranslatedString(R.string.manage_files))).perform(click());
+        onView(withText(getTranslatedString(R.string.manage_files))).check(matches(isClickable()));
+        onView(withText(getTranslatedString(R.string.manage_files))).perform(scrollTo(), click());
         return new DeleteSavedFormPage(rule).assertOnPage();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -245,5 +245,10 @@ public class MainMenuPage extends Page<MainMenuPage> {
         onView(withText(getTranslatedString(R.string.view_sent_forms_button, formCount))).perform(click());
         return new ViewSentFormPage(rule).assertOnPage();
     }
+
+    public DeleteSavedFormPage clickDeleteSavedForm() {
+        onView(withText(getTranslatedString(R.string.manage_files))).perform(click());
+        return new DeleteSavedFormPage(rule).assertOnPage();
+    }
 }
 

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -116,7 +116,7 @@ the specific language governing permissions and limitations under the License.
         <activity android:name=".activities.FillBlankFormActivity" />
         <activity android:name=".activities.FormDownloadListActivity" />
         <activity
-            android:name=".activities.FileManagerTabs"
+            android:name=".activities.DeleteSavedFormActivity"
             android:configChanges="orientation|screenSize" />
         <activity
             android:name=".activities.GoogleSheetsUploaderActivity"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DeleteSavedFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DeleteSavedFormActivity.java
@@ -16,6 +16,7 @@ package org.odk.collect.android.activities;
 
 import android.content.res.Configuration;
 import android.os.Bundle;
+
 import androidx.appcompat.widget.Toolbar;
 import androidx.viewpager2.widget.ViewPager2;
 
@@ -25,7 +26,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.FileManagerTabsAdapter;
 
-public class FileManagerTabs extends CollectAbstractActivity {
+public class DeleteSavedFormActivity extends CollectAbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -75,8 +75,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AudioControllerView;
-import org.odk.collect.android.backgroundwork.AutoSendTaskSpec;
 import org.odk.collect.android.backgroundwork.FormSubmitManager;
+import org.odk.collect.android.instancemanagement.InstanceSubmitter;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.helpers.ContentResolverHelper;
 import org.odk.collect.android.dao.helpers.FormsDaoHelper;
@@ -149,8 +149,8 @@ import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangeWidget;
 import org.odk.collect.android.widgets.interfaces.BinaryDataReceiver;
-import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.android.widgets.utilities.FormControllerWaitingForDataRegistry;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -1882,7 +1882,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         // Request auto-send if app-wide auto-send is enabled or the form that was just
                         // finalized specifies that it should always be auto-sent.
                         String formId = getFormController().getFormDef().getMainInstance().getRoot().getAttributeValue("", "id");
-                        if (AutoSendTaskSpec.formShouldBeAutoSent(formId, GeneralSharedPreferences.isAutoSendEnabled())) {
+                        if (InstanceSubmitter.formShouldBeAutoSent(formId, GeneralSharedPreferences.isAutoSendEnabled())) {
                             formSubmitManager.scheduleSubmit();
                         }
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -23,6 +23,8 @@ import android.os.Bundle;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.fragments.dialogs.SimpleDialog;
+import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.storage.StorageInitializer;
@@ -38,6 +40,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
+
+import javax.inject.Inject;
 
 import timber.log.Timber;
 
@@ -74,10 +78,13 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
     private String password;
     private Boolean deleteInstanceAfterUpload;
 
+    @Inject
+    InstancesRepository instancesRepository;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Timber.i("onCreate: %s", savedInstanceState == null ? "creating" : "re-initializing");
+        DaggerUtils.getComponent(this).inject(this);
 
         // This activity is accessed directly externally
         new PermissionUtils().requestStoragePermissions(this, new PermissionListener() {
@@ -191,6 +198,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
 
             // register this activity with the new uploader task
             instanceServerUploaderTask.setUploaderListener(this);
+            instanceServerUploaderTask.setRepositories(instancesRepository);
             instanceServerUploaderTask.execute(instancesToSend);
         }
     }
@@ -366,6 +374,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
         if (url != null) {
             instanceServerUploaderTask.setCompleteDestinationUrl(url + Collect.getInstance().getString(R.string.default_odk_submission), false);
         }
+        instanceServerUploaderTask.setRepositories(instancesRepository);
         instanceServerUploaderTask.execute(instancesToSend);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -22,6 +22,7 @@ import android.os.Bundle;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.fragments.dialogs.SimpleDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.instances.InstancesRepository;
@@ -80,6 +81,9 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
 
     @Inject
     InstancesRepository instancesRepository;
+
+    @Inject
+    FormsRepository formsRepository;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -198,7 +202,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
 
             // register this activity with the new uploader task
             instanceServerUploaderTask.setUploaderListener(this);
-            instanceServerUploaderTask.setRepositories(instancesRepository);
+            instanceServerUploaderTask.setRepositories(instancesRepository, formsRepository);
             instanceServerUploaderTask.execute(instancesToSend);
         }
     }
@@ -374,7 +378,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
         if (url != null) {
             instanceServerUploaderTask.setCompleteDestinationUrl(url + Collect.getInstance().getString(R.string.default_odk_submission), false);
         }
-        instanceServerUploaderTask.setRepositories(instancesRepository);
+        instanceServerUploaderTask.setRepositories(instancesRepository, formsRepository);
         instanceServerUploaderTask.execute(instancesToSend);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -238,7 +238,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             public void onClick(View v) {
                 if (MultiClickGuard.allowClick(getClass().getName())) {
                     Intent i = new Intent(getApplicationContext(),
-                            FileManagerTabs.class);
+                            DeleteSavedFormActivity.class);
                     startActivity(i);
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -94,7 +94,7 @@ public class FormMapViewModel extends ViewModel {
                             Double lat = coordinates.getDouble(1);
 
                             mappableFormInstances.add(new MappableFormInstance(
-                                    instance.getDatabaseId(),
+                                    instance.getId(),
                                     lat, lon,
                                     instance.getDisplayName(),
                                     instance.getLastStatusChangeDate(),
@@ -122,7 +122,7 @@ public class FormMapViewModel extends ViewModel {
                     || instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMISSION_FAILED))
                     && !instance.canEditWhenComplete()) {
                 return ClickAction.NOT_VIEWABLE_TOAST;
-            } else if (instance.getDatabaseId() != null) {
+            } else if (instance.getId() != null) {
                 if (instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED)) {
                     return ClickAction.OPEN_READ_ONLY;
                 }
@@ -134,7 +134,7 @@ public class FormMapViewModel extends ViewModel {
     }
 
     public long getDeletedDateOf(long databaseId) {
-        return instancesRepository.getBy(databaseId).getDeletedDate();
+        return instancesRepository.get(databaseId).getDeletedDate();
     }
 
     public enum ClickAction {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -57,7 +57,7 @@ public class FormMapViewModel extends ViewModel {
     }
 
     private void initializeFormInstances() {
-        List<Instance> instances = instancesRepository.getAllBy(form.getJrFormId());
+        List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
 
         // Ideally we could observe database changes instead of re-computing this every time.
         totalInstanceCount = instances.size();

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.java
@@ -18,10 +18,9 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.net.Uri;
 import android.os.Environment;
+import android.util.Pair;
 
-import androidx.annotation.NonNull;
 import androidx.work.WorkerParameters;
 
 import org.jetbrains.annotations.NotNull;
@@ -29,41 +28,21 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
-import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.instances.Instance;
-import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.instancemanagement.InstanceSubmitter;
+import org.odk.collect.android.instancemanagement.SubmitException;
 import org.odk.collect.android.network.NetworkStateProvider;
 import org.odk.collect.android.notifications.Notifier;
-import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
-import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.migration.StorageMigrationRepository;
-import org.odk.collect.android.upload.InstanceGoogleSheetsUploader;
-import org.odk.collect.android.upload.InstanceServerUploader;
-import org.odk.collect.android.upload.InstanceUploader;
-import org.odk.collect.android.upload.UploadException;
-import org.odk.collect.android.utilities.InstanceUploaderUtils;
-import org.odk.collect.android.utilities.PermissionUtils;
-import org.odk.collect.android.utilities.WebCredentialsUtils;
-import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
 import org.odk.collect.async.TaskSpec;
 import org.odk.collect.async.WorkerAdapter;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
-
-import timber.log.Timber;
-
-import static org.odk.collect.android.analytics.AnalyticsEvents.SUBMISSION;
-import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SEND;
-import static org.odk.collect.android.utilities.InstanceUploaderUtils.SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE;
 
 public class AutoSendTaskSpec implements TaskSpec {
 
@@ -79,15 +58,18 @@ public class AutoSendTaskSpec implements TaskSpec {
     @Inject
     Notifier notifier;
 
+    @Inject
+    ChangeLock changeLock;
+
     /**
      * If the app-level auto-send setting is enabled, send all finalized forms that don't specify not
      * to auto-send at the form level. If the app-level auto-send setting is disabled, send all
      * finalized forms that specify to send at the form level.
-     *
+     * <p>
      * Fails immediately if:
-     *   - storage isn't ready
-     *   - the network type that toggled on is not the desired type AND no form specifies auto-send
-     *
+     * - storage isn't ready
+     * - the network type that toggled on is not the desired type AND no form specifies auto-send
+     * <p>
      * If the network type doesn't match the auto-send settings, retry next time a connection is
      * available.
      */
@@ -102,8 +84,7 @@ public class AutoSendTaskSpec implements TaskSpec {
             }
 
             NetworkInfo currentNetworkInfo = connectivityProvider.getNetworkInfo();
-            if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)
-                    || !(networkTypeMatchesAutoSendSetting(currentNetworkInfo) || atLeastOneFormSpecifiesAutoSend())) {
+            if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED) || !(networkTypeMatchesAutoSendSetting(currentNetworkInfo) || atLeastOneFormSpecifiesAutoSend())) {
                 if (!networkTypeMatchesAutoSendSetting(currentNetworkInfo)) {
                     return false;
                 }
@@ -111,79 +92,29 @@ public class AutoSendTaskSpec implements TaskSpec {
                 return true;
             }
 
-            List<Instance> toUpload = getInstancesToAutoSend(GeneralSharedPreferences.isAutoSendEnabled());
-
-            if (toUpload.isEmpty()) {
-                return true;
-            }
-
-            GeneralSharedPreferences settings = GeneralSharedPreferences.getInstance();
-            String protocol = (String) settings.get(GeneralKeys.KEY_PROTOCOL);
-
-            InstanceUploader uploader;
-            Map<String, String> resultMessagesByInstanceId = new HashMap<>();
-            String deviceId = null;
-            boolean anyFailure = false;
-
-            if (protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets))) {
-                if (PermissionUtils.isGetAccountsPermissionGranted(Collect.getInstance())) {
-                    GoogleAccountsManager accountsManager = new GoogleAccountsManager(Collect.getInstance());
-                    String googleUsername = accountsManager.getLastSelectedAccountIfValid();
-                    if (googleUsername.isEmpty()) {
-                        notifier.onSubmission(true, Collect.getInstance().getString(R.string.google_set_account));
-                        return true;
+            return changeLock.withLock(acquiredLock -> {
+                if (acquiredLock) {
+                    try {
+                        Pair<Boolean, String> results = new InstanceSubmitter(analytics).submitUnsubmittedInstances();
+                        notifier.onSubmission(results.first, results.second);
+                    } catch (SubmitException e) {
+                        switch (e.getType()) {
+                            case GOOGLE_ACCOUNT_NOT_SET:
+                                notifier.onSubmission(true, Collect.getInstance().getString(R.string.google_set_account));
+                                break;
+                            case GOOGLE_ACCOUNT_NOT_PERMITTED:
+                                notifier.onSubmission(true, Collect.getInstance().getString(R.string.odk_permissions_fail));
+                                break;
+                            case NOTHING_TO_SUBMIT:
+                                break;
+                        }
                     }
-                    accountsManager.selectAccount(googleUsername);
-                    uploader = new InstanceGoogleSheetsUploader(accountsManager);
-                } else {
-                    notifier.onSubmission(true, Collect.getInstance().getString(R.string.odk_permissions_fail));
+
                     return true;
+                } else {
+                    return false;
                 }
-            } else {
-                OpenRosaHttpInterface httpInterface = Collect.getInstance().getComponent().openRosaHttpInterface();
-                uploader = new InstanceServerUploader(httpInterface,
-                        new WebCredentialsUtils(), new HashMap<>());
-                deviceId = new PropertyManager(Collect.getInstance().getApplicationContext())
-                        .getSingularProperty(PropertyManager.withUri(PropertyManager.PROPMGR_DEVICE_ID));
-            }
-
-            for (Instance instance : toUpload) {
-                try {
-                    String destinationUrl = uploader.getUrlToSubmitTo(instance, deviceId, null);
-                    if (protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets))
-                            && !InstanceUploaderUtils.doesUrlRefersToGoogleSheetsFile(destinationUrl)) {
-                        anyFailure = true;
-                        resultMessagesByInstanceId.put(instance.getDatabaseId().toString(), SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE);
-                        continue;
-                    }
-                    String customMessage = uploader.uploadOneSubmission(instance, destinationUrl);
-                    resultMessagesByInstanceId.put(instance.getDatabaseId().toString(), customMessage != null ? customMessage : Collect.getInstance().getString(R.string.success));
-
-                    // If the submission was successful, delete the instance if either the app-level
-                    // delete preference is set or the form definition requests auto-deletion.
-                    // TODO: this could take some time so might be better to do in a separate process,
-                    // perhaps another worker. It also feels like this could fail and if so should be
-                    // communicated to the user. Maybe successful delete should also be communicated?
-                    if (InstanceUploader.formShouldBeAutoDeleted(instance.getJrFormId(),
-                            (boolean) GeneralSharedPreferences.getInstance().get(GeneralKeys.KEY_DELETE_AFTER_SEND))) {
-                        Uri deleteForm = Uri.withAppendedPath(InstanceColumns.CONTENT_URI, instance.getDatabaseId().toString());
-                        Collect.getInstance().getContentResolver().delete(deleteForm, null, null);
-                    }
-
-                    String action = protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets)) ?
-                            "HTTP-Sheets auto" : "HTTP auto";
-                    String label = Collect.getFormIdentifierHash(instance.getJrFormId(), instance.getJrVersion());
-                    analytics.logEvent(SUBMISSION, action, label);
-                } catch (UploadException e) {
-                    Timber.d(e);
-                    anyFailure = true;
-                    resultMessagesByInstanceId.put(instance.getDatabaseId().toString(),
-                            e.getDisplayMessage());
-                }
-            }
-
-            notifier.onSubmission(anyFailure, InstanceUploaderUtils.getUploadResultMessage(Collect.getInstance(), resultMessagesByInstanceId));
-            return true;
+            });
         };
     }
 
@@ -219,53 +150,9 @@ public class AutoSendTaskSpec implements TaskSpec {
     }
 
     /**
-     * Returns instances that need to be auto-sent.
-     */
-    @NonNull
-    private List<Instance> getInstancesToAutoSend(boolean isAutoSendAppSettingEnabled) {
-        InstancesDao dao = new InstancesDao();
-        Cursor c = dao.getFinalizedInstancesCursor();
-        List<Instance> allFinalized = dao.getInstancesFromCursor(c);
-
-        List<Instance> toUpload = new ArrayList<>();
-        for (Instance instance : allFinalized) {
-            if (formShouldBeAutoSent(instance.getJrFormId(), isAutoSendAppSettingEnabled)) {
-                toUpload.add(instance);
-            }
-        }
-
-        return toUpload;
-    }
-
-    /**
-     * Returns whether a form with the specified form_id should be auto-sent given the current
-     * app-level auto-send settings. Returns false if there is no form with the specified form_id.
-     *
-     * A form should be auto-sent if auto-send is on at the app level AND this form doesn't override
-     * auto-send settings OR if auto-send is on at the form-level.
-     *
-     * @param isAutoSendAppSettingEnabled whether the auto-send option is enabled at the app level
-     */
-    public static boolean formShouldBeAutoSent(String jrFormId, boolean isAutoSendAppSettingEnabled) {
-        Cursor cursor = new FormsDao().getFormsCursorForFormId(jrFormId);
-        String formLevelAutoSend = null;
-        if (cursor != null && cursor.moveToFirst()) {
-            try {
-                int autoSendColumnIndex = cursor.getColumnIndex(AUTO_SEND);
-                formLevelAutoSend = cursor.getString(autoSendColumnIndex);
-            } finally {
-                cursor.close();
-            }
-        }
-
-        return formLevelAutoSend == null ? isAutoSendAppSettingEnabled
-                : Boolean.valueOf(formLevelAutoSend);
-    }
-
-    /**
      * Returns true if at least one form currently on the device specifies that all of its filled
      * forms should auto-send no matter the connection type.
-     *
+     * <p>
      * TODO: figure out where this should live
      */
     private boolean atLeastOneFormSpecifiesAutoSend() {

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 public class AutoSendTaskSpec implements TaskSpec {
 
@@ -59,6 +60,7 @@ public class AutoSendTaskSpec implements TaskSpec {
     Notifier notifier;
 
     @Inject
+    @Named("INSTANCES")
     ChangeLock changeLock;
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpec.java
@@ -22,13 +22,10 @@ import androidx.work.WorkerParameters;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
-import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.formmanagement.previouslydownloaded.ServerFormsUpdateChecker;
-import org.odk.collect.android.forms.FormRepository;
 import org.odk.collect.android.injection.DaggerUtils;
-import org.odk.collect.android.network.NetworkStateProvider;
 import org.odk.collect.android.notifications.Notifier;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.android.storage.migration.StorageMigrationRepository;
 import org.odk.collect.android.utilities.MultiFormDownloader;
 import org.odk.collect.async.TaskSpec;
@@ -45,22 +42,22 @@ import static org.odk.collect.android.preferences.GeneralKeys.KEY_AUTOMATIC_UPDA
 public class AutoUpdateTaskSpec implements TaskSpec {
 
     @Inject
-    ServerFormsDetailsFetcher serverFormsDetailsFetcher;
+    ServerFormsUpdateChecker serverFormsUpdateChecker;
 
     @Inject
     StorageMigrationRepository storageMigrationRepository;
 
     @Inject
-    NetworkStateProvider connectivityProvider;
-
-    @Inject
     MultiFormDownloader multiFormDownloader;
 
     @Inject
-    FormRepository formRepository;
+    Notifier notifier;
 
     @Inject
-    Notifier notifier;
+    PreferencesProvider preferencesProvider;
+
+    @Inject
+    ChangeLock changeLock;
 
     @NotNull
     @Override
@@ -68,17 +65,18 @@ public class AutoUpdateTaskSpec implements TaskSpec {
         DaggerUtils.getComponent(context).inject(this);
 
         return () -> {
-            if (!connectivityProvider.isDeviceOnline() || storageMigrationRepository.isMigrationBeingPerformed()) {
-                return true;
-            }
-
-            ServerFormsUpdateChecker checker = new ServerFormsUpdateChecker(serverFormsDetailsFetcher, formRepository);
-            List<ServerFormDetails> newUpdates = checker.check();
+            List<ServerFormDetails> newUpdates = serverFormsUpdateChecker.check();
 
             if (!newUpdates.isEmpty()) {
-                if (GeneralSharedPreferences.getInstance().getBoolean(KEY_AUTOMATIC_UPDATE, false)) {
-                    final HashMap<ServerFormDetails, String> result = multiFormDownloader.downloadForms(newUpdates, null);
-                    notifier.onUpdatesDownloaded(result);
+                if (preferencesProvider.getGeneralSharedPreferences().getBoolean(KEY_AUTOMATIC_UPDATE, false)) {
+                    changeLock.withLock(acquiredLock -> {
+                        if (acquiredLock) {
+                            final HashMap<ServerFormDetails, String> result = multiFormDownloader.downloadForms(newUpdates, null);
+                            notifier.onUpdatesDownloaded(result);
+                        }
+
+                        return null;
+                    });
                 } else {
                     notifier.onUpdatesAvailable();
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpec.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_AUTOMATIC_UPDATE;
 
@@ -57,6 +58,7 @@ public class AutoUpdateTaskSpec implements TaskSpec {
     PreferencesProvider preferencesProvider;
 
     @Inject
+    @Named("FORMS")
     ChangeLock changeLock;
 
     @NotNull

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/ChangeLock.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/ChangeLock.java
@@ -1,0 +1,8 @@
+package org.odk.collect.android.backgroundwork;
+
+import java.util.function.Function;
+
+public interface ChangeLock {
+
+    <T> T withLock(Function<Boolean, T> function);
+}

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/FormSubmitManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/FormSubmitManager.java
@@ -2,7 +2,5 @@ package org.odk.collect.android.backgroundwork;
 
 public interface FormSubmitManager {
 
-    boolean isSubmitRunning();
-
     void scheduleSubmit();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/FormUpdateManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/FormUpdateManager.java
@@ -3,6 +3,4 @@ package org.odk.collect.android.backgroundwork;
 public interface FormUpdateManager {
 
     void scheduleUpdates();
-
-    boolean isUpdateRunning();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/ReentrantLockChangeLock.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/ReentrantLockChangeLock.java
@@ -12,7 +12,11 @@ public class ReentrantLockChangeLock implements ChangeLock {
         try {
             return function.apply(lock.tryLock());
         } finally {
-            lock.unlock();
+            try {
+                lock.unlock();
+            } catch (IllegalMonitorStateException ignored) {
+                // Ignored
+            }
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/ReentrantLockChangeLock.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/ReentrantLockChangeLock.java
@@ -1,0 +1,18 @@
+package org.odk.collect.android.backgroundwork;
+
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+public class ReentrantLockChangeLock implements ChangeLock {
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    @Override
+    public <T> T withLock(Function<Boolean, T> function) {
+        try {
+            return function.apply(lock.tryLock());
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SchedulerFormUpdateAndSubmitManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SchedulerFormUpdateAndSubmitManager.java
@@ -55,21 +55,7 @@ public class SchedulerFormUpdateAndSubmitManager implements FormUpdateManager, F
     }
 
     @Override
-    public boolean isSubmitRunning() {
-        return isRunning(AUTO_SEND_TAG);
-    }
-
-    @Override
     public void scheduleSubmit() {
         scheduler.networkDeferred(AUTO_SEND_TAG, new AutoSendTaskSpec());
-    }
-
-    @Override
-    public boolean isUpdateRunning() {
-        return isRunning(MATCH_EXACTLY_SYNC_TAG) || isRunning(AUTO_UPDATE_TAG);
-    }
-
-    private boolean isRunning(String tag) {
-        return scheduler.isRunning(tag);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.openrosa.api.FormApiException;
 import org.odk.collect.async.TaskSpec;
 import org.odk.collect.async.WorkerAdapter;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
@@ -28,23 +29,30 @@ public class SyncFormsTaskSpec implements TaskSpec {
     @Inject
     Notifier notifier;
 
+    @Inject
+    ChangeLock changeLock;
+
     @NotNull
     @Override
     public Supplier<Boolean> getTask(@NotNull Context context) {
         DaggerUtils.getComponent(context).inject(this);
 
         return () -> {
-            if (!syncStatusRepository.startSync()) {
-                return true;
-            }
+            changeLock.withLock((Function<Boolean, Void>) acquiredLock -> {
+                if (acquiredLock) {
+                    syncStatusRepository.startSync();
 
-            try {
-                serverFormsSynchronizer.synchronize();
-                syncStatusRepository.finishSync(true);
-            } catch (FormApiException e) {
-                syncStatusRepository.finishSync(false);
-                notifier.onSyncFailure(e);
-            }
+                    try {
+                        serverFormsSynchronizer.synchronize();
+                        syncStatusRepository.finishSync(true);
+                    } catch (FormApiException e) {
+                        syncStatusRepository.finishSync(false);
+                        notifier.onSyncFailure(e);
+                    }
+                }
+
+                return null;
+            });
 
             return true;
         };

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 public class SyncFormsTaskSpec implements TaskSpec {
 
@@ -30,6 +31,7 @@ public class SyncFormsTaskSpec implements TaskSpec {
     Notifier notifier;
 
     @Inject
+    @Named("FORMS")
     ChangeLock changeLock;
 
     @NotNull

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -74,10 +74,6 @@ public class FormsDao {
         return getFormsCursor(null, selection, selectionArgs, order);
     }
 
-    private CursorLoader getFormsCursorLoader(String sortOrder, boolean newestByFormId) {
-        return getFormsCursorLoader(null, null, sortOrder, newestByFormId);
-    }
-
     /**
      * Returns a loader filtered by the specified charSequence in the specified sortOrder. If
      * newestByFormId is true, only the most recently-downloaded version of each form is included.
@@ -86,9 +82,9 @@ public class FormsDao {
         CursorLoader cursorLoader;
 
         if (charSequence.length() == 0) {
-            cursorLoader = getFormsCursorLoader(sortOrder, newestByFormId);
+            cursorLoader = getFormsCursorLoader(FormsColumns.DELETED + " = 0", new String[]{}, sortOrder, newestByFormId);
         } else {
-            String selection = FormsColumns.DISPLAY_NAME + " LIKE ?";
+            String selection = FormsColumns.DISPLAY_NAME + " LIKE ? AND " + FormsColumns.DELETED + " = 0";
             String[] selectionArgs = {"%" + charSequence + "%"};
 
             cursorLoader = getFormsCursorLoader(selection, selectionArgs, sortOrder, newestByFormId);

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -53,7 +53,7 @@ public class FormsDao {
         return Collect.getInstance().getContentResolver().query(uri, null, null, null, null);
     }
 
-    public Cursor getFormsCursor(String formId, String formVersion) {
+    public Cursor getFormsCursorSortedByDateDesc(String formId, String formVersion) {
         String[] selectionArgs;
         String selection;
 
@@ -117,7 +117,7 @@ public class FormsDao {
     public String getFormTitleForFormIdAndFormVersion(String formId, String formVersion) {
         String formTitle = "";
 
-        Cursor cursor = getFormsCursor(formId, formVersion);
+        Cursor cursor = getFormsCursorSortedByDateDesc(formId, formVersion);
         if (cursor != null) {
             try {
                 if (cursor.moveToFirst()) {
@@ -134,7 +134,7 @@ public class FormsDao {
     public boolean isFormEncrypted(String formId, String formVersion) {
         boolean encrypted = false;
 
-        Cursor cursor = getFormsCursor(formId, formVersion);
+        Cursor cursor = getFormsCursorSortedByDateDesc(formId, formVersion);
         if (cursor != null) {
             try {
                 if (cursor.moveToFirst()) {
@@ -151,7 +151,7 @@ public class FormsDao {
     public String getFormMediaPath(String formId, String formVersion) {
         String formMediaPath = null;
 
-        Cursor cursor = getFormsCursor(formId, formVersion);
+        Cursor cursor = getFormsCursorSortedByDateDesc(formId, formVersion);
 
         if (cursor != null) {
             try {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
@@ -334,7 +334,7 @@ public class InstancesDao {
                             .deletedDate(cursor.isNull(deletedDateColumnIndex) ? null : cursor.getLong(deletedDateColumnIndex))
                             .geometryType(cursor.getString(geometryTypeColumnIndex))
                             .geometry(cursor.getString(geometryColumnIndex))
-                            .databaseId(cursor.getLong(databaseIdIndex))
+                            .id(cursor.getLong(databaseIdIndex))
                             .build();
 
                     instances.add(instance);

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -17,6 +17,7 @@ import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.async.Scheduler;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 public class BlankFormsListViewModel extends ViewModel {
 
@@ -88,7 +89,7 @@ public class BlankFormsListViewModel extends ViewModel {
         private final ChangeLock changeLock;
 
         @Inject
-        public Factory(Application application, Scheduler scheduler, SyncStatusRepository syncRepository, ServerFormsSynchronizer serverFormsSynchronizer, PreferencesProvider preferencesProvider, Notifier notifier, ChangeLock changeLock) {
+        public Factory(Application application, Scheduler scheduler, SyncStatusRepository syncRepository, ServerFormsSynchronizer serverFormsSynchronizer, PreferencesProvider preferencesProvider, Notifier notifier, @Named("FORMS") ChangeLock changeLock) {
             this.application = application;
             this.scheduler = scheduler;
             this.syncRepository = syncRepository;

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -7,6 +7,7 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
+import org.odk.collect.android.backgroundwork.ChangeLock;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
 import org.odk.collect.android.notifications.Notifier;
@@ -25,14 +26,16 @@ public class BlankFormsListViewModel extends ViewModel {
     private final ServerFormsSynchronizer serverFormsSynchronizer;
     private final PreferencesProvider preferencesProvider;
     private final Notifier notifier;
+    private final ChangeLock changeLock;
 
-    public BlankFormsListViewModel(Application application, Scheduler scheduler, SyncStatusRepository syncRepository, ServerFormsSynchronizer serverFormsSynchronizer, PreferencesProvider preferencesProvider, Notifier notifier) {
+    public BlankFormsListViewModel(Application application, Scheduler scheduler, SyncStatusRepository syncRepository, ServerFormsSynchronizer serverFormsSynchronizer, PreferencesProvider preferencesProvider, Notifier notifier, ChangeLock changeLock) {
         this.application = application;
         this.scheduler = scheduler;
         this.syncRepository = syncRepository;
         this.serverFormsSynchronizer = serverFormsSynchronizer;
         this.preferencesProvider = preferencesProvider;
         this.notifier = notifier;
+        this.changeLock = changeLock;
     }
 
     public boolean isSyncingAvailable() {
@@ -48,21 +51,25 @@ public class BlankFormsListViewModel extends ViewModel {
     }
 
     public void syncWithServer() {
-        if (!syncRepository.startSync()) {
-            return;
-        }
+        changeLock.withLock(acquiredLock -> {
+            if (acquiredLock) {
+                syncRepository.startSync();
 
-        scheduler.immediate(() -> {
-            try {
-                serverFormsSynchronizer.synchronize();
-                syncRepository.finishSync(true);
-            } catch (FormApiException e) {
-                syncRepository.finishSync(false);
-                notifier.onSyncFailure(e);
+                scheduler.immediate(() -> {
+                    try {
+                        serverFormsSynchronizer.synchronize();
+                        syncRepository.finishSync(true);
+                    } catch (FormApiException e) {
+                        syncRepository.finishSync(false);
+                        notifier.onSyncFailure(e);
+                    }
+
+                    return null;
+                }, ignored -> { });
             }
 
             return null;
-        }, ignored -> { });
+        });
     }
 
     private boolean isMatchExactlyEnabled() {
@@ -78,21 +85,23 @@ public class BlankFormsListViewModel extends ViewModel {
         private final ServerFormsSynchronizer serverFormsSynchronizer;
         private final PreferencesProvider preferencesProvider;
         private final Notifier notifier;
+        private final ChangeLock changeLock;
 
         @Inject
-        public Factory(Application application, Scheduler scheduler, SyncStatusRepository syncRepository, ServerFormsSynchronizer serverFormsSynchronizer, PreferencesProvider preferencesProvider, Notifier notifier) {
+        public Factory(Application application, Scheduler scheduler, SyncStatusRepository syncRepository, ServerFormsSynchronizer serverFormsSynchronizer, PreferencesProvider preferencesProvider, Notifier notifier, ChangeLock changeLock) {
             this.application = application;
             this.scheduler = scheduler;
             this.syncRepository = syncRepository;
             this.serverFormsSynchronizer = serverFormsSynchronizer;
             this.preferencesProvider = preferencesProvider;
             this.notifier = notifier;
+            this.changeLock = changeLock;
         }
 
         @NonNull
         @Override
         public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-            return (T) new BlankFormsListViewModel(application, scheduler, syncRepository, serverFormsSynchronizer, preferencesProvider, notifier);
+            return (T) new BlankFormsListViewModel(application, scheduler, syncRepository, serverFormsSynchronizer, preferencesProvider, notifier, changeLock);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -4,11 +4,9 @@ import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 public class FormDeleter {
 
@@ -23,9 +21,9 @@ public class FormDeleter {
     public void delete(Long id) {
         Form form = formsRepository.get(id);
         List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
-        Stream<Instance> instancesForVersion = instances.stream().filter(instance -> Objects.equals(instance.getJrVersion(), form.getJrVersion()));
+        long instancesForVersion = instances.stream().filter(instance -> Objects.equals(instance.getJrVersion(), form.getJrVersion())).count();
 
-        if (instancesForVersion.anyMatch(instance -> !instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED))) {
+        if (instancesForVersion > 0) {
             formsRepository.softDelete(form.getId());
         } else {
             formsRepository.delete(id);

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -6,7 +6,6 @@ import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.List;
-import java.util.Objects;
 
 public class FormDeleter {
 
@@ -20,13 +19,12 @@ public class FormDeleter {
 
     public void delete(Long id) {
         Form form = formsRepository.get(id);
-        List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
-        long instancesForVersion = instances.stream().filter(instance -> Objects.equals(instance.getJrVersion(), form.getJrVersion())).count();
+        List<Instance> instancesForVersion = instancesRepository.getAllByJrFormIdAndJrVersion(form.getJrFormId(), form.getJrVersion());
 
-        if (instancesForVersion > 0) {
-            formsRepository.softDelete(form.getId());
-        } else {
+        if (instancesForVersion.isEmpty()) {
             formsRepository.delete(id);
+        } else {
+            formsRepository.softDelete(form.getId());
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -1,0 +1,29 @@
+package org.odk.collect.android.formmanagement;
+
+import org.odk.collect.android.forms.Form;
+import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.instances.InstancesRepository;
+
+import java.util.List;
+
+public class FormDeleter {
+
+    private final FormsRepository formsRepository;
+    private final InstancesRepository instancesRepository;
+
+    public FormDeleter(FormsRepository formsRepository, InstancesRepository instancesRepository) {
+        this.formsRepository = formsRepository;
+        this.instancesRepository = instancesRepository;
+    }
+
+    public void delete(Long id) {
+        Form form = formsRepository.get(id);
+        List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
+        if (instances.isEmpty()) {
+            formsRepository.delete(form.getId());
+        } else {
+            formsRepository.softDelete(form.getId());
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -7,6 +7,7 @@ import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public class FormDeleter {
@@ -22,15 +23,8 @@ public class FormDeleter {
     public void delete(Long id) {
         Form form = formsRepository.get(id);
         List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
-        Stream<Instance> instancesForVersion;
-
-        if (form.getJrVersion() != null) {
-            instancesForVersion = instances.stream().filter(instance -> instance.getJrVersion().equals(form.getJrVersion()));
-        } else {
-            instancesForVersion = instances.stream();
-        }
-
-
+        Stream<Instance> instancesForVersion = instances.stream().filter(instance -> Objects.equals(instance.getJrVersion(), form.getJrVersion()));
+        
         if (instancesForVersion.anyMatch(instance -> !instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED))) {
             formsRepository.softDelete(form.getId());
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -4,6 +4,7 @@ import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
+import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.List;
 
@@ -20,10 +21,11 @@ public class FormDeleter {
     public void delete(Long id) {
         Form form = formsRepository.get(id);
         List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
-        if (instances.isEmpty()) {
-            formsRepository.delete(form.getId());
-        } else {
+
+        if (instances.stream().anyMatch(instance -> !instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED))) {
             formsRepository.softDelete(form.getId());
+        } else {
+            formsRepository.delete(id);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -24,7 +24,7 @@ public class FormDeleter {
         Form form = formsRepository.get(id);
         List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
         Stream<Instance> instancesForVersion = instances.stream().filter(instance -> Objects.equals(instance.getJrVersion(), form.getJrVersion()));
-        
+
         if (instancesForVersion.anyMatch(instance -> !instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED))) {
             formsRepository.softDelete(form.getId());
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -7,6 +7,7 @@ import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 public class FormDeleter {
 
@@ -21,8 +22,16 @@ public class FormDeleter {
     public void delete(Long id) {
         Form form = formsRepository.get(id);
         List<Instance> instances = instancesRepository.getAllByJrFormId(form.getJrFormId());
+        Stream<Instance> instancesForVersion;
 
-        if (instances.stream().anyMatch(instance -> !instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED))) {
+        if (form.getJrVersion() != null) {
+            instancesForVersion = instances.stream().filter(instance -> instance.getJrVersion().equals(form.getJrVersion()));
+        } else {
+            instancesForVersion = instances.stream();
+        }
+
+
+        if (instancesForVersion.anyMatch(instance -> !instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED))) {
             formsRepository.softDelete(form.getId());
         } else {
             formsRepository.delete(id);

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -16,7 +16,7 @@
 
 package org.odk.collect.android.formmanagement;
 
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.forms.MediaFileRepository;
 import org.odk.collect.android.openrosa.api.FormListApi;
 import org.odk.collect.android.openrosa.api.FormApiException;
@@ -34,16 +34,16 @@ import timber.log.Timber;
 
 public class ServerFormsDetailsFetcher {
 
-    private final FormRepository formRepository;
+    private final FormsRepository formsRepository;
     private final MediaFileRepository mediaFileRepository;
     private final FormListApi formListAPI;
     private final DiskFormsSynchronizer diskFormsSynchronizer;
 
-    public ServerFormsDetailsFetcher(FormRepository formRepository,
+    public ServerFormsDetailsFetcher(FormsRepository formsRepository,
                                      MediaFileRepository mediaFileRepository,
                                      FormListApi formListAPI,
                                      DiskFormsSynchronizer diskFormsSynchronizer) {
-        this.formRepository = formRepository;
+        this.formsRepository = formsRepository;
         this.mediaFileRepository = mediaFileRepository;
         this.formListAPI = formListAPI;
         this.diskFormsSynchronizer = diskFormsSynchronizer;
@@ -94,7 +94,7 @@ public class ServerFormsDetailsFetcher {
     }
 
     private boolean isThisFormAlreadyDownloaded(String formId) {
-        return formRepository.contains(formId);
+        return formsRepository.contains(formId);
     }
 
     private ManifestFile getManifestFile(FormListApi formListAPI, String manifestUrl) {
@@ -115,7 +115,7 @@ public class ServerFormsDetailsFetcher {
             return false;
         }
 
-        return formRepository.getByMd5Hash(md5Hash) == null;
+        return formsRepository.getByMd5Hash(md5Hash) == null;
     }
 
     private boolean areNewerMediaFilesAvailable(String formId, String formVersion, List<MediaFile> newMediaFiles) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/ServerFormsSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/ServerFormsSynchronizer.java
@@ -1,43 +1,39 @@
 package org.odk.collect.android.formmanagement.matchexactly;
 
-import org.odk.collect.android.formmanagement.DiskFormsSynchronizer;
+import org.odk.collect.android.formmanagement.FormDeleter;
 import org.odk.collect.android.formmanagement.FormDownloadException;
 import org.odk.collect.android.formmanagement.FormDownloader;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
-import org.odk.collect.android.forms.MediaFileRepository;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.openrosa.api.FormApiException;
-import org.odk.collect.android.openrosa.api.FormListApi;
 
 import java.util.List;
 
 public class ServerFormsSynchronizer {
 
     private final FormsRepository formsRepository;
+    private final InstancesRepository instancesRepository;
     private final FormDownloader formDownloader;
     private final ServerFormsDetailsFetcher serverFormsDetailsFetcher;
 
-    public ServerFormsSynchronizer(FormsRepository formsRepository, MediaFileRepository mediaFileRepository, FormListApi formListAPI, FormDownloader formDownloader, DiskFormsSynchronizer diskFormsSynchronizer) {
-        this.formsRepository = formsRepository;
-        this.formDownloader = formDownloader;
-        this.serverFormsDetailsFetcher = new ServerFormsDetailsFetcher(formsRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
-    }
-
-    public ServerFormsSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader) {
+    public ServerFormsSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, InstancesRepository instancesRepository, FormDownloader formDownloader) {
         this.serverFormsDetailsFetcher = serverFormsDetailsFetcher;
         this.formsRepository = formsRepository;
+        this.instancesRepository = instancesRepository;
         this.formDownloader = formDownloader;
     }
 
     public void synchronize() throws FormApiException {
         List<ServerFormDetails> formList = serverFormsDetailsFetcher.fetchFormDetails();
         List<Form> formsOnDevice = formsRepository.getAll();
+        FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
 
         formsOnDevice.stream().forEach(form -> {
             if (formList.stream().noneMatch(f -> form.getJrFormId().equals(f.getFormId()))) {
-                formsRepository.delete(form.getId());
+                formDeleter.delete(form.getId());
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/ServerFormsSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/ServerFormsSynchronizer.java
@@ -6,7 +6,7 @@ import org.odk.collect.android.formmanagement.FormDownloader;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.forms.MediaFileRepository;
 import org.odk.collect.android.openrosa.api.FormApiException;
 import org.odk.collect.android.openrosa.api.FormListApi;
@@ -15,29 +15,29 @@ import java.util.List;
 
 public class ServerFormsSynchronizer {
 
-    private final FormRepository formRepository;
+    private final FormsRepository formsRepository;
     private final FormDownloader formDownloader;
     private final ServerFormsDetailsFetcher serverFormsDetailsFetcher;
 
-    public ServerFormsSynchronizer(FormRepository formRepository, MediaFileRepository mediaFileRepository, FormListApi formListAPI, FormDownloader formDownloader, DiskFormsSynchronizer diskFormsSynchronizer) {
-        this.formRepository = formRepository;
+    public ServerFormsSynchronizer(FormsRepository formsRepository, MediaFileRepository mediaFileRepository, FormListApi formListAPI, FormDownloader formDownloader, DiskFormsSynchronizer diskFormsSynchronizer) {
+        this.formsRepository = formsRepository;
         this.formDownloader = formDownloader;
-        this.serverFormsDetailsFetcher = new ServerFormsDetailsFetcher(formRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
+        this.serverFormsDetailsFetcher = new ServerFormsDetailsFetcher(formsRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
     }
 
-    public ServerFormsSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository, FormDownloader formDownloader) {
+    public ServerFormsSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader) {
         this.serverFormsDetailsFetcher = serverFormsDetailsFetcher;
-        this.formRepository = formRepository;
+        this.formsRepository = formsRepository;
         this.formDownloader = formDownloader;
     }
 
     public void synchronize() throws FormApiException {
         List<ServerFormDetails> formList = serverFormsDetailsFetcher.fetchFormDetails();
-        List<Form> formsOnDevice = formRepository.getAll();
+        List<Form> formsOnDevice = formsRepository.getAll();
 
         formsOnDevice.stream().forEach(form -> {
             if (formList.stream().noneMatch(f -> form.getJrFormId().equals(f.getFormId()))) {
-                formRepository.delete(form.getId());
+                formsRepository.delete(form.getId());
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusRepository.java
@@ -7,26 +7,18 @@ public class SyncStatusRepository {
 
     private final MutableLiveData<Boolean> syncing = new MutableLiveData<>(false);
     private final MutableLiveData<Boolean> lastSyncFailure = new MutableLiveData<>(false);
-    private boolean started;
 
     public LiveData<Boolean> isSyncing() {
         return syncing;
     }
 
-    public synchronized boolean startSync() {
-        if (started) {
-            return false;
-        } else {
-            syncing.postValue(true);
-            started = true;
-            return true;
-        }
+    public void startSync() {
+        syncing.postValue(true);
     }
 
     public void finishSync(boolean success) {
         lastSyncFailure.postValue(!success);
         syncing.postValue(false);
-        started = false;
     }
 
     public LiveData<Boolean> isOutOfSync() {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/previouslydownloaded/ServerFormsUpdateChecker.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/previouslydownloaded/ServerFormsUpdateChecker.java
@@ -3,7 +3,7 @@ package org.odk.collect.android.formmanagement.previouslydownloaded;
 import org.jetbrains.annotations.Nullable;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.openrosa.api.FormApiException;
 
 import java.util.ArrayList;
@@ -14,11 +14,11 @@ import static java.util.Collections.emptyList;
 public class ServerFormsUpdateChecker {
 
     private final ServerFormsDetailsFetcher serverFormsDetailsFetcher;
-    private final FormRepository formRepository;
+    private final FormsRepository formsRepository;
 
-    public ServerFormsUpdateChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository) {
+    public ServerFormsUpdateChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository) {
         this.serverFormsDetailsFetcher = serverFormsDetailsFetcher;
-        this.formRepository = formRepository;
+        this.formsRepository = formsRepository;
     }
 
     public List<ServerFormDetails> check() {
@@ -30,9 +30,9 @@ public class ServerFormsUpdateChecker {
                 String formHash = serverFormDetails.getHash();
                 String manifestFileHash = serverFormDetails.getManifestFileHash() != null ? serverFormDetails.getManifestFileHash() : "";
 
-                if (formRepository.getByLastDetectedUpdate(formHash, manifestFileHash) == null) {
+                if (formsRepository.getByLastDetectedUpdate(formHash, manifestFileHash) == null) {
                     newUpdates.add(serverFormDetails);
-                    formRepository.setLastDetectedUpdated(serverFormDetails.getFormId(), formHash, manifestFileHash);
+                    formsRepository.setLastDetectedUpdated(serverFormDetails.getFormId(), formHash, manifestFileHash);
                 }
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/forms/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/DatabaseFormsRepository.java
@@ -14,11 +14,13 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import static android.provider.BaseColumns._ID;
 import static org.odk.collect.android.dao.FormsDao.getFormsFromCursor;
+import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.DELETED;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.JR_FORM_ID;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH;
 
-public class DatabaseFormRepository implements FormRepository {
+public class DatabaseFormsRepository implements FormsRepository {
 
     @Override
     public boolean contains(String jrFormId) {
@@ -31,6 +33,14 @@ public class DatabaseFormRepository implements FormRepository {
     public List<Form> getAll() {
         try (Cursor cursor = new FormsDao().getFormsCursor()) {
             return new FormsDao().getFormsFromCursor(cursor);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Form get(Long id) {
+        try (Cursor cursor = new FormsDao().getFormsCursor(_ID + "=?", new String[]{id.toString()})) {
+            return getFormOrNull(cursor);
         }
     }
 
@@ -80,6 +90,13 @@ public class DatabaseFormRepository implements FormRepository {
     @Override
     public void delete(Long id) {
         new FormsDao().deleteFormsFromIDs(new String[]{id.toString()});
+    }
+
+    @Override
+    public void softDelete(Long id) {
+        ContentValues values = new ContentValues();
+        values.put(DELETED, 1);
+        new FormsDao().updateForm(values, _ID + "=?", new String[]{id.toString()});
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/forms/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/DatabaseFormsRepository.java
@@ -18,6 +18,7 @@ import static android.provider.BaseColumns._ID;
 import static org.odk.collect.android.dao.FormsDao.getFormsFromCursor;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.DELETED;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.JR_FORM_ID;
+import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.JR_VERSION;
 import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.LAST_DETECTED_FORM_VERSION_HASH;
 
 public class DatabaseFormsRepository implements FormsRepository {
@@ -40,6 +41,14 @@ public class DatabaseFormsRepository implements FormsRepository {
     @Override
     public Form get(Long id) {
         try (Cursor cursor = new FormsDao().getFormsCursor(_ID + "=?", new String[]{id.toString()})) {
+            return getFormOrNull(cursor);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Form get(String jrFormId, String jrVersion) {
+        try (Cursor cursor = new FormsDao().getFormsCursor(JR_FORM_ID + "=? AND " + JR_VERSION + "=?", new String[]{jrFormId, jrVersion})) {
             return getFormOrNull(cursor);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/forms/Form.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/Form.java
@@ -277,6 +277,10 @@ public final class Form {
         return lastDetectedFormVersionHash;
     }
 
+    public boolean isDeleted() {
+        return deleted;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this || other instanceof Form && this.md5Hash.equals(((Form) other).md5Hash);

--- a/collect_app/src/main/java/org/odk/collect/android/forms/Form.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/Form.java
@@ -42,6 +42,7 @@ public final class Form {
     private final String autoDelete;
     private final String lastDetectedFormVersionHash;
     private final String geometryXPath;
+    private final boolean deleted;
 
     private Form(Form.Builder builder) {
         id = builder.id;
@@ -61,6 +62,7 @@ public final class Form {
         autoDelete = builder.autoDelete;
         lastDetectedFormVersionHash = builder.lastDetectedFormVersionHash;
         geometryXPath = builder.geometryXpath;
+        deleted = builder.deleted;
     }
 
     public static class Builder {
@@ -81,6 +83,7 @@ public final class Form {
         private String autoDelete;
         private String lastDetectedFormVersionHash;
         private String geometryXpath;
+        private boolean deleted;
 
         public Builder() {
 
@@ -104,6 +107,7 @@ public final class Form {
             autoDelete = form.autoDelete;
             lastDetectedFormVersionHash = form.lastDetectedFormVersionHash;
             geometryXpath = form.geometryXPath;
+            this.deleted = form.deleted;
         }
 
         public Builder id(Long id) {
@@ -188,6 +192,11 @@ public final class Form {
 
         public Builder geometryXpath(String geometryXpath) {
             this.geometryXpath = geometryXpath;
+            return this;
+        }
+
+        public Builder deleted(boolean deleted) {
+            this.deleted = deleted;
             return this;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -6,13 +6,16 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-public interface FormRepository {
+public interface FormsRepository {
 
     Uri save(Form form);
 
     boolean contains(String jrFormId);
 
     List<Form> getAll();
+
+    @Nullable
+    Form get(Long id);
 
     @Nullable
     Form getByMd5Hash(String hash);
@@ -24,6 +27,8 @@ public interface FormRepository {
     Form getByPath(String path);
 
     void delete(Long id);
+
+    void softDelete(Long id);
 
     void setLastDetectedUpdated(String jrFormId, String formHash, String manifestHash);
 

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -18,6 +18,9 @@ public interface FormsRepository {
     Form get(Long id);
 
     @Nullable
+    Form get(String jrFormId, String jrVersion);
+
+    @Nullable
     Form getByMd5Hash(String hash);
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
@@ -14,29 +14,34 @@
 
 package org.odk.collect.android.fragments;
 
-import androidx.appcompat.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.loader.content.CursorLoader;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.loader.content.CursorLoader;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.DeleteInstancesListener;
 import org.odk.collect.android.listeners.DiskSyncListener;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.DeleteInstancesTask;
 import org.odk.collect.android.tasks.InstanceSyncTask;
 import org.odk.collect.android.utilities.ToastUtils;
+
+import javax.inject.Inject;
 
 import timber.log.Timber;
 
@@ -56,8 +61,13 @@ public class DataManagerList extends InstanceListFragment
     private InstanceSyncTask instanceSyncTask;
     private ProgressDialog progressDialog;
 
-    public static DataManagerList newInstance() {
-        return new DataManagerList();
+    @Inject
+    InstancesRepository instancesRepository;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        DaggerUtils.getComponent(context).inject(this);
     }
 
     @Nullable
@@ -68,14 +78,7 @@ public class DataManagerList extends InstanceListFragment
     }
 
     @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        Collect.getInstance().getComponent().inject(this);
-    }
-
-    @Override
     public void onViewCreated(@NonNull View rootView, Bundle savedInstanceState) {
-
         deleteButton.setOnClickListener(this);
         toggleButton.setOnClickListener(this);
 
@@ -189,7 +192,7 @@ public class DataManagerList extends InstanceListFragment
             progressDialog.show();
 
             deleteInstancesTask = new DeleteInstancesTask();
-            deleteInstancesTask.setContentResolver(getActivity().getContentResolver());
+            deleteInstancesTask.setRepositories(instancesRepository);
             deleteInstancesTask.setDeleteListener(this);
             deleteInstancesTask.execute(getCheckedIdObjects());
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
@@ -195,8 +195,7 @@ public class DataManagerList extends InstanceListFragment
             progressDialog.setCancelable(false);
             progressDialog.show();
 
-            deleteInstancesTask = new DeleteInstancesTask();
-            deleteInstancesTask.setRepositories(instancesRepository, formsRepository);
+            deleteInstancesTask = new DeleteInstancesTask(instancesRepository, formsRepository);
             deleteInstancesTask.setDeleteListener(this);
             deleteInstancesTask.execute(getCheckedIdObjects());
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/DataManagerList.java
@@ -32,6 +32,7 @@ import androidx.loader.content.CursorLoader;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.DeleteInstancesListener;
@@ -63,6 +64,9 @@ public class DataManagerList extends InstanceListFragment
 
     @Inject
     InstancesRepository instancesRepository;
+
+    @Inject
+    FormsRepository formsRepository;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -192,7 +196,7 @@ public class DataManagerList extends InstanceListFragment
             progressDialog.show();
 
             deleteInstancesTask = new DeleteInstancesTask();
-            deleteInstancesTask.setRepositories(instancesRepository);
+            deleteInstancesTask.setRepositories(instancesRepository, formsRepository);
             deleteInstancesTask.setDeleteListener(this);
             deleteInstancesTask.execute(getCheckedIdObjects());
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.fragments;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -27,7 +28,10 @@ import androidx.loader.content.CursorLoader;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.FormListAdapter;
 import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
+import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.DeleteFormsListener;
 import org.odk.collect.android.listeners.DiskSyncListener;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
@@ -35,6 +39,8 @@ import org.odk.collect.android.tasks.DeleteFormsTask;
 import org.odk.collect.android.tasks.DiskSyncTask;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.ToastUtils;
+
+import javax.inject.Inject;
 
 import timber.log.Timber;
 
@@ -51,8 +57,16 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
     private BackgroundTasks backgroundTasks; // handled across orientation changes
     private AlertDialog alertDialog;
 
-    public static FormManagerList newInstance() {
-        return new FormManagerList();
+    @Inject
+    FormsRepository formsRepository;
+
+    @Inject
+    InstancesRepository instancesRepository;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        DaggerUtils.getComponent(context).inject(this);
     }
 
     @Override
@@ -188,6 +202,7 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
             backgroundTasks.deleteFormsTask
                     .setContentResolver(getActivity().getContentResolver());
             backgroundTasks.deleteFormsTask.setDeleteListener(this);
+            backgroundTasks.deleteFormsTask.setRepositories(formsRepository, instancesRepository);
             backgroundTasks.deleteFormsTask.execute(getCheckedIdObjects());
         } else {
             ToastUtils.showLongToast(R.string.file_delete_in_progress);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -199,8 +199,6 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
             DialogUtils.showIfNotShowing(ProgressDialogFragment.class, args, getActivity().getSupportFragmentManager());
 
             backgroundTasks.deleteFormsTask = new DeleteFormsTask();
-            backgroundTasks.deleteFormsTask
-                    .setContentResolver(getActivity().getContentResolver());
             backgroundTasks.deleteFormsTask.setDeleteListener(this);
             backgroundTasks.deleteFormsTask.setRepositories(formsRepository, instancesRepository);
             backgroundTasks.deleteFormsTask.execute(getCheckedIdObjects());

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/FormManagerList.java
@@ -198,9 +198,8 @@ public class FormManagerList extends FormListFragment implements DiskSyncListene
             args.putBoolean(ProgressDialogFragment.CANCELABLE, false);
             DialogUtils.showIfNotShowing(ProgressDialogFragment.class, args, getActivity().getSupportFragmentManager());
 
-            backgroundTasks.deleteFormsTask = new DeleteFormsTask();
+            backgroundTasks.deleteFormsTask = new DeleteFormsTask(formsRepository, instancesRepository);
             backgroundTasks.deleteFormsTask.setDeleteListener(this);
-            backgroundTasks.deleteFormsTask.setRepositories(formsRepository, instancesRepository);
             backgroundTasks.deleteFormsTask.execute(getCheckedIdObjects());
         } else {
             ToastUtils.showLongToast(R.string.file_delete_in_progress);

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -44,6 +44,7 @@ import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.ExperimentalPreferencesFragment;
 import org.odk.collect.android.preferences.FormManagementPreferences;
 import org.odk.collect.android.preferences.FormMetadataFragment;
+import org.odk.collect.android.preferences.GeneralPreferencesFragment;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.IdentityPreferences;
 import org.odk.collect.android.preferences.PreferencesActivity;
@@ -201,6 +202,8 @@ public interface AppDependencyComponent {
     void inject(FormManagerList formManagerList);
 
     void inject(InstanceUploaderActivity instanceUploaderActivity);
+
+    void inject(GeneralPreferencesFragment generalPreferencesFragment);
 
     OpenRosaHttpInterface openRosaHttpInterface();
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -31,6 +31,7 @@ import org.odk.collect.android.formentry.QuitFormDialogFragment;
 import org.odk.collect.android.formentry.saving.SaveFormProgressDialogFragment;
 import org.odk.collect.android.fragments.BarCodeScannerFragment;
 import org.odk.collect.android.fragments.DataManagerList;
+import org.odk.collect.android.fragments.FormManagerList;
 import org.odk.collect.android.fragments.MapBoxInitializationFragment;
 import org.odk.collect.android.geo.GoogleMapFragment;
 import org.odk.collect.android.geo.MapboxMapFragment;
@@ -195,6 +196,8 @@ public interface AppDependencyComponent {
     void inject(AutoUpdateTaskSpec autoUpdateTaskSpec);
 
     void inject(ServerAuthDialogFragment serverAuthDialogFragment);
+
+    void inject(FormManagerList formManagerList);
 
     OpenRosaHttpInterface openRosaHttpInterface();
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -12,6 +12,7 @@ import org.odk.collect.android.activities.GeoPointMapActivity;
 import org.odk.collect.android.activities.GeoPolyActivity;
 import org.odk.collect.android.activities.GoogleDriveActivity;
 import org.odk.collect.android.activities.GoogleSheetsUploaderActivity;
+import org.odk.collect.android.activities.InstanceUploaderActivity;
 import org.odk.collect.android.activities.InstanceUploaderListActivity;
 import org.odk.collect.android.activities.MainMenuActivity;
 import org.odk.collect.android.activities.SplashScreenActivity;
@@ -198,6 +199,8 @@ public interface AppDependencyComponent {
     void inject(ServerAuthDialogFragment serverAuthDialogFragment);
 
     void inject(FormManagerList formManagerList);
+
+    void inject(InstanceUploaderActivity instanceUploaderActivity);
 
     OpenRosaHttpInterface openRosaHttpInterface();
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -41,11 +41,13 @@ import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
 import org.odk.collect.android.formmanagement.previouslydownloaded.ServerFormsUpdateChecker;
-import org.odk.collect.android.forms.DatabaseFormRepository;
+import org.odk.collect.android.forms.DatabaseFormsRepository;
 import org.odk.collect.android.forms.DatabaseMediaFileRepository;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.forms.MediaFileRepository;
 import org.odk.collect.android.geo.MapProvider;
+import org.odk.collect.android.instances.DatabaseInstancesRepository;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.metadata.InstallIDProvider;
 import org.odk.collect.android.metadata.SharedPreferencesInstallIDProvider;
@@ -370,8 +372,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormRepository providesFormRepository() {
-        return new DatabaseFormRepository();
+    public FormsRepository providesFormRepository() {
+        return new DatabaseFormsRepository();
     }
 
     @Provides
@@ -400,13 +402,13 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ServerFormsDetailsFetcher providesServerFormDetailsFetcher(FormRepository formRepository, MediaFileRepository mediaFileRepository, FormListApi formListAPI, DiskFormsSynchronizer diskFormsSynchronizer) {
-        return new ServerFormsDetailsFetcher(formRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
+    public ServerFormsDetailsFetcher providesServerFormDetailsFetcher(FormsRepository formsRepository, MediaFileRepository mediaFileRepository, FormListApi formListAPI, DiskFormsSynchronizer diskFormsSynchronizer) {
+        return new ServerFormsDetailsFetcher(formsRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
     }
 
     @Provides
-    public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository, FormDownloader formDownloader) {
-        return new ServerFormsSynchronizer(serverFormsDetailsFetcher, formRepository, formDownloader);
+    public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader) {
+        return new ServerFormsSynchronizer(serverFormsDetailsFetcher, formsRepository, formDownloader);
     }
 
     @Provides
@@ -421,7 +423,12 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ServerFormsUpdateChecker providesServerFormUpdatesChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository) {
-        return new ServerFormsUpdateChecker(serverFormsDetailsFetcher, formRepository);
+    public ServerFormsUpdateChecker providesServerFormUpdatesChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository) {
+        return new ServerFormsUpdateChecker(serverFormsDetailsFetcher, formsRepository);
+    }
+
+    @Provides
+    public InstancesRepository providesInstancesRepository() {
+        return new DatabaseInstancesRepository();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -407,8 +407,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader) {
-        return new ServerFormsSynchronizer(serverFormsDetailsFetcher, formsRepository, formDownloader);
+    public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader, InstancesRepository instancesRepository) {
+        return new ServerFormsSynchronizer(serverFormsDetailsFetcher, formsRepository, instancesRepository, formDownloader);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -92,6 +92,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -206,7 +207,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public StorageMigrator providesStorageMigrator(StoragePathProvider storagePathProvider, StorageStateProvider storageStateProvider, StorageMigrationRepository storageMigrationRepository, ReferenceManager referenceManager, FormUpdateManager formUpdateManager, FormSubmitManager formSubmitManager, Analytics analytics, ChangeLock changeLock) {
+    public StorageMigrator providesStorageMigrator(StoragePathProvider storagePathProvider, StorageStateProvider storageStateProvider, StorageMigrationRepository storageMigrationRepository, ReferenceManager referenceManager, FormUpdateManager formUpdateManager, FormSubmitManager formSubmitManager, Analytics analytics, @Named("FORMS") ChangeLock changeLock) {
         StorageEraser storageEraser = new StorageEraser(storagePathProvider);
 
         return new StorageMigrator(storagePathProvider, storageStateProvider, storageEraser, storageMigrationRepository, GeneralSharedPreferences.getInstance(), referenceManager, analytics);
@@ -417,8 +418,16 @@ public class AppDependencyModule {
     }
 
     @Provides
+    @Named("FORMS")
     @Singleton
-    public ChangeLock providesChangeLock() {
+    public ChangeLock providesFormsChangeLock() {
+        return new ReentrantLockChangeLock();
+    }
+
+    @Provides
+    @Named("INSTANCES")
+    @Singleton
+    public ChangeLock providesInstancesChangeLock() {
         return new ReentrantLockChangeLock();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -18,8 +18,10 @@ import org.odk.collect.android.analytics.FirebaseAnalytics;
 import org.odk.collect.android.application.initialization.ApplicationInitializer;
 import org.odk.collect.android.application.initialization.CollectSettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator;
+import org.odk.collect.android.backgroundwork.ChangeLock;
 import org.odk.collect.android.backgroundwork.FormSubmitManager;
 import org.odk.collect.android.backgroundwork.FormUpdateManager;
+import org.odk.collect.android.backgroundwork.ReentrantLockChangeLock;
 import org.odk.collect.android.backgroundwork.SchedulerFormUpdateAndSubmitManager;
 import org.odk.collect.android.configure.SettingsImporter;
 import org.odk.collect.android.configure.StructureAndTypeSettingsValidator;
@@ -38,6 +40,7 @@ import org.odk.collect.android.formmanagement.ServerFormDownloader;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
+import org.odk.collect.android.formmanagement.previouslydownloaded.ServerFormsUpdateChecker;
 import org.odk.collect.android.forms.DatabaseFormRepository;
 import org.odk.collect.android.forms.DatabaseMediaFileRepository;
 import org.odk.collect.android.forms.FormRepository;
@@ -152,7 +155,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    MultiFormDownloader providesMultiFormDownloader(FormsDao formsDao, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils) {
+    public MultiFormDownloader providesMultiFormDownloader(FormsDao formsDao, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils) {
         return new MultiFormDownloader(new OpenRosaXmlFetcher(openRosaHttpInterface, webCredentialsUtils));
     }
 
@@ -201,10 +204,10 @@ public class AppDependencyModule {
     }
 
     @Provides
-    StorageMigrator providesStorageMigrator(StoragePathProvider storagePathProvider, StorageStateProvider storageStateProvider, StorageMigrationRepository storageMigrationRepository, ReferenceManager referenceManager, FormUpdateManager formUpdateManager, FormSubmitManager formSubmitManager, Analytics analytics) {
+    public StorageMigrator providesStorageMigrator(StoragePathProvider storagePathProvider, StorageStateProvider storageStateProvider, StorageMigrationRepository storageMigrationRepository, ReferenceManager referenceManager, FormUpdateManager formUpdateManager, FormSubmitManager formSubmitManager, Analytics analytics, ChangeLock changeLock) {
         StorageEraser storageEraser = new StorageEraser(storagePathProvider);
 
-        return new StorageMigrator(storagePathProvider, storageStateProvider, storageEraser, storageMigrationRepository, GeneralSharedPreferences.getInstance(), referenceManager, formUpdateManager, formSubmitManager, analytics);
+        return new StorageMigrator(storagePathProvider, storageStateProvider, storageEraser, storageMigrationRepository, GeneralSharedPreferences.getInstance(), referenceManager, analytics);
     }
 
     @Provides
@@ -409,5 +412,16 @@ public class AppDependencyModule {
     @Provides
     public Notifier providesNotifier(Application application) {
         return new NotificationManagerNotifier(application);
+    }
+
+    @Provides
+    @Singleton
+    public ChangeLock providesChangeLock() {
+        return new ReentrantLockChangeLock();
+    }
+
+    @Provides
+    public ServerFormsUpdateChecker providesServerFormUpdatesChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository) {
+        return new ServerFormsUpdateChecker(serverFormsDetailsFetcher, formRepository);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
@@ -1,0 +1,30 @@
+package org.odk.collect.android.instancemanagement;
+
+import org.odk.collect.android.forms.Form;
+import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.instances.InstancesRepository;
+
+public class InstanceDeleter {
+
+    private final InstancesRepository instancesRepository;
+    private final FormsRepository formsRepository;
+
+    public InstanceDeleter(InstancesRepository instancesRepository, FormsRepository formsRepository) {
+        this.instancesRepository = instancesRepository;
+        this.formsRepository = formsRepository;
+    }
+
+    public void delete(Long id) {
+        Instance instance = instancesRepository.get(id);
+        if (instancesRepository.getAllByJrFormIdAndJrVersion(instance.getJrFormId(), instance.getJrVersion()).size() == 1) {
+            Form form = formsRepository.get(instance.getJrFormId(), instance.getJrVersion());
+
+            if (form != null && form.isDeleted()) {
+                formsRepository.delete(form.getId());
+            }
+        }
+
+        instancesRepository.delete(id);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.java
@@ -87,11 +87,11 @@ public class InstanceSubmitter {
                 if (protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets))
                         && !InstanceUploaderUtils.doesUrlRefersToGoogleSheetsFile(destinationUrl)) {
                     anyFailure = true;
-                    resultMessagesByInstanceId.put(instance.getDatabaseId().toString(), SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE);
+                    resultMessagesByInstanceId.put(instance.getId().toString(), SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE);
                     continue;
                 }
                 String customMessage = uploader.uploadOneSubmission(instance, destinationUrl);
-                resultMessagesByInstanceId.put(instance.getDatabaseId().toString(), customMessage != null ? customMessage : Collect.getInstance().getString(R.string.success));
+                resultMessagesByInstanceId.put(instance.getId().toString(), customMessage != null ? customMessage : Collect.getInstance().getString(R.string.success));
 
                 // If the submission was successful, delete the instance if either the app-level
                 // delete preference is set or the form definition requests auto-deletion.
@@ -100,7 +100,7 @@ public class InstanceSubmitter {
                 // communicated to the user. Maybe successful delete should also be communicated?
                 if (InstanceUploader.formShouldBeAutoDeleted(instance.getJrFormId(),
                         (boolean) GeneralSharedPreferences.getInstance().get(GeneralKeys.KEY_DELETE_AFTER_SEND))) {
-                    Uri deleteForm = Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI, instance.getDatabaseId().toString());
+                    Uri deleteForm = Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI, instance.getId().toString());
                     Collect.getInstance().getContentResolver().delete(deleteForm, null, null);
                 }
 
@@ -111,7 +111,7 @@ public class InstanceSubmitter {
             } catch (UploadException e) {
                 Timber.d(e);
                 anyFailure = true;
-                resultMessagesByInstanceId.put(instance.getDatabaseId().toString(),
+                resultMessagesByInstanceId.put(instance.getId().toString(),
                         e.getDisplayMessage());
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.java
@@ -1,0 +1,165 @@
+package org.odk.collect.android.instancemanagement;
+
+import android.database.Cursor;
+import android.net.Uri;
+import android.util.Pair;
+
+import androidx.annotation.NonNull;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.instancemanagement.SubmitException.Type;
+import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.upload.InstanceGoogleSheetsUploader;
+import org.odk.collect.android.upload.InstanceServerUploader;
+import org.odk.collect.android.upload.InstanceUploader;
+import org.odk.collect.android.upload.UploadException;
+import org.odk.collect.android.utilities.InstanceUploaderUtils;
+import org.odk.collect.android.utilities.PermissionUtils;
+import org.odk.collect.android.utilities.WebCredentialsUtils;
+import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
+
+import static org.odk.collect.android.analytics.AnalyticsEvents.SUBMISSION;
+import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.AUTO_SEND;
+import static org.odk.collect.android.utilities.InstanceUploaderUtils.SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE;
+
+public class InstanceSubmitter {
+
+    private final Analytics analytics;
+
+    public InstanceSubmitter(Analytics analytics) {
+        this.analytics = analytics;
+    }
+
+    public Pair<Boolean, String> submitUnsubmittedInstances() throws SubmitException {
+        List<Instance> toUpload = getInstancesToAutoSend(GeneralSharedPreferences.isAutoSendEnabled());
+
+        if (toUpload.isEmpty()) {
+            throw new SubmitException(Type.NOTHING_TO_SUBMIT);
+        }
+
+        GeneralSharedPreferences settings = GeneralSharedPreferences.getInstance();
+        String protocol = (String) settings.get(GeneralKeys.KEY_PROTOCOL);
+
+        InstanceUploader uploader;
+        Map<String, String> resultMessagesByInstanceId = new HashMap<>();
+        String deviceId = null;
+        boolean anyFailure = false;
+
+        if (protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets))) {
+            if (PermissionUtils.isGetAccountsPermissionGranted(Collect.getInstance())) {
+                GoogleAccountsManager accountsManager = new GoogleAccountsManager(Collect.getInstance());
+                String googleUsername = accountsManager.getLastSelectedAccountIfValid();
+                if (googleUsername.isEmpty()) {
+                    throw new SubmitException(Type.GOOGLE_ACCOUNT_NOT_SET);
+                }
+                accountsManager.selectAccount(googleUsername);
+                uploader = new InstanceGoogleSheetsUploader(accountsManager);
+            } else {
+                throw new SubmitException(Type.GOOGLE_ACCOUNT_NOT_PERMITTED);
+            }
+        } else {
+            OpenRosaHttpInterface httpInterface = Collect.getInstance().getComponent().openRosaHttpInterface();
+            uploader = new InstanceServerUploader(httpInterface,
+                    new WebCredentialsUtils(), new HashMap<>());
+            deviceId = new PropertyManager(Collect.getInstance().getApplicationContext())
+                    .getSingularProperty(PropertyManager.withUri(PropertyManager.PROPMGR_DEVICE_ID));
+        }
+
+        for (Instance instance : toUpload) {
+            try {
+                String destinationUrl = uploader.getUrlToSubmitTo(instance, deviceId, null);
+                if (protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets))
+                        && !InstanceUploaderUtils.doesUrlRefersToGoogleSheetsFile(destinationUrl)) {
+                    anyFailure = true;
+                    resultMessagesByInstanceId.put(instance.getDatabaseId().toString(), SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE);
+                    continue;
+                }
+                String customMessage = uploader.uploadOneSubmission(instance, destinationUrl);
+                resultMessagesByInstanceId.put(instance.getDatabaseId().toString(), customMessage != null ? customMessage : Collect.getInstance().getString(R.string.success));
+
+                // If the submission was successful, delete the instance if either the app-level
+                // delete preference is set or the form definition requests auto-deletion.
+                // TODO: this could take some time so might be better to do in a separate process,
+                // perhaps another worker. It also feels like this could fail and if so should be
+                // communicated to the user. Maybe successful delete should also be communicated?
+                if (InstanceUploader.formShouldBeAutoDeleted(instance.getJrFormId(),
+                        (boolean) GeneralSharedPreferences.getInstance().get(GeneralKeys.KEY_DELETE_AFTER_SEND))) {
+                    Uri deleteForm = Uri.withAppendedPath(InstanceProviderAPI.InstanceColumns.CONTENT_URI, instance.getDatabaseId().toString());
+                    Collect.getInstance().getContentResolver().delete(deleteForm, null, null);
+                }
+
+                String action = protocol.equals(Collect.getInstance().getString(R.string.protocol_google_sheets)) ?
+                        "HTTP-Sheets auto" : "HTTP auto";
+                String label = Collect.getFormIdentifierHash(instance.getJrFormId(), instance.getJrVersion());
+                analytics.logEvent(SUBMISSION, action, label);
+            } catch (UploadException e) {
+                Timber.d(e);
+                anyFailure = true;
+                resultMessagesByInstanceId.put(instance.getDatabaseId().toString(),
+                        e.getDisplayMessage());
+            }
+        }
+
+        return new Pair<>(anyFailure, InstanceUploaderUtils.getUploadResultMessage(Collect.getInstance(), resultMessagesByInstanceId));
+    }
+
+    /**
+     * Returns instances that need to be auto-sent.
+     */
+    @NonNull
+    private List<Instance> getInstancesToAutoSend(boolean isAutoSendAppSettingEnabled) {
+        InstancesDao dao = new InstancesDao();
+        Cursor c = dao.getFinalizedInstancesCursor();
+        List<Instance> allFinalized = dao.getInstancesFromCursor(c);
+
+        List<Instance> toUpload = new ArrayList<>();
+        for (Instance instance : allFinalized) {
+            if (formShouldBeAutoSent(instance.getJrFormId(), isAutoSendAppSettingEnabled)) {
+                toUpload.add(instance);
+            }
+        }
+
+        return toUpload;
+    }
+
+    /**
+     * Returns whether a form with the specified form_id should be auto-sent given the current
+     * app-level auto-send settings. Returns false if there is no form with the specified form_id.
+     *
+     * A form should be auto-sent if auto-send is on at the app level AND this form doesn't override
+     * auto-send settings OR if auto-send is on at the form-level.
+     *
+     * @param isAutoSendAppSettingEnabled whether the auto-send option is enabled at the app level
+     */
+    public static boolean formShouldBeAutoSent(String jrFormId, boolean isAutoSendAppSettingEnabled) {
+        Cursor cursor = new FormsDao().getFormsCursorForFormId(jrFormId);
+        String formLevelAutoSend = null;
+        if (cursor != null && cursor.moveToFirst()) {
+            try {
+                int autoSendColumnIndex = cursor.getColumnIndex(AUTO_SEND);
+                formLevelAutoSend = cursor.getString(autoSendColumnIndex);
+            } finally {
+                cursor.close();
+            }
+        }
+
+        return formLevelAutoSend == null ? isAutoSendAppSettingEnabled
+                : Boolean.valueOf(formLevelAutoSend);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/SubmitException.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/SubmitException.java
@@ -1,0 +1,20 @@
+package org.odk.collect.android.instancemanagement;
+
+public class SubmitException extends Exception {
+
+    public enum Type {
+        GOOGLE_ACCOUNT_NOT_SET,
+        GOOGLE_ACCOUNT_NOT_PERMITTED,
+        NOTHING_TO_SUBMIT;
+    }
+
+    private final Type type;
+
+    public SubmitException(Type type) {
+        this.type = type;
+    }
+
+    public Type getType() {
+        return type;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -32,7 +32,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     }
 
     @Override
-    public List<Instance> getAllBy(String formId) {
+    public List<Instance> getAllByJrFormId(String formId) {
         Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ?",
         new String[] {formId});
         return dao.getInstancesFromCursor(c);

--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -28,7 +28,7 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
     private final InstancesDao dao = new InstancesDao();
 
     @Override
-    public Instance getBy(long databaseId) {
+    public Instance get(long databaseId) {
         Cursor c = dao.getInstancesCursorForId(Long.toString(databaseId));
         List<Instance> result = dao.getInstancesFromCursor(c);
         return !result.isEmpty() ? result.get(0) : null;
@@ -36,8 +36,13 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
 
     @Override
     public List<Instance> getAllByJrFormId(String formId) {
-        Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ?",
-        new String[] {formId});
+        Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ?", new String[] {formId});
+        return dao.getInstancesFromCursor(c);
+    }
+
+    @Override
+    public List<Instance> getAllByJrFormIdAndJrVersion(String jrFormId, String jrVersion) {
+        Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ? AND " + InstanceColumns.JR_VERSION + " = ?", new String[] {jrFormId, jrVersion});
         return dao.getInstancesFromCursor(c);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -1,7 +1,9 @@
 package org.odk.collect.android.instances;
 
 import android.database.Cursor;
+import android.net.Uri;
 
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StoragePathProvider;
@@ -22,6 +24,7 @@ import java.util.List;
  * {@link InstancesDao}.
  */
 public final class DatabaseInstancesRepository implements InstancesRepository {
+
     private final InstancesDao dao = new InstancesDao();
 
     @Override
@@ -48,5 +51,11 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public void delete(Long id) {
+        Uri uri = Uri.withAppendedPath(InstanceColumns.CONTENT_URI, id.toString());
+        Collect.getInstance().getContentResolver().delete(uri, null, null);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/DatabaseInstancesRepository.java
@@ -3,12 +3,18 @@ package org.odk.collect.android.instances;
 import android.database.Cursor;
 import android.net.Uri;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.util.List;
+
+import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.JR_FORM_ID;
+import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.JR_VERSION;
 
 /**
  * Mediates between {@link Instance} objects and the underlying SQLite database that stores them.
@@ -36,14 +42,17 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
 
     @Override
     public List<Instance> getAllByJrFormId(String formId) {
-        Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ?", new String[] {formId});
+        Cursor c = dao.getInstancesCursor(JR_FORM_ID + " = ?", new String[] {formId});
         return dao.getInstancesFromCursor(c);
     }
 
     @Override
-    public List<Instance> getAllByJrFormIdAndJrVersion(String jrFormId, String jrVersion) {
-        Cursor c = dao.getInstancesCursor(InstanceColumns.JR_FORM_ID + " = ? AND " + InstanceColumns.JR_VERSION + " = ?", new String[] {jrFormId, jrVersion});
-        return dao.getInstancesFromCursor(c);
+    public List<Instance> getAllByJrFormIdAndJrVersion(@NonNull String jrFormId, @Nullable String jrVersion) {
+        if (jrVersion != null) {
+            return dao.getInstancesFromCursor(dao.getInstancesCursor(JR_FORM_ID + " = ? AND " + JR_VERSION + " = ?", new String[]{jrFormId, jrVersion}));
+        } else {
+            return dao.getInstancesFromCursor(dao.getInstancesCursor(JR_FORM_ID + " = ? AND " + JR_VERSION + " IS NULL", new String[]{jrFormId}));
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/instances/Instance.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/Instance.java
@@ -124,7 +124,7 @@ public final class Instance {
             return this;
         }
 
-        public Builder databaseId(Long databaseId) {
+        public Builder id(Long databaseId) {
             this.databaseId = databaseId;
             return this;
         }
@@ -182,7 +182,7 @@ public final class Instance {
         return geometry;
     }
 
-    public Long getDatabaseId() {
+    public Long getId() {
         return databaseId;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -21,4 +21,6 @@ public interface InstancesRepository {
      * Get the Instance corresponding to the given path or null if no unique Instance matches.
      */
     Instance getByPath(String instancePath);
+
+    void delete(Long id);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -13,9 +13,11 @@ import java.util.List;
  */
 public interface InstancesRepository {
 
-    Instance getBy(long databaseId);
+    Instance get(long databaseId);
 
     List<Instance> getAllByJrFormId(String formId);
+
+    List<Instance> getAllByJrFormIdAndJrVersion(String jrFormId, String jrVersion);
 
     /**
      * Get the Instance corresponding to the given path or null if no unique Instance matches.

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface InstancesRepository {
     Instance getBy(long databaseId);
 
-    List<Instance> getAllBy(String formId);
+    List<Instance> getAllByJrFormId(String formId);
 
     /**
      * Get the Instance corresponding to the given path or null if no unique Instance matches.

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -12,6 +12,7 @@ import java.util.List;
  * without introducing new specialized methods (e.g. get(Specification s) instead of getBy(XYZ).
  */
 public interface InstancesRepository {
+
     Instance getBy(long databaseId);
 
     List<Instance> getAllByJrFormId(String formId);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralPreferencesFragment.java
@@ -16,21 +16,30 @@
 
 package org.odk.collect.android.preferences;
 
+import android.content.Context;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.utilities.MultiClickGuard;
+import org.odk.collect.android.version.VersionInformation;
 
 import java.util.Collection;
+
+import javax.inject.Inject;
 
 import static org.odk.collect.android.preferences.AdminKeys.KEY_MAPS;
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
 
 public class GeneralPreferencesFragment extends BasePreferenceFragment implements Preference.OnPreferenceClickListener {
+
+    @Inject
+    VersionInformation versionInformation;
 
     public static GeneralPreferencesFragment newInstance(boolean adminMode) {
         Bundle bundle = new Bundle();
@@ -39,6 +48,12 @@ public class GeneralPreferencesFragment extends BasePreferenceFragment implement
         GeneralPreferencesFragment generalPreferencesFragment = new GeneralPreferencesFragment();
         generalPreferencesFragment.setArguments(bundle);
         return generalPreferencesFragment;
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        DaggerUtils.getComponent(context).inject(this);
     }
 
     @Override
@@ -56,6 +71,10 @@ public class GeneralPreferencesFragment extends BasePreferenceFragment implement
 
         if (!getArguments().getBoolean(INTENT_KEY_ADMIN_MODE)) {
             setPreferencesVisibility();
+        }
+
+        if (versionInformation.isRelease()) {
+            findPreference("experimental").setVisible(false);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProviderAPI.java
@@ -78,5 +78,7 @@ public final class FormsProviderAPI {
 
         // this is null on create, and can only be set on an update.
         public static final String LANGUAGE = "language";
+
+        public static final String DELETED = "deleted";
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationResult.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationResult.java
@@ -16,7 +16,7 @@ public enum StorageMigrationResult {
             case NOT_ENOUGH_SPACE:
                 return errorMessage + context.getString(R.string.storage_migration_not_enough_space);
             case CHANGES_IN_PROGRESS:
-                return errorMessage + context.getString(R.string.storage_migration_form_downloader_is_running);
+                return errorMessage + context.getString(R.string.changes_in_progress);
             case MOVING_FILES_FAILED:
                 return errorMessage + context.getString(R.string.storage_migration_failed);
             default:

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationResult.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrationResult.java
@@ -6,19 +6,16 @@ import org.odk.collect.android.R;
 
 public enum StorageMigrationResult {
     SUCCESS,
-    FORM_UPLOADER_IS_RUNNING,
-    FORM_DOWNLOADER_IS_RUNNING,
     NOT_ENOUGH_SPACE,
-    MOVING_FILES_FAILED;
+    MOVING_FILES_FAILED,
+    CHANGES_IN_PROGRESS;
 
     public String getErrorResultMessage(Context context) {
         String errorMessage = context.getString(R.string.error) + " ";
         switch (this) {
             case NOT_ENOUGH_SPACE:
                 return errorMessage + context.getString(R.string.storage_migration_not_enough_space);
-            case FORM_UPLOADER_IS_RUNNING:
-                return errorMessage + context.getString(R.string.storage_migration_form_uploader_is_running);
-            case FORM_DOWNLOADER_IS_RUNNING:
+            case CHANGES_IN_PROGRESS:
                 return errorMessage + context.getString(R.string.storage_migration_form_downloader_is_running);
             case MOVING_FILES_FAILED:
                 return errorMessage + context.getString(R.string.storage_migration_failed);

--- a/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/migration/StorageMigrator.java
@@ -6,8 +6,6 @@ import android.database.Cursor;
 import org.apache.commons.io.FileUtils;
 import org.javarosa.core.reference.ReferenceManager;
 import org.odk.collect.android.analytics.Analytics;
-import org.odk.collect.android.backgroundwork.FormSubmitManager;
-import org.odk.collect.android.backgroundwork.FormUpdateManager;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
@@ -40,15 +38,13 @@ public class StorageMigrator {
     private final ReferenceManager referenceManager;
 
     private final StorageMigrationRepository storageMigrationRepository;
-    private final FormUpdateManager formUpdateManager;
-    private final FormSubmitManager formSubmitManager;
 
     private final Analytics analytics;
 
     public StorageMigrator(StoragePathProvider storagePathProvider, StorageStateProvider storageStateProvider,
                            StorageEraser storageEraser, StorageMigrationRepository storageMigrationRepository,
                            GeneralSharedPreferences generalSharedPreferences, ReferenceManager referenceManager,
-                           FormUpdateManager formUpdateManager, FormSubmitManager formSubmitManager, Analytics analytics) {
+                           Analytics analytics) {
 
         this.storagePathProvider = storagePathProvider;
         this.storageStateProvider = storageStateProvider;
@@ -56,8 +52,6 @@ public class StorageMigrator {
         this.storageMigrationRepository = storageMigrationRepository;
         this.generalSharedPreferences = generalSharedPreferences;
         this.referenceManager = referenceManager;
-        this.formUpdateManager = formUpdateManager;
-        this.formSubmitManager = formSubmitManager;
         this.analytics = analytics;
     }
 
@@ -72,14 +66,6 @@ public class StorageMigrator {
 
     public StorageMigrationResult migrate() {
         storageEraser.clearOdkDirOnScopedStorage();
-
-        if (isFormUploaderRunning()) {
-            return StorageMigrationResult.FORM_UPLOADER_IS_RUNNING;
-        }
-
-        if (isFormDownloaderRunning()) {
-            return StorageMigrationResult.FORM_DOWNLOADER_IS_RUNNING;
-        }
 
         if (!storageStateProvider.isEnoughSpaceToPerformMigration(storagePathProvider)) {
             return StorageMigrationResult.NOT_ENOUGH_SPACE;
@@ -104,14 +90,6 @@ public class StorageMigrator {
         storageEraser.deleteOdkDirFromUnscopedStorage();
 
         return StorageMigrationResult.SUCCESS;
-    }
-
-    private boolean isFormUploaderRunning() {
-        return formSubmitManager.isSubmitRunning();
-    }
-
-    private boolean isFormDownloaderRunning() {
-        return formUpdateManager.isUpdateRunning();
     }
 
     boolean moveAppDataToScopedStorage() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
@@ -14,7 +14,6 @@
 
 package org.odk.collect.android.tasks;
 
-import android.content.ContentResolver;
 import android.os.AsyncTask;
 
 import org.odk.collect.android.formmanagement.FormDeleter;
@@ -32,7 +31,6 @@ import timber.log.Timber;
  */
 public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
-    private ContentResolver cr;
     private DeleteFormsListener dl;
 
     private int successCount;
@@ -44,7 +42,7 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
     protected Integer doInBackground(Long... params) {
         int deleted = 0;
 
-        if (params == null || cr == null || dl == null) {
+        if (params == null || dl == null) {
             return deleted;
         }
         toDeleteCount = params.length;
@@ -80,7 +78,6 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     @Override
     protected void onPostExecute(Integer result) {
-        cr = null;
         if (dl != null) {
             dl.deleteComplete(result);
         }
@@ -89,7 +86,6 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     @Override
     protected void onCancelled() {
-        cr = null;
         if (dl != null) {
             dl.deleteComplete(successCount);
         }
@@ -97,10 +93,6 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     public void setDeleteListener(DeleteFormsListener listener) {
         dl = listener;
-    }
-
-    public void setContentResolver(ContentResolver resolver) {
-        cr = resolver;
     }
 
     public int getDeleteCount() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
@@ -15,11 +15,12 @@
 package org.odk.collect.android.tasks;
 
 import android.content.ContentResolver;
-import android.net.Uri;
 import android.os.AsyncTask;
 
+import org.odk.collect.android.formmanagement.FormDeleter;
+import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.DeleteFormsListener;
-import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 
 import timber.log.Timber;
 
@@ -36,6 +37,8 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     private int successCount;
     private int toDeleteCount;
+    private FormsRepository formsRepository;
+    private InstancesRepository instancesRepository;
 
     @Override
     protected Integer doInBackground(Long... params) {
@@ -52,9 +55,9 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
                 break;
             }
             try {
-                Uri deleteForm = Uri.withAppendedPath(FormsColumns.CONTENT_URI, param.toString());
-                int wasDeleted = cr.delete(deleteForm, null, null);
-                deleted += wasDeleted;
+                new FormDeleter(formsRepository, instancesRepository).delete(param);
+
+                deleted++;
 
                 successCount++;
                 publishProgress(successCount, toDeleteCount);
@@ -106,5 +109,10 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     public int getToDeleteCount() {
         return toDeleteCount;
+    }
+
+    public void setRepositories(FormsRepository formsRepository, InstancesRepository instancesRepository) {
+        this.formsRepository = formsRepository;
+        this.instancesRepository = instancesRepository;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
@@ -35,8 +35,14 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     private int successCount;
     private int toDeleteCount;
-    private FormsRepository formsRepository;
-    private InstancesRepository instancesRepository;
+
+    private final FormsRepository formsRepository;
+    private final InstancesRepository instancesRepository;
+
+    public DeleteFormsTask(FormsRepository formsRepository, InstancesRepository instancesRepository) {
+        this.formsRepository = formsRepository;
+        this.instancesRepository = instancesRepository;
+    }
 
     @Override
     protected Integer doInBackground(Long... params) {
@@ -101,10 +107,5 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
 
     public int getToDeleteCount() {
         return toDeleteCount;
-    }
-
-    public void setRepositories(FormsRepository formsRepository, InstancesRepository instancesRepository) {
-        this.formsRepository = formsRepository;
-        this.instancesRepository = instancesRepository;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
@@ -14,12 +14,10 @@
 
 package org.odk.collect.android.tasks;
 
-import android.content.ContentResolver;
-import android.net.Uri;
 import android.os.AsyncTask;
 
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.DeleteInstancesListener;
-import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 
 import timber.log.Timber;
 
@@ -31,17 +29,17 @@ import timber.log.Timber;
  */
 public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
-    private ContentResolver contentResolver;
     private DeleteInstancesListener deleteInstancesListener;
 
     private int successCount;
     private int toDeleteCount;
+    private InstancesRepository instancesRepository;
 
     @Override
     protected Integer doInBackground(Long... params) {
         int deleted = 0;
 
-        if (params == null || contentResolver == null) {
+        if (params == null) {
             return deleted;
         }
 
@@ -53,11 +51,8 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
                 break;
             }
             try {
-                Uri deleteForm =
-                        Uri.withAppendedPath(InstanceColumns.CONTENT_URI, param.toString());
-
-                int wasDeleted = contentResolver.delete(deleteForm, null, null);
-                deleted += wasDeleted;
+                instancesRepository.delete(param);
+                deleted++;
 
                 successCount++;
                 publishProgress(successCount, toDeleteCount);
@@ -81,7 +76,6 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
     @Override
     protected void onPostExecute(Integer result) {
-        contentResolver = null;
         if (deleteInstancesListener != null) {
             deleteInstancesListener.deleteComplete(result);
         }
@@ -90,7 +84,6 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
     @Override
     protected void onCancelled() {
-        contentResolver = null;
         if (deleteInstancesListener != null) {
             deleteInstancesListener.deleteComplete(successCount);
         }
@@ -100,8 +93,8 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
         deleteInstancesListener = listener;
     }
 
-    public void setContentResolver(ContentResolver resolver) {
-        contentResolver = resolver;
+    public void setRepositories(InstancesRepository instancesRepository) {
+        this.instancesRepository = instancesRepository;
     }
 
     public int getDeleteCount() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
@@ -16,6 +16,8 @@ package org.odk.collect.android.tasks;
 
 import android.os.AsyncTask;
 
+import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instancemanagement.InstanceDeleter;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.DeleteInstancesListener;
 
@@ -34,6 +36,7 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
     private int successCount;
     private int toDeleteCount;
     private InstancesRepository instancesRepository;
+    private FormsRepository formsRepository;
 
     @Override
     protected Integer doInBackground(Long... params) {
@@ -45,13 +48,14 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
         toDeleteCount = params.length;
 
+        InstanceDeleter instanceDeleter = new InstanceDeleter(instancesRepository, formsRepository);
         // delete files from database and then from file system
         for (Long param : params) {
             if (isCancelled()) {
                 break;
             }
             try {
-                instancesRepository.delete(param);
+                instanceDeleter.delete(param);
                 deleted++;
 
                 successCount++;
@@ -93,8 +97,9 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
         deleteInstancesListener = listener;
     }
 
-    public void setRepositories(InstancesRepository instancesRepository) {
+    public void setRepositories(InstancesRepository instancesRepository, FormsRepository formsRepository) {
         this.instancesRepository = instancesRepository;
+        this.formsRepository = formsRepository;
     }
 
     public int getDeleteCount() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
@@ -35,8 +35,14 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
     private int successCount;
     private int toDeleteCount;
-    private InstancesRepository instancesRepository;
-    private FormsRepository formsRepository;
+    
+    private final InstancesRepository instancesRepository;
+    private final FormsRepository formsRepository;
+
+    public DeleteInstancesTask(InstancesRepository instancesRepository, FormsRepository formsRepository) {
+        this.instancesRepository = instancesRepository;
+        this.formsRepository = formsRepository;
+    }
 
     @Override
     protected Integer doInBackground(Long... params) {
@@ -95,11 +101,6 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
     public void setDeleteListener(DeleteInstancesListener listener) {
         deleteInstancesListener = listener;
-    }
-
-    public void setRepositories(InstancesRepository instancesRepository, FormsRepository formsRepository) {
-        this.instancesRepository = instancesRepository;
-        this.formsRepository = formsRepository;
     }
 
     public int getDeleteCount() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
@@ -35,7 +35,7 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
 
     private int successCount;
     private int toDeleteCount;
-    
+
     private final InstancesRepository instancesRepository;
     private final FormsRepository formsRepository;
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploaderTask.java
@@ -55,7 +55,7 @@ public class InstanceGoogleSheetsUploaderTask extends InstanceUploaderTask {
             Instance instance = instancesToUpload.get(i);
 
             if (isCancelled()) {
-                outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(),
+                outcome.messagesByInstanceId.put(instance.getId().toString(),
                         Collect.getInstance().getString(R.string.instance_upload_cancelled));
                 return outcome;
             }
@@ -68,22 +68,22 @@ public class InstanceGoogleSheetsUploaderTask extends InstanceUploaderTask {
             List<Form> forms = dao.getFormsFromCursor(formCursor);
 
             if (forms.size() != 1) {
-                outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(),
+                outcome.messagesByInstanceId.put(instance.getId().toString(),
                         Collect.getInstance().getString(R.string.not_exactly_one_blank_form_for_this_form_id));
             } else {
                 try {
                     String destinationUrl = uploader.getUrlToSubmitTo(instance, null, null);
                     if (InstanceUploaderUtils.doesUrlRefersToGoogleSheetsFile(destinationUrl)) {
                         uploader.uploadOneSubmission(instance, destinationUrl);
-                        outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(), DEFAULT_SUCCESSFUL_TEXT);
+                        outcome.messagesByInstanceId.put(instance.getId().toString(), DEFAULT_SUCCESSFUL_TEXT);
 
                         analytics.logEvent(SUBMISSION, "HTTP-Sheets", Collect.getFormIdentifierHash(instance.getJrFormId(), instance.getJrVersion()));
                     } else {
-                        outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(), SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE);
+                        outcome.messagesByInstanceId.put(instance.getId().toString(), SPREADSHEET_UPLOADED_TO_GOOGLE_DRIVE);
                     }
                 } catch (UploadException e) {
                     Timber.d(e);
-                    outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(),
+                    outcome.messagesByInstanceId.put(instance.getId().toString(),
                             e.getDisplayMessage());
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceGoogleSheetsUploaderTask.java
@@ -64,7 +64,7 @@ public class InstanceGoogleSheetsUploaderTask extends InstanceUploaderTask {
 
             // Get corresponding blank form and verify there is exactly 1
             FormsDao dao = new FormsDao();
-            Cursor formCursor = dao.getFormsCursor(instance.getJrFormId(), instance.getJrVersion());
+            Cursor formCursor = dao.getFormsCursorSortedByDateDesc(instance.getJrFormId(), instance.getJrVersion());
             List<Form> forms = dao.getFormsFromCursor(formCursor);
 
             if (forms.size() != 1) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploaderTask.java
@@ -78,7 +78,7 @@ public class InstanceServerUploaderTask extends InstanceUploaderTask {
             try {
                 String destinationUrl = uploader.getUrlToSubmitTo(instance, deviceId, completeDestinationUrl);
                 String customMessage = uploader.uploadOneSubmission(instance, destinationUrl);
-                outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(),
+                outcome.messagesByInstanceId.put(instance.getId().toString(),
                         customMessage != null ? customMessage : Collect.getInstance().getString(R.string.success));
 
                 analytics.logEvent(SUBMISSION, "HTTP", Collect.getFormIdentifierHash(instance.getJrFormId(), instance.getJrVersion()));
@@ -88,7 +88,7 @@ public class InstanceServerUploaderTask extends InstanceUploaderTask {
                 // retry. Items present in the map are considered already attempted and won't be
                 // retried.
             } catch (UploadException e) {
-                outcome.messagesByInstanceId.put(instance.getDatabaseId().toString(),
+                outcome.messagesByInstanceId.put(instance.getId().toString(),
                         e.getDisplayMessage());
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 
 import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.preferences.GeneralKeys;
@@ -42,6 +43,7 @@ import timber.log.Timber;
 public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, InstanceUploaderTask.Outcome> {
 
     private InstancesRepository instancesRepository;
+    private FormsRepository formsRepository;
     private InstanceUploaderListener stateListener;
     private Boolean deleteInstanceAfterSubmission;
 
@@ -111,7 +113,7 @@ public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, Inst
                                 }
 
                                 DeleteInstancesTask dit = new DeleteInstancesTask();
-                                dit.setRepositories(instancesRepository);
+                                dit.setRepositories(instancesRepository, formsRepository);
                                 dit.execute(toDelete.toArray(new Long[toDelete.size()]));
                             }
                         } catch (SQLException e) {
@@ -142,8 +144,9 @@ public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, Inst
         this.deleteInstanceAfterSubmission = deleteInstanceAfterSubmission;
     }
 
-    public void setRepositories(InstancesRepository instancesRepository) {
+    public void setRepositories(InstancesRepository instancesRepository, FormsRepository formsRepository) {
         this.instancesRepository = instancesRepository;
+        this.formsRepository = formsRepository;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -21,11 +21,11 @@ import android.database.SQLException;
 import android.net.Uri;
 import android.os.AsyncTask;
 
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
-import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.upload.InstanceServerUploader;
@@ -41,6 +41,7 @@ import timber.log.Timber;
 
 public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, InstanceUploaderTask.Outcome> {
 
+    private InstancesRepository instancesRepository;
     private InstanceUploaderListener stateListener;
     private Boolean deleteInstanceAfterSubmission;
 
@@ -110,7 +111,7 @@ public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, Inst
                                 }
 
                                 DeleteInstancesTask dit = new DeleteInstancesTask();
-                                dit.setContentResolver(Collect.getInstance().getContentResolver());
+                                dit.setRepositories(instancesRepository);
                                 dit.execute(toDelete.toArray(new Long[toDelete.size()]));
                             }
                         } catch (SQLException e) {
@@ -139,6 +140,10 @@ public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, Inst
 
     public void setDeleteInstanceAfterSubmission(Boolean deleteInstanceAfterSubmission) {
         this.deleteInstanceAfterSubmission = deleteInstanceAfterSubmission;
+    }
+
+    public void setRepositories(InstancesRepository instancesRepository) {
+        this.instancesRepository = instancesRepository;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -112,8 +112,7 @@ public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, Inst
                                     }
                                 }
 
-                                DeleteInstancesTask dit = new DeleteInstancesTask();
-                                dit.setRepositories(instancesRepository, formsRepository);
+                                DeleteInstancesTask dit = new DeleteInstancesTask(instancesRepository, formsRepository);
                                 dit.execute(toDelete.toArray(new Long[toDelete.size()]));
                             }
                         } catch (SQLException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -206,7 +206,7 @@ public class SaveFormToDisk {
             InstancesRepository instances = new DatabaseInstancesRepository();
             Instance instance = instances.getByPath(instancePath);
             if (instance != null) {
-                uri = Uri.withAppendedPath(InstanceColumns.CONTENT_URI, instance.getDatabaseId().toString());
+                uri = Uri.withAppendedPath(InstanceColumns.CONTENT_URI, instance.getId().toString());
 
                 String geometryXpath = getGeometryXpathForInstance(uri);
                 ContentValues geometryContentValues = extractGeometryContentValues(formInstance, geometryXpath);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -482,7 +482,7 @@ public class SaveFormToDisk {
             if (instanceCursor.moveToFirst()) {
                 String jrFormId = instanceCursor.getString(0);
                 String version = instanceCursor.getString(1);
-                try (Cursor formCursor = new FormsDao().getFormsCursor(jrFormId, version)) {
+                try (Cursor formCursor = new FormsDao().getFormsCursorSortedByDateDesc(jrFormId, version)) {
                     if (formCursor.moveToFirst()) {
                         return formCursor.getString(formCursor.getColumnIndex(FormsColumns.GEOMETRY_XPATH));
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -97,7 +97,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
         // Get corresponding blank form and verify there is exactly 1
         FormsDao dao = new FormsDao();
-        Cursor formCursor = dao.getFormsCursor(instance.getJrFormId(), instance.getJrVersion());
+        Cursor formCursor = dao.getFormsCursorSortedByDateDesc(instance.getJrFormId(), instance.getJrVersion());
         List<Form> forms = dao.getFormsFromCursor(formCursor);
 
         try {

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -76,7 +76,7 @@ public class InstanceServerUploader extends InstanceUploader {
         // the proper scheme.
         if (uriRemap.containsKey(submissionUri)) {
             submissionUri = uriRemap.get(submissionUri);
-            Timber.i("Using Uri remap for submission %s. Now: %s", instance.getDatabaseId(),
+            Timber.i("Using Uri remap for submission %s. Now: %s", instance.getId(),
                     submissionUri.toString());
         } else {
             if (submissionUri.getHost() == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
@@ -89,7 +89,7 @@ public abstract class InstanceUploader {
 
     void saveSuccessStatusToDatabase(Instance instance) {
         Uri instanceDatabaseUri = Uri.withAppendedPath(InstanceColumns.CONTENT_URI,
-                instance.getDatabaseId().toString());
+                instance.getId().toString());
 
         ContentValues contentValues = new ContentValues();
         contentValues.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
@@ -98,7 +98,7 @@ public abstract class InstanceUploader {
 
     void saveFailedStatusToDatabase(Instance instance) {
         Uri instanceDatabaseUri = Uri.withAppendedPath(InstanceColumns.CONTENT_URI,
-                instance.getDatabaseId().toString());
+                instance.getId().toString());
 
         ContentValues contentValues = new ContentValues();
         contentValues.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMISSION_FAILED);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MultiFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MultiFormDownloader.java
@@ -24,9 +24,9 @@ import org.kxml2.kdom.Element;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
-import org.odk.collect.android.forms.DatabaseFormRepository;
+import org.odk.collect.android.forms.DatabaseFormsRepository;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.listeners.FormDownloaderListener;
 import org.odk.collect.android.logic.FileReferenceFactory;
 import org.odk.collect.android.openrosa.OpenRosaXmlFetcher;
@@ -61,11 +61,11 @@ public class MultiFormDownloader {
     private static final String TEMP_DOWNLOAD_EXTENSION = ".tempDownload";
 
     private final FormListApi formListApi;
-    private final FormRepository formRepository;
+    private final FormsRepository formsRepository;
 
     @Deprecated
     public MultiFormDownloader(OpenRosaXmlFetcher openRosaXmlFetcher) {
-        this.formRepository = new DatabaseFormRepository();
+        this.formsRepository = new DatabaseFormsRepository();
         formListApi = new OpenRosaFormListApi(openRosaXmlFetcher);
     }
 
@@ -252,7 +252,7 @@ public class MultiFormDownloader {
         } else {
             String md5Hash = FileUtils.getMd5Hash(fileResult.file);
             if (md5Hash != null) {
-                formRepository.deleteFormsByMd5Hash(md5Hash);
+                formsRepository.deleteFormsByMd5Hash(md5Hash);
             }
             FileUtils.deleteAndReport(fileResult.getFile());
         }
@@ -297,7 +297,7 @@ public class MultiFormDownloader {
         FileUtils.checkMediaPath(new File(mediaPath));
 
 
-        Form form = formRepository.getByPath(formFile.getAbsolutePath());
+        Form form = formsRepository.getByPath(formFile.getAbsolutePath());
         isNew = form == null;
 
         if (isNew) {
@@ -324,7 +324,7 @@ public class MultiFormDownloader {
                 .geometryXpath(formInfo.get(FileUtils.GEOMETRY_XPATH))
                 .build();
 
-        return formRepository.save(form);
+        return formsRepository.save(form);
     }
 
     /**
@@ -353,7 +353,7 @@ public class MultiFormDownloader {
 
         // we've downloaded the file, and we may have renamed it
         // make sure it's not the same as a file we already have
-        Form form = formRepository.getByMd5Hash(FileUtils.getMd5Hash(f));
+        Form form = formsRepository.getByMd5Hash(FileUtils.getMd5Hash(f));
         if (form != null) {
             isNew = false;
 

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -102,7 +102,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_extra_small"
-                        tools:text="@string/manage_files" />
+                        tools:text="@string/w" />
 
                     <TextView
                         android:id="@+id/version_sha"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -102,7 +102,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_extra_small"
-                        tools:text="@string/w" />
+                        tools:text="@string/manage_files" />
 
                     <TextView
                         android:id="@+id/version_sha"

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -661,8 +661,7 @@
   <string name="migrate">Migrovat</string>
   <string name="error">Chyba:</string>
   <string name="storage_migration_not_enough_space">Na interním úložišti nemáte dostatek místa pro migraci dat. Uvolněte místo a zkuste to znovu.</string>
-  <string name="storage_migration_form_uploader_is_running">Je spuštěn nástroj pro nahrávání na pozadí. Prosím zkuste to znovu.</string>
-  <string name="storage_migration_form_downloader_is_running">Je spuštěno stahování formulářů na pozadí. Prosím zkuste to znovu.</string>
+    <string name="storage_migration_form_downloader_is_running">Je spuštěno stahování formulářů na pozadí. Prosím zkuste to znovu.</string>
   <string name="storage_migration_failed">Migrace dat se nezdařila. Prosím zkuste to znovu.</string>
   <string name="storage_migration_dialog_title">Migrace úložiště</string>
   <string name="storage_migration_progress_msg">Probíhá migrace. 

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -661,7 +661,7 @@
   <string name="migrate">Migrovat</string>
   <string name="error">Chyba:</string>
   <string name="storage_migration_not_enough_space">Na interním úložišti nemáte dostatek místa pro migraci dat. Uvolněte místo a zkuste to znovu.</string>
-    <string name="storage_migration_form_downloader_is_running">Je spuštěno stahování formulářů na pozadí. Prosím zkuste to znovu.</string>
+    <string name="changes_in_progress">Je spuštěno stahování formulářů na pozadí. Prosím zkuste to znovu.</string>
   <string name="storage_migration_failed">Migrace dat se nezdařila. Prosím zkuste to znovu.</string>
   <string name="storage_migration_dialog_title">Migrace úložiště</string>
   <string name="storage_migration_progress_msg">Probíhá migrace. 

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -662,7 +662,7 @@
   <string name="migrate">Migrieren</string>
   <string name="error">Fehler:</string>
   <string name="storage_migration_not_enough_space">Sie haben nicht genug Platz auf Ihrem internen Speicher um Ihre Daten zu migrieren. Bitte geben Sie Speicherplatz frei und versuchen  Sie es erneut. </string>
-    <string name="storage_migration_form_downloader_is_running">Hintergrund-Formular-Downloader läuft. Bitte erneut versuchen. </string>
+    <string name="changes_in_progress">Hintergrund-Formular-Downloader läuft. Bitte erneut versuchen. </string>
   <string name="storage_migration_failed">Datenmigration fehlgeschlagen. Bitte erneut versuchen. </string>
   <string name="storage_migration_dialog_title">Speichermigration</string>
   <string name="storage_migration_progress_msg">Migration läuft. \nDas kann einige Sekunden dauern… </string>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -662,8 +662,7 @@
   <string name="migrate">Migrieren</string>
   <string name="error">Fehler:</string>
   <string name="storage_migration_not_enough_space">Sie haben nicht genug Platz auf Ihrem internen Speicher um Ihre Daten zu migrieren. Bitte geben Sie Speicherplatz frei und versuchen  Sie es erneut. </string>
-  <string name="storage_migration_form_uploader_is_running">Hintergrund-Formular-Uploader läuft. Bitte erneut versuchen. </string>
-  <string name="storage_migration_form_downloader_is_running">Hintergrund-Formular-Downloader läuft. Bitte erneut versuchen. </string>
+    <string name="storage_migration_form_downloader_is_running">Hintergrund-Formular-Downloader läuft. Bitte erneut versuchen. </string>
   <string name="storage_migration_failed">Datenmigration fehlgeschlagen. Bitte erneut versuchen. </string>
   <string name="storage_migration_dialog_title">Speichermigration</string>
   <string name="storage_migration_progress_msg">Migration läuft. \nDas kann einige Sekunden dauern… </string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -664,7 +664,7 @@
   <string name="migrate">Iniciar Migración</string>
   <string name="error">Error:</string>
   <string name="storage_migration_not_enough_space">No tiene suficiente espacio en su almacenamiento interno para migrar sus datos. Libere espacio e intente nuevamente.</string>
-    <string name="storage_migration_form_downloader_is_running">Se está ejecutando el descargador de formularios en segundo plano. Inténtalo de nuevo.</string>
+    <string name="changes_in_progress">Se está ejecutando el descargador de formularios en segundo plano. Inténtalo de nuevo.</string>
   <string name="storage_migration_failed">La migración de datos falló. Inténtalo de nuevo.</string>
   <string name="storage_migration_dialog_title">Migración de almacenamiento</string>
   <string name="storage_migration_progress_msg">Migración en progreso.\nEsto puede tomar algunos segundos.</string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -664,8 +664,7 @@
   <string name="migrate">Iniciar Migración</string>
   <string name="error">Error:</string>
   <string name="storage_migration_not_enough_space">No tiene suficiente espacio en su almacenamiento interno para migrar sus datos. Libere espacio e intente nuevamente.</string>
-  <string name="storage_migration_form_uploader_is_running">Se está ejecutando el cargador de formularios en segundo plano. Inténtalo de nuevo.</string>
-  <string name="storage_migration_form_downloader_is_running">Se está ejecutando el descargador de formularios en segundo plano. Inténtalo de nuevo.</string>
+    <string name="storage_migration_form_downloader_is_running">Se está ejecutando el descargador de formularios en segundo plano. Inténtalo de nuevo.</string>
   <string name="storage_migration_failed">La migración de datos falló. Inténtalo de nuevo.</string>
   <string name="storage_migration_dialog_title">Migración de almacenamiento</string>
   <string name="storage_migration_progress_msg">Migración en progreso.\nEsto puede tomar algunos segundos.</string>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -662,7 +662,7 @@
   <string name="migrate">Siirrä</string>
   <string name="error">Virhe:</string>
   <string name="storage_migration_not_enough_space">Sinulla ei ole riittävästi tilaa sisäisessä muistissa tietojesi siirtämiseen. Ole hyvä ja vapauta tilaa ja yritä uudelleen.</string>
-    <string name="storage_migration_form_downloader_is_running">Lomakkeiden taustalataus käynnissä. Ole hyvä ja yritä uudelleen.</string>
+    <string name="changes_in_progress">Lomakkeiden taustalataus käynnissä. Ole hyvä ja yritä uudelleen.</string>
   <string name="storage_migration_failed">Tietojen siirto epäonnistui. Ole hyvä ja yritä uudelleen.</string>
   <string name="storage_migration_dialog_title">Tallennuksen siirto</string>
   <string name="storage_migration_progress_msg">Siirto käynnissä.\Tässä voi kulua muutama sekunti…</string>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -662,8 +662,7 @@
   <string name="migrate">Siirrä</string>
   <string name="error">Virhe:</string>
   <string name="storage_migration_not_enough_space">Sinulla ei ole riittävästi tilaa sisäisessä muistissa tietojesi siirtämiseen. Ole hyvä ja vapauta tilaa ja yritä uudelleen.</string>
-  <string name="storage_migration_form_uploader_is_running">Lomakkeiden taustalähetys käynnissä. Ole hyvä ja yritä uudelleen.</string>
-  <string name="storage_migration_form_downloader_is_running">Lomakkeiden taustalataus käynnissä. Ole hyvä ja yritä uudelleen.</string>
+    <string name="storage_migration_form_downloader_is_running">Lomakkeiden taustalataus käynnissä. Ole hyvä ja yritä uudelleen.</string>
   <string name="storage_migration_failed">Tietojen siirto epäonnistui. Ole hyvä ja yritä uudelleen.</string>
   <string name="storage_migration_dialog_title">Tallennuksen siirto</string>
   <string name="storage_migration_progress_msg">Siirto käynnissä.\Tässä voi kulua muutama sekunti…</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -662,8 +662,7 @@
   <string name="migrate">Transférer</string>
   <string name="error">Erreur:</string>
   <string name="storage_migration_not_enough_space">Votre mémoire interne n\'a pas assez d\'espace pour transférer vos données. Veuillez libérer de l\'espace et réessayer.</string>
-  <string name="storage_migration_form_uploader_is_running">Envoi de soumissions en tâche de fond en cours. Veuillez réessayer plus tard.</string>
-  <string name="storage_migration_form_downloader_is_running">Téléchargement de formulaires en tâche de fond en cours. Veuillez réessayer plus tard.</string>
+    <string name="storage_migration_form_downloader_is_running">Téléchargement de formulaires en tâche de fond en cours. Veuillez réessayer plus tard.</string>
   <string name="storage_migration_failed">Le transfert des données a échoué. Veuillez réessayer.</string>
   <string name="storage_migration_dialog_title">Transfert des données</string>
   <string name="storage_migration_progress_msg">Transfert en cours.\nCeci pourrait prendre quelques secondes…</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -662,7 +662,7 @@
   <string name="migrate">Transférer</string>
   <string name="error">Erreur:</string>
   <string name="storage_migration_not_enough_space">Votre mémoire interne n\'a pas assez d\'espace pour transférer vos données. Veuillez libérer de l\'espace et réessayer.</string>
-    <string name="storage_migration_form_downloader_is_running">Téléchargement de formulaires en tâche de fond en cours. Veuillez réessayer plus tard.</string>
+    <string name="changes_in_progress">Téléchargement de formulaires en tâche de fond en cours. Veuillez réessayer plus tard.</string>
   <string name="storage_migration_failed">Le transfert des données a échoué. Veuillez réessayer.</string>
   <string name="storage_migration_dialog_title">Transfert des données</string>
   <string name="storage_migration_progress_msg">Transfert en cours.\nCeci pourrait prendre quelques secondes…</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -659,7 +659,7 @@
   <string name="migrate">Migrasi</string>
   <string name="error">Kesalahan:</string>
   <string name="storage_migration_not_enough_space">Anda tidak memiliki ruang penyimpanan yang cukup pada penyimpanan internal untuk melakukan migrasi data yang Anda miliki. Mohon kosongkan beberapa ruang penyimpanan dan coba lagi.</string>
-    <string name="storage_migration_form_downloader_is_running">Pengunduhan formulir sedang berlangsung. Mohon coba lagi.</string>
+    <string name="changes_in_progress">Pengunduhan formulir sedang berlangsung. Mohon coba lagi.</string>
   <string name="storage_migration_failed">Migrasi data tidak berhasil. Mohon coba lagi.</string>
   <string name="storage_migration_dialog_title">Migrasi penyimpanan</string>
   <string name="storage_migration_progress_msg">Migrasi sedang berlangsung.\nProses ini mungkin perlu beberapa detik…</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -659,8 +659,7 @@
   <string name="migrate">Migrasi</string>
   <string name="error">Kesalahan:</string>
   <string name="storage_migration_not_enough_space">Anda tidak memiliki ruang penyimpanan yang cukup pada penyimpanan internal untuk melakukan migrasi data yang Anda miliki. Mohon kosongkan beberapa ruang penyimpanan dan coba lagi.</string>
-  <string name="storage_migration_form_uploader_is_running">Pengunggahan formulir sedang berlangsung. Mohon coba lagi.</string>
-  <string name="storage_migration_form_downloader_is_running">Pengunduhan formulir sedang berlangsung. Mohon coba lagi.</string>
+    <string name="storage_migration_form_downloader_is_running">Pengunduhan formulir sedang berlangsung. Mohon coba lagi.</string>
   <string name="storage_migration_failed">Migrasi data tidak berhasil. Mohon coba lagi.</string>
   <string name="storage_migration_dialog_title">Migrasi penyimpanan</string>
   <string name="storage_migration_progress_msg">Migrasi sedang berlangsung.\nProses ini mungkin perlu beberapa detik…</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -659,8 +659,7 @@
   <string name="migrate">移行</string>
   <string name="error">エラー:</string>
   <string name="storage_migration_not_enough_space">内部ストレージにデータを移行するための十分なスペースがありません。スペースを空けてもう一度お試しください。</string>
-  <string name="storage_migration_form_uploader_is_running">バックグラウンドフォームアップローダーが実行中です。もう一度お試しください。</string>
-  <string name="storage_migration_form_downloader_is_running">バックグラウンドフォームダウンローダーが実行中です。もう一度お試しください。</string>
+    <string name="storage_migration_form_downloader_is_running">バックグラウンドフォームダウンローダーが実行中です。もう一度お試しください。</string>
   <string name="storage_migration_failed">データの移行に失敗しました。もう一度お試しください。</string>
   <string name="storage_migration_dialog_title">ストレージの移行</string>
   <string name="storage_migration_progress_msg">移行中です。\nこれは数秒かかることがあります…</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -659,7 +659,7 @@
   <string name="migrate">移行</string>
   <string name="error">エラー:</string>
   <string name="storage_migration_not_enough_space">内部ストレージにデータを移行するための十分なスペースがありません。スペースを空けてもう一度お試しください。</string>
-    <string name="storage_migration_form_downloader_is_running">バックグラウンドフォームダウンローダーが実行中です。もう一度お試しください。</string>
+    <string name="changes_in_progress">バックグラウンドフォームダウンローダーが実行中です。もう一度お試しください。</string>
   <string name="storage_migration_failed">データの移行に失敗しました。もう一度お試しください。</string>
   <string name="storage_migration_dialog_title">ストレージの移行</string>
   <string name="storage_migration_progress_msg">移行中です。\nこれは数秒かかることがあります…</string>

--- a/collect_app/src/main/res/values-sw/strings.xml
+++ b/collect_app/src/main/res/values-sw/strings.xml
@@ -584,7 +584,7 @@
   <string name="missing_google_account_dialog_title">Akaunti ya Google haijawekwa sawa</string>
   <string name="missing_google_account_dialog_desc">Kuwasilisha  fomu kupitia karatasi ya Google , unatakiwa kurekebisha  akaunti yako ya Google kwenye mpangilio wa seva. </string>
   <string name="storage_migration_not_enough_space">Huna nafasi kwenye kifaa chako cha ndani kuhamisha data, Tafadhali ongeza nafasi kiasi na ujaribu tena.</string>
-    <string name="storage_migration_form_downloader_is_running">Fomu inatumika kwenye upakuaji. Tafadhali jaribu tena.</string>
+    <string name="changes_in_progress">Fomu inatumika kwenye upakuaji. Tafadhali jaribu tena.</string>
   <string name="storage_migration_failed">Hamisho la data limesitishwa, Tafadhali jaribu tena</string>
   <string name="storage_migration_dialog_title">Uhamiaji wa uhifadhi</string>
   <string name="storage_migration_progress_msg">Uhamiaji unaendelea. \ Hii inaweza kuchukua sekunde chache…</string>

--- a/collect_app/src/main/res/values-sw/strings.xml
+++ b/collect_app/src/main/res/values-sw/strings.xml
@@ -584,8 +584,7 @@
   <string name="missing_google_account_dialog_title">Akaunti ya Google haijawekwa sawa</string>
   <string name="missing_google_account_dialog_desc">Kuwasilisha  fomu kupitia karatasi ya Google , unatakiwa kurekebisha  akaunti yako ya Google kwenye mpangilio wa seva. </string>
   <string name="storage_migration_not_enough_space">Huna nafasi kwenye kifaa chako cha ndani kuhamisha data, Tafadhali ongeza nafasi kiasi na ujaribu tena.</string>
-  <string name="storage_migration_form_uploader_is_running">Fomu ya upakuaji inatumika. Tafadhali jaribu tena</string>
-  <string name="storage_migration_form_downloader_is_running">Fomu inatumika kwenye upakuaji. Tafadhali jaribu tena.</string>
+    <string name="storage_migration_form_downloader_is_running">Fomu inatumika kwenye upakuaji. Tafadhali jaribu tena.</string>
   <string name="storage_migration_failed">Hamisho la data limesitishwa, Tafadhali jaribu tena</string>
   <string name="storage_migration_dialog_title">Uhamiaji wa uhifadhi</string>
   <string name="storage_migration_progress_msg">Uhamiaji unaendelea. \ Hii inaweza kuchukua sekunde chache…</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -686,7 +686,6 @@
     <string name="migrate">Migrate</string>
     <string name="error">Error:</string>
     <string name="storage_migration_not_enough_space">You do not have enough space on your internal storage to migrate your data. Please free up some space and try again.</string>
-    <string name="storage_migration_form_uploader_is_running">Background form uploader is running. Please try again.</string>
     <string name="storage_migration_form_downloader_is_running">Background form downloader is running. Please try again.</string>
     <string name="storage_migration_failed">Data migration failed. Please try again.</string>
     <string name="storage_migration_dialog_title">Storage migration</string>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -686,7 +686,7 @@
     <string name="migrate">Migrate</string>
     <string name="error">Error:</string>
     <string name="storage_migration_not_enough_space">You do not have enough space on your internal storage to migrate your data. Please free up some space and try again.</string>
-    <string name="storage_migration_form_downloader_is_running">Background form downloader is running. Please try again.</string>
+    <string name="changes_in_progress">Automatic send or blank form download is running. Please try again later.</string>
     <string name="storage_migration_failed">Data migration failed. Please try again.</string>
     <string name="storage_migration_dialog_title">Storage migration</string>
     <string name="storage_migration_progress_msg">Migration in progress.\nThis may take a few seconds…</string>

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
@@ -23,7 +23,7 @@ import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.geo.MapProvider;
 import org.odk.collect.android.geo.TestMapFragment;
 import org.odk.collect.android.injection.config.AppDependencyModule;
-import org.odk.collect.android.instances.TestInstancesRepository;
+import org.odk.collect.android.support.InMemInstancesRepository;
 import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.MapsPreferences;
@@ -77,8 +77,8 @@ public class FormMapActivityTest {
         activityController = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
         activity = (FormMapActivity) activityController.get();
 
-        TestInstancesRepository testInstancesRepository = new TestInstancesRepository(Arrays.asList(testInstances));
-        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, testInstancesRepository);
+        InMemInstancesRepository inMemInstancesRepository = new InMemInstancesRepository(Arrays.asList(testInstances));
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, inMemInstancesRepository);
         activity.viewModelFactory = new TestFactory(viewModel);
 
         activityController.setup();
@@ -99,8 +99,8 @@ public class FormMapActivityTest {
         ActivityController controller = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
         FormMapActivity activity = (FormMapActivity) controller.get();
 
-        TestInstancesRepository testInstancesRepository = new TestInstancesRepository(new ArrayList<>());
-        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, testInstancesRepository);
+        InMemInstancesRepository inMemInstancesRepository = new InMemInstancesRepository(new ArrayList<>());
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, inMemInstancesRepository);
         activity.viewModelFactory = new TestFactory(viewModel);
 
         controller.setup();
@@ -115,8 +115,8 @@ public class FormMapActivityTest {
         ActivityController controller = RobolectricHelpers.buildThemedActivity(FormMapActivity.class);
         FormMapActivity activity = (FormMapActivity) controller.get();
 
-        TestInstancesRepository testInstancesRepository = new TestInstancesRepository(new ArrayList<>());
-        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, testInstancesRepository);
+        InMemInstancesRepository inMemInstancesRepository = new InMemInstancesRepository(new ArrayList<>());
+        FormMapViewModel viewModel = new FormMapViewModel(FormMapViewModelTest.TEST_FORM_1, inMemInstancesRepository);
         activity.viewModelFactory = new TestFactory(viewModel);
 
         controller.setup();

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -9,7 +9,7 @@ import org.odk.collect.android.activities.viewmodels.FormMapViewModel;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
-import org.odk.collect.android.instances.TestInstancesRepository;
+import org.odk.collect.android.support.InMemInstancesRepository;
 import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.Arrays;
@@ -27,7 +27,7 @@ public class FormMapViewModelTest {
     private InstancesRepository testInstancesRepository;
 
     @Before public void setUp() {
-        testInstancesRepository = new TestInstancesRepository(Arrays.asList(testInstances));
+        testInstancesRepository = new InMemInstancesRepository(Arrays.asList(testInstances));
     }
 
     @Test public void getFormTitle_returnsFormTitle() {
@@ -125,7 +125,7 @@ public class FormMapViewModelTest {
                 .canEditWhenComplete(true)
                 .status(InstanceProviderAPI.STATUS_COMPLETE).build();
 
-        ((TestInstancesRepository) testInstancesRepository).addInstance(newInstance);
+        ((InMemInstancesRepository) testInstancesRepository).addInstance(newInstance);
 
         instances = viewModel.getMappableFormInstances();
         assertThat(viewModel.getTotalInstanceCount(), is(8));
@@ -141,9 +141,9 @@ public class FormMapViewModelTest {
         assertThat(mappableInstances.size(), is(6));
 
         assertThat(mappableInstances.get(5).getClickAction(), is(FormMapViewModel.ClickAction.NOT_VIEWABLE_TOAST));
-        ((TestInstancesRepository) testInstancesRepository).removeInstanceById(6L);
+        ((InMemInstancesRepository) testInstancesRepository).removeInstanceById(6L);
 
-        ((TestInstancesRepository) testInstancesRepository).addInstance(new Instance.Builder().databaseId(6L)
+        ((InMemInstancesRepository) testInstancesRepository).addInstance(new Instance.Builder().databaseId(6L)
                 .jrFormId("formId1")
                 .jrVersion("2019103101")
                 .geometryType("")

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -117,7 +117,7 @@ public class FormMapViewModelTest {
         assertThat(viewModel.getTotalInstanceCount(), is(7));
         assertThat(instances.size(), is(6));
 
-        Instance newInstance = new Instance.Builder().databaseId(8L)
+        Instance newInstance = new Instance.Builder().id(8L)
                 .jrFormId("formId1")
                 .jrVersion("2019103101")
                 .geometryType("Point")
@@ -143,7 +143,7 @@ public class FormMapViewModelTest {
         assertThat(mappableInstances.get(5).getClickAction(), is(FormMapViewModel.ClickAction.NOT_VIEWABLE_TOAST));
         ((InMemInstancesRepository) testInstancesRepository).removeInstanceById(6L);
 
-        ((InMemInstancesRepository) testInstancesRepository).addInstance(new Instance.Builder().databaseId(6L)
+        ((InMemInstancesRepository) testInstancesRepository).addInstance(new Instance.Builder().id(6L)
                 .jrFormId("formId1")
                 .jrVersion("2019103101")
                 .geometryType("")
@@ -172,7 +172,7 @@ public class FormMapViewModelTest {
             .build();
 
     static Instance[] testInstances = {
-            new Instance.Builder().databaseId(0L)
+            new Instance.Builder().id(0L)
                     .displayName("Form1")
                     .lastStatusChangeDate(1487782554846L)
                     .jrFormId("formId1")
@@ -182,7 +182,7 @@ public class FormMapViewModelTest {
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.0]}")
                     .status(InstanceProviderAPI.STATUS_SUBMITTED).build(),
 
-            new Instance.Builder().databaseId(1L)
+            new Instance.Builder().id(1L)
                     .displayName("Form2")
                     .lastStatusChangeDate(1488782558743L)
                     .jrFormId("formId1")
@@ -192,7 +192,7 @@ public class FormMapViewModelTest {
                     .canEditWhenComplete(true)
                     .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
 
-            new Instance.Builder().databaseId(2L)
+            new Instance.Builder().id(2L)
                     .displayName("Form3")
                     .lastStatusChangeDate(1484582553254L)
                     .jrFormId("formId1")
@@ -201,14 +201,14 @@ public class FormMapViewModelTest {
                     .geometry("{\"type\":\"Point\",\"coordinates\":[126.6, 10.1]}")
                     .status(InstanceProviderAPI.STATUS_INCOMPLETE).build(),
 
-            new Instance.Builder().databaseId(3L)
+            new Instance.Builder().id(3L)
                     .displayName("Form4")
                     .lastStatusChangeDate(1488582557456L)
                     .jrFormId("formId1")
                     .jrVersion("2019103101")
                     .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
 
-            new Instance.Builder().databaseId(4L)
+            new Instance.Builder().id(4L)
                     .displayName("Form5")
                     .lastStatusChangeDate(1483582557438L)
                     .jrFormId("formId1")
@@ -218,7 +218,7 @@ public class FormMapViewModelTest {
                     .canEditWhenComplete(true)
                     .status(InstanceProviderAPI.STATUS_SUBMISSION_FAILED).build(),
 
-            new Instance.Builder().databaseId(5L)
+            new Instance.Builder().id(5L)
                     .displayName("Form6")
                     .lastStatusChangeDate(1482282559618L)
                     .jrFormId("formId1")
@@ -228,7 +228,7 @@ public class FormMapViewModelTest {
                     .canEditWhenComplete(true)
                     .status(InstanceProviderAPI.STATUS_SUBMITTED).build(),
 
-            new Instance.Builder().databaseId(6L)
+            new Instance.Builder().id(6L)
                     .displayName("Form7")
                     .lastStatusChangeDate(1484782559836L)
                     .jrFormId("formId1")
@@ -238,7 +238,7 @@ public class FormMapViewModelTest {
                     .canEditWhenComplete(false)
                     .status(InstanceProviderAPI.STATUS_SUBMISSION_FAILED).build(),
 
-            new Instance.Builder().databaseId(7L)
+            new Instance.Builder().id(7L)
                     .displayName("Form8")
                     .lastStatusChangeDate(1487982552254L)
                     .jrFormId("formId2")
@@ -247,7 +247,7 @@ public class FormMapViewModelTest {
                     .geometry("Crazy stuff")
                     .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
 
-            new Instance.Builder().databaseId(8L)
+            new Instance.Builder().id(8L)
                     .displayName("Form9")
                     .lastStatusChangeDate(1484682557369L)
                     .jrFormId("formId2")

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainActivityTest.java
@@ -74,7 +74,7 @@ public class MainActivityTest {
         ShadowActivity shadowActivity = shadowOf(mainMenuActivity);
         Intent startedIntent = shadowActivity.getNextStartedActivity();
         ShadowIntent shadowIntent = shadowOf(startedIntent);
-        assertEquals(FileManagerTabs.class.getName(),
+        assertEquals(DeleteSavedFormActivity.class.getName(),
                 shadowIntent.getIntentClass().getName());
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.java
@@ -12,7 +12,7 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.formmanagement.previouslydownloaded.ServerFormsUpdateChecker;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.preferences.GeneralKeys;
@@ -54,7 +54,7 @@ public class AutoUpdateTaskSpecTest {
             }
 
             @Override
-            public ServerFormsUpdateChecker providesServerFormUpdatesChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository) {
+            public ServerFormsUpdateChecker providesServerFormUpdatesChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository) {
                 return serverFormsUpdateChecker;
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.java
@@ -44,7 +44,7 @@ public class AutoUpdateTaskSpecTest {
 
         RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
             @Override
-            public ChangeLock providesChangeLock() {
+            public ChangeLock providesFormsChangeLock() {
                 return changeLock;
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoUpdateTaskSpecTest.java
@@ -1,0 +1,85 @@
+package org.odk.collect.android.backgroundwork;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.formmanagement.ServerFormDetails;
+import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
+import org.odk.collect.android.formmanagement.previouslydownloaded.ServerFormsUpdateChecker;
+import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.injection.config.AppDependencyModule;
+import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.PreferencesProvider;
+import org.odk.collect.android.support.BooleanChangeLock;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.odk.collect.android.utilities.MultiFormDownloader;
+import org.odk.collect.android.utilities.WebCredentialsUtils;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.function.Supplier;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class AutoUpdateTaskSpecTest {
+
+    private final BooleanChangeLock changeLock = new BooleanChangeLock();
+    private final MultiFormDownloader multiFormDownloader = mock(MultiFormDownloader.class);
+    private final ServerFormsUpdateChecker serverFormsUpdateChecker = mock(ServerFormsUpdateChecker.class);
+    private SharedPreferences generalPrefs;
+
+    @Before
+    public void setup() {
+        generalPrefs = ApplicationProvider.getApplicationContext().getSharedPreferences("test", Context.MODE_PRIVATE);
+
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ChangeLock providesChangeLock() {
+                return changeLock;
+            }
+
+            @Override
+            public MultiFormDownloader providesMultiFormDownloader(FormsDao formsDao, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils) {
+                return multiFormDownloader;
+            }
+
+            @Override
+            public ServerFormsUpdateChecker providesServerFormUpdatesChecker(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository) {
+                return serverFormsUpdateChecker;
+            }
+
+            @Override
+            public PreferencesProvider providesPreferencesProvider(Context context) {
+                return new PreferencesProvider(context) {
+                    @Override
+                    public SharedPreferences getGeneralSharedPreferences() {
+                        return generalPrefs;
+                    }
+                };
+            }
+        });
+    }
+
+    @Test
+    public void whenAutoDownloadEnabled_andChangeLockLocked_doesNotDownload() {
+        when(serverFormsUpdateChecker.check()).thenReturn(asList(new ServerFormDetails("", "", "", "", "", "", "", false, true)));
+        generalPrefs.edit().putBoolean(GeneralKeys.KEY_AUTOMATIC_UPDATE, true).apply();
+        changeLock.lock();
+
+        AutoUpdateTaskSpec taskSpec = new AutoUpdateTaskSpec();
+        Supplier<Boolean> task = taskSpec.getTask(ApplicationProvider.getApplicationContext());
+        task.get();
+
+        verifyNoInteractions(multiFormDownloader);
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
@@ -3,7 +3,6 @@ package org.odk.collect.android.formmanagement;
 import org.junit.Test;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.instances.Instance;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.support.InMemFormsRepository;
 import org.odk.collect.android.support.InMemInstancesRepository;
 
@@ -18,24 +17,6 @@ public class FormDeleterTest {
     private final InMemFormsRepository formsRepository = new InMemFormsRepository();
     private final InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
     private final FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
-
-    @Test
-    public void whenFormHasSubmittedInstances_deletesForm() {
-        formsRepository.save(new Form.Builder()
-                .id(1L)
-                .jrFormId("1")
-                .jrVersion("version")
-                .build());
-
-        instancesRepository.addInstance(new Instance.Builder()
-                .jrFormId("1")
-                .jrVersion("version")
-                .status(InstanceProviderAPI.STATUS_SUBMITTED)
-                .build());
-
-        formDeleter.delete(1L);
-        assertThat(formsRepository.getAll().isEmpty(), is(true));
-    }
 
     @Test
     public void whenOtherVersionOfFormHasInstances_deletesForm() {
@@ -58,7 +39,6 @@ public class FormDeleterTest {
         instancesRepository.addInstance(new Instance.Builder()
                 .jrFormId("1")
                 .jrVersion("old")
-                .status(InstanceProviderAPI.STATUS_COMPLETE)
                 .build());
 
         formDeleter.delete(2L);
@@ -84,7 +64,6 @@ public class FormDeleterTest {
         instancesRepository.addInstance(new Instance.Builder()
                 .jrFormId("1")
                 .jrVersion("version")
-                .status(InstanceProviderAPI.STATUS_COMPLETE)
                 .build());
 
         formDeleter.delete(2L);
@@ -104,7 +83,6 @@ public class FormDeleterTest {
         instancesRepository.addInstance(new Instance.Builder()
                 .jrFormId("1")
                 .jrVersion(null)
-                .status(InstanceProviderAPI.STATUS_COMPLETE)
                 .build());
 
         formDeleter.delete(1L);

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
@@ -7,6 +7,8 @@ import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.support.InMemFormsRepository;
 import org.odk.collect.android.support.InMemInstancesRepository;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -31,5 +33,35 @@ public class FormDeleterTest {
 
         formDeleter.delete(1L);
         assertThat(formsRepository.getAll().isEmpty(), is(true));
+    }
+
+    @Test
+    public void whenOtherVersionOfFormHasInstances_deletesForm() {
+        InMemFormsRepository formsRepository = new InMemFormsRepository();
+        InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
+        FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
+
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("old")
+                .build());
+
+        formsRepository.save(new Form.Builder()
+                .id(2L)
+                .jrFormId("1")
+                .jrVersion("new")
+                .build());
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .jrFormId("1")
+                .jrVersion("old")
+                .status(InstanceProviderAPI.STATUS_COMPLETE)
+                .build());
+
+        formDeleter.delete(2L);
+        List<Form> forms = formsRepository.getAll();
+        assertThat(forms.size(), is(1));
+        assertThat(forms.get(0).getJrVersion(), is("old"));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
@@ -15,19 +15,21 @@ import static org.hamcrest.Matchers.is;
 
 public class FormDeleterTest {
 
+    private final InMemFormsRepository formsRepository = new InMemFormsRepository();
+    private final InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
+    private final FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
+
     @Test
     public void whenFormHasSubmittedInstances_deletesForm() {
-        InMemFormsRepository formsRepository = new InMemFormsRepository();
-        InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
-        FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
-
         formsRepository.save(new Form.Builder()
                 .id(1L)
                 .jrFormId("1")
+                .jrVersion("version")
                 .build());
 
         instancesRepository.addInstance(new Instance.Builder()
                 .jrFormId("1")
+                .jrVersion("version")
                 .status(InstanceProviderAPI.STATUS_SUBMITTED)
                 .build());
 
@@ -63,5 +65,51 @@ public class FormDeleterTest {
         List<Form> forms = formsRepository.getAll();
         assertThat(forms.size(), is(1));
         assertThat(forms.get(0).getJrVersion(), is("old"));
+    }
+
+    @Test
+    public void whenFormHasNullVersion_butAnotherVersionHasInstances_deletesForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .build());
+
+        formsRepository.save(new Form.Builder()
+                .id(2L)
+                .jrFormId("1")
+                .jrVersion(null)
+                .build());
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .jrFormId("1")
+                .jrVersion("version")
+                .status(InstanceProviderAPI.STATUS_COMPLETE)
+                .build());
+
+        formDeleter.delete(2L);
+        List<Form> forms = formsRepository.getAll();
+        assertThat(forms.size(), is(1));
+        assertThat(forms.get(0).getJrVersion(), is("version"));
+    }
+
+    @Test
+    public void whenFormHasNullVersion_andInstancesWithNullVersion_softDeletesForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion(null)
+                .build());
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .jrFormId("1")
+                .jrVersion(null)
+                .status(InstanceProviderAPI.STATUS_COMPLETE)
+                .build());
+
+        formDeleter.delete(1L);
+        List<Form> forms = formsRepository.getAll();
+        assertThat(forms.size(), is(1));
+        assertThat(forms.get(0).isDeleted(), is(true));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
@@ -1,0 +1,35 @@
+package org.odk.collect.android.formmanagement;
+
+import org.junit.Test;
+import org.odk.collect.android.forms.Form;
+import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.support.InMemFormsRepository;
+import org.odk.collect.android.support.InMemInstancesRepository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+public class FormDeleterTest {
+
+    @Test
+    public void whenFormHasSubmittedInstances_deletesForm() {
+        InMemFormsRepository formsRepository = new InMemFormsRepository();
+        InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
+        FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
+
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .build());
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .jrFormId("1")
+                .status(InstanceProviderAPI.STATUS_SUBMITTED)
+                .build());
+
+        formDeleter.delete(1L);
+        assertThat(formsRepository.getAll().isEmpty(), is(true));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
@@ -3,13 +3,13 @@ package org.odk.collect.android.formmanagement;
 import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.forms.MediaFileRepository;
 import org.odk.collect.android.openrosa.api.FormListApi;
 import org.odk.collect.android.openrosa.api.FormListItem;
 import org.odk.collect.android.openrosa.api.ManifestFile;
 import org.odk.collect.android.openrosa.api.MediaFile;
-import org.odk.collect.android.support.InMemFormRepository;
+import org.odk.collect.android.support.InMemFormsRepository;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -35,12 +35,12 @@ public class ServerFormsDetailsFetcherTest {
     );
 
     private ServerFormsDetailsFetcher fetcher;
-    private FormRepository formRepository;
+    private FormsRepository formsRepository;
     private MediaFileRepository mediaFileRepository;
 
     @Before
     public void setup() throws Exception {
-        formRepository = new InMemFormRepository();
+        formsRepository = new InMemFormsRepository();
         mediaFileRepository = mock(MediaFileRepository.class);
 
         FormListApi formListAPI = mock(FormListApi.class);
@@ -51,7 +51,7 @@ public class ServerFormsDetailsFetcherTest {
         );
 
         DiskFormsSynchronizer diskFormsSynchronizer = mock(DiskFormsSynchronizer.class);
-        fetcher = new ServerFormsDetailsFetcher(formRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
+        fetcher = new ServerFormsDetailsFetcher(formsRepository, mediaFileRepository, formListAPI, diskFormsSynchronizer);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class ServerFormsDetailsFetcherTest {
 
     @Test
     public void whenAFormExists_andListContainsUpdatedVersion_isUpdated() throws Exception {
-        formRepository.save(new Form.Builder()
+        formsRepository.save(new Form.Builder()
                 .id(2L)
                 .jrFormId("form-2")
                 .md5Hash("form-2-hash-old")
@@ -75,7 +75,7 @@ public class ServerFormsDetailsFetcherTest {
 
     @Test
     public void whenAFormExists_andHasNewMediaFileOnServer_isUpdated() throws Exception {
-        formRepository.save(new Form.Builder()
+        formsRepository.save(new Form.Builder()
                 .id(2L)
                 .jrFormId("form-2")
                 .jrVersion("server")
@@ -89,7 +89,7 @@ public class ServerFormsDetailsFetcherTest {
 
     @Test
     public void whenAFormExists_andHasUpdatedMediaFileOnServer_isUpdated() throws Exception {
-        formRepository.save(new Form.Builder()
+        formsRepository.save(new Form.Builder()
                 .id(2L)
                 .jrFormId("form-2")
                 .jrVersion("server")
@@ -106,7 +106,7 @@ public class ServerFormsDetailsFetcherTest {
 
     @Test
     public void whenAFormExists_andIsNotUpdatedOnServer_andDoesNotHaveAManifest_isNotNewOrUpdated() throws Exception {
-        formRepository.save(new Form.Builder()
+        formsRepository.save(new Form.Builder()
                 .id(1L)
                 .jrFormId("form-1")
                 .jrVersion("server")
@@ -120,7 +120,7 @@ public class ServerFormsDetailsFetcherTest {
 
     @Test
     public void whenFormExists_isNotNewOrUpdated() throws Exception {
-        formRepository.save(new Form.Builder()
+        formsRepository.save(new Form.Builder()
                 .id(2L)
                 .jrFormId("form-2")
                 .jrVersion("server")

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsSynchronizerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsSynchronizerTest.java
@@ -1,12 +1,13 @@
 package org.odk.collect.android.formmanagement;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.openrosa.api.FormApiException;
 import org.odk.collect.android.support.InMemFormsRepository;
+import org.odk.collect.android.support.InMemInstancesRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,19 +25,11 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("PMD.DoubleBraceInitialization")
 public class ServerFormsSynchronizerTest {
 
-    private ServerFormsSynchronizer synchronizer;
-    private RecordingFormDownloader formDownloader;
-    private FormsRepository formsRepository;
-    private ServerFormsDetailsFetcher serverFormDetailsFetcher;
-
-    @Before
-    public void setup() {
-        formsRepository = new InMemFormsRepository();
-        formDownloader = new RecordingFormDownloader();
-        serverFormDetailsFetcher = mock(ServerFormsDetailsFetcher.class);
-
-        synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formsRepository, formDownloader);
-    }
+    private final FormsRepository formsRepository = new InMemFormsRepository();
+    private final InstancesRepository instancesRepository = new InMemInstancesRepository();
+    private final RecordingFormDownloader formDownloader = new RecordingFormDownloader();
+    private final ServerFormsDetailsFetcher serverFormDetailsFetcher = mock(ServerFormsDetailsFetcher.class);
+    private final ServerFormsSynchronizer synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formsRepository, instancesRepository, formDownloader);
 
     @Test
     public void downloadsNewForms() throws Exception {
@@ -108,7 +101,7 @@ public class ServerFormsSynchronizerTest {
         FormDownloader formDownloader = mock(FormDownloader.class);
         doThrow(new FormDownloadException()).when(formDownloader).downloadForm(serverForms.get(0));
 
-        ServerFormsSynchronizer synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formsRepository, formDownloader);
+        ServerFormsSynchronizer synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formsRepository, instancesRepository, formDownloader);
 
         try {
             synchronizer.synchronize();

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsSynchronizerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsSynchronizerTest.java
@@ -4,9 +4,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.openrosa.api.FormApiException;
-import org.odk.collect.android.support.InMemFormRepository;
+import org.odk.collect.android.support.InMemFormsRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,16 +26,16 @@ public class ServerFormsSynchronizerTest {
 
     private ServerFormsSynchronizer synchronizer;
     private RecordingFormDownloader formDownloader;
-    private FormRepository formRepository;
+    private FormsRepository formsRepository;
     private ServerFormsDetailsFetcher serverFormDetailsFetcher;
 
     @Before
     public void setup() {
-        formRepository = new InMemFormRepository();
+        formsRepository = new InMemFormsRepository();
         formDownloader = new RecordingFormDownloader();
         serverFormDetailsFetcher = mock(ServerFormsDetailsFetcher.class);
 
-        synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formRepository, formDownloader);
+        synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formsRepository, formDownloader);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class ServerFormsSynchronizerTest {
 
     @Test
     public void deletesFormsNotInList() throws Exception {
-        formRepository.save(new Form.Builder()
+        formsRepository.save(new Form.Builder()
                 .id(3L)
                 .jrFormId("form-3")
                 .md5Hash("form-3-hash")
@@ -71,7 +71,7 @@ public class ServerFormsSynchronizerTest {
         ));
 
         synchronizer.synchronize();
-        assertThat(formRepository.contains("form-3"), is(false));
+        assertThat(formsRepository.contains("form-3"), is(false));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class ServerFormsSynchronizerTest {
         FormDownloader formDownloader = mock(FormDownloader.class);
         doThrow(new FormDownloadException()).when(formDownloader).downloadForm(serverForms.get(0));
 
-        ServerFormsSynchronizer synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formRepository, formDownloader);
+        ServerFormsSynchronizer synchronizer = new ServerFormsSynchronizer(serverFormDetailsFetcher, formsRepository, formDownloader);
 
         try {
             synchronizer.synchronize();

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
@@ -42,7 +42,7 @@ public class SyncFormsTaskSpecTest {
         RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
 
             @Override
-            public ChangeLock providesChangeLock() {
+            public ChangeLock providesFormsChangeLock() {
                 return changeLock;
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
@@ -12,7 +12,7 @@ import org.odk.collect.android.backgroundwork.ChangeLock;
 import org.odk.collect.android.backgroundwork.SyncFormsTaskSpec;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.notifications.Notifier;
 import org.odk.collect.android.openrosa.api.FormApiException;
@@ -46,7 +46,7 @@ public class SyncFormsTaskSpecTest {
             }
 
             @Override
-            public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormRepository formRepository, FormDownloader formDownloader) {
+            public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader) {
                 return serverFormsSynchronizer;
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchroniz
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
 import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.injection.config.AppDependencyModule;
+import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.notifications.Notifier;
 import org.odk.collect.android.openrosa.api.FormApiException;
 import org.odk.collect.android.support.BooleanChangeLock;
@@ -46,7 +47,7 @@ public class SyncFormsTaskSpecTest {
             }
 
             @Override
-            public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader) {
+            public ServerFormsSynchronizer providesServerFormSynchronizer(ServerFormsDetailsFetcher serverFormsDetailsFetcher, FormsRepository formsRepository, FormDownloader formDownloader, InstancesRepository instancesRepository) {
                 return serverFormsSynchronizer;
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusRepositoryTest.java
@@ -15,29 +15,6 @@ public class SyncStatusRepositoryTest {
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     @Test
-    public void startSync_returnsTrue() {
-        SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
-        assertThat(syncStatusRepository.startSync(), is(true));
-    }
-
-    @Test
-    public void startSync_whenSyncAlreadyStarted_returnsFalse() {
-        SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
-        syncStatusRepository.startSync();
-
-        assertThat(syncStatusRepository.startSync(), is(false));
-    }
-
-    @Test
-    public void startSync_whenSyncFinished_returnsTrue() {
-        SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
-        syncStatusRepository.startSync();
-        syncStatusRepository.finishSync(true);
-
-        assertThat(syncStatusRepository.startSync(), is(true));
-    }
-
-    @Test
     public void isOutOfSync_isFalseAtFirst() {
         SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
         assertThat(syncStatusRepository.isOutOfSync().getValue(), is(false));

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/previouslydownloaded/ServerFormsUpdateCheckerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/previouslydownloaded/ServerFormsUpdateCheckerTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.support.InMemFormRepository;
+import org.odk.collect.android.support.InMemFormsRepository;
 
 import java.util.List;
 
@@ -20,13 +20,13 @@ import static org.mockito.Mockito.when;
 
 public class ServerFormsUpdateCheckerTest {
 
-    private InMemFormRepository formRepository;
+    private InMemFormsRepository formRepository;
     private ServerFormsDetailsFetcher serverFormDetailsFetcher;
     private ServerFormsUpdateChecker checker;
 
     @Before
     public void setup() {
-        formRepository = new InMemFormRepository();
+        formRepository = new InMemFormsRepository();
         serverFormDetailsFetcher = mock(ServerFormsDetailsFetcher.class);
         checker = new ServerFormsUpdateChecker(serverFormDetailsFetcher, formRepository);
     }

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceDeleterTest.java
@@ -1,0 +1,154 @@
+package org.odk.collect.android.instancemanagement;
+
+import org.junit.Test;
+import org.odk.collect.android.forms.Form;
+import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.support.InMemFormsRepository;
+import org.odk.collect.android.support.InMemInstancesRepository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class InstanceDeleterTest {
+
+    private final FormsRepository formsRepository = new InMemFormsRepository();
+    private final InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
+    private final InstanceDeleter instanceDeleter = new InstanceDeleter(instancesRepository, formsRepository);
+
+    @Test
+    public void whenFormForInstanceIsSoftDeleted_andThereIsAnotherInstance_doesNotDeleteForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .deleted(true)
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(2L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .build()
+        );
+
+        instanceDeleter.delete(2L);
+        assertThat(formsRepository.getAll().size(), is(1));
+    }
+
+    @Test
+    public void whenFormForInstanceIsSoftDeleted_andThereAreNoOtherInstances_deletesForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .deleted(true)
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .build()
+        );
+
+        instanceDeleter.delete(1L);
+        assertThat(formsRepository.getAll().isEmpty(), is(true));
+    }
+
+    @Test
+    public void whenFormForInstanceIsSoftDeleted_andThereAreNoOtherInstancesForThisVersion_deletesForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("1")
+                .deleted(true)
+                .build()
+        );
+
+        formsRepository.save(new Form.Builder()
+                .id(2L)
+                .jrFormId("1")
+                .jrVersion("2")
+                .deleted(true)
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("1")
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(2L)
+                .jrFormId("1")
+                .jrVersion("2")
+                .build()
+        );
+
+        instanceDeleter.delete(1L);
+        assertThat(formsRepository.getAll().size(), is(1));
+        assertThat(formsRepository.getAll().get(0).getJrVersion(), is("2"));
+    }
+
+    @Test
+    public void whenFormForInstanceIsNotSoftDeleted_andThereAreNoOtherInstances_doesNotDeleteForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .deleted(false)
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("version")
+                .build()
+        );
+
+        instanceDeleter.delete(1L);
+        assertThat(formsRepository.getAll().size(), is(1));
+    }
+
+    @Test
+    public void whenFormVersionForInstanceIsNotSoftDeleted_andThereAreNoOtherInstances_doesNotDeleteForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("1")
+                .deleted(true)
+                .build()
+        );
+
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("2")
+                .deleted(false)
+                .build()
+        );
+
+        instancesRepository.addInstance(new Instance.Builder()
+                .id(1L)
+                .jrFormId("1")
+                .jrVersion("2")
+                .build()
+        );
+
+        instanceDeleter.delete(1L);
+        assertThat(formsRepository.getAll().size(), is(2));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigrationResultTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigrationResultTest.java
@@ -18,16 +18,13 @@ public class StorageMigrationResultTest {
 
     @Test
     public void getErrorResultMessageTest() {
-        assertThat(StorageMigrationResult.FORM_UPLOADER_IS_RUNNING.getErrorResultMessage(context),
-                is("Error: Background form uploader is running. Please try again."));
-
-        assertThat(StorageMigrationResult.FORM_DOWNLOADER_IS_RUNNING.getErrorResultMessage(context),
-                is("Error: Background form downloader is running. Please try again."));
-
         assertThat(StorageMigrationResult.NOT_ENOUGH_SPACE.getErrorResultMessage(context),
                 is("Error: You do not have enough space on your internal storage to migrate your data. Please free up some space and try again."));
 
         assertThat(StorageMigrationResult.MOVING_FILES_FAILED.getErrorResultMessage(context),
                 is("Error: Data migration failed. Please try again."));
+
+        assertThat(StorageMigrationResult.CHANGES_IN_PROGRESS.getErrorResultMessage(context),
+                is("Error: Background form downloader is running. Please try again."));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigrationResultTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigrationResultTest.java
@@ -25,6 +25,6 @@ public class StorageMigrationResultTest {
                 is("Error: Data migration failed. Please try again."));
 
         assertThat(StorageMigrationResult.CHANGES_IN_PROGRESS.getErrorResultMessage(context),
-                is("Error: Background form downloader is running. Please try again."));
+                is("Error: Automatic send or blank form download is running. Please try again later."));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigrationServiceTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigrationServiceTest.java
@@ -1,0 +1,62 @@
+package org.odk.collect.android.storage.migration;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.javarosa.core.reference.ReferenceManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.backgroundwork.ChangeLock;
+import org.odk.collect.android.backgroundwork.FormSubmitManager;
+import org.odk.collect.android.backgroundwork.FormUpdateManager;
+import org.odk.collect.android.injection.config.AppDependencyModule;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageStateProvider;
+import org.odk.collect.android.support.BooleanChangeLock;
+import org.odk.collect.android.support.RobolectricHelpers;
+import org.robolectric.Robolectric;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@RunWith(AndroidJUnit4.class)
+public class StorageMigrationServiceTest {
+
+    private final StorageMigrator storageMigrator = mock(StorageMigrator.class);
+    private final StorageMigrationRepository storageMigrationRepository = mock(StorageMigrationRepository.class);
+    private final BooleanChangeLock changeLock = new BooleanChangeLock();
+
+    @Before
+    public void setup() {
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ChangeLock providesChangeLock() {
+                return changeLock;
+            }
+
+            @Override
+            public StorageMigrationRepository providesStorageMigrationRepository() {
+                return storageMigrationRepository;
+            }
+
+            @Override
+            public StorageMigrator providesStorageMigrator(StoragePathProvider storagePathProvider, StorageStateProvider storageStateProvider, StorageMigrationRepository storageMigrationRepository, ReferenceManager referenceManager, FormUpdateManager formUpdateManager, FormSubmitManager formSubmitManager, Analytics analytics, ChangeLock changeLock) {
+                return storageMigrator;
+            }
+        });
+    }
+
+    @Test
+    public void whenChangeLockLocked_doesNotMigrate_andSetsResultInRepository() {
+        changeLock.lock();
+
+        StorageMigrationService service = Robolectric.setupIntentService(StorageMigrationService.class);
+        service.onHandleIntent(null);
+
+        verifyNoInteractions(storageMigrator);
+        verify(storageMigrationRepository).setResult(StorageMigrationResult.CHANGES_IN_PROGRESS);
+        verify(storageMigrationRepository).markMigrationEnd();
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/storage/migration/StorageMigratorTest.java
@@ -4,8 +4,6 @@ import org.javarosa.core.reference.ReferenceManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.analytics.Analytics;
-import org.odk.collect.android.backgroundwork.FormSubmitManager;
-import org.odk.collect.android.backgroundwork.FormUpdateManager;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageStateProvider;
@@ -19,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_REFERENCE_LAYER;
 
 @SuppressWarnings("PMD.DoNotHardCodeSDCard")
@@ -32,35 +29,17 @@ public class StorageMigratorTest {
     private final StorageMigrationRepository storageMigrationRepository = mock(StorageMigrationRepository.class);
     private final GeneralSharedPreferences generalSharedPreferences = mock(GeneralSharedPreferences.class);
     private final ReferenceManager referenceManager = mock(ReferenceManager.class);
-    private final FormUpdateManager formUpdateManager = mock(FormUpdateManager.class);
-    private final FormSubmitManager formSubmitManager = mock(FormSubmitManager.class);
     private final Analytics analytics = mock(Analytics.class);
 
     @Before
     public void setup() {
-        whenFormDownloaderIsNotRunning();
-        whenFormUploaderIsNotRunning();
-
         doNothing().when(storageEraser).clearOdkDirOnScopedStorage();
         doNothing().when(storageEraser).deleteOdkDirFromUnscopedStorage();
         doReturn("/sdcard/odk/layers/countries/countries-raster.mbtiles").when(generalSharedPreferences).get(KEY_REFERENCE_LAYER);
 
-        storageMigrator = spy(new StorageMigrator(storagePathProvider, storageStateProvider, storageEraser, storageMigrationRepository, generalSharedPreferences, referenceManager, formUpdateManager, formSubmitManager, analytics));
+        storageMigrator = spy(new StorageMigrator(storagePathProvider, storageStateProvider, storageEraser, storageMigrationRepository, generalSharedPreferences, referenceManager, analytics));
 
         doNothing().when(storageMigrator).reopenDatabases();
-    }
-
-    @Test
-    public void when_formUploaderIsRunning_should_appropriateResultBeReturned() {
-        whenFormUploaderIsRunning();
-        assertThat(storageMigrator.migrate(), is(StorageMigrationResult.FORM_UPLOADER_IS_RUNNING));
-    }
-
-    @Test
-    public void when_formDownloaderIsRunning_should_appropriateResultBeReturned() {
-        whenFormDownloaderIsRunning();
-
-        assertThat(storageMigrator.migrate(), is(StorageMigrationResult.FORM_DOWNLOADER_IS_RUNNING));
     }
 
     @Test
@@ -179,21 +158,5 @@ public class StorageMigratorTest {
         storageMigrator.performStorageMigration();
 
         verify(storageEraser).deleteOdkDirFromUnscopedStorage();
-    }
-
-    private void whenFormDownloaderIsNotRunning() {
-        when(formUpdateManager.isUpdateRunning()).thenReturn(false);
-    }
-
-    private void whenFormDownloaderIsRunning() {
-        when(formUpdateManager.isUpdateRunning()).thenReturn(true);
-    }
-
-    private void whenFormUploaderIsNotRunning() {
-        when(formSubmitManager.isSubmitRunning()).thenReturn(false);
-    }
-
-    private void whenFormUploaderIsRunning() {
-        when(formSubmitManager.isSubmitRunning()).thenReturn(true);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/support/BooleanChangeLock.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/BooleanChangeLock.java
@@ -1,0 +1,19 @@
+package org.odk.collect.android.support;
+
+import org.odk.collect.android.backgroundwork.ChangeLock;
+
+import java.util.function.Function;
+
+public class BooleanChangeLock implements ChangeLock {
+
+    private boolean locked;
+
+    @Override
+    public <T> T withLock(Function<Boolean, T> function) {
+        return function.apply(!locked);
+    }
+
+    public void lock() {
+        locked = true;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -71,7 +71,7 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Override
     public void softDelete(Long id) {
-        Form form = forms.stream().filter(f -> f.getJrFormId().equals(id)).findFirst().orElse(null);
+        Form form = forms.stream().filter(f -> f.getId().equals(id)).findFirst().orElse(null);
 
         if (form != null) {
             forms.remove(form);

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -3,7 +3,7 @@ package org.odk.collect.android.support;
 import android.net.Uri;
 
 import org.odk.collect.android.forms.Form;
-import org.odk.collect.android.forms.FormRepository;
+import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.utilities.MultiFormDownloader;
 
 import java.util.ArrayList;
@@ -11,7 +11,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-public class InMemFormRepository implements FormRepository {
+public class InMemFormsRepository implements FormsRepository {
 
     private final List<Form> forms = new ArrayList<>();
 
@@ -29,6 +29,12 @@ public class InMemFormRepository implements FormRepository {
     @Override
     public List<Form> getAll() {
         return new ArrayList<>(forms); // Avoid anything  mutating the list externally
+    }
+
+    @Nullable
+    @Override
+    public Form get(Long id) {
+        return forms.stream().filter(f -> f.getId().equals(id)).findFirst().orElse(null);
     }
 
     @Nullable
@@ -61,6 +67,18 @@ public class InMemFormRepository implements FormRepository {
     @Override
     public void delete(Long id) {
         forms.removeIf(form -> form.getId().equals(id));
+    }
+
+    @Override
+    public void softDelete(Long id) {
+        Form form = forms.stream().filter(f -> f.getJrFormId().equals(id)).findFirst().orElse(null);
+
+        if (form != null) {
+            forms.remove(form);
+            forms.add(new Form.Builder(form)
+                    .deleted(true)
+                    .build());
+        }
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -39,6 +39,14 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Nullable
     @Override
+    public Form get(String jrFormId, String jrVersion) {
+        return forms.stream().filter(f -> {
+            return f.getJrFormId().equals(jrFormId) && f.getJrVersion().equals(jrVersion);
+        }).findFirst().orElse(null);
+    }
+
+    @Nullable
+    @Override
     public Form getByMd5Hash(String hash) {
         return forms.stream().filter(f -> f.getMD5Hash().equals(hash)).findFirst().orElse(null);
     }

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
@@ -7,10 +7,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class InMemInstancesRepository implements InstancesRepository {
+
     List<Instance> instances;
 
     public InMemInstancesRepository(List<Instance> instances) {
         this.instances = new ArrayList<>(instances);
+    }
+
+    public InMemInstancesRepository() {
+        this.instances = new ArrayList<>();
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
@@ -1,12 +1,15 @@
-package org.odk.collect.android.instances;
+package org.odk.collect.android.support;
+
+import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class TestInstancesRepository implements InstancesRepository {
+public final class InMemInstancesRepository implements InstancesRepository {
     List<Instance> instances;
 
-    public TestInstancesRepository(List<Instance> instances) {
+    public InMemInstancesRepository(List<Instance> instances) {
         this.instances = new ArrayList<>(instances);
     }
 
@@ -22,7 +25,7 @@ public final class TestInstancesRepository implements InstancesRepository {
     }
 
     @Override
-    public List<Instance> getAllBy(String formId) {
+    public List<Instance> getAllByJrFormId(String formId) {
         List<Instance> result = new ArrayList<>();
 
         for (Instance instance : instances) {

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
@@ -5,6 +5,7 @@ import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class InMemInstancesRepository implements InstancesRepository {
 
@@ -19,9 +20,9 @@ public final class InMemInstancesRepository implements InstancesRepository {
     }
 
     @Override
-    public Instance getBy(long databaseId) {
+    public Instance get(long databaseId) {
         for (Instance instance : instances) {
-            if (instance.getDatabaseId() == databaseId) {
+            if (instance.getId() == databaseId) {
                 return instance;
             }
         }
@@ -43,6 +44,13 @@ public final class InMemInstancesRepository implements InstancesRepository {
     }
 
     @Override
+    public List<Instance> getAllByJrFormIdAndJrVersion(String jrFormId, String jrVersion) {
+        return instances.stream().filter(instance -> {
+            return instance.getJrFormId().equals(jrFormId) && instance.getJrVersion().equals(jrVersion);
+        }).collect(Collectors.toList());
+    }
+
+    @Override
     public Instance getByPath(String instancePath) {
         List<Instance> result = new ArrayList<>();
 
@@ -59,13 +67,18 @@ public final class InMemInstancesRepository implements InstancesRepository {
         }
     }
 
+    @Override
+    public void delete(Long id) {
+        instances.removeIf(instance -> instance.getId().equals(id));
+    }
+
     public void addInstance(Instance instance) {
         instances.add(instance);
     }
 
     public void removeInstanceById(Long databaseId) {
         for (int i = 0; i < instances.size(); i++) {
-            if (instances.get(i).getDatabaseId().equals(databaseId)) {
+            if (instances.get(i).getId().equals(databaseId)) {
                 instances.remove(i);
                 return;
             }

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
@@ -5,6 +5,7 @@ import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public final class InMemInstancesRepository implements InstancesRepository {
@@ -46,7 +47,7 @@ public final class InMemInstancesRepository implements InstancesRepository {
     @Override
     public List<Instance> getAllByJrFormIdAndJrVersion(String jrFormId, String jrVersion) {
         return instances.stream().filter(instance -> {
-            return instance.getJrFormId().equals(jrFormId) && instance.getJrVersion().equals(jrVersion);
+            return Objects.equals(instance.getJrFormId(), jrFormId) && Objects.equals(instance.getJrVersion(), jrVersion);
         }).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Closes #3961. Closes #3991. ~~Blocked by #3986.~~

This also introduces and uses a `ChangeLock` object that lets make sure that work that updates the forms or instances on device doesn't interfere with each other. There are probably more places this could be used but I focused on making sure places that already made an effort in this direction were covered.

#### What has been done to verify that this works as intended?

Tried out flows manually and wrote a bunch of new tests.

#### Why is this the best possible solution? Were any other approaches considered?

To me it made the most sense to implement this using method objects rather than trying to change the delete logic at the bottom level. This means the logic is separate from any of the implementation of the repositories.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

With this I think we want to merge to master and then QA there for the whole match exactly feature set.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)