### PR TITLE
Fixed padding in choices

### DIFF
--- a/collect_app/src/main/res/layout/select_multi_item.xml
+++ b/collect_app/src/main/res/layout/select_multi_item.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingVertical="@dimen/margin_small"
+    android:paddingEnd="@dimen/margin_standard"
     android:button="@drawable/inset_check_box"
     tools:text="Option A">
 

--- a/collect_app/src/main/res/layout/select_one_item.xml
+++ b/collect_app/src/main/res/layout/select_one_item.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingVertical="@dimen/margin_small"
+    android:paddingEnd="@dimen/margin_standard"
     android:button="@drawable/inset_radio_button"
     tools:text="Option A">
 


### PR DESCRIPTION
Closes #4105 

#### What has been done to verify that this works as intended?
I tested the fix with select widgets and ltr/rtl languages.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only solution, we just didn't have any margin after selects (between text and the end of the screen or media buttons).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix that should only solve the issue. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with selects.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)