### PR TITLE
Fixed strange bug with mixing answers in field-list

### DIFF
--- a/collect_app/src/main/res/layout/select_minimal_widget_answer.xml
+++ b/collect_app/src/main/res/layout/select_minimal_widget_answer.xml
@@ -15,6 +15,7 @@
         android:focusable="false"
         android:drawableEnd="@drawable/ic_arrow_drop_down"
         android:cursorVisible="false"
-        android:inputType="textMultiLine|textNoSuggestions">
+        android:inputType="textMultiLine|textNoSuggestions"
+        android:saveEnabled="false">
     </com.google.android.material.textfield.TextInputEditText>
 </FrameLayout>

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidgetTest.java
@@ -33,6 +33,11 @@ public class SelectOneMinimalWidgetTest extends GeneralSelectOneWidgetTest<Selec
     }
 
     @Test
+    public void answerView_shouldHaveSavingStateDisabled() {
+        assertThat(getSpyWidget().binding.answer.isSaveEnabled(), is(false));
+    }
+
+    @Test
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
         assertThat(getSpyWidget().binding.answer.getVisibility(), is(View.VISIBLE));


### PR DESCRIPTION
Closes #4062

#### What has been done to verify that this works as intended?
I tested the solution manually.

#### Why is this the best possible solution? Were any other approaches considered?
I haven't seen anything so confusing for a very long time. At first when I saw the issue I said to myself ok I must have made some stupid bugs implementing changes in selects, it happens I will fix it in 30 minutes but then I started investigating the issue and I wasn't able to find any bug.
After debugging, playing with other widgets that use view binding my gut said try to just use a different view element to display answers and bingo it turned out that the issue happens when we use `EditTexts`.
I have no idea why. What's interesting the problem occurs only if we rotate a device, if we navigate to another question and then back everything is fine despite the fact that exactly the same methods are called building widgets in both cases.
@seadowg @SaumiaSinghal can you maybe explain that magic?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
this fix shouldn't cause any change or risk so testing only the issue would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The forms attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)