### PR TITLE
Fixed loading downloaded media files

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -449,9 +449,12 @@ public class MediaUtils {
             } else if (isDownloadsDocument(uri)) {
                 // DownloadsProvider
 
-                final String id = DocumentsContract.getDocumentId(uri);
+                String id = DocumentsContract.getDocumentId(uri);
                 if (id.startsWith("raw:")) {
                     return id.replaceFirst("raw:", "");
+                }
+                if (id.startsWith("msf:")) {
+                    id = id.replaceFirst("msf:", "");
                 }
 
                 String[] contentUriPrefixesToTry = {


### PR DESCRIPTION
Closes #4139

#### What has been done to verify that this works as intended?
I was able to reproduce the issue and confirmed the fix does the job.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only solution. We just need to handle URIs that contain `msf` prefixes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix so we can just test the described scenario, nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with media files like the All widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)