### PR TITLE
Prevent NPE in QuitFormDialogFragment

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -45,6 +45,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
@@ -459,7 +460,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         formSaveViewModel.getSaveResult().observe(this, this::handleSaveResult);
     }
 
-    private void formControllerAvailable(FormController formController) {
+    private void formControllerAvailable(@NonNull FormController formController) {
         menuDelegate.formLoaded(formController);
         identityPromptViewModel.formLoaded(formController);
         formEntryViewModel.formLoaded(formController);
@@ -519,8 +520,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             formLoaderTask = (FormLoaderTask) data;
         } else if (data == null) {
             if (!newForm) {
-                if (getFormController() != null) {
-                    FormController formController = getFormController();
+                FormController formController = getFormController();
+
+                if (formController != null) {
                     formControllerAvailable(formController);
                     refreshCurrentView();
                 } else {
@@ -529,6 +531,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     showIfNotShowing(FormLoadingDialogFragment.class, getSupportFragmentManager());
                     formLoaderTask.execute(formPath);
                 }
+
                 return;
             }
 
@@ -2291,6 +2294,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         DialogUtils.dismissDialog(FormLoadingDialogFragment.class, getSupportFragmentManager());
 
         final FormController formController = task.getFormController();
+
         if (formController != null) {
             if (readPhoneStatePermissionRequestNeeded) {
                 new PermissionUtils().requestReadPhoneStatePermission(this, true, new PermissionListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProviders;
 
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationViewModel;
 import org.odk.collect.android.formentry.questions.AnswersProvider;
@@ -40,7 +41,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
     }
 
     @Override
-    public void formLoaded(FormController formController) {
+    public void formLoaded(@NotNull FormController formController) {
         this.formController = formController;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.javarosawrapper.FormController;
@@ -34,7 +35,7 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     }
 
     @Override
-    public void formLoaded(FormController formController) {
+    public void formLoaded(@NotNull FormController formController) {
         this.formController = formController;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
@@ -19,10 +19,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.IconMenuListAdapter;
 import org.odk.collect.android.adapters.model.IconMenuItem;
 import org.odk.collect.android.analytics.Analytics;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
-import org.odk.collect.android.external.ExternalDataManager;
-import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.AdminKeys;
@@ -84,16 +81,7 @@ public class QuitFormDialogFragment extends DialogFragment {
                     listener.onSaveChangesClicked();
                 }
             } else {
-                ExternalDataManager manager = Collect.getInstance().getExternalDataManager();
-                if (manager != null) {
-                    manager.close();
-                }
-
-                if (viewModel.getAuditEventLogger() != null) {
-                    viewModel.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, System.currentTimeMillis());
-                }
-
-                viewModel.removeTempInstance();
+                viewModel.ignoreChanges();
 
                 String action = getActivity().getIntent().getAction();
                 if (Intent.ACTION_PICK.equals(action) || Intent.ACTION_EDIT.equals(action)) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RequiresFormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RequiresFormController.java
@@ -1,7 +1,9 @@
 package org.odk.collect.android.formentry;
 
+import androidx.annotation.NonNull;
+
 import org.odk.collect.android.javarosawrapper.FormController;
 
 public interface RequiresFormController {
-    void formLoaded(FormController formController);
+    void formLoaded(@NonNull FormController formController);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/IdentityPromptViewModel.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.formentry.audit;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
@@ -26,7 +27,7 @@ public class IdentityPromptViewModel extends ViewModel implements RequiresFormCo
     }
 
     @Override
-    public void formLoaded(FormController formController) {
+    public void formLoaded(@NonNull FormController formController) {
         this.formName = formController.getFormTitle();
         this.auditEventLogger = formController.getAuditEventLogger();
         updateRequiresIdentity();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -134,26 +134,29 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             manager.close();
         }
 
-        if (formController != null && formController.getInstanceFile() != null) {
+        if (formController != null) {
             formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, System.currentTimeMillis());
 
-            SaveFormToDisk.removeSavepointFiles(formController.getInstanceFile().getName());
+            if (formController.getInstanceFile() != null) {
+                SaveFormToDisk.removeSavepointFiles(formController.getInstanceFile().getName());
 
-            // if it's not already saved, erase everything
-            if (!InstancesDaoHelper.isInstanceAvailable(getAbsoluteInstancePath())) {
-                // delete media first
-                String instanceFolder = formController.getInstanceFile().getParent();
-                Timber.i("Attempting to delete: %s", instanceFolder);
-                File file = formController.getInstanceFile().getParentFile();
-                int images = MediaUtils.deleteImagesInFolderFromMediaProvider(file);
-                int audio = MediaUtils.deleteAudioInFolderFromMediaProvider(file);
-                int video = MediaUtils.deleteVideoInFolderFromMediaProvider(file);
+                // if it's not already saved, erase everything
+                if (!InstancesDaoHelper.isInstanceAvailable(getAbsoluteInstancePath())) {
+                    // delete media first
+                    String instanceFolder = formController.getInstanceFile().getParent();
+                    Timber.i("Attempting to delete: %s", instanceFolder);
+                    File file = formController.getInstanceFile().getParentFile();
+                    int images = MediaUtils.deleteImagesInFolderFromMediaProvider(file);
+                    int audio = MediaUtils.deleteAudioInFolderFromMediaProvider(file);
+                    int video = MediaUtils.deleteVideoInFolderFromMediaProvider(file);
 
-                Timber.i("Removed from content providers: %d image files, %d audio files and %d audio files.",
-                        images, audio, video);
-                FileUtils.purgeMediaPath(instanceFolder);
+                    Timber.i("Removed from content providers: %d image files, %d audio files and %d audio files.",
+                            images, audio, video);
+                    FileUtils.purgeMediaPath(instanceFolder);
+                }
             }
         }
+
         clearMediaFiles();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -16,6 +16,7 @@ import androidx.savedstate.SavedStateRegistryOwner;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryController;
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
 import org.odk.collect.android.exception.JavaRosaException;
@@ -83,7 +84,7 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
     }
 
     @Override
-    public void formLoaded(FormController formController) {
+    public void formLoaded(@NotNull FormController formController) {
         this.formController = formController;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -18,14 +18,15 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryController;
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
 import org.odk.collect.android.exception.JavaRosaException;
+import org.odk.collect.android.external.ExternalDataManager;
 import org.odk.collect.android.formentry.RequiresFormController;
 import org.odk.collect.android.formentry.audit.AuditEvent;
-import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.formentry.audit.AuditUtils;
-import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
+import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.tasks.SaveFormToDisk;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 import org.odk.collect.android.utilities.FileUtils;
@@ -34,12 +35,11 @@ import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.utilities.Clock;
 
 import java.io.File;
-
-import timber.log.Timber;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import timber.log.Timber;
 
 import static org.odk.collect.android.tasks.SaveFormToDisk.SAVED;
 import static org.odk.collect.android.tasks.SaveFormToDisk.SAVED_AND_EXIT;
@@ -128,8 +128,15 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
     }
 
     // Cleanup when user exits a form without saving
-    public void removeTempInstance() {
+    public void ignoreChanges() {
+        ExternalDataManager manager = Collect.getInstance().getExternalDataManager();
+        if (manager != null) {
+            manager.close();
+        }
+
         if (formController != null && formController.getInstanceFile() != null) {
+            formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_EXIT, true, System.currentTimeMillis());
+
             SaveFormToDisk.removeSavepointFiles(formController.getInstanceFile().getName());
 
             // if it's not already saved, erase everything
@@ -274,10 +281,6 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             return null;
         }
         return formController.getFormTitle();
-    }
-
-    public AuditEventLogger getAuditEventLogger() {
-        return formController.getAuditEventLogger();
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -411,6 +411,12 @@ public class FormSaveViewModelTest {
         verify(mediaUtils).deleteImageFileFromMediaProvider("blah");
     }
 
+    @Test
+    public void ignoreChanges_whenFormControllerNotSet_doesNothing() {
+        FormSaveViewModel viewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null);
+        viewModel.ignoreChanges(); // Checks nothing explodes
+    }
+
     private void whenReasonRequiredToSave() {
         when(logger.isChangeReasonRequired()).thenReturn(true);
         when(logger.isChangesMade()).thenReturn(true);


### PR DESCRIPTION
Closes #4036

This hopefully fixes the crash but it's hard to validate as we don't have reproduction steps.

#### What has been done to verify that this works as intended?

Isolated code with bug and wrote new test to cover it.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just prevent the one case where a `null` could be set. I think it's a simple enough change that we can merge without QA but maybe still good for them to check loading forms and then ignoring changes here so we're confident when we do a patch release.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)