### PR TITLE
Hide Extra Icon Space in Form Management Settings Preference

### DIFF
--- a/collect_app/src/main/res/xml/form_management_preferences.xml
+++ b/collect_app/src/main/res/xml/form_management_preferences.xml
@@ -14,7 +14,8 @@
             android:entries="@array/form_update_mode_entries"
             android:entryValues="@array/form_update_mode_values"
             android:key="form_update_mode"
-            android:title="@string/form_update_mode_title" />
+            android:title="@string/form_update_mode_title"
+            app:iconSpaceReserved="false" />
 
         <ListPreference
             android:dialogTitle="@string/form_update_frequency_title"


### PR DESCRIPTION
Closes #3990 
<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it.

#### Why is this the best possible solution? Were any other approaches considered?
I used `app:iconSpaceReserved = false`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
No

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)