### PR TITLE
Catch and display error when new repeat created

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -80,13 +80,17 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
             analytics.logEvent(ADD_REPEAT, "Hierarchy", formController.getCurrentFormIdentifierHash());
         }
 
-        formController.newRepeat();
+        try {
+            formController.newRepeat();
+        } catch (RuntimeException e) {
+            error.setValue(e.getCause().getMessage());
+        }
         
         if (!formController.indexIsInFieldList()) {
             try {
                 formController.stepToNextScreenEvent();
-            } catch (JavaRosaException exception) {
-                error.setValue(exception.getCause().getMessage());
+            } catch (JavaRosaException e) {
+                error.setValue(e.getCause().getMessage());
             }
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
@@ -47,6 +48,14 @@ public class FormEntryViewModelTest {
     public void addRepeat_stepsToNextScreenEvent() throws Exception {
         viewModel.addRepeat(true);
         verify(formController).stepToNextScreenEvent();
+    }
+
+    @Test
+    public void addRepeat_whenThereIsAnErrorCreatingRepeat_setsErrorWithMessage() throws Exception {
+        doThrow(new RuntimeException(new IOException("OH NO"))).when(formController).newRepeat();
+
+        viewModel.addRepeat(true);
+        assertThat(viewModel.getError().getValue(), equalTo("OH NO"));
     }
 
     @Test


### PR DESCRIPTION
Closes #4119

#### What has been done to verify that this works as intended?

Add a new test and tried out example form.

#### Why is this the best possible solution? Were any other approaches considered?

We already had a lot of the plumbing to make this work in so it ended up being a very simple fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue but good to check there aren't weird side effects in cases where the error shows now we aren't just crashing out.

#### Do we need any specific form for testing your changes? If so, please attach one.

The form in the issue is the best starting point.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)