### PR TITLE
Fixed crashes when a user changes Blank form update mode if one of related options is disabled in Admin settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/FormManagementPreferences.java
@@ -19,6 +19,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.preference.CheckBoxPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
@@ -86,28 +87,44 @@ public class FormManagementPreferences extends BasePreferenceFragment {
     private void updateDisabledPrefs() {
         SharedPreferences sharedPrefs = preferencesProvider.getGeneralSharedPreferences();
 
-        Preference updateFrequency = findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK);
-        CheckBoxPreference automaticDownload = findPreference(KEY_AUTOMATIC_UPDATE);
+        // Might be null if disabled in Admin settings
+        @Nullable Preference updateFrequency = findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK);
+        @Nullable CheckBoxPreference automaticDownload = findPreference(KEY_AUTOMATIC_UPDATE);
 
         if (Protocol.parse(getActivity(), sharedPrefs.getString(KEY_PROTOCOL, null)) == Protocol.GOOGLE) {
             displayDisabled(findPreference(KEY_FORM_UPDATE_MODE), getString(R.string.manual));
-            displayDisabled(automaticDownload, false);
-            updateFrequency.setEnabled(false);
+            if (automaticDownload != null) {
+                displayDisabled(automaticDownload, false);
+            }
+            if (updateFrequency != null) {
+                updateFrequency.setEnabled(false);
+            }
         } else {
             switch (getFormUpdateMode(requireContext(), sharedPrefs)) {
                 case MANUAL:
-                    displayDisabled(automaticDownload, false);
-                    updateFrequency.setEnabled(false);
+                    if (automaticDownload != null) {
+                        displayDisabled(automaticDownload, false);
+                    }
+                    if (updateFrequency != null) {
+                        updateFrequency.setEnabled(false);
+                    }
                     break;
                 case PREVIOUSLY_DOWNLOADED_ONLY:
-                    automaticDownload.setEnabled(true);
-                    automaticDownload.setChecked(sharedPrefs.getBoolean(KEY_AUTOMATIC_UPDATE, false));
-
-                    updateFrequency.setEnabled(true);
+                    if (automaticDownload != null) {
+                        automaticDownload.setEnabled(true);
+                        automaticDownload.setChecked(sharedPrefs.getBoolean(KEY_AUTOMATIC_UPDATE, false));
+                    }
+                    if (updateFrequency != null) {
+                        updateFrequency.setEnabled(true);
+                    }
                     break;
                 case MATCH_EXACTLY:
-                    displayDisabled(automaticDownload, true);
-                    updateFrequency.setEnabled(true);
+                    if (automaticDownload != null) {
+                        displayDisabled(automaticDownload, true);
+                    }
+                    if (updateFrequency != null) {
+                        updateFrequency.setEnabled(true);
+                    }
                     break;
             }
         }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/FormManagementPreferencesTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/FormManagementPreferencesTest.java
@@ -150,6 +150,25 @@ public class FormManagementPreferencesTest {
     }
 
     @Test
+    public void changingFormUpdateMode_shouldNotCauseAnyCrashIfRelatedPreferncesAreDisabledInAdminSettings() {
+        adminSharedPreferences.save(AdminKeys.KEY_PERIODIC_FORM_UPDATES_CHECK, false);
+        adminSharedPreferences.save(AdminKeys.KEY_AUTOMATIC_UPDATE, false);
+
+        FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
+        scenario.onFragment(f -> {
+            assertThat(f.findPreference(KEY_PERIODIC_FORM_UPDATES_CHECK), nullValue());
+            assertThat(f.findPreference(KEY_AUTOMATIC_UPDATE), nullValue());
+
+            ListPreference updateMode = f.findPreference(KEY_FORM_UPDATE_MODE);
+            updateMode.setValue(PREVIOUSLY_DOWNLOADED_ONLY.getValue(context));
+
+            updateMode.setValue(MATCH_EXACTLY.getValue(context));
+
+            updateMode.setValue(MANUAL.getValue(context));
+        });
+    }
+
+    @Test
     public void visiblePreferences_shouldBeVisibleIfOpenedFromGeneralPreferences() {
         FragmentScenario<FormManagementPreferences> scenario = FragmentScenario.launch(FormManagementPreferences.class);
         scenario.onFragment(fragment -> {


### PR DESCRIPTION
Closes #4142

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is the only solution, we just need to check for null preferences that might be disabled in admin settings.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is a safe fix that shouldn't affect anything else. We just need to test the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)