### PR TITLE
Sanitize form version

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java
@@ -184,7 +184,7 @@ public class OpenRosaFormListApi implements FormListApi {
                         break;
                     case "version":
                         version = XFormParser.getXMLText(child, true);
-                        if (version != null && version.length() == 0) {
+                        if (version != null && version.trim().isEmpty()) {
                             version = null;
                         }
                         break;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -279,7 +279,11 @@ public class FileUtils {
 
         fields.put(TITLE, formDef.getTitle());
         fields.put(FORMID, formDef.getMainInstance().getRoot().getAttributeValue(null, "id"));
-        fields.put(VERSION, formDef.getMainInstance().getRoot().getAttributeValue(null, "version"));
+        String version = formDef.getMainInstance().getRoot().getAttributeValue(null, "version");
+        if (version != null && version.trim().isEmpty()) {
+            version = null;
+        }
+        fields.put(VERSION, version);
 
         if (formDef.getSubmissionProfile() != null) {
             fields.put(SUBMISSIONURI, formDef.getSubmissionProfile().getAction());

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FileUtilsTest.java
@@ -277,6 +277,35 @@ public class FileUtilsTest {
         assertThat(metadataFromFormDefinition.get(FileUtils.GEOMETRY_XPATH), is("/data/location1"));
     }
 
+    @Test public void whenFormVersionIsEmpty_shouldBeTreatedAsNull() throws IOException {
+        String simpleForm = "<?xml version=\"1.0\"?>\n" +
+                "<h:html xmlns=\"http://www.w3.org/2002/xforms\"\n" +
+                "        xmlns:h=\"http://www.w3.org/1999/xhtml\"\n" +
+                "        xmlns:orx=\"http://openrosa.org/xforms\">\n" +
+                "    <h:head>\n" +
+                "        <h:title>My Survey</h:title>\n" +
+                "        <model>\n" +
+                "            <instance>\n" +
+                "                <data id=\"mysurvey\" orx:version=\"   \">\n" +
+                "                </data>\n" +
+                "            </instance>\n" +
+                "        </model>\n" +
+                "    </h:head>\n" +
+                "    <h:body>\n" +
+                "\n" +
+                "    </h:body>\n" +
+                "</h:html>";
+        File temp = File.createTempFile("simple_form", ".xml");
+        temp.deleteOnExit();
+
+        BufferedWriter out = new BufferedWriter(new FileWriter(temp));
+        out.write(simpleForm);
+        out.close();
+
+        HashMap<String, String> metadataFromFormDefinition = FileUtils.getMetadataFromFormDefinition(temp);
+        assertThat(metadataFromFormDefinition.get(FileUtils.VERSION), is(nullValue()));
+    }
+
     @Test
     @SuppressWarnings("PMD.DoNotHardCodeSDCard")
     public void simplifyScopedStoragePathTest() {


### PR DESCRIPTION
Closes #4095

#### What has been done to verify that this works as intended?
I tested the fix manually and added tests.

#### Why is this the best possible solution? Were any other approaches considered?
The first thing I should mention is that this issue is not a regression towards the previous version. The behavior changed a bit because we refactored the code and now is more visible but this has never worked as expected.

The problem was that the form contained and empty version (it's a specific form that's also true):
```xml
<ecsv id="ecsv" version="">
```

Reading the list of forms we can download we care about it and convert such empty values to null:
https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java#L187

```java
if (version != null && version.length() == 0) {
    version = null;
}
```

but we have never done the same saving files to database.
The result was that having such a form with an empty version and trying to compare it to the one we already have we weren't able to read proper values from database.

I think this solution is the best because the method I fixed is used every time we try to parse and save a form so it fixes cases when we download a form from a server or when we scan it from a disk.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The issue should be fixed and nothing else should be affected. We can test just the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)