### PR TITLE
Show friendlier errors on form download failure

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/GetBlankFormsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/GetBlankFormsTest.java
@@ -48,4 +48,17 @@ public class GetBlankFormsTest {
                 .assertText(R.string.report_to_project_lead)
                 .clickOK(new GetBlankFormPage(rule));
     }
+
+    @Test
+    public void whenThereIsAnErrorFetchingForms_showsError() {
+        testDependencies.server.addForm("One Question", "one-question", "one-question.xml");
+        testDependencies.server.errorOnFetchingForms();
+
+        rule.mainMenu()
+                .setServer(testDependencies.server.getURL())
+                .clickGetBlankForm()
+                .clickGetSelected()
+                .assertText("One Question (Version:: 1 ID: one-question) - Failure")
+                .clickOK(new GetBlankFormPage(rule));
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -41,6 +41,7 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
     private String username;
     private String password;
     private boolean alwaysReturnError;
+    private boolean fetchingFormsError;
 
     @NonNull
     @Override
@@ -56,6 +57,10 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         } else if (uri.getPath().equals(formListPath)) {
             return new HttpGetResult(getFormListResponse(), getStandardHeaders(), "", 200);
         } else if (uri.getPath().equals("/form")) {
+            if (fetchingFormsError) {
+                return new HttpGetResult(null, new HashMap<>(), "", 500);
+            }
+
             return new HttpGetResult(getFormResponse(uri), getStandardHeaders(), "", 200);
         } else {
             return new HttpGetResult(null, new HashMap<>(), "", 404);
@@ -122,6 +127,14 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         forms.removeIf(formManifestEntry -> formManifestEntry.getFormLabel().equals(formLabel));
     }
 
+    public void alwaysReturnError() {
+        alwaysReturnError = true;
+    }
+
+    public void errorOnFetchingForms() {
+        fetchingFormsError = true;
+    }
+
     public String getURL() {
         return "https://" + HOST;
     }
@@ -184,10 +197,6 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
 
         AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
         return assetManager.open("forms/" + xmlPath);
-    }
-
-    public void alwaysReturnError() {
-        alwaysReturnError = true;
     }
 
     private static class FormManifestEntry {

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaXmlFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaXmlFetcher.java
@@ -78,6 +78,7 @@ public class OpenRosaXmlFetcher {
         return new DocumentFetchResult(doc, inputStreamResult.isOpenRosaResponse(), inputStreamResult.getHash());
     }
 
+    @Nullable
     public InputStream getFile(@NonNull String downloadUrl, @Nullable final String contentType) throws Exception {
         return fetch(downloadUrl, contentType).getInputStream();
     }
@@ -109,10 +110,6 @@ public class OpenRosaXmlFetcher {
         }
 
         return httpInterface.executeGetRequest(uri, contentType, webCredentialsUtils.getCredentials(uri));
-    }
-
-    public OpenRosaHttpInterface getHttpInterface() {
-        return httpInterface;
     }
 
     public WebCredentialsUtils getWebCredentialsUtils() {

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java
@@ -99,12 +99,23 @@ public class OpenRosaFormListApi implements FormListApi {
 
     @Override
     public InputStream fetchForm(String formURL) throws FormApiException {
-        return mapException(() -> openRosaXMLFetcher.getFile(formURL, null));
+        return fetchFile(formURL);
     }
 
     @Override
     public InputStream fetchMediaFile(String mediaFileURL) throws FormApiException {
         return mapException(() -> openRosaXMLFetcher.getFile(mediaFileURL, null));
+    }
+
+    @NotNull
+    private InputStream fetchFile(String formURL) throws FormApiException {
+        InputStream formFile = mapException(() -> openRosaXMLFetcher.getFile(formURL, null));
+
+        if (formFile != null) {
+            return formFile;
+        } else {
+            throw new FormApiException(FETCH_ERROR);
+        }
     }
 
     private List<FormListItem> parseFormList(DocumentFetchResult result) throws FormApiException {

--- a/collect_app/src/main/res/values-ar/strings.xml
+++ b/collect_app/src/main/res/values-ar/strings.xml
@@ -635,8 +635,7 @@
   <string name="number_picker_title">منتقي الأرقام</string>
   <string name="too_complex_form">هذه الاستمارة معقدة جدًا لهذا الجهاز. حاول تبسيط التعبيرات أو طلب المساعدة في المنتدى.</string>
   <string name="reading_files">قراءة الملفات</string>
-  <string name="copying_media_files_failed">فشل نسخ ملفات الوسائط</string>
-  <string name="qr_code_not_found">كود QR غير موجود في الصورة المحددة</string>
+    <string name="qr_code_not_found">كود QR غير موجود في الصورة المحددة</string>
   <string name="not_granted_permission">النشاط الذي تحاول بدء القيام به يحتاج إلى إذن لم تحصل عليه بعد.</string>
   <string name="basemap_source_unavailable">عذرا، %s خرائط الأساس غير متاحة. الرجاء اختر خريطة أساس أخرى في الإعدادات العامة &lt; الخرائط.</string>
   <string name="enter_identity">أدخل الهوية</string>

--- a/collect_app/src/main/res/values-cs/strings.xml
+++ b/collect_app/src/main/res/values-cs/strings.xml
@@ -633,8 +633,7 @@
   <string name="number_picker_title">Výběr čísla</string>
   <string name="too_complex_form">Tento dotazník je pro toto zařízení příliš složitý. Zkuste zjednodušit výrazy nebo požádat o pomoc na fóru.</string>
   <string name="reading_files">Čtení souborů</string>
-  <string name="copying_media_files_failed">Kopírování mediálních souborů se nezdařilo</string>
-  <string name="qr_code_not_found">QR kód nebyl nalezen ve vybraném snímku</string>
+    <string name="qr_code_not_found">QR kód nebyl nalezen ve vybraném snímku</string>
   <string name="not_granted_permission">Aktivita, kterou se pokoušíte spustit, vyžaduje oprávnění, které není uděleno.</string>
   <string name="basemap_source_unavailable">Litujeme, na tomto zařízení nejsou k dispozici základní mapy %s. Vyberte jiný základní soubor v části Obecné nastavení a Mapy.</string>
   <string name="enter_identity">Zadat identitu</string>

--- a/collect_app/src/main/res/values-de/strings.xml
+++ b/collect_app/src/main/res/values-de/strings.xml
@@ -634,8 +634,7 @@
   <string name="number_picker_title">Zahlenwähler</string>
   <string name="too_complex_form">Dieses Formular ist zu komplex für dieses Gerät. Versuche Ausdrücke zu vereinfachen oder bitte im Forum um Hilfe.</string>
   <string name="reading_files">Lese Dateien</string>
-  <string name="copying_media_files_failed">Kopieren von Mediendateien fehlgeschlagen</string>
-  <string name="qr_code_not_found">Kein QR-Code im ausgewählten Bild gefunden</string>
+    <string name="qr_code_not_found">Kein QR-Code im ausgewählten Bild gefunden</string>
   <string name="not_granted_permission">Die Aktivität, die Sie versuchen zu starten, benötigt eine Berechtigung, die nicht gewährt wurde. </string>
   <string name="basemap_source_unavailable">Entschuldigung, %s Basiskarten sind auf diesem Gerät nicht verfügbar. Bitte wählen Sie eine andere Basiskarten unter Allgemeine Einstellungen &gt; Karten. </string>
   <string name="enter_identity">Identität eingeben</string>

--- a/collect_app/src/main/res/values-es/strings.xml
+++ b/collect_app/src/main/res/values-es/strings.xml
@@ -636,8 +636,7 @@
   <string name="number_picker_title">Selector de números</string>
   <string name="too_complex_form">Este formulario es muy complejo para este dispositivo. Intente simplificar las expresiones o busque ayuda en el Foro.</string>
   <string name="reading_files">Leyendo archivos</string>
-  <string name="copying_media_files_failed">La copia de los archivos de medios falló</string>
-  <string name="qr_code_not_found">Código QR no encontrado en la imagen seleccionada</string>
+    <string name="qr_code_not_found">Código QR no encontrado en la imagen seleccionada</string>
   <string name="not_granted_permission">La actividad que está intentando iniciar requiere un permiso que no se ha concedido.</string>
   <string name="basemap_source_unavailable">Lo sentimos, Los mapas base %s no están disponibles en este dispositivo. Por favor escoja otro mapa base en   Please choose another basemap in Cambiar la configuración &gt; Mapas.</string>
   <string name="enter_identity">Ingrese su Identidad</string>

--- a/collect_app/src/main/res/values-fa/strings.xml
+++ b/collect_app/src/main/res/values-fa/strings.xml
@@ -294,6 +294,5 @@
   <string name="rank_items">رده بندی اقلام</string>
   <string name="go_to_settings">رفتن به تنظیمات </string>
   <string name="reading_files">خواندن فایل ها</string>
-  <string name="copying_media_files_failed">کاپی فایل های رسانه ای ناکام شد</string>
-  <string name="not_granted_permission">فعالیتی که شما میخواهید آنرا انجام دهید به مجوزی ضرورت دارد که به شما اعطا نشده است. </string>
+    <string name="not_granted_permission">فعالیتی که شما میخواهید آنرا انجام دهید به مجوزی ضرورت دارد که به شما اعطا نشده است. </string>
 </resources>

--- a/collect_app/src/main/res/values-fi/strings.xml
+++ b/collect_app/src/main/res/values-fi/strings.xml
@@ -634,8 +634,7 @@
   <string name="number_picker_title">Numerovalitsin</string>
   <string name="too_complex_form">Tämä lomake on liian monimutkainen tälle laitteelle. Yritä lausekkeiden yksinkertaistamista tai pyydä apua verkon keskusteluryhmästä.</string>
   <string name="reading_files">Luetaan tiedostoja</string>
-  <string name="copying_media_files_failed">Mediatiedostojen kopiointi epäonnistui</string>
-  <string name="qr_code_not_found">Valitusta kuvasta ei löytynyt QR-koodia</string>
+    <string name="qr_code_not_found">Valitusta kuvasta ei löytynyt QR-koodia</string>
   <string name="not_granted_permission">Toiminto, jota yrität käynnistää, vaatii käyttöluvan jota ei ole myönnetty.</string>
   <string name="basemap_source_unavailable">Pahoittelut, %s pohjakarttoja ei ole käytettävissä tällä laitteella. Ole kyvä ja valitse toinen pohjakartta kohdassa Yleiset asetukset &gt; Kartat.</string>
   <string name="enter_identity">Syötä käyttäjätunnus</string>

--- a/collect_app/src/main/res/values-fr/strings.xml
+++ b/collect_app/src/main/res/values-fr/strings.xml
@@ -634,8 +634,7 @@
   <string name="number_picker_title">Sélecteur de numéro</string>
   <string name="too_complex_form">Ce formulaire est trop complexe pour cet appareil. Essayez de simplifier les expressions ou demandez de l\'aide sur le forum.</string>
   <string name="reading_files">lecture des fichiers</string>
-  <string name="copying_media_files_failed">Echec de la copie des fichiers media</string>
-  <string name="qr_code_not_found">Le code QR n\'a pas été trouvé dans l\'image sélectionnée. </string>
+    <string name="qr_code_not_found">Le code QR n\'a pas été trouvé dans l\'image sélectionnée. </string>
   <string name="not_granted_permission">Vous n\'avez pas les permissions requises pour démarrer l\'activité demandée</string>
   <string name="basemap_source_unavailable">Désolé mais %s cartes de base ne sont pas disponibles sur votre appareil. Merci de choisir une auter carte de base dans les Paramètres Gànéraux / Cartes</string>
   <string name="enter_identity">Entrez l\'identité</string>

--- a/collect_app/src/main/res/values-in/strings.xml
+++ b/collect_app/src/main/res/values-in/strings.xml
@@ -631,8 +631,7 @@
   <string name="number_picker_title">Pemilihan nomor</string>
   <string name="too_complex_form">Formulir ini terlalu rumit untuk perangkat ini. Coba sederhanakan ekspresi atau minta bantuan di forum.</string>
   <string name="reading_files">Membaca berkas</string>
-  <string name="copying_media_files_failed">Menyalin berkas media tidak berhasil</string>
-  <string name="qr_code_not_found">Kode QR tidak ditemukan pada gambar terpilih</string>
+    <string name="qr_code_not_found">Kode QR tidak ditemukan pada gambar terpilih</string>
   <string name="not_granted_permission">Aktivitas yang sedang Anda coba memerlukan izin yang belum Anda diberikan.</string>
   <string name="basemap_source_unavailable">Maaf, peta dasar %s tidak tersedia pada perangkat ini. Mohon pilih peta dasar lain di Pengaturan Umum &gt; Peta.</string>
   <string name="enter_identity">Masukan identitas</string>

--- a/collect_app/src/main/res/values-ja/strings.xml
+++ b/collect_app/src/main/res/values-ja/strings.xml
@@ -631,8 +631,7 @@
   <string name="number_picker_title">数値選択</string>
   <string name="too_complex_form">この形式はこの端末には複雑すぎます。 表現を単純化するか、フォーラムで助けを求めてください。</string>
   <string name="reading_files">ファイルを読み込んでいます</string>
-  <string name="copying_media_files_failed">メディアファイルのコピーに失敗しました</string>
-  <string name="qr_code_not_found">選択した画像に QR コードが見つかりませんでした</string>
+    <string name="qr_code_not_found">選択した画像に QR コードが見つかりませんでした</string>
   <string name="not_granted_permission">開始しようとしているアクティビティは、必要なアクセス許可が付与されていません。</string>
   <string name="basemap_source_unavailable">申し訳ありません。 このデバイスでは %s ベースマップは利用できません。 一般設定 &gt; 地図 で別のベースマップを選択してください。</string>
   <string name="enter_identity">IDの入力</string>

--- a/collect_app/src/main/res/values-pl/strings.xml
+++ b/collect_app/src/main/res/values-pl/strings.xml
@@ -629,8 +629,7 @@
   <string name="number_picker_title">Wybór Wartości</string>
   <string name="too_complex_form">Formularz jest zbyt skomplikowany dla tego urządzenia. Spróbuj uprościć wyrażenia, lub poproś o pomoc na forum.</string>
   <string name="reading_files">Odczyt plików</string>
-  <string name="copying_media_files_failed">Kopiowanie plików mediów nie powiodło się</string>
-  <string name="qr_code_not_found">Na wybranym zdjęciu nie odnaleziono kodu QR</string>
+    <string name="qr_code_not_found">Na wybranym zdjęciu nie odnaleziono kodu QR</string>
   <string name="not_granted_permission">Aktywność, którą próbujesz wykonać, wymaga autoryzacji, której nie posiadasz.</string>
   <string name="basemap_source_unavailable">Przepraszamy, mapy bazowe %s nie są dostępne na tym urządzeniu.  Wybierz inną mapę bazową z Ustawień Ogólnych &gt; Mapy.</string>
   <string name="enter_identity">Wprowadź swoje dane</string>

--- a/collect_app/src/main/res/values-sr/strings.xml
+++ b/collect_app/src/main/res/values-sr/strings.xml
@@ -594,7 +594,6 @@
   <string name="number_picker_title">Birač brojeva</string>
   <string name="too_complex_form">Formular je previše kompleksan za vaoj uređaj. Pokušaj da uprostiš izraze ili zatraži pomoć na forumu.</string>
   <string name="reading_files">Učitavanje fajlova</string>
-  <string name="copying_media_files_failed">Kopiranje medija fajlova nije uspjelo</string>
-  <string name="qr_code_not_found">QR kod nije pronađen na odabranoj slici</string>
+    <string name="qr_code_not_found">QR kod nije pronađen na odabranoj slici</string>
   <string name="not_granted_permission">Aktivnost koju pokušavate da pokrenete zahtijeva dozvolu koja nije odobrena.</string>
 </resources>

--- a/collect_app/src/main/res/values-te/strings.xml
+++ b/collect_app/src/main/res/values-te/strings.xml
@@ -616,8 +616,7 @@
   <string name="number_picker_title">నెంబర్ ను ఎంచుకునేది </string>
   <string name="too_complex_form">ఈ పరికరం కోసం ఈ ఫారం చాలా క్లిష్టంగా ఉంటుంది. వ్యక్తీకరణలను సరళీకృతం చేయడానికి ప్రయత్నించండి లేదా ఫోరమ్‌లో సహాయం కోసం అడగండి.</string>
   <string name="reading_files">ఫైళ్ళను చదవడం జరుగుతున్నది</string>
-  <string name="copying_media_files_failed">మీడియా ఫైళ్ళను కాపీ చేయడం విఫలమైంది</string>
-  <string name="qr_code_not_found">ఎంచుకున్న ఫోటో లో QR కోడ్ కనపడటం లేదు</string>
+    <string name="qr_code_not_found">ఎంచుకున్న ఫోటో లో QR కోడ్ కనపడటం లేదు</string>
   <string name="not_granted_permission">మీరు మొదులు పెట్టడానికి ప్రయత్నిస్తున్న పనికి అనుమతి అవసరం. అది మీకు ఇవ్వబడలేదు.</string>
   <string name="basemap_source_unavailable">క్షమించండి, %s ఈ పరికరంలో బేస్‌మ్యాప్‌లు అందుబాటులో లేవు. దయచేసి సాధారణ సెట్టింగులలో మరొక బేస్‌మ్యాప్‌ ఎంచుకోండి &amp; gt; మ్యాప్స్.</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -703,5 +703,6 @@
     <string name="report_to_project_lead">If you keep having this problem, report it to the person who asked you to collect data.</string>
     <string name="unreachable_error">Collect can\'t reach the server at %s. Did you enter the URL correctly?</string>
     <string name="security_error">Collect can\'t connect securely to the server at %s. Did you enter the URL correctly?</string>
+    <string name="failure">Failure</string>
     <string name="form_update_succeeded">Form update succeeded</string>
 </resources>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -657,7 +657,6 @@
     <string name="number_picker_title">Number Picker</string>
     <string name="too_complex_form">This form is too complex for this device. Try simplifying expressions or ask for help on the forum.</string>
     <string name="reading_files">Reading files</string>
-    <string name="copying_media_files_failed">Copying media files failed</string>
     <string name="qr_code_not_found">QR Code not found in the selected image</string>
     <string name="not_granted_permission">The activity you are trying to start requires a permission which is not granted.</string>
     <string name="basemap_source_unavailable">Sorry, %s basemaps are not available on this device.  Please choose another basemap in General Settings &gt; Maps.</string>

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/MultiFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/MultiFormDownloaderTest.java
@@ -367,7 +367,7 @@ public class MultiFormDownloaderTest {
         forms.add(serverFormDetails);
 
         HashMap<ServerFormDetails, String> messages = downloader.downloadForms(forms, null);
-        assertThat(messages.get(serverFormDetails), containsString("<label> node for itemset doesn't exist!"));
+        assertThat(messages.get(serverFormDetails), containsString("Failure"));
     }
 
     public static DocumentFetchResult buildManifestFetchResult(String filename) throws Exception {


### PR DESCRIPTION
While working on something else I noticed that for v1.28 we're throwing the exception messages up to the user when form download fails for things like server errors (a 500 or a 404 for example). I think for 1.29 we want to look at improving these errors but for the moment I think making them simpler is the best/easiest thing. For now any form download error will just show as "Failure" (if it succeeds we simply put "Success") as the result of the individual download.

#### What has been done to verify that this works as intended?

Wrote a new test as it's hard to verify manually.

#### Why is this the best possible solution? Were any other approaches considered?

I think there are a lot of better things we could do. My ideal would be to make the details of the error available to the user but maybe hide them behind an expanding text view or something. Then we could potentially have a simpler "everything succeeded" or "everything failed" message.

I think creating an issue and fixing as part of #4040 might be a nice plan? If people agree I can start an issue for discussion/mockups.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just make errors friendlier. Good to check other form download failures than just server errors to check nothing weird has been introduced.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)