### PR TITLE
Do not save answers again after closing select minimal dialog to improve performance

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/AbstractSelectListAdapter.java
@@ -323,4 +323,6 @@ public abstract class AbstractSelectListAdapter extends RecyclerView.Adapter<Abs
     }
 
     public abstract void clearAnswer();
+
+    public abstract boolean hasAnswerChanged();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
@@ -36,10 +36,12 @@ import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.formentry.questions.AudioVideoImageTextLabel;
 import org.odk.collect.android.listeners.SelectItemClickListener;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
 
+    private final List<Selection> originallySelectedItems;
     private final List<Selection> selectedItems;
     protected SelectItemClickListener listener;
 
@@ -49,6 +51,7 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
                                      FormEntryPrompt prompt, ReferenceManager referenceManager, AudioHelper audioHelper,
                                      int playColor, int numColumns, boolean noButtonsMode) {
         super(context, items, prompt, referenceManager, audioHelper, playColor, numColumns, noButtonsMode);
+        this.originallySelectedItems = new ArrayList<>(selectedItems);
         this.selectedItems = selectedItems;
         this.listener = listener;
     }
@@ -156,5 +159,26 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
     @Override
     public List<Selection> getSelectedItems() {
         return selectedItems;
+    }
+
+    @Override
+    public boolean hasAnswerChanged() {
+        if (originallySelectedItems.size() != selectedItems.size()) {
+            return true;
+        }
+        for (Selection item : originallySelectedItems) {
+            boolean foundEqualElement = false;
+            for (Selection item2 : selectedItems) {
+                if (item.xmlValue.equals(item2.xmlValue)) {
+                    foundEqualElement = true;
+                    break;
+                }
+            }
+            if (!foundEqualElement) {
+                return false;
+            }
+        }
+
+        return false;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectOneListAdapter.java
@@ -39,8 +39,10 @@ import org.odk.collect.android.listeners.SelectItemClickListener;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class SelectOneListAdapter extends AbstractSelectListAdapter implements CompoundButton.OnCheckedChangeListener {
+    private final String originallySelectedValue;
     private String selectedValue;
     private RadioButton selectedRadioButton;
     private View selectedItem;
@@ -51,6 +53,7 @@ public class SelectOneListAdapter extends AbstractSelectListAdapter implements C
                                 List<SelectChoice> items, FormEntryPrompt prompt, ReferenceManager referenceManager,
                                 AudioHelper audioHelper, int playColor, int numColumns, boolean noButtonsMode) {
         super(context, items, prompt, referenceManager, audioHelper, playColor, numColumns, noButtonsMode);
+        this.originallySelectedValue = selectedValue;
         this.selectedValue = selectedValue;
         this.listener = listener;
     }
@@ -158,5 +161,10 @@ public class SelectOneListAdapter extends AbstractSelectListAdapter implements C
             }
         }
         return null;
+    }
+
+    @Override
+    public boolean hasAnswerChanged() {
+        return !Objects.equals(originallySelectedValue, selectedValue);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialog.java
@@ -96,7 +96,9 @@ public abstract class SelectMinimalDialog extends MaterialFullScreenDialogFragme
 
     protected void closeDialogAndSaveAnswers() {
         viewModel.getSelectListAdapter().getFilter().filter("");
-        listener.updateSelectedItems(viewModel.getSelectListAdapter().getSelectedItems());
+        if (viewModel.getSelectListAdapter().hasAnswerChanged()) {
+            listener.updateSelectedItems(viewModel.getSelectListAdapter().getSelectedItems());
+        }
         dismiss();
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialogTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMinimalDialogTest.java
@@ -23,16 +23,14 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 public class SelectMinimalDialogTest {
 
-    private FragmentManager fragmentManager;
-    private SelectOneMinimalDialog dialogFragment;
-    private FormEntryPrompt formEntryPrompt;
+    protected FragmentManager fragmentManager;
+    protected SelectMinimalDialog dialogFragment;
+    protected FormEntryPrompt formEntryPrompt;
 
     @Before
     public void setup() {
@@ -41,7 +39,7 @@ public class SelectMinimalDialogTest {
     }
 
     @Test
-    public void whenClickBackButton_shouldDialogBeClosedAndListenerCalled() {
+    public void whenClickBackButton_shouldDialogBeClosed() {
         List<SelectChoice> items = getTestChoices();
         setUpFormEntryPrompt(items, "autocomplete");
         dialogFragment = new SelectOneMinimalDialog(null, false, true, ApplicationProvider.getApplicationContext(), items, formEntryPrompt, null, 0, 1, false);
@@ -52,11 +50,10 @@ public class SelectMinimalDialogTest {
         assertThat(isDialogVisible(), is(true));
         dialogFragment.onBackPressed();
         assertThat(isDialogVisible(), is(false));
-        verify(listener).updateSelectedItems(anyList());
     }
 
     @Test
-    public void whenClickBackArrowButton_shouldDialogBeClosedAndListenerCalled() {
+    public void whenClickBackArrowButton_shouldDialogBeClosed() {
         List<SelectChoice> items = getTestChoices();
         setUpFormEntryPrompt(items, "autocomplete");
         dialogFragment = new SelectOneMinimalDialog(null, false, true, ApplicationProvider.getApplicationContext(), items, formEntryPrompt, null, 0, 1, false);
@@ -67,7 +64,6 @@ public class SelectMinimalDialogTest {
         assertThat(isDialogVisible(), is(true));
         dialogFragment.getToolbar().getChildAt(0).performClick();
         assertThat(isDialogVisible(), is(false));
-        verify(listener).updateSelectedItems(anyList());
     }
 
     @Test
@@ -82,21 +78,21 @@ public class SelectMinimalDialogTest {
         assertThat(dialogFragment.getToolbar().findViewById(R.id.menu_filter).getVisibility(), equalTo(View.VISIBLE));
     }
 
-    private boolean isDialogVisible() {
+    protected boolean isDialogVisible() {
         return dialogFragment != null
                 && dialogFragment.getDialog() != null
                 && dialogFragment.getDialog().isShowing()
                 && !dialogFragment.isRemoving();
     }
 
-    private List<SelectChoice> getTestChoices() {
+    protected List<SelectChoice> getTestChoices() {
         return asList(
                 new SelectChoice("AAA", "AAA"),
                 new SelectChoice("BBB", "BBB")
         );
     }
 
-    private void setUpFormEntryPrompt(List<SelectChoice> items, String appearance) {
+    protected void setUpFormEntryPrompt(List<SelectChoice> items, String appearance) {
         formEntryPrompt = new MockFormEntryPromptBuilder()
                 .withSelectChoices(items)
                 .withAppearance(appearance)

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMultiMinimalDialogTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectMultiMinimalDialogTest.java
@@ -1,0 +1,55 @@
+package org.odk.collect.android.fragments.dialogs;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.helper.Selection;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SelectMultiMinimalDialogTest extends SelectMinimalDialogTest {
+    @Test
+    public void whenClickBackButton_shouldAnswerBeSavedOnlyIfChanged() {
+        List<SelectChoice> items = getTestChoices();
+        setUpFormEntryPrompt(items, "autocomplete");
+        List<Selection> selectedItems = new ArrayList<>();
+        selectedItems.add(items.get(0).selection());
+        dialogFragment = new SelectMultiMinimalDialog(selectedItems, false, true, ApplicationProvider.getApplicationContext(), items, formEntryPrompt, null, 0, 1, false);
+        SelectMinimalDialog.SelectMinimalDialogListener listener = mock(SelectMinimalDialog.SelectMinimalDialogListener.class);
+        dialogFragment.setListener(listener);
+
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.onBackPressed();
+        verify(listener, times(0)).updateSelectedItems(anyList());
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.adapter.clearAnswer();
+        dialogFragment.onBackPressed();
+        verify(listener, times(1)).updateSelectedItems(anyList());
+    }
+
+    @Test
+    public void whenClickBackArrowButton_shouldAnswerBeSavedOnlyIfChanged() {
+        List<SelectChoice> items = getTestChoices();
+        setUpFormEntryPrompt(items, "autocomplete");
+        List<Selection> selectedItems = new ArrayList<>();
+        selectedItems.add(items.get(0).selection());
+        dialogFragment = new SelectMultiMinimalDialog(selectedItems, false, true, ApplicationProvider.getApplicationContext(), items, formEntryPrompt, null, 0, 1, false);
+        SelectMinimalDialog.SelectMinimalDialogListener listener = mock(SelectMinimalDialog.SelectMinimalDialogListener.class);
+        dialogFragment.setListener(listener);
+
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.getToolbar().getChildAt(0).performClick();
+        verify(listener, times(0)).updateSelectedItems(anyList());
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.adapter.clearAnswer();
+        dialogFragment.getToolbar().getChildAt(0).performClick();
+        verify(listener, times(1)).updateSelectedItems(anyList());
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectOneMinimalDialogTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/SelectOneMinimalDialogTest.java
@@ -1,0 +1,49 @@
+package org.odk.collect.android.fragments.dialogs;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.javarosa.core.model.SelectChoice;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SelectOneMinimalDialogTest extends SelectMinimalDialogTest {
+    @Test
+    public void whenClickBackButton_shouldAnswerBeSavedOnlyIfChanged() {
+        List<SelectChoice> items = getTestChoices();
+        setUpFormEntryPrompt(items, "autocomplete");
+        dialogFragment = new SelectOneMinimalDialog("AAA", false, true, ApplicationProvider.getApplicationContext(), items, formEntryPrompt, null, 0, 1, false);
+        SelectMinimalDialog.SelectMinimalDialogListener listener = mock(SelectMinimalDialog.SelectMinimalDialogListener.class);
+        dialogFragment.setListener(listener);
+
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.onBackPressed();
+        verify(listener, times(0)).updateSelectedItems(anyList());
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.adapter.clearAnswer();
+        dialogFragment.onBackPressed();
+        verify(listener, times(1)).updateSelectedItems(anyList());
+    }
+
+    @Test
+    public void whenClickBackArrowButton_shouldAnswerBeSavedOnlyIfChanged() {
+        List<SelectChoice> items = getTestChoices();
+        setUpFormEntryPrompt(items, "autocomplete");
+        dialogFragment = new SelectOneMinimalDialog("AAA", false, true, ApplicationProvider.getApplicationContext(), items, formEntryPrompt, null, 0, 1, false);
+        SelectMinimalDialog.SelectMinimalDialogListener listener = mock(SelectMinimalDialog.SelectMinimalDialogListener.class);
+        dialogFragment.setListener(listener);
+
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.getToolbar().getChildAt(0).performClick();
+        verify(listener, times(0)).updateSelectedItems(anyList());
+        dialogFragment.show(fragmentManager, "TAG");
+        dialogFragment.adapter.clearAnswer();
+        dialogFragment.getToolbar().getChildAt(0).performClick();
+        verify(listener, times(1)).updateSelectedItems(anyList());
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import com.google.android.flexbox.FlexboxLayoutManager;
 
 import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
@@ -387,6 +388,28 @@ public class ChoicesRecyclerViewTest {
         recyclerView.initRecyclerView(adapter, false);
 
         assertThat(getChoiceView(0).isLongClickable(), is(true));
+    }
+
+    @Test
+    public void whenChangingAnswer_shouldHasAnswerChangedReturnCorrectValue() {
+        List<SelectChoice> items = getTestChoices();
+        setUpFormEntryPrompt(items, "");
+
+        SelectItemClickListener listener = mock(SelectItemClickListener.class);
+        List<Selection> selectedItems = new ArrayList<>();
+        selectedItems.add(items.get(0).selection());
+        SelectMultipleListAdapter adapter = new SelectMultipleListAdapter(selectedItems, listener, activityController.get(), items, formEntryPrompt, null, null, 0, 1, false);
+
+        recyclerView.initRecyclerView(adapter, false);
+
+        clickChoice(1); // Select BBB
+        assertThat(adapter.hasAnswerChanged(), is(true));
+
+        clickChoice(1); // Unselect BBB
+        assertThat(adapter.hasAnswerChanged(), is(false));
+
+        clickChoice(0); // Unselect AAA
+        assertThat(adapter.hasAnswerChanged(), is(true));
     }
 
     private List<SelectChoice> getTestChoices() {


### PR DESCRIPTION
Closes #4052 

#### What has been done to verify that this works as intended?
I tested the changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
There is just no need to update answers if they changed. There is no better solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I'm not sure about testing because it's an improvement that might be not even visible so it will be difficult to verify. Maybe trying older devices would help?

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)