### PR TITLE
Use latest Circle CI Android image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
   android_config: &android_config
     working_directory: *workspace
     docker:
-      - image: circleci/android:api-27
+      - image: circleci/android:api-30
 
 jobs:
   check_quality:

--- a/async/build.gradle
+++ b/async/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21

--- a/async/build.gradle
+++ b/async/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -68,7 +68,7 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 
 android {
-    compileSdkVersion(28)
+    compileSdkVersion 28
 
     viewBinding {
         enabled = true
@@ -76,8 +76,8 @@ android {
 
     defaultConfig {
         applicationId('org.odk.collect.android')
-        minSdkVersion(21)
-        targetSdkVersion(28)
+        minSdkVersion 21
+        targetSdkVersion 28
         versionCode LEGACY_BUILD_NUMBER_OFFSET + getMasterCommitCount()
         versionName getVersionName()
         testInstrumentationRunner('androidx.test.runner.AndroidJUnitRunner')

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -68,7 +68,7 @@ def googleMapsApiKey = secrets.getProperty('GOOGLE_MAPS_API_KEY', '')
 def mapboxToken = secrets.getProperty('MAPBOX_ACCESS_TOKEN', '')
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     viewBinding {
         enabled = true

--- a/material/build.gradle
+++ b/material/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     buildToolsVersion "29.0.2"
 
     defaultConfig {

--- a/nbi-stubs/build.gradle
+++ b/nbi-stubs/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     buildToolsVersion "29.0.2"
 
     defaultConfig {


### PR DESCRIPTION
This makes the min SDK used across the app consistent and bumps us up to using the latest Circle CI image so we get more cache hits when pulling the image in.