### PR TITLE
Remove code to hide experimental themes in settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/UserInterfacePreferencesFragment.java
@@ -33,7 +33,6 @@ import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.version.VersionInformation;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.TreeMap;
 
 import javax.inject.Inject;
@@ -76,10 +75,6 @@ public class UserInterfacePreferencesFragment extends BasePreferenceFragment {
         final ListPreference pref = findPreference(KEY_APP_THEME);
 
         if (pref != null) {
-            if (versionInformation.isRelease()) {
-                hideExperimentalThemes(pref);
-            }
-
             pref.setSummary(pref.getEntry());
             pref.setOnPreferenceChangeListener((preference, newValue) -> {
                 int index = ((ListPreference) preference).findIndexOfValue(newValue.toString());
@@ -91,14 +86,6 @@ public class UserInterfacePreferencesFragment extends BasePreferenceFragment {
                 return true;
             });
         }
-    }
-
-    private void hideExperimentalThemes(ListPreference pref) {
-        CharSequence[] entries = pref.getEntries();
-        pref.setEntries(Arrays.copyOfRange(entries, 0, entries.length - 1));
-
-        CharSequence[] entryValues = pref.getEntryValues();
-        pref.setEntryValues(Arrays.copyOfRange(entryValues, 0, entryValues.length - 1));
     }
 
     private void initNavigationPrefs() {


### PR DESCRIPTION
There's now an Experimental section. The result of this is that the `Dark theme` was being removed. This only was observable if on a tagged release build.

#### What has been done to verify that this works as intended?
Created a fake release tag, verified that the dark theme is visible. Ran `userInterfaceSettings_shouldBeReset` and verified that it passes. Verified that the Experimental menu is still hidden.

#### Why is this the best possible solution? Were any other approaches considered?
This was a mistake and there aren't any alternatives to fixing it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This code is straightforward to understand and verify so it should be low risk. We don't want any special behavior based on the build type in the main settings.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)