### PR TITLE
Handle widgets waiting for data using WaitingForDataRegistry

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -160,7 +160,7 @@ public class WidgetFactory {
                 // considered in each widget by calls to ExternalDataUtil.getSearchXPathExpression.
                 // This means normal appearances should be put before search().
                 if (appearance.contains(WidgetAppearanceUtils.MINIMAL)) {
-                    questionWidget = new SelectOneMinimalWidget(context, questionDetails, isQuick);
+                    questionWidget = new SelectOneMinimalWidget(context, questionDetails, isQuick, waitingForDataRegistry);
                 } else if (appearance.contains(WidgetAppearanceUtils.LIKERT)) {
                     questionWidget = new LikertWidget(context, questionDetails);
                 } else if (appearance.contains(WidgetAppearanceUtils.LIST_NO_LABEL)) {
@@ -180,7 +180,7 @@ public class WidgetFactory {
                 // considered in each widget by calls to ExternalDataUtil.getSearchXPathExpression.
                 // This means normal appearances should be put before search().
                 if (appearance.contains(WidgetAppearanceUtils.MINIMAL)) {
-                    questionWidget = new SelectMultiMinimalWidget(context, questionDetails);
+                    questionWidget = new SelectMultiMinimalWidget(context, questionDetails, waitingForDataRegistry);
                 } else if (appearance.startsWith(WidgetAppearanceUtils.LIST_NO_LABEL)) {
                     questionWidget = new ListMultiWidget(context, questionDetails, false);
                 } else if (appearance.startsWith(WidgetAppearanceUtils.LIST)) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMinimalWidget.java
@@ -6,19 +6,20 @@ import android.view.View;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.databinding.SelectMinimalWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.utilities.QuestionFontSizeUtils;
 import org.odk.collect.android.widgets.interfaces.BinaryDataReceiver;
 import org.odk.collect.android.widgets.interfaces.MultiChoiceWidget;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 public abstract class SelectMinimalWidget extends ItemsWidget implements BinaryDataReceiver, MultiChoiceWidget {
     SelectMinimalWidgetAnswerBinding binding;
+    private final WaitingForDataRegistry waitingForDataRegistry;
 
-    public SelectMinimalWidget(Context context, QuestionDetails prompt) {
+    public SelectMinimalWidget(Context context, QuestionDetails prompt, WaitingForDataRegistry waitingForDataRegistry) {
         super(context, prompt);
+        this.waitingForDataRegistry = waitingForDataRegistry;
     }
 
     @Override
@@ -29,10 +30,7 @@ public abstract class SelectMinimalWidget extends ItemsWidget implements BinaryD
             binding.answer.setEnabled(false);
         } else {
             binding.answer.setOnClickListener(v -> {
-                FormController formController = Collect.getInstance().getFormController();
-                if (formController != null) {
-                    formController.setIndexWaitingForData(prompt.getIndex());
-                }
+                waitingForDataRegistry.waitForData(prompt.getIndex());
                 showDialog();
             });
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
@@ -12,6 +12,7 @@ import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
 import org.odk.collect.android.fragments.dialogs.SelectMultiMinimalDialog;
 import org.odk.collect.android.utilities.StringUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.android.widgets.warnings.SpacesInUnderlyingValuesWarning;
 
 import java.util.ArrayList;
@@ -22,8 +23,8 @@ import static org.odk.collect.android.formentry.media.FormMediaUtils.getPlayColo
 public class SelectMultiMinimalWidget extends SelectMinimalWidget {
     private List<Selection> selectedItems;
 
-    public SelectMultiMinimalWidget(Context context, QuestionDetails prompt) {
-        super(context, prompt);
+    public SelectMultiMinimalWidget(Context context, QuestionDetails prompt, WaitingForDataRegistry waitingForDataRegistry) {
+        super(context, prompt, waitingForDataRegistry);
         selectedItems = getFormEntryPrompt().getAnswerValue() == null
                 ? new ArrayList<>() :
                 (List<Selection>) getFormEntryPrompt().getAnswerValue().getValue();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidget.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.fragments.dialogs.SelectOneMinimalDialog;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.utilities.StringUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import java.util.List;
 
@@ -23,8 +24,8 @@ public class SelectOneMinimalWidget extends SelectMinimalWidget {
     private final boolean autoAdvance;
     private AdvanceToNextListener autoAdvanceListener;
 
-    public SelectOneMinimalWidget(Context context, QuestionDetails prompt, boolean autoAdvance) {
-        super(context, prompt);
+    public SelectOneMinimalWidget(Context context, QuestionDetails prompt, boolean autoAdvance, WaitingForDataRegistry waitingForDataRegistry) {
+        super(context, prompt, waitingForDataRegistry);
         selectedItem = getQuestionDetails().getPrompt().getAnswerValue() == null
                 ? null
                 : ((Selection) getQuestionDetails().getPrompt().getAnswerValue().getValue());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/FormControllerWaitingForDataRegistry.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/FormControllerWaitingForDataRegistry.java
@@ -4,6 +4,8 @@ import org.javarosa.core.model.FormIndex;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.javarosawrapper.FormController;
 
+import timber.log.Timber;
+
 public class FormControllerWaitingForDataRegistry implements WaitingForDataRegistry {
 
     @Override
@@ -15,6 +17,7 @@ public class FormControllerWaitingForDataRegistry implements WaitingForDataRegis
 
         FormController formController = collect.getFormController();
         if (formController == null) {
+            Timber.w("Can not call setIndexWaitingForData() because of null formController");
             return;
         }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidgetTest.java
@@ -14,6 +14,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.widgets.base.GeneralSelectMultiWidgetTest;
+import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +31,7 @@ public class SelectMultiMinimalWidgetTest extends GeneralSelectMultiWidgetTest<S
     @NonNull
     @Override
     public SelectMultiMinimalWidget createWidget() {
-        return new SelectMultiMinimalWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID"));
+        return new SelectMultiMinimalWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID"), new FakeWaitingForDataRegistry());
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidgetTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.widgets.base.GeneralSelectOneWidgetTest;
+import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 
 import java.util.Collections;
 
@@ -24,7 +25,7 @@ public class SelectOneMinimalWidgetTest extends GeneralSelectOneWidgetTest<Selec
     @NonNull
     @Override
     public SelectOneMinimalWidget createWidget() {
-        return new SelectOneMinimalWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID"), false);
+        return new SelectOneMinimalWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID"), false, new FakeWaitingForDataRegistry());
     }
 
     @Test


### PR DESCRIPTION
Closes #4122

#### What has been done to verify that this works as intended?
I tested the app manually.

#### Why is this the best possible solution? Were any other approaches considered?
WaitingForDataRegistry is what we use in other places to handle widgets waiting for data.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Since we are not able to reproduce the issue we can merge without testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)