### PR TITLE
Fixed downloading forms from an external app

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/tasks/DownloadFormListTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/tasks/DownloadFormListTaskTest.java
@@ -1,0 +1,23 @@
+package org.odk.collect.android.instrumented.tasks;
+
+import org.junit.Test;
+import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
+import org.odk.collect.android.tasks.DownloadFormListTask;
+import org.odk.collect.android.utilities.WebCredentialsUtils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class DownloadFormListTaskTest {
+
+    @Test
+    public void whenAlternateCredentialsAreSet_shouldServerFormsDetailsFetcherBeUpdated() {
+        ServerFormsDetailsFetcher serverFormsDetailsFetcher = mock(ServerFormsDetailsFetcher.class);
+        WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
+
+        DownloadFormListTask task = new DownloadFormListTask(serverFormsDetailsFetcher);
+        task.setAlternateCredentials(webCredentialsUtils, "https://test-server.com", "testUser", "testPassword");
+        verify(serverFormsDetailsFetcher).updateFormListApi("https://test-server.com", webCredentialsUtils);
+    }
+
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -25,6 +25,7 @@ import org.odk.collect.android.openrosa.api.ManifestFile;
 import org.odk.collect.android.openrosa.api.MediaFile;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MultiFormDownloader;
+import org.odk.collect.android.utilities.WebCredentialsUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -148,5 +149,10 @@ public class ServerFormsDetailsFetcher {
             }
         }
         return false;
+    }
+
+    public void updateFormListApi(String url, WebCredentialsUtils webCredentialsUtils) {
+        formListAPI.updateUrl(url);
+        formListAPI.updateWebCredentialsUtils(webCredentialsUtils);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaXmlFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaXmlFetcher.java
@@ -27,7 +27,7 @@ public class OpenRosaXmlFetcher {
     private static final String HTTP_CONTENT_TYPE_TEXT_XML = "text/xml";
 
     private final OpenRosaHttpInterface httpInterface;
-    private final WebCredentialsUtils webCredentialsUtils;
+    private WebCredentialsUtils webCredentialsUtils;
 
     public OpenRosaXmlFetcher(OpenRosaHttpInterface httpInterface, WebCredentialsUtils webCredentialsUtils) {
         this.httpInterface = httpInterface;
@@ -114,5 +114,9 @@ public class OpenRosaXmlFetcher {
 
     public WebCredentialsUtils getWebCredentialsUtils() {
         return webCredentialsUtils;
+    }
+
+    public void updateWebCredentialsUtils(WebCredentialsUtils webCredentialsUtils) {
+        this.webCredentialsUtils = webCredentialsUtils;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/api/FormListApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/api/FormListApi.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.openrosa.api;
 
+import org.odk.collect.android.utilities.WebCredentialsUtils;
+
 import java.io.InputStream;
 import java.util.List;
 
@@ -12,4 +14,8 @@ public interface FormListApi {
     InputStream fetchForm(String formURL) throws FormApiException;
 
     InputStream fetchMediaFile(String mediaFileURL) throws FormApiException;
+
+    void updateUrl(String url);
+
+    void updateWebCredentialsUtils(WebCredentialsUtils webCredentialsUtils);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/api/OpenRosaFormListApi.java
@@ -32,7 +32,7 @@ public class OpenRosaFormListApi implements FormListApi {
             "http://openrosa.org/xforms/xformsManifest";
 
     private final OpenRosaXmlFetcher openRosaXMLFetcher;
-    private final String serverURL;
+    private String serverURL;
     private final String formListPath;
 
     public OpenRosaFormListApi(String serverURL, String formListPath, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils) {
@@ -105,6 +105,16 @@ public class OpenRosaFormListApi implements FormListApi {
     @Override
     public InputStream fetchMediaFile(String mediaFileURL) throws FormApiException {
         return mapException(() -> openRosaXMLFetcher.getFile(mediaFileURL, null));
+    }
+
+    @Override
+    public void updateUrl(String url) {
+        this.serverURL = url;
+    }
+
+    @Override
+    public void updateWebCredentialsUtils(WebCredentialsUtils webCredentialsUtils) {
+        this.openRosaXMLFetcher.updateWebCredentialsUtils(webCredentialsUtils);
     }
 
     @NotNull

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -101,6 +101,7 @@ public class DownloadFormListTask extends AsyncTask<Void, String, Pair<List<Serv
         this.url = url;
         this.username = username;
         this.password = password;
+        serverFormsDetailsFetcher.updateFormListApi(url, webCredentialsUtils);
     }
 
     private void setTemporaryCredentials() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -150,6 +150,12 @@ public final class DialogUtils {
         DialogFragment existingDialog = (DialogFragment) fragmentManager.findFragmentByTag(dialogClazz.getName());
         if (existingDialog != null) {
             existingDialog.dismissAllowingStateLoss();
+
+            // We need to execute this transaction. Otherwise a next attempt to display a dialog
+            // could happen before the Fragment is dismissed in Fragment Manager and so the
+            // call to findFragmentByTag would return something (not null) and as a result the
+            // next dialog won't be displayed.
+            fragmentManager.executePendingTransactions();
         }
     }
 


### PR DESCRIPTION
Closes #4094

#### What has been done to verify that this works as intended?
I tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that we didn't update `ServerFormsDetailsFetcher` after creating the task for downloading from an external app so it always contained credentials from Collect.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The fix is safe so we can focus on the scenario described in the issue testing it, nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)