### PR TITLE
Handle negative location accuracy values

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/location/client/AndroidLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/AndroidLocationClient.java
@@ -145,6 +145,9 @@ class AndroidLocationClient
         Timber.i("Location changed: %s", location.toString());
 
         if (locationListener != null) {
+            if (location.getAccuracy() < 0) {
+                location.setAccuracy(0);
+            }
             locationListener.onLocationChanged(location);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleFusedLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleFusedLocationClient.java
@@ -214,6 +214,9 @@ public class GoogleFusedLocationClient
         Timber.i("Location changed: %s", location.toString());
 
         if (locationListener != null) {
+            if (location.getAccuracy() < 0) {
+                location.setAccuracy(0);
+            }
             locationListener.onLocationChanged(location);
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/location/client/GoogleFusedLocationClientTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/location/client/GoogleFusedLocationClientTest.java
@@ -10,11 +10,13 @@ import com.google.android.gms.location.FusedLocationProviderApi;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.odk.collect.android.location.LocationTestUtils;
+import org.robolectric.RobolectricTestRunner;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
@@ -24,17 +26,17 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class GoogleFusedLocationClientTest {
 
-    @Mock FusedLocationProviderApi fusedLocationProviderApi;
-    @Mock GoogleApiClient googleApiClient;
-    @Mock LocationManager locationManager;
-
+    private GoogleApiClient googleApiClient;
     private GoogleFusedLocationClient client;
 
     @Before
     public void setUp() {
+        FusedLocationProviderApi fusedLocationProviderApi = mock(FusedLocationProviderApi.class);
+        googleApiClient = mock(GoogleApiClient.class);
+        LocationManager locationManager = mock(LocationManager.class);
         client = new GoogleFusedLocationClient(googleApiClient, fusedLocationProviderApi, locationManager);
     }
 
@@ -154,6 +156,19 @@ public class GoogleFusedLocationClientTest {
     @Test
     public void canSetUpdateIntervalsShouldReturnTrue() {
         assertTrue(client.canSetUpdateIntervals());
+    }
+
+    @Test
+    public void whenAccuracyIsNegative_shouldBeSanitized() {
+        client.start();
+
+        TestLocationListener listener = new TestLocationListener();
+        client.requestLocationUpdates(listener);
+
+        Location location = LocationTestUtils.createLocation("GPS", 7, 2, 3, -1);
+        client.onLocationChanged(location);
+
+        assertThat(listener.getLastLocation().getAccuracy(), is(0.0f));
     }
 
     private static Location newMockLocation() {


### PR DESCRIPTION
Closes #4102

#### What has been done to verify that this works as intended?
I tested the behavior with hardcoded negative values and added tests.

#### Why is this the best possible solution? Were any other approaches considered?
The issue is not our bug it's something rare probably device firmware is responsible for that as said in https://stackoverflow.com/questions/34232835/android-location-getaccuracy-returns-negative-accuracy
so everything we can do is handling such cases.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think it doesn't require testing because it's almost not possible to reproduce.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)