### PR TITLE
Update JavaRosa to v3.0.0

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -232,7 +232,7 @@ dependencies {
     implementation "com.rarepebble:colorpicker:3.0.1"
     implementation "commons-io:commons-io:2.6"
     implementation "net.sf.opencsv:opencsv:2.4"
-    implementation("org.getodk:javarosa:2.18.0-SNAPSHOT") {
+    implementation("org.getodk:javarosa:3.0.0") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
There's no difference in behavior between 2.18-snapshot and this one. This just gets us on a release build rather than a snapshot.