### PR TITLE
Catch updateFieldListQuestions when updating field list

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2678,7 +2678,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    updateFieldListQuestions(changedWidget.getFormEntryPrompt().getIndex());
+                    try {
+                        updateFieldListQuestions(changedWidget.getFormEntryPrompt().getIndex());
+                    } catch (RuntimeException e) {
+                        Timber.w(e);
+                    }
 
                     odkView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
                         @Override


### PR DESCRIPTION
Closes #4145

#### What has been done to verify that this works as intended?
Nothing since I wan't able to reproduce the issue.

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue so I decided to just catch it. Generally it's because of having repeats inside field-list group what we don't support. We catch this scenario in other parts of our code https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java#L1250 and display a dialog. I don't know why updateFieldListQuestions() is called before what cause the crash I guess it might be race condition problem. Catching the exception and doing noting in that case is totally fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)