### PR TITLE
Alternative fix for redownloading delete forms from Google Drive

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.feature.formmanagement;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -89,30 +88,6 @@ public class DeleteBlankFormTest {
                 .clickGetSelected()
                 .assertText("One Question (Version:: 1 ID: one_question) - Success")
                 .clickOK(new MainMenuPage(rule))
-                .clickFillBlankForm()
-                .assertFormExists("One Question");
-    }
-
-    @Test
-    @Ignore("https://github.com/getodk/collect/issues/4124")
-    public void afterFillingAForm_andDeletingIt_allowsFormToBeReloadedDirectly() {
-        rule.mainMenu()
-                .copyForm("one-question.xml")
-                .startBlankForm("One Question")
-                .answerQuestion("what is your age", "22")
-                .swipeToEndScreen()
-                .clickSaveAndExit()
-
-                .clickDeleteSavedForm()
-                .clickBlankForms()
-                .clickForm("One Question")
-                .clickDeleteSelected(1)
-                .clickDeleteForms()
-                .assertTextDoesNotExist("One Question")
-                .pressBack(new MainMenuPage(rule))
-
-                .copyForm("one-question.xml")
-                .wait250ms() // We need to account for inaccuracy in calls to system time
                 .clickFillBlankForm()
                 .assertFormExists("One Question");
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
@@ -92,17 +92,6 @@ public class FormsDirDiskFormsSynchronizer implements DiskFormsSynchronizer {
                                         cursor.getColumnIndex(FormsProviderAPI.FormsColumns._ID));
                                 Uri updateUri = Uri.withAppendedPath(FormsProviderAPI.FormsColumns.CONTENT_URI, id);
                                 uriToUpdate.add(new UriFile(updateUri, sqlFile));
-                            } else {
-                                if (!cursor.isNull(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DELETED_DATE))) {
-                                    long deletedDate = cursor.getLong(cursor.getColumnIndex(FormsProviderAPI.FormsColumns.DELETED_DATE));
-
-                                    if (sqlFile.lastModified() > deletedDate) {
-                                        String id = cursor.getString(
-                                                cursor.getColumnIndex(FormsProviderAPI.FormsColumns._ID));
-                                        Uri updateUri = Uri.withAppendedPath(FormsProviderAPI.FormsColumns.CONTENT_URI, id);
-                                        uriToUpdate.add(new UriFile(updateUri, sqlFile));
-                                    }
-                                }
                             }
                         } else {
                             //File not found in sdcard but file path found in database


### PR DESCRIPTION
Closes #4124.

Alternative fix for #4103. Instead of the (we suspect) flakey solution that allows forms to be restored if they are modified on disk this just explicitly restores forms downloaded from Google Drive.

#### What has been done to verify that this works as intended?

Not much at all. I figured it is best to let QA check it out rather than spending time setting up Google Drive for myself locally (I believe they have it set up already).

If there are any problems I can come back to this and take the time to set up a proper environment.

On testing, it feels to me like we need to rip apart a bunch of the Google Drive code and have it use the use case/method objects we're building like `ServerFormDownloader` so we can write tests for it without spending a lot more time implementing stub Google Drive code for a feature we don't consider "production ready". Going down that road right now doesn't seem right so I've left this change untested so we can just move on.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed before but explicitly restoring forms like this avoids us relying on last modified data on files which can cause timing issues in tests (and potentially in real life).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be no effect but I think we should check this as if we were fixing the issue again.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)