### PR TITLE
Fixed multiclicking on menu items in FormEntryActivity

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -19,6 +19,7 @@ import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.utilities.MenuDelegate;
+import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PlayServicesChecker;
 
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_BACKGROUND_LOCATION;
@@ -86,21 +87,23 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_add_repeat:
-                getFormSaveViewModel().saveAnswersForScreen(answersProvider.getAnswers());
-                getFormEntryViewModel().promptForNewRepeat();
-                formIndexAnimationHandler.handle(getFormEntryViewModel().getCurrentIndex());
-                return true;
+        if (MultiClickGuard.allowClick(getClass().getName())) {
+            switch (item.getItemId()) {
+                case R.id.menu_add_repeat:
+                    getFormSaveViewModel().saveAnswersForScreen(answersProvider.getAnswers());
+                    getFormEntryViewModel().promptForNewRepeat();
+                    formIndexAnimationHandler.handle(getFormEntryViewModel().getCurrentIndex());
+                    return true;
 
-            case R.id.menu_preferences:
-                Intent pref = new Intent(activity, PreferencesActivity.class);
-                activity.startActivity(pref);
-                return true;
+                case R.id.menu_preferences:
+                    Intent pref = new Intent(activity, PreferencesActivity.class);
+                    activity.startActivity(pref);
+                    return true;
 
-            case R.id.track_location:
-                getBackgroundLocationViewModel().backgroundLocationPreferenceToggled();
-                return true;
+                case R.id.track_location:
+                    getBackgroundLocationViewModel().backgroundLocationPreferenceToggled();
+                    return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
Closes #3998

#### What has been done to verify that this works as intended?
I tested the fix manually. I wanted to add an automated test but reproducing the issue is not easy because we need to click very quickly and tests seem to be too slow so I wasn't able to reproduce the issue with tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's the easiest solution that should be sufficient. I could also add a boolean property which would block the button after first clicking on it and unblock once "Add new repeat" dialog disappears but it would require more changes and make the code more complicated so think my solution is ok.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe change that should just fix the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with repeats.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)