### PR TITLE
Hide delete forms for Match Exactly

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/MatchExactlyTest.java
@@ -115,10 +115,12 @@ public class MatchExactlyTest {
     }
 
     @Test
-    public void whenMatchExactlyEnabled_hidesGetBlankForms() {
+    public void whenMatchExactlyEnabled_hidesGetBlankFormsAndDeleteBlankForms() {
         rule.mainMenu()
                 .enableMatchExactly()
-                .assertTextNotDisplayed(R.string.get_forms);
+                .assertTextNotDisplayed(R.string.get_forms)
+                .clickDeleteSavedForm()
+                .assertTextDoesNotExist(R.string.forms);
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DeleteSavedFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DeleteSavedFormActivity.java
@@ -59,7 +59,7 @@ public class DeleteSavedFormActivity extends CollectAbstractActivity {
         String[] tabNames = {getString(R.string.data), getString(R.string.forms)};
         ViewPager2 viewPager = findViewById(R.id.viewPager);
         TabLayout tabLayout = findViewById(R.id.tabLayout);
-        viewPager.setAdapter(new DeleteFormsTabsAdapter(this, viewModel.isSyncingAvailable()));
+        viewPager.setAdapter(new DeleteFormsTabsAdapter(this, viewModel.isMatchExactlyEnabled()));
         new TabLayoutMediator(tabLayout, viewPager, (tab, position) -> tab.setText(tabNames[position])).attach();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DeleteSavedFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DeleteSavedFormActivity.java
@@ -18,18 +18,30 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 
 import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.adapters.FileManagerTabsAdapter;
+import org.odk.collect.android.adapters.DeleteFormsTabsAdapter;
+import org.odk.collect.android.formmanagement.BlankFormsListViewModel;
+import org.odk.collect.android.injection.DaggerUtils;
+
+import javax.inject.Inject;
 
 public class DeleteSavedFormActivity extends CollectAbstractActivity {
+
+    @Inject
+    BlankFormsListViewModel.Factory viewModelFactory;
+    BlankFormsListViewModel viewModel;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        DaggerUtils.getComponent(this).inject(this);
+        viewModel = new ViewModelProvider(this, viewModelFactory).get(BlankFormsListViewModel.class);
 
         setContentView(R.layout.tabs_layout);
         initToolbar(getString(R.string.manage_files));
@@ -47,7 +59,7 @@ public class DeleteSavedFormActivity extends CollectAbstractActivity {
         String[] tabNames = {getString(R.string.data), getString(R.string.forms)};
         ViewPager2 viewPager = findViewById(R.id.viewPager);
         TabLayout tabLayout = findViewById(R.id.tabLayout);
-        viewPager.setAdapter(new FileManagerTabsAdapter(this));
+        viewPager.setAdapter(new DeleteFormsTabsAdapter(this, viewModel.isSyncingAvailable()));
         new TabLayoutMediator(tabLayout, viewPager, (tab, position) -> tab.setText(tabNames[position])).attach();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/DeleteFormsTabsAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/DeleteFormsTabsAdapter.java
@@ -5,12 +5,16 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
-import org.odk.collect.android.fragments.DataManagerList;
-import org.odk.collect.android.fragments.FormManagerList;
+import org.odk.collect.android.fragments.BlankFormListFragment;
+import org.odk.collect.android.fragments.SavedFormListFragment;
 
-public class FileManagerTabsAdapter extends FragmentStateAdapter {
-    public FileManagerTabsAdapter(FragmentActivity fa) {
+public class DeleteFormsTabsAdapter extends FragmentStateAdapter {
+
+    private final boolean matchExactlyEnabled;
+
+    public DeleteFormsTabsAdapter(FragmentActivity fa, boolean matchExactlyEnabled) {
         super(fa);
+        this.matchExactlyEnabled = matchExactlyEnabled;
     }
 
     @NonNull
@@ -18,9 +22,9 @@ public class FileManagerTabsAdapter extends FragmentStateAdapter {
     public Fragment createFragment(int position) {
         switch (position) {
             case 0:
-                return new DataManagerList();
+                return new SavedFormListFragment();
             case 1:
-                return new FormManagerList();
+                return new BlankFormListFragment();
             default:
                 // should never reach here
                 throw new IllegalArgumentException("Fragment position out of bounds");
@@ -29,6 +33,10 @@ public class FileManagerTabsAdapter extends FragmentStateAdapter {
 
     @Override
     public int getItemCount() {
-        return 2;
+        if (matchExactlyEnabled) {
+            return 1;
+        } else {
+            return 2;
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormListMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormListMenuDelegate.java
@@ -41,7 +41,7 @@ public class BlankFormListMenuDelegate implements MenuDelegate {
     public void onPrepareOptionsMenu(Menu menu) {
         MenuItem refreshItem = menu.findItem(R.id.menu_refresh);
 
-        refreshItem.setVisible(blankFormsListViewModel.isSyncingAvailable());
+        refreshItem.setVisible(blankFormsListViewModel.isMatchExactlyEnabled());
         refreshItem.setEnabled(!syncing);
 
         if (outOfSync) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -42,8 +42,9 @@ public class BlankFormsListViewModel extends ViewModel {
         this.changeLock = changeLock;
     }
 
-    public boolean isSyncingAvailable() {
-        return isMatchExactlyEnabled();
+    public boolean isMatchExactlyEnabled() {
+        FormUpdateMode formUpdateMode = FormUpdateMode.parse(application, preferencesProvider.getGeneralSharedPreferences().getString(GeneralKeys.KEY_FORM_UPDATE_MODE, null));
+        return formUpdateMode == FormUpdateMode.MATCH_EXACTLY;
     }
 
     public LiveData<Boolean> isSyncing() {
@@ -85,11 +86,6 @@ public class BlankFormsListViewModel extends ViewModel {
 
             return null;
         });
-    }
-
-    private boolean isMatchExactlyEnabled() {
-        FormUpdateMode formUpdateMode = FormUpdateMode.parse(application, preferencesProvider.getGeneralSharedPreferences().getString(GeneralKeys.KEY_FORM_UPDATE_MODE, null));
-        return formUpdateMode == FormUpdateMode.MATCH_EXACTLY;
     }
 
     public static class Factory implements ViewModelProvider.Factory {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
@@ -51,7 +51,7 @@ import timber.log.Timber;
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
-public class FormManagerList extends FormListFragment implements DiskSyncListener,
+public class BlankFormListFragment extends FormListFragment implements DiskSyncListener,
         DeleteFormsListener, View.OnClickListener {
     private static final String FORM_MANAGER_LIST_SORTING_ORDER = "formManagerListSortingOrder";
     private BackgroundTasks backgroundTasks; // handled across orientation changes

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
@@ -53,7 +53,7 @@ import timber.log.Timber;
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Yaw Anokwa (yanokwa@gmail.com)
  */
-public class DataManagerList extends InstanceListFragment
+public class SavedFormListFragment extends InstanceListFragment
         implements DeleteInstancesListener, DiskSyncListener, View.OnClickListener {
     private static final String DATA_MANAGER_LIST_SORTING_ORDER = "dataManagerListSortingOrder";
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.injection.config;
 import android.app.Application;
 
 import org.javarosa.core.reference.ReferenceManager;
+import org.odk.collect.android.activities.DeleteSavedFormActivity;
 import org.odk.collect.android.activities.FillBlankFormActivity;
 import org.odk.collect.android.activities.FormDownloadListActivity;
 import org.odk.collect.android.activities.FormEntryActivity;
@@ -31,8 +32,8 @@ import org.odk.collect.android.formentry.ODKView;
 import org.odk.collect.android.formentry.QuitFormDialogFragment;
 import org.odk.collect.android.formentry.saving.SaveFormProgressDialogFragment;
 import org.odk.collect.android.fragments.BarCodeScannerFragment;
-import org.odk.collect.android.fragments.DataManagerList;
-import org.odk.collect.android.fragments.FormManagerList;
+import org.odk.collect.android.fragments.BlankFormListFragment;
+import org.odk.collect.android.fragments.SavedFormListFragment;
 import org.odk.collect.android.fragments.MapBoxInitializationFragment;
 import org.odk.collect.android.geo.GoogleMapFragment;
 import org.odk.collect.android.geo.MapboxMapFragment;
@@ -107,7 +108,7 @@ public interface AppDependencyComponent {
 
     void inject(InstanceUploaderAdapter instanceUploaderAdapter);
 
-    void inject(DataManagerList dataManagerList);
+    void inject(SavedFormListFragment savedFormListFragment);
 
     void inject(PropertyManager propertyManager);
 
@@ -199,11 +200,13 @@ public interface AppDependencyComponent {
 
     void inject(ServerAuthDialogFragment serverAuthDialogFragment);
 
-    void inject(FormManagerList formManagerList);
+    void inject(BlankFormListFragment blankFormListFragment);
 
     void inject(InstanceUploaderActivity instanceUploaderActivity);
 
     void inject(GeneralPreferencesFragment generalPreferencesFragment);
+
+    void inject(DeleteSavedFormActivity deleteSavedFormActivity);
 
     OpenRosaHttpInterface openRosaHttpInterface();
 


### PR DESCRIPTION
The intention here is to remove the ability to delete blank forms when Match Exactly is enabled. This also closes #62 as we feel like blank forms can now be protected from deletion.

#### What has been done to verify that this works as intended?

New test and verified manually

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to check forms are still deletable in other circumstances and that this works as expected.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)