### PR TITLE
Fix flakey delete form test

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -110,6 +110,7 @@ public class DeleteBlankFormTest {
                 .pressBack(new MainMenuPage(rule))
 
                 .copyForm("one-question.xml")
+                .wait250ms() // We need to account for inaccuracy in calls to system time
                 .clickFillBlankForm()
                 .assertFormExists("One Question");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -32,7 +32,7 @@ public class DeleteBlankFormTest {
                 .clickDeleteForms()
                 .pressBack(new MainMenuPage(rule))
                 .clickFillBlankForm()
-                .assertTextDoesNotExist("One Question");
+                .assertNoForms();
     }
 
     @Test
@@ -49,10 +49,9 @@ public class DeleteBlankFormTest {
                 .clickForm("One Question")
                 .clickDeleteSelected(1)
                 .clickDeleteForms()
-                .assertTextDoesNotExist("One Question")
                 .pressBack(new MainMenuPage(rule))
                 .clickFillBlankForm()
-                .assertTextDoesNotExist("One Question")
+                .assertNoForms()
                 .pressBack(new MainMenuPage(rule))
 
                 .clickEditSavedForm()
@@ -83,14 +82,14 @@ public class DeleteBlankFormTest {
                 .clickForm("One Question")
                 .clickDeleteSelected(1)
                 .clickDeleteForms()
-                .assertTextDoesNotExist("One Question")
                 .pressBack(new MainMenuPage(rule))
 
                 .clickGetBlankForm()
                 .clickGetSelected()
                 .assertText("One Question (Version:: 1 ID: one_question) - Success")
                 .clickOK(new MainMenuPage(rule))
-                .startBlankForm("One Question");
+                .clickFillBlankForm()
+                .assertFormExists("One Question");
     }
 
     @Test
@@ -111,6 +110,7 @@ public class DeleteBlankFormTest {
                 .pressBack(new MainMenuPage(rule))
 
                 .copyForm("one-question.xml")
-                .startBlankForm("One Question");
+                .clickFillBlankForm()
+                .assertFormExists("One Question");
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
@@ -12,6 +12,7 @@ import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.CursorMatchers.withRowString;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -86,6 +87,7 @@ public class FillBlankFormPage extends Page<FillBlankFormPage> {
     }
 
     private void clickOnFormButton(String formName) {
+        assertFormExists(formName);
         onData(withRowString(FormsColumns.DISPLAY_NAME, formName)).perform(click());
     }
 
@@ -107,5 +109,23 @@ public class FillBlankFormPage extends Page<FillBlankFormPage> {
     public ServerAuthDialog clickRefreshWithAuthError() {
         onView(withId(R.id.menu_refresh)).perform(click());
         return new ServerAuthDialog(rule).assertOnPage();
+    }
+
+    public FillBlankFormPage assertFormExists(String formName) {
+        // Seen problems with disk syncing not being waited for even though it's an AsyncTask
+        return waitFor(() -> {
+            onData(withRowString(FormsColumns.DISPLAY_NAME, formName)).check(matches(isDisplayed()));
+            return this;
+        });
+    }
+
+    public FillBlankFormPage assertFormDoesNotExist(String formName) {
+        onData(withRowString(FormsColumns.DISPLAY_NAME, formName)).check(doesNotExist());
+        return this;
+    }
+
+    public FillBlankFormPage assertNoForms() {
+        assertText(R.string.no_items_display_forms);
+        return this;
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FillBlankFormPage.java
@@ -114,6 +114,7 @@ public class FillBlankFormPage extends Page<FillBlankFormPage> {
     public FillBlankFormPage assertFormExists(String formName) {
         // Seen problems with disk syncing not being waited for even though it's an AsyncTask
         return waitFor(() -> {
+            assertTextNotDisplayed(R.string.no_items_display_forms);
             onData(withRowString(FormsColumns.DISPLAY_NAME, formName)).check(matches(isDisplayed()));
             return this;
         });

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -13,6 +13,8 @@ import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import androidx.test.runner.lifecycle.Stage;
 
+import junit.framework.AssertionFailedError;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.FormLoadingUtils;
 import org.odk.collect.android.support.actions.RotateAction;
@@ -339,12 +341,7 @@ abstract class Page<T extends Page<T>> {
                 return;
             } catch (Exception e) {
                 failure = e;
-
-                try {
-                    Thread.sleep(250);
-                } catch (InterruptedException ignored) {
-                    // ignored
-                }
+                wait250ms();
             }
         }
 
@@ -357,26 +354,32 @@ abstract class Page<T extends Page<T>> {
 
     protected <T> T waitFor(Callable<T> callable) {
         int counter = 0;
-        Exception failure = null;
+        Throwable failure = null;
 
         // Try 20 times/for 5 seconds
         while (counter < 20) {
             try {
                 return callable.call();
-            } catch (Exception throwable) {
+            } catch (Exception | AssertionFailedError throwable) {
                 failure = throwable;
             }
 
-            try {
-                Thread.sleep(250);
-            } catch (InterruptedException ignored) {
-                // ignored
-            }
+            wait250ms();
 
             counter++;
         }
 
         throw new RuntimeException("waitFor failed", failure);
+    }
+
+    public T wait250ms() {
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException ignored) {
+            // ignored
+        }
+
+        return (T) this;
     }
 
     public T assertTextNotDisplayed(int string) {


### PR DESCRIPTION
Closes #4124 

This attempts for timing issues caused by the various I/O/async work that happens when loading forms and also for issues that might be caused by calls to system time only being so accurate (which could lead to two successive calls not returning monotonic values as expected).

#### What has been done to verify that this works as intended?

Ran locally and on test lab several times.

#### Why is this the best possible solution? Were any other approaches considered?

The best solution is to move coverage of this feature to a lower level as it's a very detailed scenario which we don't really want to bother with in Espresso. This is hard because it would require some rework to get the disk sync code in a testable place.

Another thing we could do is use a fake time source (probably a stub or fake of our `Clock`). This would also require some rework as we are dealing with `File#lastModified()`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be no change as it's just test code so good to merge after review!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)