### PR TITLE
Remove Answer Text View in Url Widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -73,6 +73,12 @@ public class AnalyticsEvents {
     public static final String AUDIO_QUESTION = "Prompt";
 
     /**
+     * Track form definitions with url widget. The action should be the widget name and
+     * the label should be a hash of the form definition.
+     */
+    public static final String URL_WIDGET = "Prompt";
+
+    /**
      * Track scoped storage migration attempts. The action should be the result of the attempt.
      */
     public static final String SCOPED_STORAGE_MIGRATION = "ScopedStorageMigration";

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -67,16 +67,10 @@ public class AnalyticsEvents {
     public static final String SAVE_INCOMPLETE = "WidgetAttribute";
 
     /**
-     * Track displays of audio question types. The action should be the type of audio question and
+     * Track displays of widget/question types. The action should be the type of widget and
      * the label should be a hash of the form definition.
      */
-    public static final String AUDIO_QUESTION = "Prompt";
-
-    /**
-     * Track form definitions with url widget. The action should be the widget name and
-     * the label should be a hash of the form definition.
-     */
-    public static final String URL_WIDGET = "Prompt";
+    public static final String PROMPT = "Prompt";
 
     /**
      * Track scoped storage migration attempts. The action should be the result of the attempt.

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -263,8 +263,8 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
      * Note: if the given question is of an unsupported type, a text widget will be created.
      */
     private QuestionWidget configureWidgetForQuestion(FormEntryPrompt question, boolean readOnlyOverride) {
-        QuestionWidget qw = WidgetFactory.createWidgetFromPrompt(question, getContext(),
-                readOnlyOverride, questionMediaManager, waitingForDataRegistry);
+        QuestionWidget qw = WidgetFactory.createWidgetFromPrompt(question, getContext(), readOnlyOverride,
+                waitingForDataRegistry, questionMediaManager, analytics);
         qw.setOnLongClickListener(this);
         qw.setValueChangedListener(this);
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/media/PromptAutoplayer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/media/PromptAutoplayer.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static org.odk.collect.android.analytics.AnalyticsEvents.AUDIO_QUESTION;
+import static org.odk.collect.android.analytics.AnalyticsEvents.PROMPT;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getClipID;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayableAudioURI;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.NO_BUTTONS;
@@ -44,13 +44,13 @@ public class PromptAutoplayer {
             Clip promptClip = getPromptClip(prompt);
             if (promptClip != null) {
                 clipsToPlay.add(promptClip);
-                analytics.logEvent(AUDIO_QUESTION, "AutoplayAudioLabel", formIdentifierHash);
+                analytics.logEvent(PROMPT, "AutoplayAudioLabel", formIdentifierHash);
             }
 
             List<Clip> selectClips = getSelectClips(prompt);
             if (!selectClips.isEmpty()) {
                 clipsToPlay.addAll(selectClips);
-                analytics.logEvent(AUDIO_QUESTION, "AutoplayAudioChoice", formIdentifierHash);
+                analytics.logEvent(PROMPT, "AutoplayAudioChoice", formIdentifierHash);
             }
 
             if (clipsToPlay.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -69,7 +69,7 @@ import javax.inject.Inject;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.analytics.AnalyticsEvents.AUDIO_QUESTION;
+import static org.odk.collect.android.analytics.AnalyticsEvents.PROMPT;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getClipID;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayColor;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayableAudioURI;
@@ -191,7 +191,7 @@ public abstract class QuestionWidget
             }
             if (playableAudioURI != null) {
                 label.setAudio(playableAudioURI, audioHelper);
-                analytics.logEvent(AUDIO_QUESTION, "AudioLabel", questionDetails.getFormAnalyticsID());
+                analytics.logEvent(PROMPT, "AudioLabel", questionDetails.getFormAnalyticsID());
             }
         } catch (InvalidReferenceException e) {
             Timber.d(e, "Invalid media reference due to %s ", e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -43,13 +43,8 @@ public class UrlWidget extends QuestionWidget {
     @Override
     protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
         binding = UrlWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
-
-        if (prompt.isReadOnly()) {
-            binding.urlButton.setVisibility(GONE);
-        } else {
-            binding.urlButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
-            binding.urlButton.setOnClickListener(v -> onButtonClick());
-        }
+        binding.urlButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+        binding.urlButton.setOnClickListener(v -> onButtonClick());
 
         return binding.getRoot();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.net.Uri;
 import android.util.TypedValue;
 import android.view.View;
-import android.widget.TextView;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -51,8 +50,6 @@ public class UrlWidget extends QuestionWidget {
             binding.urlButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.urlButton.setOnClickListener(v -> onButtonClick());
         }
-        binding.urlAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
-        binding.urlAnswerText.setText(prompt.getAnswerText());
 
         return binding.getRoot();
     }
@@ -64,10 +61,9 @@ public class UrlWidget extends QuestionWidget {
 
     @Override
     public IAnswerData getAnswer() {
-        String answerText = binding.urlAnswerText.getText().toString();
-        return !answerText.isEmpty()
-                ? new StringData(answerText)
-                : null;
+        return getFormEntryPrompt().getAnswerValue() == null
+                ? null
+                : new StringData(getFormEntryPrompt().getAnswerText());
     }
 
     @Override
@@ -79,7 +75,6 @@ public class UrlWidget extends QuestionWidget {
     public void cancelLongPress() {
         super.cancelLongPress();
         binding.urlButton.cancelLongPress();
-        binding.urlAnswerText.cancelLongPress();
     }
 
     @Override
@@ -91,20 +86,11 @@ public class UrlWidget extends QuestionWidget {
     }
 
     public void onButtonClick() {
-        if (!isUrlEmpty(binding.urlAnswerText)) {
+        if (getFormEntryPrompt().getAnswerValue() != null) {
             customTabHelper.bindCustomTabsService(getContext(), null);
-            customTabHelper.openUri(getContext(), getUri());
+            customTabHelper.openUri(getContext(), Uri.parse(getFormEntryPrompt().getAnswerText()));
         } else {
             ToastUtils.showShortToast("No URL set");
         }
-    }
-
-    private boolean isUrlEmpty(TextView stringAnswer) {
-        return stringAnswer == null || stringAnswer.getText() == null
-                || stringAnswer.getText().toString().isEmpty();
-    }
-
-    private Uri getUri() {
-        return Uri.parse(binding.urlAnswerText.getText().toString());
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -19,6 +19,7 @@ import android.hardware.SensorManager;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.CameraUtils;
@@ -39,6 +40,7 @@ import org.odk.collect.android.widgets.items.SelectOneMinimalWidget;
 import org.odk.collect.android.widgets.items.SelectOneWidget;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
+import static org.odk.collect.android.analytics.AnalyticsEvents.URL_WIDGET;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.MAPS;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.PLACEMENT_MAP;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.hasAppearance;
@@ -62,7 +64,7 @@ public class WidgetFactory {
      * @param readOnlyOverride a flag to be ORed with JR readonly attribute.
      */
     public static QuestionWidget createWidgetFromPrompt(FormEntryPrompt prompt, Context context, boolean readOnlyOverride,
-                                                        QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
+                                                        WaitingForDataRegistry waitingForDataRegistry, QuestionMediaManager questionMediaManager, Analytics analytics) {
 
         String appearance = WidgetAppearanceUtils.getSanitizedAppearanceHint(prompt);
         QuestionDetails questionDetails = new QuestionDetails(prompt, Collect.getCurrentFormIdentifierHash());
@@ -125,6 +127,8 @@ public class WidgetFactory {
                             questionWidget = new StringNumberWidget(context, questionDetails, readOnlyOverride);
                         } else if (appearance.equals(WidgetAppearanceUtils.URL)) {
                             questionWidget = new UrlWidget(context, questionDetails, new CustomTabHelper());
+
+                            analytics.logEvent(URL_WIDGET, "UrlWidget", questionDetails.getFormAnalyticsID());
                         } else {
                             questionWidget = new StringWidget(context, questionDetails, readOnlyOverride);
                         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -40,7 +40,7 @@ import org.odk.collect.android.widgets.items.SelectOneMinimalWidget;
 import org.odk.collect.android.widgets.items.SelectOneWidget;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
-import static org.odk.collect.android.analytics.AnalyticsEvents.URL_WIDGET;
+import static org.odk.collect.android.analytics.AnalyticsEvents.PROMPT;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.MAPS;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.PLACEMENT_MAP;
 import static org.odk.collect.android.utilities.WidgetAppearanceUtils.hasAppearance;
@@ -128,7 +128,7 @@ public class WidgetFactory {
                         } else if (appearance.equals(WidgetAppearanceUtils.URL)) {
                             questionWidget = new UrlWidget(context, questionDetails, new CustomTabHelper());
 
-                            analytics.logEvent(URL_WIDGET, "UrlWidget", questionDetails.getFormAnalyticsID());
+                            analytics.logEvent(PROMPT, "Url", questionDetails.getFormAnalyticsID());
                         } else {
                             questionWidget = new StringWidget(context, questionDetails, readOnlyOverride);
                         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/BaseSelectListWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/BaseSelectListWidget.java
@@ -18,7 +18,7 @@ import org.odk.collect.android.utilities.SoftKeyboardUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
 
-import static org.odk.collect.android.analytics.AnalyticsEvents.AUDIO_QUESTION;
+import static org.odk.collect.android.analytics.AnalyticsEvents.PROMPT;
 import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayableAudioURI;
 
 public abstract class BaseSelectListWidget extends ItemsWidget implements MultiChoiceWidget, SelectItemClickListener {
@@ -108,7 +108,7 @@ public abstract class BaseSelectListWidget extends ItemsWidget implements MultiC
                 String audioURI = getPlayableAudioURI(questionDetails.getPrompt(), choice, getReferenceManager());
 
                 if (audioURI != null) {
-                    analytics.logEvent(AUDIO_QUESTION, "AudioChoice", questionDetails.getFormAnalyticsID());
+                    analytics.logEvent(PROMPT, "AudioChoice", questionDetails.getFormAnalyticsID());
                     break;
                 }
             }

--- a/collect_app/src/main/res/layout/url_widget_answer.xml
+++ b/collect_app/src/main/res/layout/url_widget_answer.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -8,9 +9,5 @@
         android:id="@+id/url_button"
         style="@style/Widget.Collect.Button.WidgetAnswer"
         android:text="@string/open_url" />
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/url_answer_text"
-        style="@style/Widget.Collect.TextView.WidgetAnswer" />
 
 </LinearLayout>

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/UrlWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/UrlWidgetTest.java
@@ -1,7 +1,6 @@
 package org.odk.collect.android.widgets;
 
 import android.net.Uri;
-import android.view.View;
 import android.view.View.OnLongClickListener;
 
 import androidx.browser.customtabs.CustomTabsServiceConnection;
@@ -26,7 +25,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAnswer;
-import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnly;
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
 
 /**
@@ -55,12 +53,6 @@ public class UrlWidgetTest {
     public void getAnswer_whenPromptHasAnswer_returnsAnswer() {
         UrlWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
         assertThat(widget.getAnswer().getDisplayText(), equalTo("blah"));
-    }
-
-    @Test
-    public void usingReadOnlyOption_doesNotShowUrlButton() {
-        UrlWidget widget = createWidget(promptWithReadOnly());
-        assertThat(widget.binding.urlButton.getVisibility(), equalTo(View.GONE));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/UrlWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/UrlWidgetTest.java
@@ -15,6 +15,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.support.TestScreenContextActivity;
 import org.odk.collect.android.utilities.CustomTabHelper;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowToast;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -57,7 +58,7 @@ public class UrlWidgetTest {
     }
 
     @Test
-    public void usingReadOnlyOption_makeAllClickableElementsDisabled() {
+    public void usingReadOnlyOption_doesNotShowUrlButton() {
         UrlWidget widget = createWidget(promptWithReadOnly());
         assertThat(widget.binding.urlButton.getVisibility(), equalTo(View.GONE));
     }
@@ -70,19 +71,14 @@ public class UrlWidgetTest {
     }
 
     @Test
-    public void whenPromptHasAnswer_displaysAnswer() {
+    public void clearAnswer_showsToastThatTheUrlIsReadOnly() {
         UrlWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
-        assertThat(widget.binding.urlAnswerText.getText().toString(), equalTo("blah"));
+        widget.clearAnswer();
+        assertThat(ShadowToast.getTextOfLatestToast(), equalTo("URL is readonly"));
     }
 
     @Test
-    public void whenPromptAnswerDoesNotHaveAnswer_displayEmptyString() {
-        UrlWidget widget = createWidget(promptWithAnswer(null));
-        assertThat(widget.binding.urlAnswerText.getText().toString(), equalTo(""));
-    }
-
-    @Test
-    public void clickingButtonWhenUrlIsEmpty_doesNotCallOpenUri() {
+    public void clickingButton_whenUrlIsEmpty_doesNotOpensUri() {
         UrlWidget widget = createWidget(promptWithAnswer(null));
         widget.binding.urlButton.performClick();
 
@@ -91,7 +87,17 @@ public class UrlWidgetTest {
     }
 
     @Test
-    public void clickingButtonWhenUrlIsNotEmpty_callsOpenUri() {
+    public void clickingButton_whenUrlIsEmpty_showsToastMessage() {
+        UrlWidget widget = createWidget(promptWithAnswer(null));
+        widget.binding.urlButton.performClick();
+
+        verify(customTabHelper, never()).bindCustomTabsService(null, null);
+        verify(customTabHelper, never()).openUri(null, null);
+        assertThat(ShadowToast.getTextOfLatestToast(), equalTo("No URL set"));
+    }
+
+    @Test
+    public void clickingButton_whenUrlIsNotEmpty_opensUriAndBindsCustomTabService() {
         UrlWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
         widget.binding.urlButton.performClick();
 


### PR DESCRIPTION
This PR updates the UI of the URL widget. As discussed in ODK forum [here](https://forum.getodk.org/t/use-materialcardview-to-update-the-ui-of-url-widget/27500/6), the answer text view is removed and user simply sees the button to open the url in the widget. 

As discussed with @seadowg, this PR does not change the button text for the moment, so `Open Url` button is shown. As the user is not allowed to change the url, the widget is `readonly` all times, so I am removing any specific behavior concerning the `readonly` widget in this PR.

![WhatsApp Image 2020-08-12 at 03 13 53](https://user-images.githubusercontent.com/35730054/89952154-57fb5080-dc4a-11ea-85c9-377859c648c9.jpeg)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I changed the value fo the string resource `open_url` to `Visit Website`, and that change is not migrated to all the other languages of Collect, so this change won't appear good in when the user views the form in a language other than English. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form having URL Widget like AllWidgetsForm.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)