### PR TITLE
Remove August 2020 from messages

### DIFF
--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -676,7 +676,7 @@
     <string name="scoped_storage_learn_more">Learn more and migrate</string>
     <string name="storage_migration_completed">Storage migration completed!</string>
     <string name="scoped_storage_dismiss">Dismiss</string>
-    <string name="storage_migration_dialog_message1">Android requirements have changed and files used by Collect must be migrated by August 2020.</string>
+    <string name="storage_migration_dialog_message1">Android requirements have changed and files used by Collect must be migrated.</string>
     <string name="storage_migration_dialog_message2">You have %d unsent submissions. You are encouraged to submit all data before migrating.</string>
     <string name="storage_migration_dialog_message3">If you use an external application integration such as OpenMapKit, please do not migrate yet.</string>
     <string name="storage_migration_more_details">More details</string>
@@ -689,7 +689,7 @@
     <string name="storage_migration_dialog_title">Storage migration</string>
     <string name="storage_migration_progress_msg">Migration in progress.\nThis may take a few seconds…</string>
 
-    <string name="install_id">Install ID - will replace Device ID in August 2020</string>
+    <string name="install_id">Install ID - will replace Device ID in Collect v1.29</string>
     <string name="preference_not_available">Not available</string>
     <string name="custom_server_paths">Custom server paths</string>
     <string name="legacy_custom_server_paths_summary">Will be removed in a future version. Please use /formList and /submission on your server.</string>


### PR DESCRIPTION
We initially thought we had to target API 29 in August 2020 but we actually have until November. We need to update messages in the app to remove the confusing allusions to August 2020.

#### What has been done to verify that this works as intended?
Visual inspection of diff.

#### Why is this the best possible solution? Were any other approaches considered?
No alternatives considered. I used the Collect version number in the deviceID message since we know it. I don't think we need any precision in the migration dialog since we already say the version number in the banner.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
None.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
I will update the forum posts to reflect the new timeline.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)