### PR TITLE
Fixed automatic location recording

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 
 public class SettingsDialogFragment extends DialogFragment {
@@ -35,7 +36,7 @@ public class SettingsDialogFragment extends DialogFragment {
     private int accuracyThresholdIndex = -1;
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NotNull Context context) {
         super.onAttach(context);
 
         if (context instanceof SettingsDialogCallback) {
@@ -50,16 +51,9 @@ public class SettingsDialogFragment extends DialogFragment {
 
         View settingsView = getActivity().getLayoutInflater().inflate(R.layout.geopoly_dialog, null);
         radioGroup = settingsView.findViewById(R.id.radio_group);
-        radioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(RadioGroup group, int checkedId) {
-                checkedRadioButtonId = checkedId;
-                if (checkedId == R.id.automatic_mode) {
-                    autoOptions.setVisibility(View.VISIBLE);
-                } else {
-                    autoOptions.setVisibility(View.GONE);
-                }
-            }
+        radioGroup.setOnCheckedChangeListener((group, checkedId) -> {
+            checkedRadioButtonId = checkedId;
+            autoOptions.setVisibility(checkedId == R.id.automatic_mode ? View.VISIBLE : View.GONE);
         });
 
         autoOptions = settingsView.findViewById(R.id.auto_options);
@@ -115,11 +109,9 @@ public class SettingsDialogFragment extends DialogFragment {
                     callback.setIntervalIndex(intervalIndex);
                     callback.setAccuracyThresholdIndex(accuracyThresholdIndex);
                     callback.startInput();
-                    dialog.cancel();
                     dismiss();
                 })
                 .setNegativeButton(R.string.cancel, (dialog, id) -> {
-                    dialog.cancel();
                     dismiss();
                 })
                 .create();
@@ -128,9 +120,9 @@ public class SettingsDialogFragment extends DialogFragment {
     /** Formats a time interval as a whole number of seconds or minutes. */
     private String formatInterval(int seconds) {
         int minutes = seconds / 60;
-        return minutes > 0 ?
-                getResources().getQuantityString(R.plurals.number_of_minutes, minutes, minutes) :
-                getResources().getQuantityString(R.plurals.number_of_seconds, seconds, seconds);
+        return minutes > 0
+                ? getResources().getQuantityString(R.plurals.number_of_minutes, minutes, minutes)
+                : getResources().getQuantityString(R.plurals.number_of_seconds, seconds, seconds);
     }
 
     /** Populates a Spinner with the option labels in the given array. */
@@ -143,13 +135,12 @@ public class SettingsDialogFragment extends DialogFragment {
 
     /** Formats an entry in the accuracy threshold dropdown. */
     private String formatAccuracyThreshold(int meters) {
-        return meters > 0 ?
-                getResources().getQuantityString(R.plurals.number_of_meters, meters, meters) :
-                getString(R.string.none);
+        return meters > 0
+                ? getResources().getQuantityString(R.plurals.number_of_meters, meters, meters)
+                : getString(R.string.none);
     }
 
     public interface SettingsDialogCallback {
-
         void startInput();
         void updateRecordingMode(int checkedId);
 

--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -111,6 +111,9 @@ public class SettingsDialogFragment extends DialogFragment {
                 .setTitle(getString(R.string.input_method))
                 .setView(settingsView)
                 .setPositiveButton(getString(R.string.start), (dialog, id) -> {
+                    callback.updateRecordingMode(radioGroup.getCheckedRadioButtonId());
+                    callback.setIntervalIndex(intervalIndex);
+                    callback.setAccuracyThresholdIndex(accuracyThresholdIndex);
                     callback.startInput();
                     dialog.cancel();
                     dismiss();
@@ -143,14 +146,6 @@ public class SettingsDialogFragment extends DialogFragment {
         return meters > 0 ?
                 getResources().getQuantityString(R.plurals.number_of_meters, meters, meters) :
                 getString(R.string.none);
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        callback.updateRecordingMode(radioGroup.getCheckedRadioButtonId());
-        callback.setIntervalIndex(intervalIndex);
-        callback.setAccuracyThresholdIndex(accuracyThresholdIndex);
     }
 
     public interface SettingsDialogCallback {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/SettingsDialogFragment.java
@@ -14,7 +14,6 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
-import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 
 public class SettingsDialogFragment extends DialogFragment {
@@ -36,7 +35,7 @@ public class SettingsDialogFragment extends DialogFragment {
     private int accuracyThresholdIndex = -1;
 
     @Override
-    public void onAttach(@NotNull Context context) {
+    public void onAttach(@NonNull Context context) {
         super.onAttach(context);
 
         if (context instanceof SettingsDialogCallback) {


### PR DESCRIPTION
Closes #3984

#### What has been done to verify that this works as intended?
I tested implemented changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is a bug fix and the only solution. The problem was that we tried to start recording first after clicking Start button and then in `onDestroy` method we set properties we need to start the process. It should work the other way around.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's just a bug fix so I find it pretty safe. I think that testing recording locations would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with GeoTrace/GeoShape widgets like the all widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)