### PR TITLE
Make sure database connections are cleaned up after test

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/forms/DatabaseFormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/DatabaseFormsRepositoryTest.java
@@ -2,8 +2,10 @@ package org.odk.collect.android.forms;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.provider.FormsProvider;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -19,6 +21,11 @@ public class DatabaseFormsRepositoryTest extends FormsRepositoryTest {
         RobolectricHelpers.mountExternalStorage();
         storagePathProvider = new StoragePathProvider();
         new StorageInitializer().createOdkDirsOnStorage();
+    }
+
+    @After
+    public void teardown() {
+        FormsProvider.releaseDatabaseHelper();
     }
 
     @Override


### PR DESCRIPTION
This prevents us from running into problems where Robolectric explodes when opening a new database connection during tests.