### PR TITLE
Remove extra spacing from question widget and help layout

### DIFF
--- a/collect_app/src/main/res/layout/help_layout.xml
+++ b/collect_app/src/main/res/layout/help_layout.xml
@@ -12,8 +12,7 @@
     <RelativeLayout
         android:id="@+id/text_layout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_small">
+        android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/help_icon"
@@ -40,7 +39,6 @@
         android:id="@+id/guidance_text_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_small"
         android:orientation="vertical"
         android:visibility="gone"
         tools:visibility="visible">
@@ -58,7 +56,6 @@
         style="@style/TextAppearance.Collect.Subtitle1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_small"
         android:textColor="?attr/colorError"
         android:visibility="gone"
         tools:text="A warning"

--- a/collect_app/src/main/res/layout/question_widget.xml
+++ b/collect_app/src/main/res/layout/question_widget.xml
@@ -20,12 +20,10 @@
 
     </FrameLayout>
 
-
     <RelativeLayout
         android:id="@+id/answer_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_small">
+        android:layout_height="wrap_content">
 
     </RelativeLayout>
 


### PR DESCRIPTION
This removes some extra spacing we don't need. Some widgets might look a bit cramped now but I think given we have a lot of widget PRs in flight it'd be best to look at merging this in and then revising this later in the release cycle as part of #4129.

#### What has been done to verify that this works as intended?

Scrolled through the `All widgets` form to check that nothing looks broken.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed above.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Will just change the layout of the widgets slightly. As mentioned some widgets might look a little cramped but we can revise as part of the later issue (#4129).

#### Do we need any specific form for testing your changes? If so, please attach one.

`All widgets` is best.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)