### PR TITLE
Add self signed release build

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -96,6 +96,7 @@ android {
             }
         }
 
+        // This uses the default debug keystore that the Android tooling creates https://stackoverflow.com/questions/16622528/android-studio-debug-keystore
         selfSignedRelease {
             storeFile new File(System.getProperty("user.home") + '/.android/debug.keystore')
             storePassword 'android'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -95,6 +95,13 @@ android {
                 keyPassword secrets.getProperty('RELEASE_KEY_PASSWORD')
             }
         }
+
+        selfSignedRelease {
+            storeFile new File(System.getProperty("user.home") + '/.android/debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
     }
 
     buildTypes {
@@ -116,6 +123,18 @@ android {
             if (secrets.getProperty('RELEASE_STORE_FILE')) {
                 signingConfig signingConfigs.release
             }
+            minifyEnabled(true)
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            resValue("bool", "CRASHLYTICS_ENABLED", "true")
+            resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
+            buildConfigField 'String', "MAPBOX_ACCESS_TOKEN", '"' + mapboxToken + '"'
+
+            matchingFallbacks = ['release'] // So other modules use release build type for this
+        }
+
+        selfSignedRelease {
+            signingConfig signingConfigs.selfSignedRelease
+
             minifyEnabled(true)
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             resValue("bool", "CRASHLYTICS_ENABLED", "true")


### PR DESCRIPTION
This adds a build variant that has same configuration as `odkCollectRelease` but uses the default Android tooling debug keystore. This means you can build and test it from a machine without having a signing key (and update/install consistently from that machine).

#### What has been done to verify that this works as intended?

Installed on emulator using new variant.

#### Why is this the best possible solution? Were any other approaches considered?

We could include our own generated debug keystore but I think this is neater and also prevents us running into problems where the debug keystore is mistaken for the real signing key (as the default debug keystore is different on different machines).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No changes to behaviour. Should be good to merge once reviewed!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)