### PR TITLE
Updates for JDK 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   test_unit:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
   android_config: &android_config
     working_directory: *workspace
     docker:
-      - image: circleci/android@sha256:518e47707dd74ee23aad7fc68fef2742b58c1d855be2348bfd4c8214e3db4ef0
+      - image: circleci/android:api-27
 
 jobs:
   check_quality:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   test_unit:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -Djavax.net.ssl.trustStoreType=JKS" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   test_unit:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -Djavax.net.ssl.trustStoreType=JKS" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
 

--- a/collect_app/src/test/java/org/odk/collect/android/application/TestCollect.java
+++ b/collect_app/src/test/java/org/odk/collect/android/application/TestCollect.java
@@ -22,6 +22,9 @@ public class TestCollect extends Collect {
     public void onCreate() {
         super.onCreate();
 
+        // Prevents OKHttp from exploding on initialization https://github.com/robolectric/robolectric/issues/5115
+        System.setProperty("javax.net.ssl.trustStore", "NONE");
+
         // We need this so WorkManager.getInstance doesn't explode
         try {
             WorkManager.initialize(RuntimeEnvironment.application, new Configuration.Builder().build());

--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -7,6 +7,7 @@ jacoco {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 tasks.register("jacocoTestReport", JacocoReport) {


### PR DESCRIPTION
Per https://github.com/gradle/gradle/issues/5184\#issuecomment-457865951. This is necessary because CircleCI just [updated the Android image to JDK 11](https://discuss.circleci.com/t/android-image-updated-to-java-v11/37089).