### PR TITLE
Fixed selecting answers in select_multiple minimal

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/SelectMultipleListAdapter.java
@@ -175,7 +175,7 @@ public class SelectMultipleListAdapter extends AbstractSelectListAdapter {
                 }
             }
             if (!foundEqualElement) {
-                return false;
+                return true;
             }
         }
 

--- a/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/views/ChoicesRecyclerViewTest.java
@@ -405,11 +405,14 @@ public class ChoicesRecyclerViewTest {
         clickChoice(1); // Select BBB
         assertThat(adapter.hasAnswerChanged(), is(true));
 
-        clickChoice(1); // Unselect BBB
-        assertThat(adapter.hasAnswerChanged(), is(false));
-
         clickChoice(0); // Unselect AAA
         assertThat(adapter.hasAnswerChanged(), is(true));
+
+        clickChoice(1); // Unselect BBB
+        assertThat(adapter.hasAnswerChanged(), is(true));
+
+        clickChoice(0); // Select AAA
+        assertThat(adapter.hasAnswerChanged(), is(false));
     }
 
     private List<SelectChoice> getTestChoices() {


### PR DESCRIPTION
Closes #4085

#### What has been done to verify that this works as intended?
I tested the fix manually and improved tests.

#### Why is this the best possible solution? Were any other approaches considered?
It was just a silly bug in `hasAnswerChanged()` where in one case we returned wrong boolean value.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe and isolated fix so we can just test the scenario described in the issue and nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)