### PR TITLE
Make sure soft-deleted form can be re-downloaded

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -24,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
-import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.ResetStateRule;
@@ -54,7 +54,7 @@ public class EncryptedFormTest {
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed(R.string.data_saved_ok)
                 .clickEditSavedForm()
-                .checkInstanceState("encrypted", InstanceProviderAPI.STATUS_COMPLETE)
+                .checkInstanceState("encrypted", Instance.STATUS_COMPLETE)
                 .clickOnFormWithDialog("encrypted")
                 .assertText(R.string.cannot_edit_completed_form);
     }
@@ -68,6 +68,6 @@ public class EncryptedFormTest {
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed("This form does not specify an instanceID. You must specify one to enable encryption. Form has not been saved as finalized.")
                 .clickEditSavedForm()
-                .checkInstanceState("encrypted-no-instanceID", InstanceProviderAPI.STATUS_INCOMPLETE);
+                .checkInstanceState("encrypted-no-instanceID", Instance.STATUS_INCOMPLETE);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/dao/InstancesDaoTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/dao/InstancesDaoTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.instances.Instance;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -158,7 +157,7 @@ public class InstancesDaoTest {
                 .displayName("Biggest N of Set")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/Biggest N of Set_2017-02-20_14-24-46/Biggest N of Set_2017-02-20_14-24-46.xml")
                 .jrFormId("N_Biggest")
-                .status(InstanceProviderAPI.STATUS_SUBMITTED)
+                .status(Instance.STATUS_SUBMITTED)
                 .lastStatusChangeDate(1487597090653L)
                 .build();
 
@@ -180,7 +179,7 @@ public class InstancesDaoTest {
                 .jrFormId("fake")
                 .displayName("Form with geopoint")
                 .instanceFilePath("/my/fake/path")
-                .status(InstanceProviderAPI.STATUS_SUBMITTED)
+                .status(Instance.STATUS_SUBMITTED)
                 .lastStatusChangeDate(1487595836793L)
                 .geometryType("Point")
                 .geometry("{\"type\":\"Point\",\"coordinates\":[127.6, 11.1]}")
@@ -201,7 +200,7 @@ public class InstancesDaoTest {
                 .displayName("Hypertension Screening")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/Hypertension Screening_2017-02-20_14-03-53/Hypertension Screening_2017-02-20_14-03-53.xml")
                 .jrFormId("hypertension")
-                .status(InstanceProviderAPI.STATUS_INCOMPLETE)
+                .status(Instance.STATUS_INCOMPLETE)
                 .lastStatusChangeDate(1487595836793L)
                 .build();
         instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(hypertensionScreeningInstance));
@@ -210,7 +209,7 @@ public class InstancesDaoTest {
                 .displayName("Cascading Select Form")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/Cascading Select Form_2017-02-20_14-06-44/Cascading Select Form_2017-02-20_14-06-44.xml")
                 .jrFormId("CascadingSelect")
-                .status(InstanceProviderAPI.STATUS_INCOMPLETE)
+                .status(Instance.STATUS_INCOMPLETE)
                 .lastStatusChangeDate(1487596015000L)
                 .build();
         instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(cascadingSelectInstance));
@@ -219,7 +218,7 @@ public class InstancesDaoTest {
                 .displayName("Biggest N of Set")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/Biggest N of Set_2017-02-20_14-06-51/Biggest N of Set_2017-02-20_14-06-51.xml")
                 .jrFormId("N_Biggest")
-                .status(InstanceProviderAPI.STATUS_SUBMITTED)
+                .status(Instance.STATUS_SUBMITTED)
                 .lastStatusChangeDate(1487596015100L)
                 .build();
         instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(biggestNOfSetInstance));
@@ -228,7 +227,7 @@ public class InstancesDaoTest {
                 .displayName("Widgets")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/Widgets_2017-02-20_14-06-58/Widgets_2017-02-20_14-06-58.xml")
                 .jrFormId("widgets")
-                .status(InstanceProviderAPI.STATUS_SUBMITTED)
+                .status(Instance.STATUS_SUBMITTED)
                 .lastStatusChangeDate(1487596020803L)
                 .deletedDate(1487596020803L)
                 .build();
@@ -238,7 +237,7 @@ public class InstancesDaoTest {
                 .displayName("sample")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/sample_2017-02-20_14-07-03/sample_2017-02-20_14-07-03.xml")
                 .jrFormId("sample")
-                .status(InstanceProviderAPI.STATUS_INCOMPLETE)
+                .status(Instance.STATUS_INCOMPLETE)
                 .lastStatusChangeDate(1487596026373L)
                 .build();
         instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(sampleInstance));
@@ -247,7 +246,7 @@ public class InstancesDaoTest {
                 .displayName("Biggest N of Set")
                 .instanceFilePath(storagePathProvider.getDirPath(StorageSubdirectory.INSTANCES) + "/Biggest N of Set_2017-02-20_14-24-46/Biggest N of Set_2017-02-20_14-24-46.xml")
                 .jrFormId("N_Biggest")
-                .status(InstanceProviderAPI.STATUS_COMPLETE)
+                .status(Instance.STATUS_COMPLETE)
                 .lastStatusChangeDate(1487597090653L)
                 .build();
         instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(biggestNOfSet2Instance));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/tasks/InstanceServerUploaderTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/tasks/InstanceServerUploaderTaskTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.openrosa.OpenRosaConstants;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.tasks.InstanceServerUploaderTask;
 import org.odk.collect.android.tasks.InstanceUploaderTask;
@@ -91,7 +90,7 @@ public class InstanceServerUploaderTaskTest extends MockedServerTest {
                 .displayName("Test Form")
                 .instanceFilePath(xml.getAbsolutePath())
                 .jrFormId("test_form")
-                .status(InstanceProviderAPI.STATUS_COMPLETE)
+                .status(Instance.STATUS_COMPLETE)
                 .lastStatusChangeDate(123L)
                 .build();
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/InstanceUploaderUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/InstanceUploaderUtilsTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.instances.Instance;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
@@ -59,7 +58,7 @@ public class InstanceUploaderUtilsTest {
                     .displayName("InstanceTest")
                     .instanceFilePath(new StoragePathProvider().getDirPath(StorageSubdirectory.INSTANCES) + "/InstanceTest_" + time + "/InstanceTest_" + time + ".xml")
                     .jrFormId("instanceTest")
-                    .status(InstanceProviderAPI.STATUS_COMPLETE)
+                    .status(Instance.STATUS_COMPLETE)
                     .lastStatusChangeDate(time)
                     .build();
             instancesDao.saveInstance(instancesDao.getValuesFromInstanceObject(instance));

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -13,7 +13,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
-import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.support.ActivityHelpers;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.CopyFormRule;
@@ -553,7 +553,7 @@ public class FillBlankFormTest {
                 .clickSaveAndExit()
                 .checkIsToastWithMessageDisplayed("This form does not specify an instanceID. You must specify one to enable encryption. Form has not been saved as finalized.")
                 .clickEditSavedForm()
-                .checkInstanceState("Birds", InstanceProviderAPI.STATUS_INCOMPLETE);
+                .checkInstanceState("Birds", Instance.STATUS_INCOMPLETE);
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -14,10 +14,12 @@ import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.runner.lifecycle.Stage;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.support.FormLoadingUtils;
 import org.odk.collect.android.support.actions.RotateAction;
 import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
 import org.odk.collect.android.support.matchers.ToastMatcher;
 
+import java.io.IOException;
 import java.util.concurrent.Callable;
 
 import timber.log.Timber;
@@ -388,6 +390,16 @@ abstract class Page<T extends Page<T>> {
 
     protected void assertToolbarTitle(int title) {
         assertToolbarTitle(getTranslatedString(title));
+    }
+
+    public T copyForm(String formFilename) {
+        try {
+            FormLoadingUtils.copyFormToStorage(formFilename);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return (T) this;
     }
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -17,7 +17,6 @@ package org.odk.collect.android.activities;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -498,10 +497,8 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
             return true;
         }
 
-        try (Cursor formCursor = formsDao.getFormsCursorForFormId(formId)) {
-            return formCursor != null && formCursor.getCount() == 0 // form does not already exist locally
-                    || viewModel.getFormDetailsByFormId().get(formId).isUpdated(); // or a newer version of this form is available
-        }
+        ServerFormDetails form = viewModel.getFormDetailsByFormId().get(formId);
+        return form.isNotOnDevice() || form.isUpdated();
     }
 
     /**
@@ -510,7 +507,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
      * convenience to users to download the latest version of those forms from the server.
      */
     private void selectSupersededForms() {
-
         ListView ls = listView;
         for (int idx = 0; idx < filteredFormList.size(); idx++) {
             HashMap<String, String> item = filteredFormList.get(idx);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.java
@@ -43,6 +43,7 @@ import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.geo.MapProvider;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.database.DatabaseInstancesRepository;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
@@ -308,13 +309,13 @@ public class FormMapActivity extends BaseGeoMapActivity {
 
     private static int getDrawableIdForStatus(String status, boolean enlarged) {
         switch (status) {
-            case InstanceProviderAPI.STATUS_INCOMPLETE:
+            case Instance.STATUS_INCOMPLETE:
                 return enlarged ? R.drawable.ic_room_blue_48dp : R.drawable.ic_room_blue_24dp;
-            case InstanceProviderAPI.STATUS_COMPLETE:
+            case Instance.STATUS_COMPLETE:
                 return enlarged ? R.drawable.ic_room_deep_purple_48dp : R.drawable.ic_room_deep_purple_24dp;
-            case InstanceProviderAPI.STATUS_SUBMITTED:
+            case Instance.STATUS_SUBMITTED:
                 return enlarged ? R.drawable.ic_room_green_48dp : R.drawable.ic_room_green_24dp;
-            case InstanceProviderAPI.STATUS_SUBMISSION_FAILED:
+            case Instance.STATUS_SUBMISSION_FAILED:
                 return enlarged ? R.drawable.ic_room_red_48dp : R.drawable.ic_room_red_24dp;
         }
         return R.drawable.ic_map_point;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -33,9 +33,9 @@ import android.widget.Toast;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.dao.InstancesDao;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.listeners.DiskSyncListener;
 import org.odk.collect.android.listeners.PermissionListener;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.tasks.InstanceSyncTask;
@@ -143,7 +143,7 @@ public class InstanceChooserList extends InstanceListActivity implements
                     String strCanEditWhenComplete =
                             c.getString(c.getColumnIndex(InstanceColumns.CAN_EDIT_WHEN_COMPLETE));
 
-                    boolean canEdit = status.equals(InstanceProviderAPI.STATUS_INCOMPLETE)
+                    boolean canEdit = status.equals(Instance.STATUS_INCOMPLETE)
                             || Boolean.parseBoolean(strCanEditWhenComplete);
                     if (!canEdit) {
                         createErrorDialog(getString(R.string.cannot_edit_completed_form),

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -8,7 +8,6 @@ import org.json.JSONObject;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -117,13 +116,13 @@ public class FormMapViewModel extends ViewModel {
                 return ClickAction.DELETED_TOAST;
             }
 
-            if ((instance.getStatus().equals(InstanceProviderAPI.STATUS_COMPLETE)
-                    || instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED)
-                    || instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMISSION_FAILED))
+            if ((instance.getStatus().equals(Instance.STATUS_COMPLETE)
+                    || instance.getStatus().equals(Instance.STATUS_SUBMITTED)
+                    || instance.getStatus().equals(Instance.STATUS_SUBMISSION_FAILED))
                     && !instance.canEditWhenComplete()) {
                 return ClickAction.NOT_VIEWABLE_TOAST;
             } else if (instance.getId() != null) {
-                if (instance.getStatus().equals(InstanceProviderAPI.STATUS_SUBMITTED)) {
+                if (instance.getStatus().equals(Instance.STATUS_SUBMITTED)) {
                     return ClickAction.OPEN_READ_ONLY;
                 }
                 return ClickAction.OPEN_EDIT;

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceListCursorAdapter.java
@@ -26,9 +26,9 @@ import android.widget.TextView;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.dao.FormsDao;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
 import org.odk.collect.android.provider.InstanceProvider;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 
 import java.text.SimpleDateFormat;
@@ -157,13 +157,13 @@ public class InstanceListCursorAdapter extends SimpleCursorAdapter {
 
     public static int getFormStateImageResourceIdForStatus(String formStatus) {
         switch (formStatus) {
-            case InstanceProviderAPI.STATUS_INCOMPLETE:
+            case Instance.STATUS_INCOMPLETE:
                 return R.drawable.form_state_saved_circle;
-            case InstanceProviderAPI.STATUS_COMPLETE:
+            case Instance.STATUS_COMPLETE:
                 return R.drawable.form_state_finalized_circle;
-            case InstanceProviderAPI.STATUS_SUBMITTED:
+            case Instance.STATUS_SUBMITTED:
                 return R.drawable.form_state_submitted_circle;
-            case InstanceProviderAPI.STATUS_SUBMISSION_FAILED:
+            case Instance.STATUS_SUBMISSION_FAILED:
                 return R.drawable.form_state_submission_failed_circle;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/InstanceUploaderAdapter.java
@@ -22,8 +22,8 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.disposables.CompositeDisposable;
 
-import static org.odk.collect.android.provider.InstanceProviderAPI.STATUS_SUBMISSION_FAILED;
-import static org.odk.collect.android.provider.InstanceProviderAPI.STATUS_SUBMITTED;
+import static org.odk.collect.android.instances.Instance.STATUS_SUBMISSION_FAILED;
+import static org.odk.collect.android.instances.Instance.STATUS_SUBMITTED;
 
 public class InstanceUploaderAdapter extends CursorAdapter {
     private final CompositeDisposable compositeDisposable;

--- a/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/FormsDao.java
@@ -239,6 +239,7 @@ public class FormsDao {
                     int autoSendColumnIndex = cursor.getColumnIndex(FormsColumns.AUTO_SEND);
                     int autoDeleteColumnIndex = cursor.getColumnIndex(FormsColumns.AUTO_DELETE);
                     int geometryXpathColumnIndex = cursor.getColumnIndex(FormsColumns.GEOMETRY_XPATH);
+                    int deletedColumnIndex = cursor.getColumnIndex(FormsColumns.DELETED);
 
                     Form form = new Form.Builder()
                             .id(cursor.getLong(idColumnIndex))
@@ -257,6 +258,7 @@ public class FormsDao {
                             .autoSend(cursor.getString(autoSendColumnIndex))
                             .autoDelete(cursor.getString(autoDeleteColumnIndex))
                             .geometryXpath(cursor.getString(geometryXpathColumnIndex))
+                            .deleted(cursor.getInt(deletedColumnIndex) != 0)
                             .build();
 
                     forms.add(form);

--- a/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/InstancesDao.java
@@ -24,7 +24,6 @@ import androidx.loader.content.CursorLoader;
 
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.instances.Instance;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
@@ -40,7 +39,7 @@ public class InstancesDao {
 
     public Cursor getSentInstancesCursor() {
         String selection = InstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_SUBMITTED};
+        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
         String sortOrder = InstanceColumns.DISPLAY_NAME + " ASC";
 
         return getInstancesCursor(null, selection, selectionArgs, sortOrder);
@@ -55,7 +54,7 @@ public class InstancesDao {
                     InstanceColumns.STATUS + " =? and "
                             + InstanceColumns.DISPLAY_NAME + " LIKE ?";
             String[] selectionArgs = {
-                    InstanceProviderAPI.STATUS_SUBMITTED,
+                    Instance.STATUS_SUBMITTED,
                     "%" + charSequence + "%"};
 
             cursorLoader = getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
@@ -66,14 +65,14 @@ public class InstancesDao {
 
     public CursorLoader getSentInstancesCursorLoader(String sortOrder) {
         String selection = InstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_SUBMITTED};
+        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
 
         return getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
     }
 
     public Cursor getUnsentInstancesCursor() {
         String selection = InstanceColumns.STATUS + " !=? ";
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_SUBMITTED};
+        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
         String sortOrder = InstanceColumns.STATUS + " DESC, " + InstanceColumns.DISPLAY_NAME + " ASC";
 
         return getInstancesCursor(null, selection, selectionArgs, sortOrder);
@@ -81,7 +80,7 @@ public class InstancesDao {
 
     public CursorLoader getUnsentInstancesCursorLoader(String sortOrder) {
         String selection = InstanceColumns.STATUS + " !=? ";
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_SUBMITTED};
+        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
 
         return getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
     }
@@ -95,7 +94,7 @@ public class InstancesDao {
                     InstanceColumns.STATUS + " !=? and "
                             + InstanceColumns.DISPLAY_NAME + " LIKE ?";
             String[] selectionArgs = {
-                    InstanceProviderAPI.STATUS_SUBMITTED,
+                    Instance.STATUS_SUBMITTED,
                     "%" + charSequence + "%"};
 
             cursorLoader = getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
@@ -133,7 +132,7 @@ public class InstancesDao {
 
     public Cursor getFinalizedInstancesCursor() {
         String selection = InstanceColumns.STATUS + "=? or " + InstanceColumns.STATUS + "=?";
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_COMPLETE, InstanceProviderAPI.STATUS_SUBMISSION_FAILED};
+        String[] selectionArgs = {Instance.STATUS_COMPLETE, Instance.STATUS_SUBMISSION_FAILED};
         String sortOrder = InstanceColumns.DISPLAY_NAME + " ASC";
 
         return getInstancesCursor(null, selection, selectionArgs, sortOrder);
@@ -141,7 +140,7 @@ public class InstancesDao {
 
     public CursorLoader getFinalizedInstancesCursorLoader(String sortOrder) {
         String selection = InstanceColumns.STATUS + "=? or " + InstanceColumns.STATUS + "=?";
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_COMPLETE, InstanceProviderAPI.STATUS_SUBMISSION_FAILED};
+        String[] selectionArgs = {Instance.STATUS_COMPLETE, Instance.STATUS_SUBMISSION_FAILED};
 
         return getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
     }
@@ -156,8 +155,8 @@ public class InstancesDao {
                             + InstanceColumns.STATUS + "=?) and "
                             + InstanceColumns.DISPLAY_NAME + " LIKE ?";
             String[] selectionArgs = {
-                    InstanceProviderAPI.STATUS_COMPLETE,
-                    InstanceProviderAPI.STATUS_SUBMISSION_FAILED,
+                    Instance.STATUS_COMPLETE,
+                    Instance.STATUS_SUBMISSION_FAILED,
                     "%" + charSequence + "%"};
 
             cursorLoader = getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
@@ -179,9 +178,9 @@ public class InstancesDao {
                 + InstanceColumns.STATUS + "=? or "
                 + InstanceColumns.STATUS + "=?)";
 
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_COMPLETE,
-                InstanceProviderAPI.STATUS_SUBMISSION_FAILED,
-                InstanceProviderAPI.STATUS_SUBMITTED};
+        String[] selectionArgs = {Instance.STATUS_COMPLETE,
+                Instance.STATUS_SUBMISSION_FAILED,
+                Instance.STATUS_SUBMITTED};
         String sortOrder = InstanceColumns.DISPLAY_NAME + " ASC";
 
         return getInstancesCursor(null, selection, selectionArgs, sortOrder);
@@ -193,9 +192,9 @@ public class InstancesDao {
                 + InstanceColumns.STATUS + "=? or "
                 + InstanceColumns.STATUS + "=?)";
 
-        String[] selectionArgs = {InstanceProviderAPI.STATUS_COMPLETE,
-                InstanceProviderAPI.STATUS_SUBMISSION_FAILED,
-                InstanceProviderAPI.STATUS_SUBMITTED};
+        String[] selectionArgs = {Instance.STATUS_COMPLETE,
+                Instance.STATUS_SUBMISSION_FAILED,
+                Instance.STATUS_SUBMITTED};
 
         return getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);
     }
@@ -212,9 +211,9 @@ public class InstancesDao {
                     + InstanceColumns.DISPLAY_NAME + " LIKE ?";
 
             String[] selectionArgs = {
-                    InstanceProviderAPI.STATUS_COMPLETE,
-                    InstanceProviderAPI.STATUS_SUBMISSION_FAILED,
-                    InstanceProviderAPI.STATUS_SUBMITTED,
+                    Instance.STATUS_COMPLETE,
+                    Instance.STATUS_SUBMISSION_FAILED,
+                    Instance.STATUS_SUBMITTED,
                     "%" + charSequence + "%"};
 
             cursorLoader = getInstancesCursorLoader(null, selection, selectionArgs, sortOrder);

--- a/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/helpers/InstancesDaoHelper.java
@@ -23,7 +23,6 @@ import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 
 import timber.log.Timber;
@@ -67,7 +66,7 @@ public final class InstancesDaoHelper {
                     c.moveToFirst();
                     int columnIndex = c.getColumnIndex(InstanceColumns.STATUS);
                     String status = c.getString(columnIndex);
-                    if (InstanceProviderAPI.STATUS_COMPLETE.equals(status)) {
+                    if (Instance.STATUS_COMPLETE.equals(status)) {
                         complete = true;
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
@@ -24,10 +24,8 @@ import static org.odk.collect.android.provider.FormsProviderAPI.FormsColumns.JR_
 public class DatabaseFormsRepository implements FormsRepository {
 
     @Override
-    public boolean contains(String jrFormId) {
-        try (Cursor cursor = new FormsDao().getFormsCursorForFormId(jrFormId)) {
-            return cursor != null && cursor.getCount() > 0;
-        }
+    public List<Form> getByJrFormIdNotDeleted(String jrFormId) {
+        return queryForForms(JR_FORM_ID + "=? AND " + DELETED + "=0", new String[]{jrFormId});
     }
 
     @Override
@@ -82,6 +80,7 @@ public class DatabaseFormsRepository implements FormsRepository {
         v.put(FormsProviderAPI.FormsColumns.AUTO_DELETE, form.getAutoDelete());
         v.put(FormsProviderAPI.FormsColumns.AUTO_SEND, form.getAutoSend());
         v.put(FormsProviderAPI.FormsColumns.GEOMETRY_XPATH, form.getGeometryXpath());
+        v.put(FormsProviderAPI.FormsColumns.DELETED, form.isDeleted());
         return new FormsDao().saveForm(v);
     }
 
@@ -125,6 +124,13 @@ public class DatabaseFormsRepository implements FormsRepository {
     private Form queryForForm(String selection, String[] selectionArgs) {
         try (Cursor cursor = new FormsDao().getFormsCursor(selection, selectionArgs)) {
             return getFormOrNull(cursor);
+        }
+    }
+
+    @Nullable
+    private List<Form> queryForForms(String selection, String[] selectionArgs) {
+        try (Cursor cursor = new FormsDao().getFormsCursor(selection, selectionArgs)) {
+            return new FormsDao().getFormsFromCursor(cursor);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
@@ -97,6 +97,13 @@ public class DatabaseFormsRepository implements FormsRepository {
     }
 
     @Override
+    public void restore(Long id) {
+        ContentValues values = new ContentValues();
+        values.put(DELETED, 0);
+        new FormsDao().updateForm(values, _ID + "=?", new String[]{id.toString()});
+    }
+
+    @Override
     public void deleteFormsByMd5Hash(String md5Hash) {
         FormsDao formsDao = new FormsDao();
         List<String> idsToDelete = new ArrayList<>();

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseInstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseInstancesRepository.java
@@ -15,6 +15,7 @@ import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.util.List;
 
+import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.DELETED_DATE;
 import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.JR_FORM_ID;
 import static org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns.JR_VERSION;
 
@@ -54,6 +55,15 @@ public final class DatabaseInstancesRepository implements InstancesRepository {
             return dao.getInstancesFromCursor(dao.getInstancesCursor(JR_FORM_ID + " = ? AND " + JR_VERSION + " = ?", new String[]{jrFormId, jrVersion}));
         } else {
             return dao.getInstancesFromCursor(dao.getInstancesCursor(JR_FORM_ID + " = ? AND " + JR_VERSION + " IS NULL", new String[]{jrFormId}));
+        }
+    }
+
+    @Override
+    public List<Instance> getAllByJrFormIdAndJrVersionNotDeleted(String jrFormId, String jrVersion) {
+        if (jrVersion != null) {
+            return dao.getInstancesFromCursor(dao.getInstancesCursor(JR_FORM_ID + " = ? AND " + JR_VERSION + " = ? AND " + DELETED_DATE + " IS NULL", new String[]{jrFormId, jrVersion}));
+        } else {
+            return dao.getInstancesFromCursor(dao.getInstancesCursor(JR_FORM_ID + " = ? AND " + JR_VERSION + " IS NULL AND " + DELETED_DATE + " IS NULL", new String[]{jrFormId}));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/InstancesDatabaseHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/InstancesDatabaseHelper.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * You may obtain a copy of theø License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -20,8 +20,7 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
-import org.odk.collect.android.provider.InstanceProviderAPI;
-
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.SQLiteUtils;
@@ -140,7 +139,7 @@ public class InstancesDatabaseHelper extends SQLiteOpenHelper {
             db.execSQL("UPDATE " + INSTANCES_TABLE_NAME + " SET "
                     + CAN_EDIT_WHEN_COMPLETE + " = '" + true
                     + "' WHERE " + STATUS + " IS NOT NULL AND "
-                    + STATUS + " != '" + InstanceProviderAPI.STATUS_INCOMPLETE
+                    + STATUS + " != '" + Instance.STATUS_INCOMPLETE
                     + "'");
         }
     }
@@ -155,8 +154,8 @@ public class InstancesDatabaseHelper extends SQLiteOpenHelper {
 
     /**
      * Upgrade to version 5. Prior versions of the instances table included a {@code displaySubtext}
-     * column which was redundant with the {@link InstanceProviderAPI.InstanceColumns#STATUS} and
-     * {@link InstanceProviderAPI.InstanceColumns#LAST_STATUS_CHANGE_DATE} columns and included
+     * column which was redundant with the {@link org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns#STATUS} and
+     * {@link org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns#LAST_STATUS_CHANGE_DATE} columns and included
      * unlocalized text. Version 5 removes this column.
      */
     private void upgradeToVersion5(SQLiteDatabase db) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -7,6 +7,8 @@ import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.List;
 
+import static org.odk.collect.android.instances.Instance.STATUS_SUBMITTED;
+
 public class FormDeleter {
 
     private final FormsRepository formsRepository;
@@ -21,10 +23,16 @@ public class FormDeleter {
         Form form = formsRepository.get(id);
         List<Instance> instancesForVersion = instancesRepository.getAllByJrFormIdAndJrVersion(form.getJrFormId(), form.getJrVersion());
 
-        if (instancesForVersion.isEmpty()) {
+        if (instancesForVersion.isEmpty() || instancesAreSoftDeleted(instancesForVersion)) {
             formsRepository.delete(id);
         } else {
             formsRepository.softDelete(form.getId());
         }
+    }
+
+    private boolean instancesAreSoftDeleted(List<Instance> instancesForVersion) {
+        return instancesForVersion.stream().allMatch(f -> {
+            return f.getStatus().equals(STATUS_SUBMITTED) && f.getDeletedDate() != null;
+        });
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -7,8 +7,6 @@ import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.List;
 
-import static org.odk.collect.android.instances.Instance.STATUS_SUBMITTED;
-
 public class FormDeleter {
 
     private final FormsRepository formsRepository;
@@ -31,8 +29,6 @@ public class FormDeleter {
     }
 
     private boolean instancesAreSoftDeleted(List<Instance> instancesForVersion) {
-        return instancesForVersion.stream().allMatch(f -> {
-            return f.getStatus().equals(STATUS_SUBMITTED) && f.getDeletedDate() != null;
-        });
+        return instancesForVersion.stream().allMatch(f -> f.getDeletedDate() != null);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDeleter.java
@@ -19,16 +19,12 @@ public class FormDeleter {
 
     public void delete(Long id) {
         Form form = formsRepository.get(id);
-        List<Instance> instancesForVersion = instancesRepository.getAllByJrFormIdAndJrVersion(form.getJrFormId(), form.getJrVersion());
 
-        if (instancesForVersion.isEmpty() || instancesAreSoftDeleted(instancesForVersion)) {
+        List<Instance> instancesForVersion = instancesRepository.getAllByJrFormIdAndJrVersionNotDeleted(form.getJrFormId(), form.getJrVersion());
+        if (instancesForVersion.isEmpty()) {
             formsRepository.delete(id);
         } else {
             formsRepository.softDelete(form.getId());
         }
-    }
-
-    private boolean instancesAreSoftDeleted(List<Instance> instancesForVersion) {
-        return instancesForVersion.stream().allMatch(f -> f.getDeletedDate() != null);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -94,7 +94,7 @@ public class ServerFormsDetailsFetcher {
     }
 
     private boolean isThisFormAlreadyDownloaded(String formId) {
-        return formsRepository.contains(formId);
+        return !formsRepository.getByJrFormIdNotDeleted(formId).isEmpty();
     }
 
     private ManifestFile getManifestFile(FormListApi formListAPI, String manifestUrl) {

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -10,8 +10,6 @@ public interface FormsRepository {
 
     Uri save(Form form);
 
-    boolean contains(String jrFormId);
-
     List<Form> getAll();
 
     @Nullable
@@ -19,6 +17,8 @@ public interface FormsRepository {
 
     @Nullable
     Form get(String jrFormId, @Nullable String jrVersion);
+
+    List<Form> getByJrFormIdNotDeleted(String jrFormId);
 
     @Nullable
     Form getByMd5Hash(String hash);

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -31,4 +31,6 @@ public interface FormsRepository {
     void softDelete(Long id);
 
     void deleteFormsByMd5Hash(String md5Hash);
+
+    void restore(Long id);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
@@ -23,14 +23,10 @@ public class InstanceDeleter {
 
         Form form = formsRepository.get(instance.getJrFormId(), instance.getJrVersion());
         if (form != null && form.isDeleted()) {
-            List<Instance> instancesForVersion = instancesRepository.getAllByJrFormIdAndJrVersion(form.getJrFormId(), form.getJrVersion());
-            if (instancesForVersion.isEmpty() || instancesAreSoftDeleted(instancesForVersion)) {
+            List<Instance> otherInstances = instancesRepository.getAllByJrFormIdAndJrVersionNotDeleted(form.getJrFormId(), form.getJrVersion());
+            if (otherInstances.isEmpty()) {
                 formsRepository.delete(form.getId());
             }
         }
-    }
-
-    private boolean instancesAreSoftDeleted(List<Instance> instancesForVersion) {
-        return instancesForVersion.stream().allMatch(f -> f.getDeletedDate() != null);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
@@ -7,8 +7,6 @@ import org.odk.collect.android.instances.InstancesRepository;
 
 import java.util.List;
 
-import static org.odk.collect.android.instances.Instance.STATUS_SUBMITTED;
-
 public class InstanceDeleter {
 
     private final InstancesRepository instancesRepository;
@@ -33,8 +31,6 @@ public class InstanceDeleter {
     }
 
     private boolean instancesAreSoftDeleted(List<Instance> instancesForVersion) {
-        return instancesForVersion.stream().allMatch(f -> {
-            return f.getStatus().equals(STATUS_SUBMITTED) && f.getDeletedDate() != null;
-        });
+        return instancesForVersion.stream().allMatch(f -> f.getDeletedDate() != null);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instances/Instance.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/Instance.java
@@ -24,6 +24,12 @@ import org.odk.collect.android.storage.StoragePathProvider;
  * Objects of this class are created using the builder pattern: https://en.wikipedia.org/wiki/Builder_pattern
  */
 public final class Instance {
+    // status for instances
+    public static final String STATUS_INCOMPLETE = "incomplete";
+    public static final String STATUS_COMPLETE = "complete";
+    public static final String STATUS_SUBMITTED = "submitted";
+    public static final String STATUS_SUBMISSION_FAILED = "submissionFailed";
+
     private final String displayName;
     private final String submissionUri;
     private final boolean canEditWhenComplete;

--- a/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instances/InstancesRepository.java
@@ -19,6 +19,8 @@ public interface InstancesRepository {
 
     List<Instance> getAllByJrFormIdAndJrVersion(String jrFormId, String jrVersion);
 
+    List<Instance> getAllByJrFormIdAndJrVersionNotDeleted(String jrFormId, String jrVersion);
+
     /**
      * Get the Instance corresponding to the given path or null if no unique Instance matches.
      */

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -564,5 +564,6 @@ public class FormsProvider extends ContentProvider {
         sFormsProjectionMap.put(FormsColumns.AUTO_DELETE, FormsColumns.AUTO_DELETE);
         sFormsProjectionMap.put(FormsColumns.AUTO_SEND, FormsColumns.AUTO_SEND);
         sFormsProjectionMap.put(FormsColumns.GEOMETRY_XPATH, FormsColumns.GEOMETRY_XPATH);
+        sFormsProjectionMap.put(FormsColumns.DELETED, FormsColumns.DELETED);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProvider.java
@@ -31,6 +31,7 @@ import androidx.annotation.NonNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.InstancesDatabaseHelper;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
@@ -171,7 +172,7 @@ public class InstanceProvider extends ContentProvider {
             }
 
             if (!values.containsKey(InstanceColumns.STATUS)) {
-                values.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_INCOMPLETE);
+                values.put(InstanceColumns.STATUS, Instance.STATUS_INCOMPLETE);
             }
 
             long rowId = instancesDatabaseHelper.getWritableDatabase().insert(INSTANCES_TABLE_NAME, null, values);
@@ -190,16 +191,16 @@ public class InstanceProvider extends ContentProvider {
             if (state == null) {
                 return new SimpleDateFormat(context.getString(R.string.added_on_date_at_time),
                         Locale.getDefault()).format(date);
-            } else if (InstanceProviderAPI.STATUS_INCOMPLETE.equalsIgnoreCase(state)) {
+            } else if (Instance.STATUS_INCOMPLETE.equalsIgnoreCase(state)) {
                 return new SimpleDateFormat(context.getString(R.string.saved_on_date_at_time),
                         Locale.getDefault()).format(date);
-            } else if (InstanceProviderAPI.STATUS_COMPLETE.equalsIgnoreCase(state)) {
+            } else if (Instance.STATUS_COMPLETE.equalsIgnoreCase(state)) {
                 return new SimpleDateFormat(context.getString(R.string.finalized_on_date_at_time),
                         Locale.getDefault()).format(date);
-            } else if (InstanceProviderAPI.STATUS_SUBMITTED.equalsIgnoreCase(state)) {
+            } else if (Instance.STATUS_SUBMITTED.equalsIgnoreCase(state)) {
                 return new SimpleDateFormat(context.getString(R.string.sent_on_date_at_time),
                         Locale.getDefault()).format(date);
-            } else if (InstanceProviderAPI.STATUS_SUBMISSION_FAILED.equalsIgnoreCase(state)) {
+            } else if (Instance.STATUS_SUBMISSION_FAILED.equalsIgnoreCase(state)) {
                 return new SimpleDateFormat(
                         context.getString(R.string.sending_failed_on_date_at_time),
                         Locale.getDefault()).format(date);
@@ -303,7 +304,7 @@ public class InstanceProvider extends ContentProvider {
                     }
 
                     // Keep sent instance database rows but delete corresponding files
-                    if (status != null && status.equals(InstanceProviderAPI.STATUS_SUBMITTED)) {
+                    if (status != null && status.equals(Instance.STATUS_SUBMITTED)) {
                         ContentValues cv = new ContentValues();
                         cv.put(InstanceColumns.DELETED_DATE, System.currentTimeMillis());
 

--- a/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/InstanceProviderAPI.java
@@ -26,12 +26,6 @@ public final class InstanceProviderAPI {
     private InstanceProviderAPI() {
     }
 
-    // status for instances
-    public static final String STATUS_INCOMPLETE = "incomplete";
-    public static final String STATUS_COMPLETE = "complete";
-    public static final String STATUS_SUBMITTED = "submitted";
-    public static final String STATUS_SUBMISSION_FAILED = "submissionFailed";
-
     public static final class InstanceColumns implements BaseColumns {
         // This class cannot be instantiated
         private InstanceColumns() {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -27,11 +27,11 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.exception.EncryptionException;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.listeners.DiskSyncListener;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.EncryptionUtils;
@@ -125,7 +125,7 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                                 instanceCursor.getColumnIndex(InstanceColumns.INSTANCE_FILE_PATH)));
                         String instanceStatus = instanceCursor.getString(
                                 instanceCursor.getColumnIndex(InstanceColumns.STATUS));
-                        if (candidateInstances.contains(instanceFilename) || instanceStatus.equals(InstanceProviderAPI.STATUS_SUBMITTED)) {
+                        if (candidateInstances.contains(instanceFilename) || instanceStatus.equals(Instance.STATUS_SUBMITTED)) {
                             candidateInstances.remove(instanceFilename);
                         } else {
                             filesToRemove.add(instanceFilename);
@@ -175,7 +175,7 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                                 values.put(InstanceColumns.JR_FORM_ID, jrFormId);
                                 values.put(InstanceColumns.JR_VERSION, jrVersion);
                                 values.put(InstanceColumns.STATUS, instanceSyncFlag
-                                        ? InstanceProviderAPI.STATUS_COMPLETE : InstanceProviderAPI.STATUS_INCOMPLETE);
+                                        ? Instance.STATUS_COMPLETE : Instance.STATUS_INCOMPLETE);
                                 values.put(InstanceColumns.CAN_EDIT_WHEN_COMPLETE, Boolean.toString(true));
                                 // save the new instance object
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceUploaderTask.java
@@ -23,11 +23,11 @@ import android.os.AsyncTask;
 
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.upload.InstanceServerUploader;
 import org.odk.collect.android.utilities.ApplicationConstants;
@@ -88,7 +88,7 @@ public abstract class InstanceUploaderTask extends AsyncTask<Long, Integer, Inst
 
                         count -= selectionArgs.length - 1;
                         selection.append(") and status=?");
-                        selectionArgs[i] = InstanceProviderAPI.STATUS_SUBMITTED;
+                        selectionArgs[i] = Instance.STATUS_SUBMITTED;
 
                         try (Cursor results = new InstancesDao().getInstancesCursor(selection.toString(),
                                 selectionArgs)) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -48,7 +48,6 @@ import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -173,9 +172,9 @@ public class SaveFormToDisk {
             values.put(InstanceColumns.DISPLAY_NAME, instanceName);
         }
         if (incomplete || !shouldFinalize) {
-            values.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_INCOMPLETE);
+            values.put(InstanceColumns.STATUS, Instance.STATUS_INCOMPLETE);
         } else {
-            values.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_COMPLETE);
+            values.put(InstanceColumns.STATUS, Instance.STATUS_COMPLETE);
         }
         values.put(InstanceColumns.CAN_EDIT_WHEN_COMPLETE, Boolean.toString(canEditAfterCompleted));
 

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
@@ -25,7 +25,6 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.dao.InstancesDao;
 import org.odk.collect.android.instances.Instance;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 import org.odk.collect.android.provider.InstanceProviderAPI.InstanceColumns;
 import org.odk.collect.android.utilities.ApplicationConstants;
 
@@ -92,7 +91,7 @@ public abstract class InstanceUploader {
                 instance.getId().toString());
 
         ContentValues contentValues = new ContentValues();
-        contentValues.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMITTED);
+        contentValues.put(InstanceColumns.STATUS, Instance.STATUS_SUBMITTED);
         Collect.getInstance().getContentResolver().update(instanceDatabaseUri, contentValues, null, null);
     }
 
@@ -101,7 +100,7 @@ public abstract class InstanceUploader {
                 instance.getId().toString());
 
         ContentValues contentValues = new ContentValues();
-        contentValues.put(InstanceColumns.STATUS, InstanceProviderAPI.STATUS_SUBMISSION_FAILED);
+        contentValues.put(InstanceColumns.STATUS, Instance.STATUS_SUBMISSION_FAILED);
         Collect.getInstance().getContentResolver().update(instanceDatabaseUri, contentValues, null, null);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/IconUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/IconUtils.java
@@ -24,7 +24,7 @@ import android.graphics.drawable.Drawable;
 import androidx.core.content.ContextCompat;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.provider.InstanceProviderAPI;
+import org.odk.collect.android.instances.Instance;
 
 public class IconUtils {
 
@@ -58,13 +58,13 @@ public class IconUtils {
 
     public static Drawable getSubmissionSummaryStatusIcon(Context context, String instanceStatus) {
         switch (instanceStatus) {
-            case InstanceProviderAPI.STATUS_INCOMPLETE:
+            case Instance.STATUS_INCOMPLETE:
                 return ContextCompat.getDrawable(context, R.drawable.form_state_saved);
-            case InstanceProviderAPI.STATUS_COMPLETE:
+            case Instance.STATUS_COMPLETE:
                 return ContextCompat.getDrawable(context, R.drawable.form_state_finalized);
-            case InstanceProviderAPI.STATUS_SUBMITTED:
+            case Instance.STATUS_SUBMITTED:
                 return ContextCompat.getDrawable(context, R.drawable.form_state_submited);
-            case InstanceProviderAPI.STATUS_SUBMISSION_FAILED:
+            case Instance.STATUS_SUBMISSION_FAILED:
                 return ContextCompat.getDrawable(context, R.drawable.form_state_submission_failed);
         }
         return null;

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -10,7 +10,6 @@ import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.instances.Instance;
 import org.odk.collect.android.instances.InstancesRepository;
 import org.odk.collect.android.support.InMemInstancesRepository;
-import org.odk.collect.android.provider.InstanceProviderAPI;
 
 import java.util.Arrays;
 import java.util.List;
@@ -123,9 +122,9 @@ public class FormMapViewModelTest {
                 .geometryType("Point")
                 .geometry("{\"type\":\"Point\",\"coordinates\":[127.6, 11.1]}")
                 .canEditWhenComplete(true)
-                .status(InstanceProviderAPI.STATUS_COMPLETE).build();
+                .status(Instance.STATUS_COMPLETE).build();
 
-        ((InMemInstancesRepository) testInstancesRepository).addInstance(newInstance);
+        ((InMemInstancesRepository) testInstancesRepository).save(newInstance);
 
         instances = viewModel.getMappableFormInstances();
         assertThat(viewModel.getTotalInstanceCount(), is(8));
@@ -143,13 +142,13 @@ public class FormMapViewModelTest {
         assertThat(mappableInstances.get(5).getClickAction(), is(FormMapViewModel.ClickAction.NOT_VIEWABLE_TOAST));
         ((InMemInstancesRepository) testInstancesRepository).removeInstanceById(6L);
 
-        ((InMemInstancesRepository) testInstancesRepository).addInstance(new Instance.Builder().id(6L)
+        ((InMemInstancesRepository) testInstancesRepository).save(new Instance.Builder().id(6L)
                 .jrFormId("formId1")
                 .jrVersion("2019103101")
                 .geometryType("")
                 .geometry("")
                 .canEditWhenComplete(false)
-                .status(InstanceProviderAPI.STATUS_SUBMISSION_FAILED).build());
+                .status(Instance.STATUS_SUBMISSION_FAILED).build());
 
         mappableInstances = viewModel.getMappableFormInstances();
         assertThat(viewModel.getTotalInstanceCount(), is(7));
@@ -180,7 +179,7 @@ public class FormMapViewModelTest {
                     .deletedDate(1487782554846L)
                     .geometryType("Point")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.0]}")
-                    .status(InstanceProviderAPI.STATUS_SUBMITTED).build(),
+                    .status(Instance.STATUS_SUBMITTED).build(),
 
             new Instance.Builder().id(1L)
                     .displayName("Form2")
@@ -190,7 +189,7 @@ public class FormMapViewModelTest {
                     .geometryType("Point")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.1]}")
                     .canEditWhenComplete(true)
-                    .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
+                    .status(Instance.STATUS_COMPLETE).build(),
 
             new Instance.Builder().id(2L)
                     .displayName("Form3")
@@ -199,14 +198,14 @@ public class FormMapViewModelTest {
                     .jrVersion("2019103102")
                     .geometryType("Point")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[126.6, 10.1]}")
-                    .status(InstanceProviderAPI.STATUS_INCOMPLETE).build(),
+                    .status(Instance.STATUS_INCOMPLETE).build(),
 
             new Instance.Builder().id(3L)
                     .displayName("Form4")
                     .lastStatusChangeDate(1488582557456L)
                     .jrFormId("formId1")
                     .jrVersion("2019103101")
-                    .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
+                    .status(Instance.STATUS_COMPLETE).build(),
 
             new Instance.Builder().id(4L)
                     .displayName("Form5")
@@ -216,7 +215,7 @@ public class FormMapViewModelTest {
                     .geometryType("Point")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.3]}")
                     .canEditWhenComplete(true)
-                    .status(InstanceProviderAPI.STATUS_SUBMISSION_FAILED).build(),
+                    .status(Instance.STATUS_SUBMISSION_FAILED).build(),
 
             new Instance.Builder().id(5L)
                     .displayName("Form6")
@@ -226,7 +225,7 @@ public class FormMapViewModelTest {
                     .geometryType("Point")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.7, 10.3]}")
                     .canEditWhenComplete(true)
-                    .status(InstanceProviderAPI.STATUS_SUBMITTED).build(),
+                    .status(Instance.STATUS_SUBMITTED).build(),
 
             new Instance.Builder().id(6L)
                     .displayName("Form7")
@@ -236,7 +235,7 @@ public class FormMapViewModelTest {
                     .geometryType("Point")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.4]}")
                     .canEditWhenComplete(false)
-                    .status(InstanceProviderAPI.STATUS_SUBMISSION_FAILED).build(),
+                    .status(Instance.STATUS_SUBMISSION_FAILED).build(),
 
             new Instance.Builder().id(7L)
                     .displayName("Form8")
@@ -245,7 +244,7 @@ public class FormMapViewModelTest {
                     .jrVersion("2019103101")
                     .geometryType("Point")
                     .geometry("Crazy stuff")
-                    .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
+                    .status(Instance.STATUS_COMPLETE).build(),
 
             new Instance.Builder().id(8L)
                     .displayName("Form9")
@@ -254,6 +253,6 @@ public class FormMapViewModelTest {
                     .jrVersion("2019103101")
                     .geometryType("Crazy stuff")
                     .geometry("{\"type\":\"Point\",\"coordinates\":[125.6, 10.4]}")
-                    .status(InstanceProviderAPI.STATUS_COMPLETE).build(),
+                    .status(Instance.STATUS_COMPLETE).build(),
             };
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
@@ -20,7 +20,7 @@ public class FormDeleterTest {
     private final FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
 
     @Test
-    public void whenFormHasSubmittedInstances_softDeletesForm() {
+    public void whenFormHasSoftDeletedInstances_deletesForm() {
         formsRepository.save(new Form.Builder()
                 .id(1L)
                 .jrFormId("id")
@@ -30,27 +30,6 @@ public class FormDeleterTest {
         instancesRepository.save(new Instance.Builder()
                 .jrFormId("id")
                 .jrVersion("version")
-                .status(Instance.STATUS_SUBMITTED)
-                .build());
-
-        formDeleter.delete(1L);
-        List<Form> forms = formsRepository.getAll();
-        assertThat(forms.size(), is(1));
-        assertThat(forms.get(0).isDeleted(), is(true));
-    }
-
-    @Test
-    public void whenFormHasSubmitted_andSoftDeletedInstances_deletesForm() {
-        formsRepository.save(new Form.Builder()
-                .id(1L)
-                .jrFormId("id")
-                .jrVersion("version")
-                .build());
-
-        instancesRepository.save(new Instance.Builder()
-                .jrFormId("id")
-                .jrVersion("version")
-                .status(Instance.STATUS_SUBMITTED)
                 .deletedDate(0L)
                 .build());
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormDeleterTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.odk.collect.android.support.InstanceUtils.buildInstance;
 
 
 public class FormDeleterTest {
@@ -19,11 +20,46 @@ public class FormDeleterTest {
     private final FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
 
     @Test
-    public void whenOtherVersionOfFormHasInstances_deletesForm() {
-        InMemFormsRepository formsRepository = new InMemFormsRepository();
-        InMemInstancesRepository instancesRepository = new InMemInstancesRepository();
-        FormDeleter formDeleter = new FormDeleter(formsRepository, instancesRepository);
+    public void whenFormHasSubmittedInstances_softDeletesForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("id")
+                .jrVersion("version")
+                .build());
 
+        instancesRepository.save(new Instance.Builder()
+                .jrFormId("id")
+                .jrVersion("version")
+                .status(Instance.STATUS_SUBMITTED)
+                .build());
+
+        formDeleter.delete(1L);
+        List<Form> forms = formsRepository.getAll();
+        assertThat(forms.size(), is(1));
+        assertThat(forms.get(0).isDeleted(), is(true));
+    }
+
+    @Test
+    public void whenFormHasSubmitted_andSoftDeletedInstances_deletesForm() {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("id")
+                .jrVersion("version")
+                .build());
+
+        instancesRepository.save(new Instance.Builder()
+                .jrFormId("id")
+                .jrVersion("version")
+                .status(Instance.STATUS_SUBMITTED)
+                .deletedDate(0L)
+                .build());
+
+        formDeleter.delete(1L);
+        assertThat(formsRepository.getAll().size(), is(0));
+    }
+
+    @Test
+    public void whenOtherVersionOfFormHasInstances_deletesForm() {
         formsRepository.save(new Form.Builder()
                 .id(1L)
                 .jrFormId("1")
@@ -36,7 +72,7 @@ public class FormDeleterTest {
                 .jrVersion("new")
                 .build());
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .jrFormId("1")
                 .jrVersion("old")
                 .build());
@@ -61,7 +97,7 @@ public class FormDeleterTest {
                 .jrVersion(null)
                 .build());
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .jrFormId("1")
                 .jrVersion("version")
                 .build());
@@ -80,10 +116,7 @@ public class FormDeleterTest {
                 .jrVersion(null)
                 .build());
 
-        instancesRepository.addInstance(new Instance.Builder()
-                .jrFormId("1")
-                .jrVersion(null)
-                .build());
+        instancesRepository.save(buildInstance(1L, "1", null).build());
 
         formDeleter.delete(1L);
         List<Form> forms = formsRepository.getAll();

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
@@ -55,7 +55,22 @@ public class ServerFormsDetailsFetcherTest {
     }
 
     @Test
-    public void whenNoFormsExist_isNew() throws Exception {
+    public void whenNoFormsExist_isNotOnDevice() throws Exception {
+        List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
+        assertThat(serverFormDetails.get(0).isNotOnDevice(), is(true));
+        assertThat(serverFormDetails.get(1).isNotOnDevice(), is(true));
+    }
+
+    @Test
+    public void whenAFormIsSoftDeleted_isNotOnDevice() throws Exception {
+        formsRepository.save(new Form.Builder()
+                .id(1L)
+                .jrFormId("form-1")
+                .jrVersion("server")
+                .md5Hash("form-1-hash")
+                .deleted(true)
+                .build());
+
         List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
         assertThat(serverFormDetails.get(0).isNotOnDevice(), is(true));
         assertThat(serverFormDetails.get(1).isNotOnDevice(), is(true));

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsSynchronizerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsSynchronizerTest.java
@@ -64,7 +64,7 @@ public class ServerFormsSynchronizerTest {
         ));
 
         synchronizer.synchronize();
-        assertThat(formsRepository.contains("form-3"), is(false));
+        assertThat(formsRepository.getAll().isEmpty(), is(true));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -29,6 +29,27 @@ public abstract class FormsRepositoryTest {
     }
 
     @Test
+    public void softDelete_marksDeletedAsTrue() {
+        FormsRepository formsRepository = buildSubject();
+        formsRepository.save(buildForm(1L, "1", null)
+                .build());
+
+        formsRepository.softDelete(1L);
+        assertThat(formsRepository.get(1L).isDeleted(), is(true));
+    }
+
+    @Test
+    public void restore_marksDeletedAsFalse() {
+        FormsRepository formsRepository = buildSubject();
+        formsRepository.save(buildForm(1L, "1", null)
+                .deleted(true)
+                .build());
+
+        formsRepository.restore(1L);
+        assertThat(formsRepository.get(1L).isDeleted(), is(false));
+    }
+
+    @Test
     public void getByJrFormIdNotDeleted_doesNotReturnDeletedForms() {
         FormsRepository formsRepository = buildSubject();
         formsRepository.save(buildForm(1L, "1", "deleted")

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -4,8 +4,10 @@ import org.junit.Test;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -18,23 +20,44 @@ public abstract class FormsRepositoryTest {
     @Test
     public void get_whenFormHasNullVersion_returnsForm() {
         FormsRepository formsRepository = buildSubject();
-
-        File formFile = new File(getFormFilesPath() + "/form.xml");
-        FileUtils.write(formFile, "blah".getBytes());
-        String mediaPath = new File(getFormFilesPath() + "/form-media").getAbsolutePath();
-
-        formsRepository.save(new Form.Builder()
-                .id(1L)
-                .displayName("Test Form")
-                .formFilePath(formFile.getAbsolutePath())
-                .formMediaPath(mediaPath)
-                .jrFormId("1")
-                .jrVersion(null)
-                .build()
-        );
+        formsRepository.save(buildForm(1L, "1", null)
+                .build());
 
         Form form = formsRepository.get("1", null);
         assertThat(form, notNullValue());
         assertThat(form.getId(), is(1L));
+    }
+
+    @Test
+    public void getByJrFormIdNotDeleted_doesNotReturnDeletedForms() {
+        FormsRepository formsRepository = buildSubject();
+        formsRepository.save(buildForm(1L, "1", "deleted")
+                .deleted(true)
+                .build()
+        );
+
+        formsRepository.save(buildForm(2L, "1", "not-deleted")
+                .deleted(false)
+                .build()
+        );
+
+        List<Form> forms = formsRepository.getByJrFormIdNotDeleted("1");
+        assertThat(forms.size(), is(1));
+        assertThat(forms.get(0).getJrVersion(), equalTo("not-deleted"));
+    }
+
+    private Form.Builder buildForm(long id, String jrFormId, String jrVersion) {
+        String fileName = jrFormId + "-" + jrVersion;
+        File formFile = new File(getFormFilesPath() + "/" + fileName + ".xml");
+        FileUtils.write(formFile, "blah".getBytes());
+        String mediaPath = new File(getFormFilesPath() + "/" + fileName + "-media").getAbsolutePath();
+
+        return new Form.Builder()
+                .id(id)
+                .displayName("Test Form")
+                .formFilePath(formFile.getAbsolutePath())
+                .formMediaPath(mediaPath)
+                .jrFormId(jrFormId)
+                .jrVersion(jrVersion);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceDeleterTest.java
@@ -35,40 +35,7 @@ public class InstanceDeleterTest {
     }
 
     @Test
-    public void whenFormForInstanceIsSoftDeleted_andThereIsAnotherSubmittedInstance_doesNotDeleteForm() {
-        formsRepository.save(new Form.Builder()
-                .id(1L)
-                .jrFormId("1")
-                .jrVersion("version")
-                .deleted(true)
-                .build()
-        );
-
-        instancesRepository.save(buildInstance(1L, "1", "version")
-                .status(Instance.STATUS_SUBMITTED)
-                .build());
-
-        instancesRepository.save(new Instance.Builder()
-                .id(1L)
-                .jrFormId("1")
-                .status(Instance.STATUS_SUBMITTED)
-                .jrVersion("version")
-                .build()
-        );
-
-        instancesRepository.save(new Instance.Builder()
-                .id(2L)
-                .jrFormId("1")
-                .jrVersion("version")
-                .build()
-        );
-
-        instanceDeleter.delete(2L);
-        assertThat(formsRepository.getAll().size(), is(1));
-    }
-
-    @Test
-    public void whenFormForInstanceIsSoftDeleted_andThereIsAnotherSoftDeletedSubmittedInstance_deletesForm() {
+    public void whenFormForInstanceIsSoftDeleted_andThereIsAnotherSoftDeletedInstance_deletesForm() {
         formsRepository.save(new Form.Builder()
                 .id(1L)
                 .jrFormId("1")
@@ -80,7 +47,6 @@ public class InstanceDeleterTest {
         instancesRepository.save(new Instance.Builder()
                 .id(1L)
                 .jrFormId("1")
-                .status(Instance.STATUS_SUBMITTED)
                 .deletedDate(0L)
                 .jrVersion("version")
                 .build()

--- a/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceDeleterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/instancemanagement/InstanceDeleterTest.java
@@ -26,14 +26,14 @@ public class InstanceDeleterTest {
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(1L)
                 .jrFormId("1")
                 .jrVersion("version")
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(2L)
                 .jrFormId("1")
                 .jrVersion("version")
@@ -54,7 +54,7 @@ public class InstanceDeleterTest {
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(1L)
                 .jrFormId("1")
                 .jrVersion("version")
@@ -83,14 +83,14 @@ public class InstanceDeleterTest {
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(1L)
                 .jrFormId("1")
                 .jrVersion("1")
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(2L)
                 .jrFormId("1")
                 .jrVersion("2")
@@ -112,7 +112,7 @@ public class InstanceDeleterTest {
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(1L)
                 .jrFormId("1")
                 .jrVersion("version")
@@ -141,7 +141,7 @@ public class InstanceDeleterTest {
                 .build()
         );
 
-        instancesRepository.addInstance(new Instance.Builder()
+        instancesRepository.save(new Instance.Builder()
                 .id(1L)
                 .jrFormId("1")
                 .jrVersion("2")

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -11,6 +11,8 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import static java.util.stream.Collectors.toList;
+
 public class InMemFormsRepository implements FormsRepository {
 
     private final List<Form> forms = new ArrayList<>();
@@ -22,8 +24,8 @@ public class InMemFormsRepository implements FormsRepository {
     }
 
     @Override
-    public boolean contains(String jrFormId) {
-        return forms.stream().anyMatch(f -> f.getJrFormId().equals(jrFormId));
+    public List<Form> getByJrFormIdNotDeleted(String jrFormId) {
+        return forms.stream().filter(f -> f.getJrFormId().equals(jrFormId) && !f.isDeleted()).collect(toList());
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -77,6 +77,18 @@ public class InMemFormsRepository implements FormsRepository {
     }
 
     @Override
+    public void restore(Long id) {
+        Form form = forms.stream().filter(f -> f.getId().equals(id)).findFirst().orElse(null);
+
+        if (form != null) {
+            forms.remove(form);
+            forms.add(new Form.Builder(form)
+                    .deleted(false)
+                    .build());
+        }
+    }
+
+    @Override
     public void deleteFormsByMd5Hash(String md5Hash) {
         throw new UnsupportedOperationException();
     }

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
@@ -73,7 +73,7 @@ public final class InMemInstancesRepository implements InstancesRepository {
         instances.removeIf(instance -> instance.getId().equals(id));
     }
 
-    public void addInstance(Instance instance) {
+    public void save(Instance instance) {
         instances.add(instance);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemInstancesRepository.java
@@ -52,6 +52,15 @@ public final class InMemInstancesRepository implements InstancesRepository {
     }
 
     @Override
+    public List<Instance> getAllByJrFormIdAndJrVersionNotDeleted(String jrFormId, String jrVersion) {
+        return instances.stream().filter(instance -> {
+            return Objects.equals(instance.getJrFormId(), jrFormId)
+                    && Objects.equals(instance.getJrVersion(), jrVersion)
+                    && instance.getDeletedDate() == null;
+        }).collect(Collectors.toList());
+    }
+
+    @Override
     public Instance getByPath(String instancePath) {
         List<Instance> result = new ArrayList<>();
 

--- a/collect_app/src/test/java/org/odk/collect/android/support/InstanceUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InstanceUtils.java
@@ -1,0 +1,18 @@
+package org.odk.collect.android.support;
+
+import org.odk.collect.android.instances.Instance;
+
+public class InstanceUtils {
+
+    private InstanceUtils() {
+
+    }
+
+    public static Instance.Builder buildInstance(long id, String jrFormId, String jrFormVersion) {
+        return new Instance.Builder()
+                .id(id)
+                .jrFormId(jrFormId)
+                .jrVersion(jrFormVersion)
+                .status(Instance.STATUS_INCOMPLETE);
+    }
+}


### PR DESCRIPTION
Closes #4026

#### What has been done to verify that this works as intended?

Manually verified and wrote new test.

#### Why is this the best possible solution? Were any other approaches considered?

I'm not a fan of testing this at an Espresso level. I started at writing tests at a lower level but it would mean a bit of a complicated dance around the `MultiFormDownloader` and `ServerFormDownloader`. I think this would get everything to a better place and potentially mean killing the `MultiFormDownloader` which would be nice. I'm going to continue that work immediately but didn't want to hold the regression fix up or add more risk to it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to just check the issue is fixed and that form download still seems to be working!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)