### PR TITLE
Correct `InlineDecline` analytics

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -95,9 +95,9 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
             return;
         }
 
-        analytics.logEvent(ADD_REPEAT, "InlineDecline", formController.getCurrentFormIdentifierHash());
-
         if (jumpBackIndex != null) {
+            analytics.logEvent(ADD_REPEAT, "InlineDecline", formController.getCurrentFormIdentifierHash());
+            
             formController.jumpToIndex(jumpBackIndex);
             jumpBackIndex = null;
         } else {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -84,6 +84,12 @@ public class FormEntryViewModelTest {
     }
 
     @Test
+    public void cancelRepeatPrompt_doesNotLogInlineDeclineAnalytics() {
+        viewModel.cancelRepeatPrompt();
+        verify(analytics, never()).logEvent(AnalyticsEvents.ADD_REPEAT, "InlineDecline", "formIdentifierHash");
+    }
+
+    @Test
     public void cancelRepeatPrompt_afterPromptForNewRepeatAndAddRepeat_doesNotJumpBack() {
         viewModel.promptForNewRepeat();
         viewModel.addRepeat(true);


### PR DESCRIPTION
While looking at the analytics I noticed that the `AddRepeat`/`InlineDecline` event was very frequent which surprised me. Looking at the code though it seems we were sending this event whenever the user cancelled adding a repeat, not just when the cancel adding a repeat after pressing the ➕ button. This fixes that.

#### What has been done to verify that this works as intended?

New test.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Can merge straight in after approval!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)