### PR TITLE
Handle NPE in DatabaseMediaFileRepository#getAll()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseMediaFileRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseMediaFileRepository.java
@@ -13,7 +13,10 @@ public class DatabaseMediaFileRepository implements MediaFileRepository {
     @Override
     public List<File> getAll(String jrFormID, String formVersion) {
         String formMediaPath = new FormsDao().getFormMediaPath(jrFormID, formVersion);
-        File[] files = new File(formMediaPath).listFiles();
+        File[] files = new File[0];
+        if (formMediaPath != null) {
+            files = new File(formMediaPath).listFiles();
+        }
         return asList(files);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseMediaFileRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseMediaFileRepository.java
@@ -10,10 +10,15 @@ import java.util.List;
 import static java.util.Arrays.asList;
 
 public class DatabaseMediaFileRepository implements MediaFileRepository {
+    private final FormsDao formsDao;
+
+    public DatabaseMediaFileRepository(FormsDao formsDao) {
+        this.formsDao = formsDao;
+    }
 
     @Override
     public List<File> getAll(String jrFormID, String formVersion) {
-        String formMediaPath = new FormsDao().getFormMediaPath(jrFormID, formVersion);
+        String formMediaPath = formsDao.getFormMediaPath(jrFormID, formVersion);
         return formMediaPath == null
                 ? new ArrayList<>()
                 : asList(new File(formMediaPath).listFiles());

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseMediaFileRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseMediaFileRepository.java
@@ -4,6 +4,7 @@ import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.forms.MediaFileRepository;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -13,10 +14,8 @@ public class DatabaseMediaFileRepository implements MediaFileRepository {
     @Override
     public List<File> getAll(String jrFormID, String formVersion) {
         String formMediaPath = new FormsDao().getFormMediaPath(jrFormID, formVersion);
-        File[] files = new File[0];
-        if (formMediaPath != null) {
-            files = new File(formMediaPath).listFiles();
-        }
-        return asList(files);
+        return formMediaPath == null
+                ? new ArrayList<>()
+                : asList(new File(formMediaPath).listFiles());
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -383,7 +383,7 @@ public class AppDependencyModule {
 
     @Provides
     public MediaFileRepository providesMediaFileRepository() {
-        return new DatabaseMediaFileRepository();
+        return new DatabaseMediaFileRepository(new FormsDao());
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/database/DatabaseMediaFileRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/DatabaseMediaFileRepositoryTest.java
@@ -1,0 +1,20 @@
+package org.odk.collect.android.database;
+
+import org.junit.Test;
+import org.odk.collect.android.dao.FormsDao;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DatabaseMediaFileRepositoryTest {
+
+    @Test
+    public void whenThereIsNoFormForgivenFormIdAndVersion_shouldGetAllMethodReturnEmptyArray() {
+        FormsDao formsDao = mock(FormsDao.class);
+        when(formsDao.getFormMediaPath("1", "1")).thenReturn(null);
+
+        assertThat(new DatabaseMediaFileRepository(formsDao).getAll("1", "1").size(), is(0));
+    }
+}


### PR DESCRIPTION
Closes #4034

#### What has been done to verify that this works as intended?
I reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
The issue was caused by null `formMediaPath`. if that value is null and we call `newFile(formMediaPath)` NPE is thrown. Another solution would be to catch that exception but since we now what is the cause its' a better approach to just avoid it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think this doesn't require testing. A review from another contributor should be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)