### PR TITLE
Make sure Automatic Download setting makes sense for Form Update mode

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormManagementSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormManagementSettingsTest.java
@@ -128,6 +128,8 @@ public class FormManagementSettingsTest {
                 .assertDisabled(R.string.form_update_frequency_title)
                 .assertDisabled(R.string.automatic_download)
                 .assertText(R.string.manually);
+
+        assertThat(testDependencies.scheduler.getDeferredTasks().size(), is(0));
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormManagementSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormManagementSettingsTest.java
@@ -43,42 +43,6 @@ public class FormManagementSettingsTest {
             .around(rule);
 
     @Test
-    public void whenManualUpdatesEnabled_disablesPrefs() {
-        new MainMenuPage(rule).assertOnPage()
-                .clickOnMenu()
-                .clickGeneralSettings()
-                .clickFormManagement()
-                .clickUpdateForms()
-                .clickOption(R.string.manually)
-                .assertDisabled(R.string.form_update_frequency_title)
-                .assertDisabled(R.string.automatic_download);
-    }
-
-    @Test
-    public void whenPreviouslyDownloadedOnlyEnabled_disablesPrefs() {
-        new MainMenuPage(rule).assertOnPage()
-                .clickOnMenu()
-                .clickGeneralSettings()
-                .clickFormManagement()
-                .clickUpdateForms()
-                .clickOption(R.string.previously_downloaded_only)
-                .assertEnabled(R.string.form_update_frequency_title)
-                .assertEnabled(R.string.automatic_download);
-    }
-
-    @Test
-    public void whenMatchExactlyEnabled_disablesPrefs() {
-        new MainMenuPage(rule).assertOnPage()
-                .clickOnMenu()
-                .clickGeneralSettings()
-                .clickFormManagement()
-                .clickUpdateForms()
-                .clickOption(R.string.match_exactly)
-                .assertEnabled(R.string.form_update_frequency_title)
-                .assertDisabled(R.string.automatic_download);
-    }
-
-    @Test
     public void whenMatchExactlyEnabled_changingAutomaticUpdateFrequency_changesTaskFrequency() {
         List<TestScheduler.DeferredTask> deferredTasks = testDependencies.scheduler.getDeferredTasks();
         assertThat(deferredTasks, is(empty()));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ServerSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ServerSettingsTest.java
@@ -1,61 +1,46 @@
 package org.odk.collect.android.feature.settings;
 
-import android.Manifest;
-import android.webkit.MimeTypeMap;
-
+import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
-import org.odk.collect.android.injection.config.AppDependencyModule;
-import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
-import org.odk.collect.android.support.CollectTestRule;
-import org.odk.collect.android.support.ResetStateRule;
-import org.odk.collect.android.support.StubOpenRosaServer;
+import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.support.TestDependencies;
+import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.GeneralSettingsPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
-import org.odk.collect.utilities.UserAgentProvider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @RunWith(AndroidJUnit4.class)
 public class ServerSettingsTest {
 
-    public final StubOpenRosaServer server = new StubOpenRosaServer();
+    private final TestDependencies testDependencies = new TestDependencies();
 
-    public CollectTestRule rule = new CollectTestRule();
+    public IntentsTestRule<MainMenuActivity> rule = new IntentsTestRule<>(MainMenuActivity.class);
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
-            .outerRule(GrantPermissionRule.grant(
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    Manifest.permission.READ_PHONE_STATE,
-                    Manifest.permission.GET_ACCOUNTS
-            ))
-            .around(new ResetStateRule(new AppDependencyModule() {
-                @Override
-                public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider) {
-                    return server;
-                }
-            }))
+    public RuleChain copyFormChain = TestRuleChain.chain(testDependencies)
             .around(rule);
 
     @Test
     public void whenUsingODKServer_canAddCredentialsForServer() {
-        server.setCredentials("Joe", "netsky");
-        server.addForm("One Question", "one-question", "one-question.xml");
+        testDependencies.server.setCredentials("Joe", "netsky");
+        testDependencies.server.addForm("One Question", "one-question", "one-question.xml");
 
-        rule.mainMenu()
+        new MainMenuPage(rule).assertOnPage()
                 .clickOnMenu()
                 .clickGeneralSettings()
                 .clickServerSettings()
                 .clickOnURL()
-                .inputText(server.getURL())
+                .inputText(testDependencies.server.getURL())
                 .clickOKOnDialog()
-                .assertText(server.getURL())
+                .assertText(testDependencies.server.getURL())
                 .clickServerUsername()
                 .inputText("Joe")
                 .clickOKOnDialog()
@@ -81,7 +66,7 @@ public class ServerSettingsTest {
      */
     @Test
     public void selectingGoogleAccount_showsGoogleAccountSettings() {
-        rule.mainMenu()
+        new MainMenuPage(rule).assertOnPage()
                 .clickOnMenu()
                 .clickGeneralSettings()
                 .clickServerSettings()
@@ -89,5 +74,15 @@ public class ServerSettingsTest {
                 .clickOnString(R.string.server_platform_google_sheets)
                 .assertText(R.string.selected_google_account_text)
                 .assertText(R.string.google_sheets_url);
+    }
+
+    @Test
+    public void selectingGoogleAccount_disablesAutomaticUpdates() {
+        MainMenuPage mainMenu = new MainMenuPage(rule).assertOnPage()
+                .enablePreviouslyDownloadedOnlyUpdates();
+        assertThat(testDependencies.scheduler.getDeferredTasks().size(), is(1));
+
+        mainMenu.setGoogleDriveAccount("steph@curry.basket");
+        assertThat(testDependencies.scheduler.getDeferredTasks().size(), is(0));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.java
@@ -1,0 +1,28 @@
+package org.odk.collect.android.application;
+
+import org.odk.collect.android.backgroundwork.FormUpdateManager;
+import org.odk.collect.android.configure.SettingsChangeHandler;
+import org.odk.collect.android.logic.PropertyManager;
+
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_FORM_UPDATE_MODE;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_PERIODIC_FORM_UPDATES_CHECK;
+
+public class CollectSettingsChangeHandler implements SettingsChangeHandler {
+
+    private final PropertyManager propertyManager;
+    private final FormUpdateManager formUpdateManager;
+
+    public CollectSettingsChangeHandler(PropertyManager propertyManager, FormUpdateManager formUpdateManager) {
+        this.propertyManager = propertyManager;
+        this.formUpdateManager = formUpdateManager;
+    }
+
+    @Override
+    public void onSettingChanged(String changedKey) {
+        propertyManager.reload();
+
+        if (changedKey.equals(KEY_FORM_UPDATE_MODE) || changedKey.equals(KEY_PERIODIC_FORM_UPDATES_CHECK)) {
+            formUpdateManager.scheduleUpdates();
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/configure/SettingsChangeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/SettingsChangeHandler.java
@@ -1,0 +1,5 @@
+package org.odk.collect.android.configure;
+
+public interface SettingsChangeHandler {
+    void onSettingsChanged();
+}

--- a/collect_app/src/main/java/org/odk/collect/android/configure/SettingsChangeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/SettingsChangeHandler.java
@@ -1,5 +1,5 @@
 package org.odk.collect.android.configure;
 
 public interface SettingsChangeHandler {
-    void onSettingsChanged();
+    void onSettingChanged(String changedKey);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/configure/SettingsImporter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/SettingsImporter.java
@@ -62,7 +62,13 @@ public class SettingsImporter {
         loadDefaults(generalSharedPrefs, generalDefaults);
         loadDefaults(adminSharedPrefs, adminDefaults);
 
-        settingsChangedHandler.onSettingsChanged();
+        for (String key: generalSharedPrefs.getAll().keySet()) {
+            settingsChangedHandler.onSettingChanged(key);
+        }
+
+        for (String key: adminSharedPrefs.getAll().keySet()) {
+            settingsChangedHandler.onSettingChanged(key);
+        }
 
         return true;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/configure/SettingsImporter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/SettingsImporter.java
@@ -22,9 +22,9 @@ public class SettingsImporter {
     private final SettingsValidator settingsValidator;
     private final Map<String, Object> generalDefaults;
     private final Map<String, Object> adminDefaults;
-    private final Runnable settingsChangedHandler;
+    private final SettingsChangeHandler settingsChangedHandler;
 
-    public SettingsImporter(SharedPreferences generalSharedPrefs, SharedPreferences adminSharedPrefs, SettingsPreferenceMigrator preferenceMigrator, SettingsValidator settingsValidator, Map<String, Object> generalDefaults, Map<String, Object> adminDefaults, Runnable settingsChangedHandler) {
+    public SettingsImporter(SharedPreferences generalSharedPrefs, SharedPreferences adminSharedPrefs, SettingsPreferenceMigrator preferenceMigrator, SettingsValidator settingsValidator, Map<String, Object> generalDefaults, Map<String, Object> adminDefaults, SettingsChangeHandler settingsChangedHandler) {
         this.generalSharedPrefs = generalSharedPrefs;
         this.adminSharedPrefs = adminSharedPrefs;
         this.preferenceMigrator = preferenceMigrator;
@@ -62,7 +62,7 @@ public class SettingsImporter {
         loadDefaults(generalSharedPrefs, generalDefaults);
         loadDefaults(adminSharedPrefs, adminDefaults);
 
-        settingsChangedHandler.run();
+        settingsChangedHandler.onSettingsChanged();
 
         return true;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -42,6 +42,7 @@ import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.preferences.AdminPasswordDialogFragment;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
+import org.odk.collect.android.preferences.BasePreferenceFragment;
 import org.odk.collect.android.preferences.ExperimentalPreferencesFragment;
 import org.odk.collect.android.preferences.FormManagementPreferences;
 import org.odk.collect.android.preferences.FormMetadataFragment;
@@ -199,6 +200,8 @@ public interface AppDependencyComponent {
     void inject(AutoUpdateTaskSpec autoUpdateTaskSpec);
 
     void inject(ServerAuthDialogFragment serverAuthDialogFragment);
+
+    void inject(BasePreferenceFragment basePreferenceFragment);
 
     void inject(BlankFormListFragment blankFormListFragment);
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -15,6 +15,7 @@ import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.analytics.FirebaseAnalytics;
+import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.initialization.ApplicationInitializer;
 import org.odk.collect.android.application.initialization.CollectSettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator;
@@ -348,10 +349,7 @@ public class AppDependencyModule {
 
     @Provides
     public SettingsChangeHandler providesSettingsChangeHandler(PropertyManager propertyManager, FormUpdateManager formUpdateManager) {
-        return () -> {
-            propertyManager.reload();
-            formUpdateManager.scheduleUpdates();
-        };
+        return new CollectSettingsChangeHandler(propertyManager, formUpdateManager);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/AdminPreferencesFragment.java
@@ -50,8 +50,6 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-        super.onCreatePreferences(savedInstanceState, rootKey);
-
         getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
         setPreferencesFromResource(R.xml.admin_preferences, rootKey);
@@ -146,11 +144,10 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
     public static class MainMenuAccessPreferences extends BasePreferenceFragment {
 
         @Override
-        public void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
+        public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
-            addPreferencesFromResource(R.xml.main_menu_access_preferences);
+            setPreferencesFromResource(R.xml.main_menu_access_preferences, rootKey);
             findPreference(KEY_EDIT_SAVED).setEnabled((Boolean) AdminSharedPreferences.getInstance().get(ALLOW_OTHER_WAYS_OF_EDITING_FORM));
         }
     }
@@ -158,18 +155,16 @@ public class AdminPreferencesFragment extends BasePreferenceFragment implements 
     public static class UserSettingsAccessPreferences extends BasePreferenceFragment {
 
         @Override
-        public void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
+        public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
-
-            addPreferencesFromResource(R.xml.user_settings_access_preferences);
+            setPreferencesFromResource(R.xml.user_settings_access_preferences, rootKey);
         }
     }
 
     public static class FormEntryAccessPreferences extends BasePreferenceFragment {
+
         @Override
-        public void onCreate(Bundle savedInstanceState) {
-            super.onCreate(savedInstanceState);
+        public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             getPreferenceManager().setSharedPreferencesName(ADMIN_PREFERENCES);
 
             addPreferencesFromResource(R.xml.form_entry_access_preferences);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
@@ -54,7 +54,7 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat im
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        settingsChangeHandler.onSettingsChanged();
+        settingsChangeHandler.onSettingChanged(key);
     }
 
     void removeDisabledPrefs() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
@@ -3,23 +3,27 @@ package org.odk.collect.android.preferences;
 import android.os.Bundle;
 import android.view.View;
 
-import org.odk.collect.android.activities.CollectAbstractActivity;
-
 import androidx.annotation.Nullable;
+import androidx.fragment.app.FragmentActivity;
 import androidx.preference.PreferenceFragmentCompat;
+
+import org.odk.collect.android.activities.CollectAbstractActivity;
 
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
 
-public class BasePreferenceFragment extends PreferenceFragmentCompat {
+public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-
+        // This should be overridden in implementation classes instead. Remove this once they all do
     }
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        ((CollectAbstractActivity) getActivity()).initToolbar(getPreferenceScreen().getTitle());
+        FragmentActivity activity = getActivity();
+        if (activity instanceof CollectAbstractActivity) {
+            ((CollectAbstractActivity) activity).initToolbar(getPreferenceScreen().getTitle());
+        }
         removeDisabledPrefs();
 
         super.onViewCreated(view, savedInstanceState);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
@@ -14,6 +14,7 @@ import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY
 public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
 
     @Override
+    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         // This should be overridden in implementation classes instead. Remove this once they all do
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
@@ -14,12 +14,6 @@ import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY
 public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
 
     @Override
-    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
-    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
-        // This should be overridden in implementation classes instead. Remove this once they all do
-    }
-
-    @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         FragmentActivity activity = getActivity();
         if (activity instanceof CollectAbstractActivity) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/BasePreferenceFragment.java
@@ -1,17 +1,33 @@
 package org.odk.collect.android.preferences;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.preference.PreferenceFragmentCompat;
 
 import org.odk.collect.android.activities.CollectAbstractActivity;
+import org.odk.collect.android.configure.SettingsChangeHandler;
+import org.odk.collect.android.injection.DaggerUtils;
+
+import javax.inject.Inject;
 
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
 
-public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
+public abstract class BasePreferenceFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    @Inject
+    SettingsChangeHandler settingsChangeHandler;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        DaggerUtils.getComponent(context).inject(this);
+    }
 
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
@@ -22,6 +38,23 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
         removeDisabledPrefs();
 
         super.onViewCreated(view, savedInstanceState);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        settingsChangeHandler.onSettingsChanged();
     }
 
     void removeDisabledPrefs() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -43,7 +43,7 @@ import static org.odk.collect.android.preferences.GeneralKeys.KEY_PERIODIC_FORM_
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_PROTOCOL;
 import static org.odk.collect.android.preferences.PreferencesActivity.INTENT_KEY_ADMIN_MODE;
 
-public class FormManagementPreferences extends BasePreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class FormManagementPreferences extends BasePreferenceFragment {
 
     @Inject
     Analytics analytics;
@@ -86,9 +86,9 @@ public class FormManagementPreferences extends BasePreferenceFragment implements
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals(KEY_FORM_UPDATE_MODE) || key.equals(KEY_PERIODIC_FORM_UPDATES_CHECK)) {
-            formUpdateManager.scheduleUpdates();
+        super.onSharedPreferenceChanged(sharedPreferences, key);
 
+        if (key.equals(KEY_FORM_UPDATE_MODE) || key.equals(KEY_PERIODIC_FORM_UPDATES_CHECK)) {
             String newValue = sharedPreferences.getString(KEY_FORM_UPDATE_MODE, null);
             updateDisabledPrefs(newValue, sharedPreferences.getString(KEY_PROTOCOL, null));
 
@@ -97,19 +97,12 @@ public class FormManagementPreferences extends BasePreferenceFragment implements
         }
     }
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        preferencesProvider.getGeneralSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
-    }
-
     private void setupFormUpdateMode() {
         SharedPreferences sharedPreferences = preferencesProvider.getGeneralSharedPreferences();
         updateDisabledPrefs(sharedPreferences.getString(KEY_FORM_UPDATE_MODE, null), sharedPreferences.getString(KEY_PROTOCOL, null));
 
         Preference formUpdateMode = findPreference(KEY_FORM_UPDATE_MODE);
         formUpdateMode.setSummary(((ListPreference) formUpdateMode).getEntry());
-        sharedPreferences.registerOnSharedPreferenceChangeListener(this);
     }
 
     private void updateDisabledPrefs(String formUpdateMode, String protocol) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -14,9 +14,12 @@
 
 package org.odk.collect.android.preferences;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
+import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 
@@ -62,10 +65,14 @@ public class FormManagementPreferences extends BasePreferenceFragment implements
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.form_management_preferences);
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
         Collect.getInstance().getComponent().inject(this);
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.form_management_preferences, rootKey);
 
         initListPref(KEY_PERIODIC_FORM_UPDATES_CHECK);
         initPref(KEY_AUTOMATIC_UPDATE);
@@ -75,6 +82,25 @@ public class FormManagementPreferences extends BasePreferenceFragment implements
         initGuidancePrefs();
 
         setupFormUpdateMode();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (key.equals(KEY_FORM_UPDATE_MODE) || key.equals(KEY_PERIODIC_FORM_UPDATES_CHECK)) {
+            formUpdateManager.scheduleUpdates();
+
+            String newValue = sharedPreferences.getString(KEY_FORM_UPDATE_MODE, null);
+            updateDisabledPrefs(newValue, sharedPreferences.getString(KEY_PROTOCOL, null));
+
+            Preference preference = findPreference(KEY_FORM_UPDATE_MODE);
+            preference.setSummary(((ListPreference) preference).getEntry());
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        preferencesProvider.getGeneralSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
     }
 
     private void setupFormUpdateMode() {
@@ -87,30 +113,37 @@ public class FormManagementPreferences extends BasePreferenceFragment implements
     }
 
     private void updateDisabledPrefs(String formUpdateMode, String protocol) {
+        Preference updateFrequency = findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK);
+        CheckBoxPreference automaticDownload = findPreference(KEY_AUTOMATIC_UPDATE);
+
         if (Protocol.parse(getActivity(), protocol) == Protocol.GOOGLE) {
             findPreference(KEY_FORM_UPDATE_MODE).setEnabled(false);
-            findPreference(KEY_AUTOMATIC_UPDATE).setEnabled(false);
-            findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).setEnabled(false);
+            automaticDownload.setEnabled(false);
+            updateFrequency.setEnabled(false);
         } else {
             switch (FormUpdateMode.parse(getActivity(), formUpdateMode)) {
                 case MANUAL:
-                    findPreference(KEY_AUTOMATIC_UPDATE).setEnabled(false);
-                    findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).setEnabled(false);
+                    automaticDownload.setEnabled(false);
+                    automaticDownload.setChecked(false);
+
+                    updateFrequency.setEnabled(false);
                     break;
                 case PREVIOUSLY_DOWNLOADED_ONLY:
-                    findPreference(KEY_AUTOMATIC_UPDATE).setEnabled(true);
-                    findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).setEnabled(true);
+                    automaticDownload.setEnabled(true);
+                    updateFrequency.setEnabled(true);
                     break;
                 case MATCH_EXACTLY:
-                    findPreference(KEY_AUTOMATIC_UPDATE).setEnabled(false);
-                    findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).setEnabled(true);
+                    automaticDownload.setEnabled(false);
+                    automaticDownload.setChecked(true);
+
+                    updateFrequency.setEnabled(true);
                     break;
             }
         }
     }
 
     private void initListPref(String key) {
-        final ListPreference pref = (ListPreference) findPreference(key);
+        final ListPreference pref = findPreference(key);
 
         if (pref != null) {
             pref.setSummary(pref.getEntry());
@@ -151,40 +184,18 @@ public class FormManagementPreferences extends BasePreferenceFragment implements
     }
 
     private void initGuidancePrefs() {
-        final ListPreference guidance = (ListPreference) findPreference(KEY_GUIDANCE_HINT);
+        final ListPreference guidance = findPreference(KEY_GUIDANCE_HINT);
 
         if (guidance == null) {
             return;
         }
 
         guidance.setSummary(guidance.getEntry());
-        guidance.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object newValue) {
-                int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
-                String entry = (String) ((ListPreference) preference).getEntries()[index];
-                preference.setSummary(entry);
-                return true;
-            }
+        guidance.setOnPreferenceChangeListener((preference, newValue) -> {
+            int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
+            String entry = (String) ((ListPreference) preference).getEntries()[index];
+            preference.setSummary(entry);
+            return true;
         });
-    }
-
-    @Override
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        if (key.equals(KEY_FORM_UPDATE_MODE) || key.equals(KEY_PERIODIC_FORM_UPDATES_CHECK)) {
-            formUpdateManager.scheduleUpdates();
-
-            String newValue = sharedPreferences.getString(KEY_FORM_UPDATE_MODE, null);
-            updateDisabledPrefs(newValue, sharedPreferences.getString(KEY_PROTOCOL, null));
-
-            Preference preference = findPreference(KEY_FORM_UPDATE_MODE);
-            preference.setSummary(((ListPreference) preference).getEntry());
-        }
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        preferencesProvider.getGeneralSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralPreferencesFragment.java
@@ -57,10 +57,8 @@ public class GeneralPreferencesFragment extends BasePreferenceFragment implement
     }
 
     @Override
-    public void onCreate(final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        addPreferencesFromResource(R.xml.general_preferences);
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.general_preferences, rootKey);
 
         findPreference("protocol").setOnPreferenceClickListener(this);
         findPreference("user_interface").setOnPreferenceClickListener(this);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/IdentityPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/IdentityPreferences.java
@@ -14,8 +14,10 @@
 
 package org.odk.collect.android.preferences;
 
+import android.content.Context;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.preference.CheckBoxPreference;
 
@@ -45,10 +47,14 @@ public class IdentityPreferences extends BasePreferenceFragment {
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.identity_preferences);
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
         Collect.getInstance().getComponent().inject(this);
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.identity_preferences, rootKey);
 
         findPreference("form_metadata").setOnPreferenceClickListener(preference -> {
             if (MultiClickGuard.allowClick(getClass().getName())) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/MapsPreferences.java
@@ -86,9 +86,9 @@ public class MapsPreferences extends BasePreferenceFragment {
             .commit();
     }
 
-    @Override public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.maps_preferences);
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.maps_preferences, rootKey);
 
         context = getPreferenceScreen().getContext();
         initBasemapSourcePref();

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -99,10 +99,18 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
         return serverPreferencesFragment;
     }
 
+
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        addPreferencesFromResource(R.xml.server_preferences);
+    public void onAttach(@NotNull Context context) {
+        super.onAttach(context);
+        DaggerUtils.getComponent(context).inject(this);
+
+        ((PreferencesActivity) context).setOnBackPressedListener(this);
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.server_preferences, rootKey);
         initProtocolPrefs();
     }
 
@@ -150,14 +158,6 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                 addGooglePreferences();
                 break;
         }
-    }
-
-    @Override
-    public void onAttach(@NotNull Context context) {
-        super.onAttach(context);
-        DaggerUtils.getComponent(context).inject(this);
-
-        ((PreferencesActivity) context).setOnBackPressedListener(this);
     }
 
     public void addAggregatePreferences() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -147,8 +147,6 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                         preferencesProvider.getGeneralSharedPreferences().edit()
                                 .putString(KEY_FORM_UPDATE_MODE, FormUpdateMode.MANUAL.getValue(getActivity()))
                                 .apply();
-
-                        formUpdateManager.scheduleUpdates();
                         break;
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/ServerPreferencesFragment.java
@@ -37,6 +37,7 @@ import androidx.preference.Preference;
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.backgroundwork.FormUpdateManager;
 import org.odk.collect.android.formmanagement.FormUpdateMode;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.OnBackPressedListener;
@@ -84,6 +85,9 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
 
     @Inject
     PreferencesProvider preferencesProvider;
+
+    @Inject
+    FormUpdateManager formUpdateManager;
 
     private ListPopupWindow listPopupWindow;
     private Preference selectedGoogleAccountPreference;
@@ -143,6 +147,8 @@ public class ServerPreferencesFragment extends BasePreferenceFragment implements
                         preferencesProvider.getGeneralSharedPreferences().edit()
                                 .putString(KEY_FORM_UPDATE_MODE, FormUpdateMode.MANUAL.getValue(getActivity()))
                                 .apply();
+
+                        formUpdateManager.scheduleUpdates();
                         break;
                 }
             }

--- a/collect_app/src/test/java/org/odk/collect/android/application/CollectSettingsChangeHandlerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/application/CollectSettingsChangeHandlerTest.java
@@ -1,0 +1,42 @@
+package org.odk.collect.android.application;
+
+import org.junit.Test;
+import org.odk.collect.android.backgroundwork.FormUpdateManager;
+import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.preferences.GeneralKeys;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class CollectSettingsChangeHandlerTest {
+
+    private final PropertyManager propertyManager = mock(PropertyManager.class);
+    private final FormUpdateManager formUpdateManager = mock(FormUpdateManager.class);
+
+    CollectSettingsChangeHandler handler = new CollectSettingsChangeHandler(propertyManager, formUpdateManager);
+
+    @Test
+    public void updatesPropertyManager() {
+        handler.onSettingChanged("blah");
+        verify(propertyManager).reload();
+    }
+
+    @Test
+    public void doesNotScheduleUpdates() {
+        handler.onSettingChanged("blah");
+        verify(formUpdateManager, never()).scheduleUpdates();
+    }
+
+    @Test
+    public void whenChangedKeyIsFormUpdateMode_schedulesUpdates() {
+        handler.onSettingChanged(GeneralKeys.KEY_FORM_UPDATE_MODE);
+        verify(formUpdateManager).scheduleUpdates();
+    }
+
+    @Test
+    public void whenChangedKeyIsPeriodicUpdatesCheck_schedulesUpdates() {
+        handler.onSettingChanged(GeneralKeys.KEY_PERIODIC_FORM_UPDATES_CHECK);
+        verify(formUpdateManager).scheduleUpdates();
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.java
@@ -11,11 +11,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -51,7 +54,7 @@ public class SettingsImporterTest {
         settingsValidator = mock(SettingsValidator.class);
         when(settingsValidator.isValid(any())).thenReturn(true);
 
-        importer = new SettingsImporter(generalPrefs, adminPrefs, (SharedPreferences generalSharedPreferences, SharedPreferences adminSharedPreferences) -> {}, settingsValidator, generalDefaults, adminDefaults, () -> {});
+        importer = new SettingsImporter(generalPrefs, adminPrefs, (SharedPreferences generalSharedPreferences, SharedPreferences adminSharedPreferences) -> {}, settingsValidator, generalDefaults, adminDefaults, key -> {});
     }
 
     @Test
@@ -112,7 +115,7 @@ public class SettingsImporterTest {
             }
         };
 
-        importer = new SettingsImporter(generalPrefs, adminPrefs, migrator, settingsValidator, generalDefaults, adminDefaults, () -> {});
+        importer = new SettingsImporter(generalPrefs, adminPrefs, migrator, settingsValidator, generalDefaults, adminDefaults, key -> {});
         assertThat(importer.fromJSON(emptySettings()), is(true));
     }
 
@@ -128,20 +131,17 @@ public class SettingsImporterTest {
             }
         };
 
-        importer = new SettingsImporter(generalPrefs, adminPrefs, migrator, settingsValidator, generalDefaults, adminDefaults, () -> {});
+        importer = new SettingsImporter(generalPrefs, adminPrefs, migrator, settingsValidator, generalDefaults, adminDefaults, key -> {});
         assertThat(importer.fromJSON(json.toString()), is(true));
     }
 
     @Test
-    public void afterSettingsImportedAndMigrated_runsSettingsChangeHandler() throws Exception {
-        final String[] key1ValueWhenCalled = {null};
-        SettingsChangeHandler handler = () -> {
-            key1ValueWhenCalled[0] = generalPrefs.getString("key1", null);
-        };
+    public void afterSettingsImportedAndMigrated_runsSettingsChangeHandlerForEveryKey() throws Exception {
+        RecordingSettingsChangeHandler handler = new RecordingSettingsChangeHandler();
 
         importer = new SettingsImporter(generalPrefs, adminPrefs, (SharedPreferences generalSharedPreferences, SharedPreferences adminSharedPreferences) -> {}, settingsValidator, generalDefaults, adminDefaults, handler);
         assertThat(importer.fromJSON(emptySettings()), is(true));
-        assertThat(key1ValueWhenCalled[0], is("default"));
+        assertThat(handler.keys, containsInAnyOrder("key1", "key2", "key1"));
     }
 
     private String emptySettings() throws Exception {
@@ -153,5 +153,15 @@ public class SettingsImporterTest {
         return new JSONObject()
                 .put("general", new JSONObject())
                 .put("admin", new JSONObject());
+    }
+
+    private static class RecordingSettingsChangeHandler implements SettingsChangeHandler {
+
+        public List<String> keys = new ArrayList<>();
+
+        @Override
+        public void onSettingChanged(String changedKey) {
+            keys.add(changedKey);
+        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.java
@@ -135,7 +135,7 @@ public class SettingsImporterTest {
     @Test
     public void afterSettingsImportedAndMigrated_runsSettingsChangeHandler() throws Exception {
         final String[] key1ValueWhenCalled = {null};
-        Runnable handler = () -> {
+        SettingsChangeHandler handler = () -> {
             key1ValueWhenCalled[0] = generalPrefs.getString("key1", null);
         };
 

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/FormManagementPreferencesTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/FormManagementPreferencesTest.java
@@ -1,0 +1,68 @@
+package org.odk.collect.android.preferences;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.fragment.app.testing.FragmentScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.odk.collect.android.formmanagement.FormUpdateMode.MANUAL;
+import static org.odk.collect.android.formmanagement.FormUpdateMode.MATCH_EXACTLY;
+import static org.odk.collect.android.formmanagement.FormUpdateMode.PREVIOUSLY_DOWNLOADED_ONLY;
+import static org.odk.collect.android.injection.DaggerUtils.getComponent;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_AUTOMATIC_UPDATE;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_FORM_UPDATE_MODE;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_PERIODIC_FORM_UPDATES_CHECK;
+
+@RunWith(AndroidJUnit4.class)
+public class FormManagementPreferencesTest {
+
+    private SharedPreferences prefs;
+    private Context context;
+
+    @Before
+    public void setup() {
+        context = ApplicationProvider.getApplicationContext();
+        prefs = getComponent(context).preferencesProvider().getGeneralSharedPreferences();
+    }
+
+    @Test
+    public void whenManualUpdatesEnabled_disablesPrefs() {
+        prefs.edit().putString(KEY_FORM_UPDATE_MODE, MANUAL.getValue(context)).apply();
+
+        FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
+        scenario.onFragment(f -> {
+            assertThat(f.findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).isEnabled(), is(false));
+            assertThat(f.findPreference(KEY_AUTOMATIC_UPDATE).isEnabled(), is(false));
+        });
+    }
+
+    @Test
+    public void whenPreviouslyDownloadedOnlyEnabled_disablesPrefs() {
+        prefs.edit().putString(KEY_FORM_UPDATE_MODE, PREVIOUSLY_DOWNLOADED_ONLY.getValue(context)).apply();
+
+        FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
+        scenario.onFragment(f -> {
+            assertThat(f.findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).isEnabled(), is(true));
+            assertThat(f.findPreference(KEY_AUTOMATIC_UPDATE).isEnabled(), is(true));
+        });
+    }
+
+    @Test
+    public void whenMatchExactlyEnabled_disablesPrefs() {
+        prefs.edit().putString(KEY_FORM_UPDATE_MODE, MATCH_EXACTLY.getValue(context)).apply();
+
+        FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
+        scenario.onFragment(f -> {
+            assertThat(f.findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).isEnabled(), is(true));
+            assertThat(f.findPreference(KEY_AUTOMATIC_UPDATE).isEnabled(), is(false));
+        });
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/FormManagementPreferencesTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/FormManagementPreferencesTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import androidx.fragment.app.testing.FragmentScenario;
+import androidx.preference.CheckBoxPreference;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -63,6 +64,30 @@ public class FormManagementPreferencesTest {
         scenario.onFragment(f -> {
             assertThat(f.findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK).isEnabled(), is(true));
             assertThat(f.findPreference(KEY_AUTOMATIC_UPDATE).isEnabled(), is(false));
+        });
+    }
+
+    @Test
+    public void whenMatchExactlyEnabled_andAutomaticDownloadDisabled_showsAutomaticDownloadAsChecked() {
+        prefs.edit().putString(KEY_FORM_UPDATE_MODE, MATCH_EXACTLY.getValue(context)).apply();
+        prefs.edit().putBoolean(KEY_AUTOMATIC_UPDATE, false).apply();
+
+        FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
+        scenario.onFragment(f -> {
+            CheckBoxPreference automaticDownload = f.findPreference(KEY_AUTOMATIC_UPDATE);
+            assertThat(automaticDownload.isChecked(), is(true));
+        });
+    }
+
+    @Test
+    public void whenManualUpdatesEnabled_andAutomaticDownloadEnabled_showsAutomaticDownloadAsNotChecked() {
+        prefs.edit().putString(KEY_FORM_UPDATE_MODE, MANUAL.getValue(context)).apply();
+        prefs.edit().putBoolean(KEY_AUTOMATIC_UPDATE, true).apply();
+
+        FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
+        scenario.onFragment(f -> {
+            CheckBoxPreference automaticDownload = f.findPreference(KEY_AUTOMATIC_UPDATE);
+            assertThat(automaticDownload.isChecked(), is(false));
         });
     }
 }

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -24,7 +24,7 @@ and update this document as the code evolves.
 * App stores data in flat files indexed in SQLite
 * Access to data in SQLite is done inconsistently through a mix of provider, helper and DAO objects
 * Raw access to database rows is favored over the use of domain objects
-* Settings for the app use (the now deprecated) Android's Preferences abstraction
+* Settings for the app use Android's Preferences abstraction
 * Material Components styles are used in some places but app still uses AppCompat theme
 * Dagger is used to inject "black box" objects such as Activity and in some other places but isn't set up in a particularly advanced way
 * Http is handled using OkHttp3 and https client abstractions are generally wrapped in Android's AsyncTask (and some Rx)
@@ -37,14 +37,12 @@ and update this document as the code evolves.
 * Trying to adopt Material Design's language to make design decisions and conversations easier in the absence of designers and to make the UI more consistent for enumerators ([“Typography rework” discussion](https://forum.getodk.org/t/reworking-collects-typography/20634))
 * Moving non UI testing away from Espresso to cut down on long test startup times
 * Slowly moving responsibilities out of FormEntryActivity
-* Talk of moving to Kotlin but not real plans as of yet ([“Using Kotlin for ODK Android apps” discussion](https://forum.getodk.org/t/using-kotlin-for-odk-android-apps/18367))
+* Some Kotlin being introduced in code pulled into Gradle submodules
 * General effort to increase test coverage and quality while working on anything and pushing more for tests in PR review
 * Trying to remove technical debt flagged with `@Deprecated`
 * Favoring domain objects (instance, form) with related logic where possible to more explicitly link data and logic
 * Moving code to packages based on domain slices (`audio` or `formentry` for instance) to make it easier to work on isolated features and navigate code
-* Refactoring towards an OpenRosa abstraction (`OpenRosaAPIClient`) closer to its [documented API](https://docs.getodk.org/openrosa/) and takes care of all interactions with Aggregate, Central etc (currently some high level work interacts with `OpenRosaHttpInterface` directly)
 * `QuestionWiget` implementations are moving from defining their "answer" view programmatically to [implementing `onCreateAnswerView`](WIDGETS.md)
-* Converting settings screens to using the new AndroidX Preferences framework as we touch them
 * Replacing Rx (and other async work) with LiveData + Scheduler abstraction
 * Moving away from custom `SharedPreferences` abstractions (`GeneralSharedPreferences` and `AdminSharedPreferences`) to just using `SharedPreferences` interface
 * Replacing `..Factory` and `..Provider` objects with the new Java `Supplier` interface as much as possible


### PR DESCRIPTION
Closes #3982

#### What has been done to verify that this works as intended?

Played around with it manually and added new tests

#### Why is this the best possible solution? Were any other approaches considered?

I also considered trying to make the setting just display correctly rather than changing it when the form update changes. This seemed like it was going to end up being pretty complex though, so I just went with the path of least resistance.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the bug! Good to double check how the settings change when the form update mode changes makes sense to everyone else.

This shouldn't skip QA like the other Match Exactly PRs.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)