### PR TITLE
Use old docker circle CI image with JDK 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
   android_config: &android_config
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-27
+      - image: circleci/android@sha256:518e47707dd74ee23aad7fc68fef2742b58c1d855be2348bfd4c8214e3db4ef0
 
 jobs:
   check_quality:


### PR DESCRIPTION
Circle CI have moved their Android images to JDK 11 which has caused all kinds of problems for us. This reverts us back to the JDK8 image for the moment, allowing us to fix the JDK issues without stress.

#### What has been done to verify that this works as intended?

Running checks with Circle CI to make sure we're back to green.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)