### PR TITLE
Stop null pointer on progress update

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -684,10 +684,12 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
     @Override
     public void progressUpdate(String currentFile, int progress, int total) {
-        RefreshFormListDialogFragment fragment = (RefreshFormListDialogFragment) getSupportFragmentManager()
-                .findFragmentByTag(RefreshFormListDialogFragment.class.getName());
-        fragment.setMessage(getString(R.string.fetching_file, currentFile,
-                String.valueOf(progress), String.valueOf(total)));
+        RefreshFormListDialogFragment fragment = (RefreshFormListDialogFragment) getSupportFragmentManager().findFragmentByTag(RefreshFormListDialogFragment.class.getName());
+
+        if (fragment != null) {
+            fragment.setMessage(getString(R.string.fetching_file, currentFile,
+                    String.valueOf(progress), String.valueOf(total)));
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes #3989 

#### What has been done to verify that this works as intended?

I wasn't able to reproduce but this change should protect us from the possibility of the null pointer.

#### Why is this the best possible solution? Were any other approaches considered?

I initially spiked out reworking this code the status/progress of the download could use `LiveData` and have a reworked dialog observe the status (rather than the activity pass the progress message from a listener to the dialog). This would hopefully give us safer code but it seemed like it was going to be a lot of work (mainly due to progress updates being embedded in the `MultiFormDownloader`). I'm keen to look at pushing this kind of rework into the 1.29 work as it'd be great to clean all this up and also get rid of `AsyncTask` as much as possible. I'll be back.

![](https://media.giphy.com/media/JDKxRN0Bvmm2c/giphy.gif)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the regression!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)