### PR TITLE
Rework Osm Widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SimpleDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SimpleDialog.java
@@ -18,7 +18,6 @@ package org.odk.collect.android.fragments.dialogs;
 
 import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
-import android.content.DialogInterface;
 import android.os.Bundle;
 
 import androidx.fragment.app.DialogFragment;
@@ -78,12 +77,9 @@ public class SimpleDialog extends DialogFragment {
                 .setTitle(getArguments().getString(DIALOG_TITLE))
                 .setIcon(getArguments().getInt(ICON_ID))
                 .setMessage(getArguments().getString(MESSAGE))
-                .setPositiveButton(getArguments().getString(BUTTON_TITLE), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int id) {
-                        if (getArguments().getBoolean(FINISH_ACTIVITY)) {
-                            getActivity().finish();
-                        }
+                .setPositiveButton(getArguments().getString(BUTTON_TITLE), (dialog, id) -> {
+                    if (getArguments().getBoolean(FINISH_ACTIVITY)) {
+                        getActivity().finish();
                     }
                 })
                 .create();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -3,36 +3,30 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import androidx.appcompat.app.AlertDialog;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
-import android.graphics.Typeface;
+import android.util.TypedValue;
 import android.view.View;
-import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TableLayout;
-import android.widget.TextView;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.osm.OSMTag;
 import org.javarosa.core.model.osm.OSMTagItem;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.databinding.OsmWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
-import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.odk.collect.android.formentry.questions.WidgetViewUtils.createSimpleButton;
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
@@ -42,7 +36,9 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
  * @author Nicholas Hallahan nhallahan@spatialdev.com
  */
 @SuppressLint("ViewConstructor")
-public class OSMWidget extends QuestionWidget implements WidgetDataReceiver, ButtonClickListener {
+public class OSMWidget extends QuestionWidget implements WidgetDataReceiver {
+    OsmWidgetAnswerBinding binding;
+
     public static final String FORM_ID = "FORM_ID";
     public static final String INSTANCE_ID = "INSTANCE_ID";
     public static final String INSTANCE_DIR = "INSTANCE_DIR";
@@ -53,19 +49,14 @@ public class OSMWidget extends QuestionWidget implements WidgetDataReceiver, But
     private static final int OSM_GREEN = Color.rgb(126, 188, 111);
     private static final int OSM_BLUE = Color.rgb(112, 146, 255);
 
-    final Button launchOpenMapKitButton;
-    private final String instanceDirectory;
-    final TextView errorTextView;
-    final TextView osmFileNameHeaderTextView;
-    final TextView osmFileNameTextView;
+    private final WaitingForDataRegistry waitingForDataRegistry;
+    private final ActivityAvailability activityAvailability;
 
     private final List<OSMTag> osmRequiredTags;
     private final String instanceId;
-    private final int formId;
+    private final String instanceDirectory;
     private final String formFileName;
-    private final WaitingForDataRegistry waitingForDataRegistry;
-    private final ActivityAvailability activityAvailability;
-    private String osmFileName;
+    private final int formId;
 
     public OSMWidget(Context context, QuestionDetails questionDetails, WaitingForDataRegistry waitingForDataRegistry,
                      ActivityAvailability activityAvailability, FormController formController) {
@@ -79,63 +70,35 @@ public class OSMWidget extends QuestionWidget implements WidgetDataReceiver, But
         instanceId = formController.getSubmissionMetadata().instanceId;
         formId = formController.getFormDef().getID();
 
-        errorTextView = new TextView(context);
-        errorTextView.setId(View.generateViewId());
-        errorTextView.setText(R.string.invalid_osm_data);
-
         // Determine the tags required
         osmRequiredTags = questionDetails.getPrompt().getQuestion().getOsmTags();
 
         // If an OSM File has already been saved, get the name.
-        osmFileName = questionDetails.getPrompt().getAnswerText();
+        String osmFileName = questionDetails.getPrompt().getAnswerText();
 
-        // Setup Launch OpenMapKit Button
-        launchOpenMapKitButton = createSimpleButton(getContext(), R.id.simple_button, getFormEntryPrompt().isReadOnly(), getAnswerFontSize(), this);
-
-        // Button Styling
         if (osmFileName != null) {
-            launchOpenMapKitButton.setBackgroundColor(OSM_BLUE);
+            binding.launchOpenMapKitButton.setText(getContext().getString(R.string.recapture_osm));
+            binding.launchOpenMapKitButton.setBackgroundColor(OSM_BLUE);
+
+            binding.osmFileText.setText(osmFileName);
         } else {
-            launchOpenMapKitButton.setBackgroundColor(OSM_GREEN);
+            binding.launchOpenMapKitButton.setBackgroundColor(OSM_GREEN);
+            binding.osmFileHeaderText.setVisibility(View.GONE);
         }
-        launchOpenMapKitButton.setTextColor(Color.WHITE); // White text
-        if (osmFileName != null) {
-            launchOpenMapKitButton.setText(getContext().getString(R.string.recapture_osm));
+    }
+
+    @Override
+    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
+        binding = OsmWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
+
+        if (prompt.isReadOnly()) {
+            binding.launchOpenMapKitButton.setVisibility(GONE);
         } else {
-            launchOpenMapKitButton.setText(getContext().getString(R.string.capture_osm));
+            binding.launchOpenMapKitButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+            binding.launchOpenMapKitButton.setOnClickListener(v -> onButtonClick());
         }
 
-        osmFileNameHeaderTextView = new TextView(context);
-        osmFileNameHeaderTextView.setId(View.generateViewId());
-        osmFileNameHeaderTextView.setTextSize(20);
-        osmFileNameHeaderTextView.setTypeface(null, Typeface.BOLD);
-        osmFileNameHeaderTextView.setPadding(10, 0, 0, 10);
-        osmFileNameHeaderTextView.setText(R.string.edited_osm_file);
-
-        // text view showing the resulting OSM file name
-        osmFileNameTextView = new TextView(context);
-        osmFileNameTextView.setId(View.generateViewId());
-        osmFileNameTextView.setTextSize(18);
-        osmFileNameTextView.setTypeface(null, Typeface.ITALIC);
-        if (osmFileName != null) {
-            osmFileNameTextView.setText(osmFileName);
-        } else {
-            osmFileNameHeaderTextView.setVisibility(View.GONE);
-        }
-        TableLayout.LayoutParams params = new TableLayout.LayoutParams();
-        params.setMargins(35, 30, 30, 35);
-        osmFileNameTextView.setLayoutParams(params);
-
-        // finish complex layout
-        LinearLayout answerLayout = new LinearLayout(getContext());
-        answerLayout.setOrientation(LinearLayout.VERTICAL);
-        answerLayout.addView(launchOpenMapKitButton);
-        answerLayout.addView(errorTextView);
-        answerLayout.addView(osmFileNameHeaderTextView);
-        answerLayout.addView(osmFileNameTextView);
-        addAnswerView(answerLayout, WidgetViewUtils.getStandardMargin(context));
-
-        errorTextView.setVisibility(View.GONE);
+        return binding.getRoot();
     }
 
     private void launchOpenMapKit() {
@@ -157,7 +120,8 @@ public class OSMWidget extends QuestionWidget implements WidgetDataReceiver, But
             launchIntent.putExtra(FORM_FILE_NAME, formFileName);
 
             //send OSM file name if there was a previous edit
-            if (osmFileName != null) {
+            String osmFileName = binding.osmFileText.getText().toString();
+            if (!osmFileName.isEmpty()) {
                 launchIntent.putExtra(OSM_EDIT_FILE_NAME, osmFileName);
             }
 
@@ -169,7 +133,7 @@ public class OSMWidget extends QuestionWidget implements WidgetDataReceiver, But
                 ((Activity) getContext()).startActivityForResult(launchIntent, RequestCodes.OSM_CAPTURE);
             } else {
                 waitingForDataRegistry.cancelWaitingForData();
-                errorTextView.setVisibility(View.VISIBLE);
+                binding.errorText.setVisibility(View.VISIBLE);
             }
 
         } catch (Exception ex) {
@@ -188,40 +152,36 @@ public class OSMWidget extends QuestionWidget implements WidgetDataReceiver, But
     @Override
     public void setData(Object answer) {
         // show file name of saved osm data
-        osmFileName = (String) answer;
-        osmFileNameTextView.setText(osmFileName);
-        osmFileNameHeaderTextView.setVisibility(View.VISIBLE);
-        osmFileNameTextView.setVisibility(View.VISIBLE);
-
+        binding.osmFileText.setText((String) answer);
+        binding.osmFileHeaderText.setVisibility(View.VISIBLE);
+        binding.launchOpenMapKitButton.setText(getContext().getString(R.string.recapture_osm));
         widgetValueChanged();
     }
 
     @Override
     public IAnswerData getAnswer() {
-        String s = osmFileNameTextView.getText().toString();
-
-        return !s.isEmpty()
-                ? new StringData(s)
-                : null;
+        String osmFileName = binding.osmFileText.getText().toString();
+        return osmFileName.isEmpty() ? null : new StringData(osmFileName);
     }
 
     @Override
     public void clearAnswer() {
-        osmFileNameTextView.setText(null);
+        binding.osmFileText.setText(null);
+        binding.osmFileHeaderText.setVisibility(View.GONE);
+        binding.launchOpenMapKitButton.setText(getContext().getString(R.string.capture_osm));
         widgetValueChanged();
     }
 
     @Override
-    public void onButtonClick(int buttonId) {
-        launchOpenMapKitButton.setBackgroundColor(OSM_BLUE);
-        errorTextView.setVisibility(View.GONE);
-        launchOpenMapKit();
+    public void setOnLongClickListener(OnLongClickListener l) {
+        binding.osmFileText.setOnLongClickListener(l);
+        binding.launchOpenMapKitButton.setOnLongClickListener(l);
     }
 
-    @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        osmFileNameTextView.setOnLongClickListener(l);
-        launchOpenMapKitButton.setOnLongClickListener(l);
+    private void onButtonClick() {
+        binding.launchOpenMapKitButton.setBackgroundColor(OSM_BLUE);
+        binding.errorText.setVisibility(View.GONE);
+        launchOpenMapKit();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -44,6 +44,7 @@ public class UrlWidget extends QuestionWidget {
     @Override
     protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
         binding = UrlWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
+
         binding.urlButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
         binding.urlButton.setOnClickListener(v -> onButtonClick());
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -201,7 +201,8 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_OSM_CAPTURE:
-                questionWidget = new OSMWidget(context, questionDetails, waitingForDataRegistry);
+                questionWidget = new OSMWidget(context, questionDetails, waitingForDataRegistry,
+                        new ActivityAvailability(context), Collect.getInstance().getFormController());
                 break;
             case Constants.CONTROL_AUDIO_CAPTURE:
                 RecordingRequester recordingRequester = recordingRequesterProvider.create(prompt, useExternalRecorder);

--- a/collect_app/src/main/res/layout/arbitrary_file_widget_answer.xml
+++ b/collect_app/src/main/res/layout/arbitrary_file_widget_answer.xml
@@ -3,7 +3,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/arbitrary_file_button"

--- a/collect_app/src/main/res/layout/audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/audio_widget_answer.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/capture_button"

--- a/collect_app/src/main/res/layout/barcode_widget_answer.xml
+++ b/collect_app/src/main/res/layout/barcode_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/barcode_button"

--- a/collect_app/src/main/res/layout/bearing_widget_answer.xml
+++ b/collect_app/src/main/res/layout/bearing_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/bearing_button"

--- a/collect_app/src/main/res/layout/date_widget_answer.xml
+++ b/collect_app/src/main/res/layout/date_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/date_button"

--- a/collect_app/src/main/res/layout/ex_arbitrary_file_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_arbitrary_file_widget_answer.xml
@@ -3,7 +3,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/ex_arbitrary_file_button"

--- a/collect_app/src/main/res/layout/ex_audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_audio_widget_answer.xml
@@ -3,7 +3,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/launch_external_app_button"

--- a/collect_app/src/main/res/layout/ex_image_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_image_widget_answer.xml
@@ -3,7 +3,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/launch_external_app_button"

--- a/collect_app/src/main/res/layout/ex_video_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_video_widget_answer.xml
@@ -3,7 +3,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/capture_video_button"

--- a/collect_app/src/main/res/layout/geo_widget_answer.xml
+++ b/collect_app/src/main/res/layout/geo_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/simple_button"

--- a/collect_app/src/main/res/layout/osm_widget_answer.xml
+++ b/collect_app/src/main/res/layout/osm_widget_answer.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/launch_open_map_kit_button"

--- a/collect_app/src/main/res/layout/osm_widget_answer.xml
+++ b/collect_app/src/main/res/layout/osm_widget_answer.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.odk.collect.android.views.MultiClickSafeButton
+        android:id="@+id/launch_open_map_kit_button"
+        style="@style/Widget.Collect.Button.WidgetAnswer"
+        android:text="@string/capture_osm"
+        android:textColor="#FFFFFF"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/error_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:paddingHorizontal="@dimen/margin_standard"
+        android:text="@string/invalid_osm_data"
+        android:visibility="gone"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/osm_file_header_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:paddingHorizontal="@dimen/margin_standard"
+        android:text="@string/edited_osm_file"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:textColor="?colorOnSurface"
+        android:textAppearance="@style/TextAppearance.Collect.Body1" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/osm_file_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small"
+        android:paddingHorizontal="@dimen/margin_large"
+        android:textSize="18sp"
+        android:textStyle="italic"
+        android:textColor="?colorOnSurface"
+        android:textAppearance="@style/TextAppearance.Collect.Body1"/>
+
+</LinearLayout>

--- a/collect_app/src/main/res/layout/range_picker_widget_answer.xml
+++ b/collect_app/src/main/res/layout/range_picker_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/widget_button"

--- a/collect_app/src/main/res/layout/time_widget_answer.xml
+++ b/collect_app/src/main/res/layout/time_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/time_button"

--- a/collect_app/src/main/res/layout/url_widget_answer.xml
+++ b/collect_app/src/main/res/layout/url_widget_answer.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_standard">
+    android:paddingTop="@dimen/margin_small"
+    android:paddingHorizontal="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/url_button"

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -163,7 +163,7 @@ public class OSMWidgetTest {
     @Test
     public void setData_updatesWidgetDisplayedAnswer() {
         OSMWidget widget = createWidget(promptWithAnswer(null));
-        widget.setBinaryData("blah");
+        widget.setData("blah");
 
         assertThat(widget.binding.osmFileHeaderText.getVisibility(), is(View.VISIBLE));
         assertThat(widget.binding.osmFileText.getVisibility(), is(View.VISIBLE));
@@ -173,7 +173,7 @@ public class OSMWidgetTest {
     @Test
     public void setData_showsRecaptureOsmButton() {
         OSMWidget widget = createWidget(promptWithAnswer(null));
-        widget.setBinaryData("blah");
+        widget.setData("blah");
         assertThat(widget.binding.launchOpenMapKitButton.getText(), is(widgetActivity.getString(R.string.recapture_osm)));
     }
 
@@ -182,7 +182,7 @@ public class OSMWidgetTest {
         OSMWidget widget = createWidget(promptWithAnswer(null));
         WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
 
-        widget.setBinaryData("blah");
+        widget.setData("blah");
         verify(valueChangedListener).widgetValueChanged(widget);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -80,33 +80,32 @@ public class OSMWidgetTest {
 
     @Test
     public void usingReadOnlyOption_doesNotShowButton() {
-        assertThat(createWidget(promptWithReadOnly()).launchOpenMapKitButton.getVisibility(), is(View.GONE));
+        assertThat(createWidget(promptWithReadOnly()).binding.launchOpenMapKitButton.getVisibility(), is(View.GONE));
     }
 
     @Test
     public void whenPromptDoesNotHaveAnswer_widgetShowsNullAnswer() {
         OSMWidget widget = createWidget(promptWithAnswer(null));
 
-        assertThat(widget.errorTextView.getVisibility(), is(View.GONE));
-        assertThat(widget.osmFileNameHeaderTextView.getVisibility(), is(View.GONE));
-        assertThat(widget.osmFileNameTextView.getText(), is(""));
+        assertThat(widget.binding.errorText.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.osmFileHeaderText.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.osmFileText.getText(), is(""));
     }
 
     @Test
     public void whenPromptHasAnswer_widgetShowsCorrectAnswer() {
         OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
 
-        assertThat(widget.errorTextView.getVisibility(), is(View.GONE));
-        assertThat(widget.osmFileNameHeaderTextView.getText(), is(widgetActivity.getString(R.string.edited_osm_file)));
-        assertThat(widget.osmFileNameTextView.getText(), is("blah"));
+        assertThat(widget.binding.errorText.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.osmFileHeaderText.getText(), is(widgetActivity.getString(R.string.edited_osm_file)));
+        assertThat(widget.binding.osmFileText.getText(), is("blah"));
     }
 
     @Test
     public void whenPromptHasAnswer_recaptureOsmButtonIsDisplayed() {
         OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
-        assertThat(widget.launchOpenMapKitButton.getText(), is(widgetActivity.getString(R.string.recapture_osm)));
+        assertThat(widget.binding.launchOpenMapKitButton.getText(), is(widgetActivity.getString(R.string.recapture_osm)));
     }
-
 
     @Test
     public void getAnswer_whenPromptAnswerDoesNotHaveAnswer_returnsNull() {
@@ -123,7 +122,15 @@ public class OSMWidgetTest {
     public void clearAnswer_clearsWidgetAnswer() {
         OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
         widget.clearAnswer();
-        assertThat(widget.getAnswer(), nullValue());
+        assertThat(widget.binding.osmFileHeaderText.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.osmFileText.getText(), is(""));
+    }
+
+    @Test
+    public void clearAnswer_showsCaptureOsmButton() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        widget.clearAnswer();
+        assertThat(widget.binding.launchOpenMapKitButton.getText(), is(widgetActivity.getString(R.string.capture_osm)));
     }
 
     @Test
@@ -141,16 +148,16 @@ public class OSMWidgetTest {
         OSMWidget widget = createWidget(promptWithAnswer(null));
         widget.setOnLongClickListener(listener);
 
-        widget.launchOpenMapKitButton.performLongClick();
-        widget.osmFileNameTextView.performLongClick();
-        widget.osmFileNameHeaderTextView.performLongClick();
-        widget.errorTextView.performLongClick();
+        widget.binding.launchOpenMapKitButton.performLongClick();
+        widget.binding.osmFileText.performLongClick();
+        widget.binding.osmFileHeaderText.performLongClick();
+        widget.binding.errorText.performLongClick();
 
-        verify(listener).onLongClick(widget.launchOpenMapKitButton);
-        verify(listener).onLongClick(widget.osmFileNameTextView);
+        verify(listener).onLongClick(widget.binding.launchOpenMapKitButton);
+        verify(listener).onLongClick(widget.binding.osmFileText);
 
-        verify(listener, never()).onLongClick(widget.osmFileNameHeaderTextView);
-        verify(listener, never()).onLongClick(widget.errorTextView);
+        verify(listener, never()).onLongClick(widget.binding.osmFileHeaderText);
+        verify(listener, never()).onLongClick(widget.binding.errorText);
     }
 
     @Test
@@ -158,9 +165,16 @@ public class OSMWidgetTest {
         OSMWidget widget = createWidget(promptWithAnswer(null));
         widget.setBinaryData("blah");
 
-        assertThat(widget.osmFileNameHeaderTextView.getVisibility(), is(View.VISIBLE));
-        assertThat(widget.osmFileNameTextView.getVisibility(), is(View.VISIBLE));
-        assertThat(widget.osmFileNameTextView.getText(), is("blah"));
+        assertThat(widget.binding.osmFileHeaderText.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.binding.osmFileText.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.binding.osmFileText.getText(), is("blah"));
+    }
+
+    @Test
+    public void setData_showsRecaptureOsmButton() {
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        widget.setBinaryData("blah");
+        assertThat(widget.binding.launchOpenMapKitButton.getText(), is(widgetActivity.getString(R.string.recapture_osm)));
     }
 
     @Test
@@ -176,17 +190,16 @@ public class OSMWidgetTest {
     public void clickingButton_whenActivityIsNotAvailable_showsErrorTextView() {
         when(activityAvailability.isActivityAvailable(ArgumentMatchers.any())).thenReturn(false);
         OSMWidget widget = createWidget(promptWithAnswer(null));
-        widget.launchOpenMapKitButton.performClick();
+        widget.binding.launchOpenMapKitButton.performClick();
 
-        assertThat(widget.errorTextView.getVisibility(), is(View.VISIBLE));
-        assertThat(widget.errorTextView.getText(), is(widgetActivity.getString(R.string.invalid_osm_data)));
+        assertThat(widget.binding.errorText.getVisibility(), is(View.VISIBLE));
     }
 
     @Test
     public void clickingButton_whenActivityIsNotAvailable_DoesNotLAunchAnyIntentAndCancelsWaitingForData() {
         when(activityAvailability.isActivityAvailable(ArgumentMatchers.any())).thenReturn(false);
         OSMWidget widget = createWidget(promptWithAnswer(null));
-        widget.launchOpenMapKitButton.performClick();
+        widget.binding.launchOpenMapKitButton.performClick();
 
         assertThat(shadowActivity.getNextStartedActivity(), nullValue());
         assertThat(fakeWaitingForDataRegistry.waiting.isEmpty(), is(true));
@@ -199,7 +212,7 @@ public class OSMWidgetTest {
         when(prompt.getIndex()).thenReturn(formIndex);
 
         OSMWidget widget = createWidget(prompt);
-        widget.launchOpenMapKitButton.performClick();
+        widget.binding.launchOpenMapKitButton.performClick();
 
         assertThat(fakeWaitingForDataRegistry.waiting.contains(formIndex), is(true));
     }
@@ -207,14 +220,14 @@ public class OSMWidgetTest {
     @Test
     public void clickingButton_whenActivityIsAvailableAndPromptDoesNotHaveAnswer_launchesCorrectIntent() {
         OSMWidget widget = createWidget(promptWithAnswer(null));
-        widget.launchOpenMapKitButton.performClick();
+        widget.binding.launchOpenMapKitButton.performClick();
         assertIntentExtrasEquals(null);
     }
 
     @Test
     public void clickingButton_whenActivityIsAvailableAndPromptHasAnswer_launchesCorrectIntent() {
         OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
-        widget.launchOpenMapKitButton.performClick();
+        widget.binding.launchOpenMapKitButton.performClick();
         assertIntentExtrasEquals("blah");
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/OSMWidgetTest.java
@@ -3,102 +3,240 @@ package org.odk.collect.android.widgets;
 import android.content.Intent;
 import android.view.View;
 
-import androidx.annotation.NonNull;
-
 import com.google.common.collect.ImmutableList;
 
-import net.bytebuddy.utility.RandomString;
-
 import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.osm.OSMTag;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.javarosawrapper.FormController;
-import org.odk.collect.android.widgets.base.BinaryWidgetTest;
+import org.odk.collect.android.listeners.WidgetValueChangedListener;
+import org.odk.collect.android.support.TestScreenContextActivity;
+import org.odk.collect.android.utilities.ActivityAvailability;
+import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowActivity;
 
 import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAnswer;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnly;
+import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
+import static org.robolectric.Shadows.shadowOf;
 
 /**
  * @author James Knight
  */
-public class OSMWidgetTest extends BinaryWidgetTest<OSMWidget, StringData> {
+@RunWith(RobolectricTestRunner.class)
+public class OSMWidgetTest {
+    private final FakeWaitingForDataRegistry fakeWaitingForDataRegistry = new FakeWaitingForDataRegistry();
 
-    @Mock
-    public File instancePath;
-    @Mock
-    File mediaFolder;
-    @Mock
-    FormDef formDef;
-    @Mock
-    QuestionDef questionDef;
-    private String fileName;
+    private final File instancePath = new File("instancePath/blah");
+    private final File mediaFolder = new File("mediaFolderPath");
 
-    @NonNull
-    @Override
-    public OSMWidget createWidget() {
-        return new OSMWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID"), new FakeWaitingForDataRegistry());
-    }
-
-    @NonNull
-    @Override
-    public StringData getNextAnswer() {
-        return new StringData(fileName);
-    }
-
-    @Override
-    public StringData getInitialAnswer() {
-        return new StringData(RandomString.make());
-    }
-
-    @Override
-    public Object createBinaryData(StringData answerData) {
-        return answerData.getValue();
-    }
+    private TestScreenContextActivity widgetActivity;
+    private ShadowActivity shadowActivity;
+    private ActivityAvailability activityAvailability;
+    private FormController formController;
+    private QuestionDef questionDef;
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        when(formController.getInstanceFile()).thenReturn(instancePath);
-        when(formEntryPrompt.isReadOnly()).thenReturn(false);
+    public void setUp() {
+        widgetActivity = widgetTestActivity();
+        shadowActivity = shadowOf(widgetActivity);
 
+        activityAvailability = mock(ActivityAvailability.class);
+        formController = mock(FormController.class);
+        FormDef formDef = mock(FormDef.class);
+        questionDef = mock(QuestionDef.class);
+
+        when(activityAvailability.isActivityAvailable(ArgumentMatchers.any())).thenReturn(true);
+        when(formController.getInstanceFile()).thenReturn(instancePath);
         when(formController.getMediaFolder()).thenReturn(mediaFolder);
         when(formController.getSubmissionMetadata()).thenReturn(
-                new FormController.InstanceMetadata("", "", null)
+                new FormController.InstanceMetadata("instanceId", "instanceTesTName", null)
         );
-
         when(formController.getFormDef()).thenReturn(formDef);
         when(formDef.getID()).thenReturn(0);
+    }
 
-        when(mediaFolder.getName()).thenReturn("test-media");
+    @Test
+    public void usingReadOnlyOption_doesNotShowButton() {
+        assertThat(createWidget(promptWithReadOnly()).launchOpenMapKitButton.getVisibility(), is(View.GONE));
+    }
 
-        when(formEntryPrompt.getQuestion()).thenReturn(questionDef);
+    @Test
+    public void whenPromptDoesNotHaveAnswer_widgetShowsNullAnswer() {
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+
+        assertThat(widget.errorTextView.getVisibility(), is(View.GONE));
+        assertThat(widget.osmFileNameHeaderTextView.getVisibility(), is(View.GONE));
+        assertThat(widget.osmFileNameTextView.getText(), is(""));
+    }
+
+    @Test
+    public void whenPromptHasAnswer_widgetShowsCorrectAnswer() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+
+        assertThat(widget.errorTextView.getVisibility(), is(View.GONE));
+        assertThat(widget.osmFileNameHeaderTextView.getText(), is(widgetActivity.getString(R.string.edited_osm_file)));
+        assertThat(widget.osmFileNameTextView.getText(), is("blah"));
+    }
+
+    @Test
+    public void whenPromptHasAnswer_recaptureOsmButtonIsDisplayed() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        assertThat(widget.launchOpenMapKitButton.getText(), is(widgetActivity.getString(R.string.recapture_osm)));
+    }
+
+
+    @Test
+    public void getAnswer_whenPromptAnswerDoesNotHaveAnswer_returnsNull() {
+        assertThat(createWidget(promptWithAnswer(null)).getAnswer(), nullValue());
+    }
+
+    @Test
+    public void getAnswer_whenPromptHasAnswer_returnsAnswer() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        assertThat(widget.getAnswer().getDisplayText(), equalTo("blah"));
+    }
+
+    @Test
+    public void clearAnswer_clearsWidgetAnswer() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        widget.clearAnswer();
+        assertThat(widget.getAnswer(), nullValue());
+    }
+
+    @Test
+    public void clearAnswer_callsValueChangeListeners() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
+
+        widget.clearAnswer();
+        verify(valueChangedListener).widgetValueChanged(widget);
+    }
+
+    @Test
+    public void clickingButtonAndAnswerTextViewForLong_callsLongClickListener() {
+        View.OnLongClickListener listener = mock(View.OnLongClickListener.class);
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        widget.setOnLongClickListener(listener);
+
+        widget.launchOpenMapKitButton.performLongClick();
+        widget.osmFileNameTextView.performLongClick();
+        widget.osmFileNameHeaderTextView.performLongClick();
+        widget.errorTextView.performLongClick();
+
+        verify(listener).onLongClick(widget.launchOpenMapKitButton);
+        verify(listener).onLongClick(widget.osmFileNameTextView);
+
+        verify(listener, never()).onLongClick(widget.osmFileNameHeaderTextView);
+        verify(listener, never()).onLongClick(widget.errorTextView);
+    }
+
+    @Test
+    public void setData_updatesWidgetDisplayedAnswer() {
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        widget.setBinaryData("blah");
+
+        assertThat(widget.osmFileNameHeaderTextView.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.osmFileNameTextView.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.osmFileNameTextView.getText(), is("blah"));
+    }
+
+    @Test
+    public void setData_callsValueChangeListeners() {
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
+
+        widget.setBinaryData("blah");
+        verify(valueChangedListener).widgetValueChanged(widget);
+    }
+
+    @Test
+    public void clickingButton_whenActivityIsNotAvailable_showsErrorTextView() {
+        when(activityAvailability.isActivityAvailable(ArgumentMatchers.any())).thenReturn(false);
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        widget.launchOpenMapKitButton.performClick();
+
+        assertThat(widget.errorTextView.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.errorTextView.getText(), is(widgetActivity.getString(R.string.invalid_osm_data)));
+    }
+
+    @Test
+    public void clickingButton_whenActivityIsNotAvailable_DoesNotLAunchAnyIntentAndCancelsWaitingForData() {
+        when(activityAvailability.isActivityAvailable(ArgumentMatchers.any())).thenReturn(false);
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        widget.launchOpenMapKitButton.performClick();
+
+        assertThat(shadowActivity.getNextStartedActivity(), nullValue());
+        assertThat(fakeWaitingForDataRegistry.waiting.isEmpty(), is(true));
+    }
+
+    @Test
+    public void clickingButton_whenActivityIsAvailable_setsWidgetWaitingForData() {
+        FormIndex formIndex = mock(FormIndex.class);
+        FormEntryPrompt prompt = promptWithAnswer(null);
+        when(prompt.getIndex()).thenReturn(formIndex);
+
+        OSMWidget widget = createWidget(prompt);
+        widget.launchOpenMapKitButton.performClick();
+
+        assertThat(fakeWaitingForDataRegistry.waiting.contains(formIndex), is(true));
+    }
+
+    @Test
+    public void clickingButton_whenActivityIsAvailableAndPromptDoesNotHaveAnswer_launchesCorrectIntent() {
+        OSMWidget widget = createWidget(promptWithAnswer(null));
+        widget.launchOpenMapKitButton.performClick();
+        assertIntentExtrasEquals(null);
+    }
+
+    @Test
+    public void clickingButton_whenActivityIsAvailableAndPromptHasAnswer_launchesCorrectIntent() {
+        OSMWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        widget.launchOpenMapKitButton.performClick();
+        assertIntentExtrasEquals("blah");
+    }
+
+    private OSMWidget createWidget(FormEntryPrompt prompt) {
+        when(prompt.getQuestion()).thenReturn(questionDef);
         when(questionDef.getOsmTags()).thenReturn(ImmutableList.<OSMTag>of());
 
-        fileName = RandomString.make();
+        return new OSMWidget(widgetActivity, new QuestionDetails(prompt, "formAnalyticsID"),
+                fakeWaitingForDataRegistry, activityAvailability, formController);
     }
 
-    @Test
-    public void buttonsShouldLaunchCorrectIntents() {
-        stubAllRuntimePermissionsGranted(true);
+    private void assertIntentExtrasEquals(String fileName) {
+        Intent startedIntent = shadowActivity.getNextStartedActivity();
 
-        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
-        assertActionEquals(Intent.ACTION_SEND, intent);
-    }
+        assertThat(shadowActivity.getNextStartedActivityForResult().requestCode, is(ApplicationConstants.RequestCodes.OSM_CAPTURE));
+        assertThat(startedIntent.getAction(), is(Intent.ACTION_SEND));
+        assertThat(startedIntent.getType(), is("text/plain"));
 
-    @Test
-    public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
-        when(formEntryPrompt.isReadOnly()).thenReturn(true);
-
-        assertThat(getSpyWidget().launchOpenMapKitButton.getVisibility(), is(View.GONE));
+        assertThat(startedIntent.getStringExtra(OSMWidget.FORM_ID), is("0"));
+        assertThat(startedIntent.getStringExtra(OSMWidget.INSTANCE_ID), is("instanceId"));
+        assertThat(startedIntent.getStringExtra(OSMWidget.INSTANCE_DIR), is("instancePath"));
+        assertThat(startedIntent.getStringExtra(OSMWidget.FORM_FILE_NAME), is("mediaFolderPath"));
+        assertThat(startedIntent.getStringExtra(OSMWidget.OSM_EDIT_FILE_NAME), is(fileName));
     }
 }


### PR DESCRIPTION
This PR includes reworking the OSM Widget class, and adding proper test coverage.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I used `ActivityAvaibility` object in the widget to check for the case when the intent cannot be launched. I have missed the test coverage for some part of the code, like for the try-catch statement when launching an intent. Also, I feel it would be better to show the alert dialog in a fragment.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form having OSM integration widget, like AllWidgetsForm

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)