### PR TITLE
Revise notification behaviour for Match Exactly

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.java
@@ -52,13 +52,33 @@ public class MatchExactlyTest {
     }
 
     @Test
+    public void whenMatchExactlyEnabled_clickingFillBlankForm_andClickingRefresh_whenThereIsAnError_showsNotification_andClickingNotification_returnsToFillBlankForms() throws Exception {
+        testDependencies.server.alwaysReturnError();
+
+        rule.mainMenu()
+                .setServer(testDependencies.server.getURL())
+                .enableMatchExactly()
+                .clickFillBlankForm()
+                .clickRefresh();
+
+        notificationDrawerRule
+                .open()
+                .clickNotification(
+                        "ODK Collect",
+                        "Form update failed",
+                        "If you keep having this problem, report it to the person who asked you to collect data.",
+                        "Fill Blank Form",
+                        new FillBlankFormPage(rule)
+                ).pressBack(new MainMenuPage(rule)); // Check we return to Fill Blank Form, not open a new one
+    }
+
+    @Test
     public void whenMatchExactlyEnabled_clickingFillBlankForm_andClickingRefresh_whenThereIsAnAuthenticationError_promptsForCredentials() throws Exception {
-        String url = testDependencies.server.getURL();
         testDependencies.server.addForm("One Question Updated", "one_question", "one-question-updated.xml");
         testDependencies.server.setCredentials("Klay", "Thompson");
 
         rule.mainMenu()
-                .setServer(url)
+                .setServer(testDependencies.server.getURL())
                 .enableMatchExactly()
                 .clickFillBlankForm()
                 .clickRefreshWithAuthError()
@@ -92,28 +112,6 @@ public class MatchExactlyTest {
                 .clickFillBlankForm()
                 .assertText("One Question Updated")
                 .assertTextDoesNotExist("Two Question");
-    }
-
-    @Test
-    public void whenMatchExactlyEnabled_andThereIsAnErrorDuringUpdate_clickingErrorNotification_goesToFillBlankForm() throws Exception {
-        String url = testDependencies.server.getURL();
-
-        rule.mainMenu()
-                .setServer(url)
-                .enableMatchExactly();
-
-        testDependencies.server.alwaysReturnError();
-        testDependencies.scheduler.runDeferredTasks();
-
-        notificationDrawerRule
-                .open()
-                .clickNotification(
-                        "ODK Collect",
-                        "Form update failed",
-                        "If you keep having this problem, report it to the person who asked you to collect data.",
-                        "Fill Blank Form",
-                        new FillBlankFormPage(rule)
-                );
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.java
@@ -14,7 +14,6 @@ import org.odk.collect.android.support.TestDependencies;
 import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.FillBlankFormPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
-import org.odk.collect.android.support.pages.ServerAuthDialog;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -50,6 +49,24 @@ public class MatchExactlyTest {
                 .assertText("Two Question") // Check new form downloaded
                 .assertText("One Question Updated") // Check updated form updated
                 .assertTextDoesNotExist("One Question Repeat"); // Check deleted form deleted
+    }
+
+    @Test
+    public void whenMatchExactlyEnabled_clickingFillBlankForm_andClickingRefresh_whenThereIsAnAuthenticationError_promptsForCredentials() throws Exception {
+        String url = testDependencies.server.getURL();
+        testDependencies.server.addForm("One Question Updated", "one_question", "one-question-updated.xml");
+        testDependencies.server.setCredentials("Klay", "Thompson");
+
+        rule.mainMenu()
+                .setServer(url)
+                .enableMatchExactly()
+                .clickFillBlankForm()
+                .clickRefreshWithAuthError()
+                .fillUsername("Klay")
+                .fillPassword("Thompson")
+                .clickOK(new FillBlankFormPage(rule))
+                .clickRefresh()
+                .assertText("One Question Updated");
     }
 
     @Test
@@ -97,34 +114,6 @@ public class MatchExactlyTest {
                         "Fill Blank Form",
                         new FillBlankFormPage(rule)
                 );
-    }
-
-    @Test
-    public void whenMatchExactlyEnabled_andThereIsAnAuthenticationErrorDuringUpdate_clickingErrorNotification_goesToFillBlankForm_andPromptsForCredentials() throws Exception {
-        String url = testDependencies.server.getURL();
-
-        rule.mainMenu()
-                .setServer(url)
-                .enableMatchExactly();
-
-        testDependencies.server.addForm("One Question Updated", "one_question", "one-question-updated.xml");
-        testDependencies.server.setCredentials("Klay", "Thompson");
-        testDependencies.scheduler.runDeferredTasks();
-
-        notificationDrawerRule
-                .open()
-                .clickNotification(
-                        "ODK Collect",
-                        "Form update failed",
-                        "If you keep having this problem, report it to the person who asked you to collect data.",
-                        "Server Requires Authentication",
-                        new ServerAuthDialog(rule)
-                )
-                .fillUsername("Klay")
-                .fillPassword("Thompson")
-                .clickOK(new FillBlankFormPage(rule))
-                .clickRefresh()
-                .assertText("One Question Updated");
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
@@ -98,4 +98,9 @@ public class FillBlankFormPage extends Page<FillBlankFormPage> {
         onView(withId(R.id.menu_refresh)).perform(click());
         return this;
     }
+
+    public ServerAuthDialog clickRefreshWithAuthError() {
+        onView(withId(R.id.menu_refresh)).perform(click());
+        return new ServerAuthDialog(rule).assertOnPage();
+    }
 }

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -113,7 +113,7 @@ the specific language governing permissions and limitations under the License.
             android:configChanges="orientation|screenSize"
             android:windowSoftInputMode="stateHidden" />
         <activity android:name=".activities.InstanceChooserList" />
-        <activity android:name=".activities.FillBlankFormActivity" />
+        <activity android:name=".activities.FillBlankFormActivity" android:launchMode="singleTop"/>
         <activity android:name=".activities.FormDownloadListActivity" />
         <activity
             android:name=".activities.DeleteSavedFormActivity"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
@@ -69,8 +69,6 @@ import static org.odk.collect.android.utilities.PermissionUtils.finishAllActivit
 public class FillBlankFormActivity extends FormListActivity implements
         DiskSyncListener, AdapterView.OnItemClickListener, LoaderManager.LoaderCallbacks<Cursor> {
 
-    public static final String EXTRA_AUTH_REQUIRED = "auth_error";
-
     private static final String FORM_CHOOSER_LIST_SORTING_ORDER = "formChooserListSortingOrder";
     private static final boolean EXIT = true;
 
@@ -107,6 +105,8 @@ public class FillBlankFormActivity extends FormListActivity implements
         blankFormsListViewModel.isAuthenticationRequired().observe(this, authenticationRequired -> {
             if (authenticationRequired) {
                 DialogUtils.showIfNotShowing(ServerAuthDialogFragment.class, getSupportFragmentManager());
+            } else {
+                DialogUtils.dismissDialog(ServerAuthDialogFragment.class, getSupportFragmentManager());
             }
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
@@ -104,6 +104,12 @@ public class FillBlankFormActivity extends FormListActivity implements
             }
         });
 
+        blankFormsListViewModel.isAuthenticationRequired().observe(this, authenticationRequired -> {
+            if (authenticationRequired) {
+                DialogUtils.showIfNotShowing(ServerAuthDialogFragment.class, getSupportFragmentManager());
+            }
+        });
+
         menuDelegate = new BlankFormListMenuDelegate(this, blankFormsListViewModel);
 
         new PermissionUtils().requestStoragePermissions(this, new PermissionListener() {
@@ -167,10 +173,6 @@ public class FillBlankFormActivity extends FormListActivity implements
 
         setupAdapter();
         getSupportLoaderManager().initLoader(LOADER_ID, null, this);
-
-        if (getIntent().getBooleanExtra(EXTRA_AUTH_REQUIRED, false)) {
-            DialogUtils.showIfNotShowing(ServerAuthDialogFragment.class, getSupportFragmentManager());
-        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
@@ -47,9 +47,10 @@ public class SyncFormsTaskSpec implements TaskSpec {
                     try {
                         serverFormsSynchronizer.synchronize();
                         syncStatusRepository.finishSync(null);
+                        notifier.onSync(null);
                     } catch (FormApiException e) {
                         syncStatusRepository.finishSync(e);
-                        notifier.onSyncFailure(e);
+                        notifier.onSync(e);
                     }
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpec.java
@@ -46,9 +46,9 @@ public class SyncFormsTaskSpec implements TaskSpec {
 
                     try {
                         serverFormsSynchronizer.synchronize();
-                        syncStatusRepository.finishSync(true);
+                        syncStatusRepository.finishSync(null);
                     } catch (FormApiException e) {
-                        syncStatusRepository.finishSync(false);
+                        syncStatusRepository.finishSync(e);
                         notifier.onSyncFailure(e);
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -73,9 +73,10 @@ public class BlankFormsListViewModel extends ViewModel {
                     try {
                         serverFormsSynchronizer.synchronize();
                         syncRepository.finishSync(null);
+                        notifier.onSync(null);
                     } catch (FormApiException e) {
                         syncRepository.finishSync(e);
-                        notifier.onSyncFailure(e);
+                        notifier.onSync(e);
                     }
 
                     return null;

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -4,6 +4,7 @@ import android.app.Application;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Transformations;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -15,6 +16,8 @@ import org.odk.collect.android.openrosa.api.FormApiException;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.async.Scheduler;
+
+import java.util.Objects;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -48,7 +51,17 @@ public class BlankFormsListViewModel extends ViewModel {
     }
 
     public LiveData<Boolean> isOutOfSync() {
-        return syncRepository.isOutOfSync();
+        return Transformations.map(syncRepository.getSyncError(), Objects::nonNull);
+    }
+
+    public LiveData<Boolean> isAuthenticationRequired() {
+        return Transformations.map(syncRepository.getSyncError(), error -> {
+            if (error != null) {
+                return error.getType() == FormApiException.Type.AUTH_REQUIRED;
+            } else {
+                return false;
+            }
+        });
     }
 
     public void syncWithServer() {
@@ -59,9 +72,9 @@ public class BlankFormsListViewModel extends ViewModel {
                 scheduler.immediate(() -> {
                     try {
                         serverFormsSynchronizer.synchronize();
-                        syncRepository.finishSync(true);
+                        syncRepository.finishSync(null);
                     } catch (FormApiException e) {
-                        syncRepository.finishSync(false);
+                        syncRepository.finishSync(e);
                         notifier.onSyncFailure(e);
                     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusRepository.java
@@ -1,12 +1,15 @@
 package org.odk.collect.android.formmanagement.matchexactly;
 
+import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+
+import org.odk.collect.android.openrosa.api.FormApiException;
 
 public class SyncStatusRepository {
 
     private final MutableLiveData<Boolean> syncing = new MutableLiveData<>(false);
-    private final MutableLiveData<Boolean> lastSyncFailure = new MutableLiveData<>(false);
+    private final MutableLiveData<FormApiException> lastSyncFailure = new MutableLiveData<>(null);
 
     public LiveData<Boolean> isSyncing() {
         return syncing;
@@ -16,12 +19,12 @@ public class SyncStatusRepository {
         syncing.postValue(true);
     }
 
-    public void finishSync(boolean success) {
-        lastSyncFailure.postValue(!success);
+    public void finishSync(@Nullable FormApiException exception) {
+        lastSyncFailure.postValue(exception);
         syncing.postValue(false);
     }
 
-    public LiveData<Boolean> isOutOfSync() {
+    public LiveData<FormApiException> getSyncError() {
         return lastSyncFailure;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.java
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import static android.content.Context.NOTIFICATION_SERVICE;
 import static org.odk.collect.android.activities.FormDownloadListActivity.DISPLAY_ONLY_UPDATED_FORMS;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes.FORMS_DOWNLOADED_NOTIFICATION;
@@ -82,19 +84,23 @@ public class NotificationManagerNotifier implements Notifier {
     }
 
     @Override
-    public void onSyncFailure(FormApiException exception) {
-        Intent intent = new Intent(application, FillBlankFormActivity.class);
-        PendingIntent contentIntent = PendingIntent.getActivity(application, FORM_SYNC_NOTIFICATION_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    public void onSync(@Nullable FormApiException exception) {
+        if (exception != null) {
+            Intent intent = new Intent(application, FillBlankFormActivity.class);
+            PendingIntent contentIntent = PendingIntent.getActivity(application, FORM_SYNC_NOTIFICATION_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        Resources localizedResources = getLocalizedResources(application);
-        showNotification(
-                application,
-                notificationManager,
-                localizedResources.getString(R.string.form_update_error),
-                new FormApiExceptionMapper(localizedResources).getMessage(exception),
-                contentIntent,
-                FORM_SYNC_NOTIFICATION_ID
-        );
+            Resources localizedResources = getLocalizedResources(application);
+            showNotification(
+                    application,
+                    notificationManager,
+                    localizedResources.getString(R.string.form_update_error),
+                    new FormApiExceptionMapper(localizedResources).getMessage(exception),
+                    contentIntent,
+                    FORM_SYNC_NOTIFICATION_ID
+            );
+        } else {
+            notificationManager.cancel(FORM_SYNC_NOTIFICATION_ID);
+        }
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.java
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.java
@@ -84,11 +84,6 @@ public class NotificationManagerNotifier implements Notifier {
     @Override
     public void onSyncFailure(FormApiException exception) {
         Intent intent = new Intent(application, FillBlankFormActivity.class);
-
-        if (exception.getType() == FormApiException.Type.AUTH_REQUIRED) {
-            intent.putExtra(FillBlankFormActivity.EXTRA_AUTH_REQUIRED, true);
-        }
-
         PendingIntent contentIntent = PendingIntent.getActivity(application, FORM_SYNC_NOTIFICATION_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         Resources localizedResources = getLocalizedResources(application);

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/Notifier.java
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/Notifier.java
@@ -11,7 +11,7 @@ public interface Notifier {
 
     void onUpdatesDownloaded(HashMap<ServerFormDetails, String> result);
 
-    void onSyncFailure(FormApiException exception);
+    void onSync(FormApiException exception);
 
     void onSubmission(boolean failure, String message);
 }

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/SyncFormsTaskSpecTest.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.formmanagement;
+package org.odk.collect.android.backgroundwork;
 
 import android.app.Application;
 
@@ -8,8 +8,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
-import org.odk.collect.android.backgroundwork.ChangeLock;
-import org.odk.collect.android.backgroundwork.SyncFormsTaskSpec;
+import org.odk.collect.android.formmanagement.FormDownloader;
+import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
 import org.odk.collect.android.forms.FormsRepository;
@@ -64,7 +64,7 @@ public class SyncFormsTaskSpecTest {
     }
 
     @Test
-    public void setsRepositoryToSyncing_runsSync_thenSetsRepositoryToNotSyncing() throws Exception {
+    public void setsRepositoryToSyncing_runsSync_thenSetsRepositoryToNotSyncingAndNotifies() throws Exception {
         InOrder inOrder = inOrder(syncStatusRepository, serverFormsSynchronizer);
 
         SyncFormsTaskSpec taskSpec = new SyncFormsTaskSpec();
@@ -74,6 +74,8 @@ public class SyncFormsTaskSpecTest {
         inOrder.verify(syncStatusRepository).startSync();
         inOrder.verify(serverFormsSynchronizer).synchronize();
         inOrder.verify(syncStatusRepository).finishSync(null);
+
+        verify(notifier).onSync(null);
     }
 
     @Test
@@ -89,7 +91,8 @@ public class SyncFormsTaskSpecTest {
         inOrder.verify(syncStatusRepository).startSync();
         inOrder.verify(serverFormsSynchronizer).synchronize();
         inOrder.verify(syncStatusRepository).finishSync(exception);
-        verify(notifier).onSyncFailure(exception);
+
+        verify(notifier).onSync(exception);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/BlankFormsListViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/BlankFormsListViewModelTest.java
@@ -81,12 +81,14 @@ public class BlankFormsListViewModelTest {
     @Test
     public void syncWithServer_whenTaskFinishes_finishesSyncOnRepository() {
         FakeScheduler fakeScheduler = new FakeScheduler();
+        Notifier notifier = mock(Notifier.class);
 
-        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), fakeScheduler, syncRepository, mock(ServerFormsSynchronizer.class), mock(PreferencesProvider.class), mock(Notifier.class), changeLock);
+        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), fakeScheduler, syncRepository, mock(ServerFormsSynchronizer.class), mock(PreferencesProvider.class), notifier, changeLock);
         viewModel.syncWithServer();
 
         fakeScheduler.runBackground();
         verify(syncRepository).finishSync(null);
+        verify(notifier).onSync(null);
     }
 
     @Test
@@ -103,7 +105,7 @@ public class BlankFormsListViewModelTest {
         fakeScheduler.runBackground();
 
         verify(syncRepository).finishSync(exception);
-        verify(notifier).onSyncFailure(exception);
+        verify(notifier).onSync(exception);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/BlankFormsListViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/BlankFormsListViewModelTest.java
@@ -3,8 +3,10 @@ package org.odk.collect.android.formmanagement;
 import android.app.Application;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer;
@@ -14,6 +16,7 @@ import org.odk.collect.android.openrosa.api.FormApiException;
 import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.android.support.BooleanChangeLock;
 import org.odk.collect.android.support.FakeScheduler;
+import org.odk.collect.android.support.LiveDataTester;
 import org.odk.collect.async.Scheduler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,9 +32,15 @@ public class BlankFormsListViewModelTest {
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
+    private final LiveDataTester liveDataTester = new LiveDataTester();
+
     private final SyncStatusRepository syncRepository = mock(SyncStatusRepository.class);
     private final BooleanChangeLock changeLock = new BooleanChangeLock();
 
+    @After
+    public void teardown() {
+        liveDataTester.teardown();
+    }
 
     @Test
     public void isSyncing_followsRepositoryIsSyncing() {
@@ -46,15 +55,17 @@ public class BlankFormsListViewModelTest {
     }
 
     @Test
-    public void isOutOfSync_followsRepositoryIsOutOfSync() {
-        MutableLiveData<Boolean> liveData = new MutableLiveData<>(true);
-        when(syncRepository.isOutOfSync()).thenReturn(liveData);
+    public void isOutOfSync_followsRepositorySyncError() {
+        MutableLiveData<FormApiException> liveData = new MutableLiveData<>(new FormApiException(FormApiException.Type.FETCH_ERROR));
+        when(syncRepository.getSyncError()).thenReturn(liveData);
 
         BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), mock(Scheduler.class), syncRepository, mock(ServerFormsSynchronizer.class), mock(PreferencesProvider.class), mock(Notifier.class), changeLock);
-        assertThat(viewModel.isOutOfSync().getValue(), is(true));
+        LiveData<Boolean> outOfSync = liveDataTester.activate(viewModel.isOutOfSync());
 
-        liveData.setValue(false);
-        assertThat(viewModel.isOutOfSync().getValue(), is(false));
+        assertThat(outOfSync.getValue(), is(true));
+
+        liveData.setValue(null);
+        assertThat(outOfSync.getValue(), is(false));
     }
 
     @Test
@@ -75,7 +86,7 @@ public class BlankFormsListViewModelTest {
         viewModel.syncWithServer();
 
         fakeScheduler.runBackground();
-        verify(syncRepository).finishSync(true);
+        verify(syncRepository).finishSync(null);
     }
 
     @Test
@@ -91,7 +102,7 @@ public class BlankFormsListViewModelTest {
         viewModel.syncWithServer();
         fakeScheduler.runBackground();
 
-        verify(syncRepository).finishSync(false);
+        verify(syncRepository).finishSync(exception);
         verify(notifier).onSyncFailure(exception);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncFormsTaskSpecTest.java
@@ -73,7 +73,7 @@ public class SyncFormsTaskSpecTest {
 
         inOrder.verify(syncStatusRepository).startSync();
         inOrder.verify(serverFormsSynchronizer).synchronize();
-        inOrder.verify(syncStatusRepository).finishSync(true);
+        inOrder.verify(syncStatusRepository).finishSync(null);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class SyncFormsTaskSpecTest {
 
         inOrder.verify(syncStatusRepository).startSync();
         inOrder.verify(serverFormsSynchronizer).synchronize();
-        inOrder.verify(syncStatusRepository).finishSync(false);
+        inOrder.verify(syncStatusRepository).finishSync(exception);
         verify(notifier).onSyncFailure(exception);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusRepositoryTest.java
@@ -5,9 +5,12 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusRepository;
+import org.odk.collect.android.openrosa.api.FormApiException;
+import org.odk.collect.android.openrosa.api.FormApiException.Type;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SyncStatusRepositoryTest {
 
@@ -15,26 +18,27 @@ public class SyncStatusRepositoryTest {
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
     @Test
-    public void isOutOfSync_isFalseAtFirst() {
+    public void getSyncError_isNullAtFirst() {
         SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
-        assertThat(syncStatusRepository.isOutOfSync().getValue(), is(false));
+        assertThat(syncStatusRepository.getSyncError().getValue(), is(nullValue()));
     }
 
     @Test
-    public void isOutOfSync_whenFinishSyncWithFalse_isTrue() {
+    public void getSyncError_whenFinishSyncWithException_isException() {
         SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
         syncStatusRepository.startSync();
-        syncStatusRepository.finishSync(false);
+        FormApiException exception = new FormApiException(Type.FETCH_ERROR);
+        syncStatusRepository.finishSync(exception);
 
-        assertThat(syncStatusRepository.isOutOfSync().getValue(), is(true));
+        assertThat(syncStatusRepository.getSyncError().getValue(), is(exception));
     }
 
     @Test
-    public void isOutOfSync_whenFinishSyncWithTrue_isFalse() {
+    public void getSyncError_whenFinishSyncWithNull_isNull() {
         SyncStatusRepository syncStatusRepository = new SyncStatusRepository();
         syncStatusRepository.startSync();
-        syncStatusRepository.finishSync(true);
+        syncStatusRepository.finishSync(null);
 
-        assertThat(syncStatusRepository.isOutOfSync().getValue(), is(false));
+        assertThat(syncStatusRepository.getSyncError().getValue(), is(nullValue()));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/notifications/NotificationManagerNotifierTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/notifications/NotificationManagerNotifierTest.java
@@ -1,0 +1,34 @@
+package org.odk.collect.android.notifications;
+
+import android.app.Application;
+import android.app.NotificationManager;
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.openrosa.api.FormApiException;
+import org.robolectric.shadows.ShadowNotificationManager;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(AndroidJUnit4.class)
+public class NotificationManagerNotifierTest {
+
+    @Test
+    public void onSync_whenExceptionNull_clearsNotification() {
+        Application context = ApplicationProvider.getApplicationContext();
+        ShadowNotificationManager shadowNotificationManager = shadowOf((NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE));
+        NotificationManagerNotifier notifier = new NotificationManagerNotifier(context);
+
+        notifier.onSync(new FormApiException(FormApiException.Type.FETCH_ERROR));
+        assertThat(shadowNotificationManager.getAllNotifications().size(), is(1));
+
+        notifier.onSync(null);
+        assertThat(shadowNotificationManager.getAllNotifications().size(), is(0));
+    }
+}


### PR DESCRIPTION
Closes #3999. ~~Blocked by #3992.~~

In addition to the problems described in the issue I also made it so error notifications are cleared/cancelled when a sync succeeds.

#### What has been done to verify that this works as intended?

New/revised tests and was able to verify manually

#### Why is this the best possible solution? Were any other approaches considered?

I've left some comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to just check the issue is fixed and that Match Exactly notifications behave as expected.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)