### PR TITLE
Make changes to test API 29

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -68,7 +68,7 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 
 android {
-    compileSdkVersion(28)
+    compileSdkVersion(29)
 
     viewBinding {
         enabled = true
@@ -77,7 +77,7 @@ android {
     defaultConfig {
         applicationId('org.odk.collect.android')
         minSdkVersion(21)
-        targetSdkVersion(28)
+        targetSdkVersion(29)
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')
@@ -94,6 +94,13 @@ android {
                 keyAlias secrets.getProperty('RELEASE_KEY_ALIAS')
                 keyPassword secrets.getProperty('RELEASE_KEY_PASSWORD')
             }
+        }
+
+        selfSignedRelease {
+            storeFile new File(System.getProperty("user.home") + '/.android/debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
         }
     }
 
@@ -116,6 +123,18 @@ android {
             if (secrets.getProperty('RELEASE_STORE_FILE')) {
                 signingConfig signingConfigs.release
             }
+            minifyEnabled(true)
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            resValue("bool", "CRASHLYTICS_ENABLED", "true")
+            resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
+            buildConfigField 'String', "MAPBOX_ACCESS_TOKEN", '"' + mapboxToken + '"'
+
+            matchingFallbacks = ['release'] // So other modules use release build type for this
+        }
+
+        selfSignedRelease {
+            signingConfig signingConfigs.selfSignedRelease
+
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             resValue("bool", "CRASHLYTICS_ENABLED", "true")

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -77,6 +77,7 @@ the specific language governing permissions and limitations under the License.
         android:label="@string/app_name"
         android:largeHeap="true"
         android:supportsRtl="true"
+        android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true"
         android:allowBackup="true">
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -234,32 +234,26 @@ public class AppDependencyModule {
 
     @Provides
     public DeviceDetailsProvider providesDeviceDetailsProvider(Context context) {
-        TelephonyManager telMgr = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-
         return new DeviceDetailsProvider() {
 
             @Override
-            @SuppressLint({"MissingPermission", "HardwareIds"})
             public String getDeviceId() {
-                return telMgr.getDeviceId();
+                return "";
             }
 
             @Override
-            @SuppressLint({"MissingPermission", "HardwareIds"})
             public String getLine1Number() {
-                return telMgr.getLine1Number();
+                return "";
             }
 
             @Override
-            @SuppressLint({"MissingPermission", "HardwareIds"})
             public String getSubscriberId() {
-                return telMgr.getSubscriberId();
+                return "";
             }
 
             @Override
-            @SuppressLint({"MissingPermission", "HardwareIds"})
             public String getSimSerialNumber() {
-                return telMgr.getSimSerialNumber();
+                return "";
             }
         };
     }


### PR DESCRIPTION
I built and installed the `selfSignedRelease` variant on my Pixel 2 (running Android 11), ran the storage migration in app and then did:

```
adb push ~/Downloads/form.xml /sdcard/Android/data/org.odk.collect.android/files/forms/form.xml
```

I was able to view the form in the app.

To check:

- [x] `adb push` works with `requestLegacyExternalStorage` and targeting API 29 after scoped storage migration
- [x] `adb pull` works with `requestLegacyExternalStorage` and targeting API 29 after scoped storage migration
- [x] `adb push` works without `requestLegacyExternalStorage` and targeting API 29 after scoped storage migration
- [x] `adb push` works without `requestLegacyExternalStorage` and targeting API 29 after scoped storage migration

