### PR TITLE
Fixed setting username from the auth dialog which displays in the list of forms to download

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
@@ -25,6 +25,7 @@ import android.widget.EditText;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.logic.PropertyManager;
 
 import javax.inject.Inject;
 
@@ -40,6 +41,7 @@ public class AuthDialogUtility {
     private String customPassword;
 
     @Inject WebCredentialsUtils webCredentialsUtils;
+    @Inject PropertyManager propertyManager;
 
     public AuthDialogUtility() {
         Collect.getInstance().getComponent().inject(this);
@@ -89,7 +91,7 @@ public class AuthDialogUtility {
                 if (customUsername != null && customPassword != null) {
                     webCredentialsUtils.saveCredentials(finalOverriddenUrl != null ? finalOverriddenUrl : webCredentialsUtils.getServerUrlFromPreferences(), userNameValue, passwordValue);
                 } else if (finalOverriddenUrl == null) {
-                    webCredentialsUtils.saveCredentialsPreferences(userNameValue, passwordValue);
+                    webCredentialsUtils.saveCredentialsPreferences(userNameValue, passwordValue, propertyManager);
                 } else {
                     webCredentialsUtils.saveCredentials(finalOverriddenUrl, userNameValue, passwordValue);
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
@@ -26,6 +26,7 @@ import android.widget.EditText;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 
 import javax.inject.Inject;
 
@@ -40,8 +41,12 @@ public class AuthDialogUtility {
     private String customUsername;
     private String customPassword;
 
-    @Inject WebCredentialsUtils webCredentialsUtils;
-    @Inject PropertyManager propertyManager;
+    @Inject
+    WebCredentialsUtils webCredentialsUtils;
+    @Inject
+    PropertyManager propertyManager;
+    @Inject
+    GeneralSharedPreferences generalSharedPreferences;
 
     public AuthDialogUtility() {
         Collect.getInstance().getComponent().inject(this);
@@ -91,7 +96,7 @@ public class AuthDialogUtility {
                 if (customUsername != null && customPassword != null) {
                     webCredentialsUtils.saveCredentials(finalOverriddenUrl != null ? finalOverriddenUrl : webCredentialsUtils.getServerUrlFromPreferences(), userNameValue, passwordValue);
                 } else if (finalOverriddenUrl == null) {
-                    webCredentialsUtils.saveCredentialsPreferences(userNameValue, passwordValue, propertyManager);
+                    webCredentialsUtils.saveCredentialsPreferences(generalSharedPreferences, userNameValue, passwordValue, propertyManager);
                 } else {
                     webCredentialsUtils.saveCredentials(finalOverriddenUrl, userNameValue, passwordValue);
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
@@ -30,9 +30,9 @@ public class WebCredentialsUtils {
         HOST_CREDENTIALS.put(host, new HttpCredentials(username, password));
     }
 
-    public void saveCredentialsPreferences(String userName, String password, PropertyManager propertyManager) {
-        GeneralSharedPreferences.getInstance().save(GeneralKeys.KEY_USERNAME, userName);
-        GeneralSharedPreferences.getInstance().save(GeneralKeys.KEY_PASSWORD, password);
+    public void saveCredentialsPreferences(GeneralSharedPreferences generalSharedPreferences, String userName, String password, PropertyManager propertyManager) {
+        generalSharedPreferences.save(GeneralKeys.KEY_USERNAME, userName);
+        generalSharedPreferences.save(GeneralKeys.KEY_PASSWORD, password);
 
         propertyManager.reload();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.openrosa.HttpCredentials;
 import org.odk.collect.android.openrosa.HttpCredentialsInterface;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
@@ -29,9 +30,11 @@ public class WebCredentialsUtils {
         HOST_CREDENTIALS.put(host, new HttpCredentials(username, password));
     }
 
-    public void saveCredentialsPreferences(String userName, String password) {
+    public void saveCredentialsPreferences(String userName, String password, PropertyManager propertyManager) {
         GeneralSharedPreferences.getInstance().save(GeneralKeys.KEY_USERNAME, userName);
         GeneralSharedPreferences.getInstance().save(GeneralKeys.KEY_PASSWORD, password);
+
+        propertyManager.reload();
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/WebCredentialsUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/WebCredentialsUtilsTest.java
@@ -1,0 +1,26 @@
+package org.odk.collect.android.utilities;
+
+import org.junit.Test;
+import org.odk.collect.android.logic.PropertyManager;
+import org.odk.collect.android.preferences.GeneralKeys;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class WebCredentialsUtilsTest {
+
+    @Test
+    public void saveCredentialsPreferencesMethod_shouldSaveNewCredentialsAndReloadPropertyManager() {
+        WebCredentialsUtils webCredentialsUtils = new WebCredentialsUtils();
+        GeneralSharedPreferences generalSharedPreferences = mock(GeneralSharedPreferences.class);
+        PropertyManager propertyManager = mock(PropertyManager.class);
+
+        webCredentialsUtils.saveCredentialsPreferences(generalSharedPreferences, "username", "password", propertyManager);
+
+        verify(generalSharedPreferences, times(1)).save(GeneralKeys.KEY_USERNAME, "username");
+        verify(generalSharedPreferences, times(1)).save(GeneralKeys.KEY_PASSWORD, "password");
+        verify(propertyManager, times(1)).reload();
+    }
+}


### PR DESCRIPTION
Closes #4027

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's a bug fix and there is no other solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It just fixes the bug. Since the method I fixed i used only in one place (in the dialog that displays when we have a wrong username/password trying to open list of forms to download) I find it safe and we can test just the fix and no other related functionalities.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with username, i used this one: 
[username.xml.txt](https://github.com/getodk/collect/files/5117265/username.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)