### PR TITLE
Fixed checking for spaces in underlying values

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/ListMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/ListMultiWidget.java
@@ -42,6 +42,7 @@ import org.odk.collect.android.external.ExternalSelectChoice;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -233,6 +234,10 @@ public class ListMultiWidget extends ItemsWidget implements MultiChoiceWidget {
 
                 buttonLayout.addView(answer, answerParams);
             }
+
+            SpacesInUnderlyingValuesWarning
+                    .forQuestionWidget(this)
+                    .renderWarningIfNecessary(items);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
@@ -12,6 +12,7 @@ import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
 import org.odk.collect.android.fragments.dialogs.SelectMultiMinimalDialog;
 import org.odk.collect.android.utilities.StringUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,9 @@ public class SelectMultiMinimalWidget extends SelectMinimalWidget {
                 ? new ArrayList<>() :
                 (List<Selection>) getFormEntryPrompt().getAnswerValue().getValue();
         updateAnswerLabel();
+        SpacesInUnderlyingValuesWarning
+                .forQuestionWidget(this)
+                .renderWarningIfNecessary(items);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiWidget.java
@@ -24,6 +24,7 @@ import org.odk.collect.android.adapters.AbstractSelectListAdapter;
 import org.odk.collect.android.adapters.SelectMultipleListAdapter;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
+import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +41,9 @@ import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayColo
 public class SelectMultiWidget extends BaseSelectListWidget {
     public SelectMultiWidget(Context context, QuestionDetails prompt) {
         super(context, prompt);
+        SpacesInUnderlyingValuesWarning
+                .forQuestionWidget(this)
+                .renderWarningIfNecessary(items);
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/ListMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/ListMultiWidgetTest.java
@@ -2,13 +2,18 @@ package org.odk.collect.android.widgets.items;
 
 import android.view.View;
 import android.widget.CheckBox;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import org.javarosa.core.model.SelectChoice;
 import org.junit.Test;
+import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.widgets.base.GeneralSelectMultiWidgetTest;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
@@ -32,5 +37,19 @@ public class ListMultiWidgetTest extends GeneralSelectMultiWidgetTest<ListMultiW
             assertThat(checkBox.getVisibility(), is(View.VISIBLE));
             assertThat(checkBox.isEnabled(), is(Boolean.FALSE));
         }
+    }
+
+    @Test
+    public void whenSpacesInUnderlyingValuesExist_shouldAppropriateWarningBeDisplayed() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(asList(
+                        new SelectChoice("a", "a a"),
+                        new SelectChoice("a", "b b")
+                ))
+                .build();
+
+        TextView warningTv = getWidget().findViewById(R.id.warning_text);
+        assertThat(warningTv.getVisibility(), is(View.VISIBLE));
+        assertThat(warningTv.getText(), is("Warning: underlying values a a, b b have spaces"));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/RankingWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/RankingWidgetTest.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.widgets.items;
 
 import android.view.View;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
@@ -9,12 +10,15 @@ import org.javarosa.core.model.data.MultipleItemsData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.junit.Test;
+import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.widgets.base.SelectWidgetTest;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
@@ -45,5 +49,19 @@ public class RankingWidgetTest extends SelectWidgetTest<RankingWidget, MultipleI
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
         assertThat(getSpyWidget().showRankingDialogButton.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenSpacesInUnderlyingValuesExist_shouldAppropriateWarningBeDisplayed() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(asList(
+                        new SelectChoice("a", "a a"),
+                        new SelectChoice("a", "b b")
+                ))
+                .build();
+
+        TextView warningTv = getWidget().findViewById(R.id.warning_text);
+        assertThat(warningTv.getVisibility(), is(View.VISIBLE));
+        assertThat(warningTv.getText(), is("Warning: underlying values a a, b b have spaces"));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiImageMapWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiImageMapWidgetTest.java
@@ -1,5 +1,8 @@
 package org.odk.collect.android.widgets.items;
 
+import android.view.View;
+import android.widget.TextView;
+
 import androidx.annotation.NonNull;
 
 import com.google.common.collect.ImmutableList;
@@ -7,9 +10,16 @@ import com.google.common.collect.ImmutableList;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
+import org.junit.Test;
+import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 
 import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class SelectMultiImageMapWidgetTest extends SelectImageMapWidgetTest<SelectMultiImageMapWidget, SelectMultiData> {
     @NonNull
@@ -28,5 +38,20 @@ public class SelectMultiImageMapWidgetTest extends SelectImageMapWidgetTest<Sele
 
         Selection selection = new Selection(selectChoice);
         return new SelectMultiData(ImmutableList.of(selection));
+    }
+
+    @Test
+    public void whenSpacesInUnderlyingValuesExist_shouldAppropriateWarningBeDisplayed() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(asList(
+                        new SelectChoice("a", "a a"),
+                        new SelectChoice("a", "b b")
+                ))
+                .withImageURI("jr://images/body.svg")
+                .build();
+
+        TextView warningTv = getWidget().findViewById(R.id.warning_text);
+        assertThat(warningTv.getVisibility(), is(View.VISIBLE));
+        assertThat(warningTv.getText(), is("Warning: underlying values a a, b b have spaces"));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidgetTest.java
@@ -1,19 +1,24 @@
 package org.odk.collect.android.widgets.items;
 
 import android.view.View;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.junit.Test;
+import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
+import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.widgets.base.GeneralSelectMultiWidgetTest;
 
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
@@ -73,5 +78,19 @@ public class SelectMultiMinimalWidgetTest extends GeneralSelectMultiWidgetTest<S
         getSpyWidget().setBinaryData(Collections.singletonList(selectedChoice));
 
         verify(valueChangedListener).widgetValueChanged(getSpyWidget());
+    }
+
+    @Test
+    public void whenSpacesInUnderlyingValuesExist_shouldAppropriateWarningBeDisplayed() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(asList(
+                        new SelectChoice("a", "a a"),
+                        new SelectChoice("a", "b b")
+                ))
+                .build();
+
+        TextView warningTv = getWidget().findViewById(R.id.warning_text);
+        assertThat(warningTv.getVisibility(), is(View.VISIBLE));
+        assertThat(warningTv.getText(), is("Warning: underlying values a a, b b have spaces"));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiWidgetTest.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
@@ -21,6 +22,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.audio.AudioButton;
 import org.odk.collect.android.audio.AudioHelper;
@@ -204,6 +206,20 @@ public class SelectMultiWidgetTest extends GeneralSelectMultiWidgetTest<SelectMu
 
         FrameLayout view = (FrameLayout) getSpyWidget().binding.choicesRecyclerView.getLayoutManager().getChildAt(0);
         assertThat(view.isEnabled(), is(Boolean.FALSE));
+    }
+
+    @Test
+    public void whenSpacesInUnderlyingValuesExist_shouldAppropriateWarningBeDisplayed() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withSelectChoices(asList(
+                        new SelectChoice("a", "a a"),
+                        new SelectChoice("a", "b b")
+                ))
+                .build();
+
+        TextView warningTv = getWidget().findViewById(R.id.warning_text);
+        assertThat(warningTv.getVisibility(), is(View.VISIBLE));
+        assertThat(warningTv.getText(), is("Warning: underlying values a a, b b have spaces"));
     }
 
     private ViewGroup getChoiceView(SelectMultiWidget widget, int index) {


### PR DESCRIPTION
Closes #4078

#### What has been done to verify that this works as intended?
I tested implemented changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I moved checking for spaces in underlying values to the main ItemsWidget class what is the best solution because all widgets that need the warning extend that class, so we have everything in one place and we can test it easily.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test the form attached to he issue and I think it would be enough since the change is pretty safe and we have automated tests.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue is ok.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)