### PR TITLE
Don't attempt to stop location updates if GoogleAPIClient is not already connected

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleFusedLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleFusedLocationClient.java
@@ -120,7 +120,7 @@ public class GoogleFusedLocationClient
 
     @SuppressLint("MissingPermission") // Permission checks for location services handled in widgets
     public void requestLocationUpdates(@NonNull LocationListener locationListener) {
-        if (!isMonitoringLocation()) {
+        if (!isMonitoringLocation() && googleApiClient.isConnected()) {
             fusedLocationProviderApi.requestLocationUpdates(googleApiClient, createLocationRequest(), this);
         }
 
@@ -128,7 +128,7 @@ public class GoogleFusedLocationClient
     }
 
     public void stopLocationUpdates() {
-        if (!isMonitoringLocation()) {
+        if (!isMonitoringLocation() || !googleApiClient.isConnected()) {
             return;
         }
 
@@ -141,7 +141,7 @@ public class GoogleFusedLocationClient
     public Location getLastLocation() {
         // We need to block if the Client isn't already connected:
         if (!googleApiClient.isConnected()) {
-            googleApiClient.blockingConnect();
+            new Thread(googleApiClient::blockingConnect).start();
         }
 
         return fusedLocationProviderApi.getLastLocation(googleApiClient);

--- a/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleFusedLocationClient.java
+++ b/collect_app/src/main/java/org/odk/collect/android/location/client/GoogleFusedLocationClient.java
@@ -128,11 +128,13 @@ public class GoogleFusedLocationClient
     }
 
     public void stopLocationUpdates() {
-        if (!isMonitoringLocation() || !googleApiClient.isConnected()) {
+        if (!isMonitoringLocation()) {
             return;
         }
 
-        fusedLocationProviderApi.removeLocationUpdates(googleApiClient, locationListener);
+        if (googleApiClient.isConnected()) {
+            fusedLocationProviderApi.removeLocationUpdates(googleApiClient, locationListener);
+        }
         locationListener = null;
     }
 
@@ -141,7 +143,7 @@ public class GoogleFusedLocationClient
     public Location getLastLocation() {
         // We need to block if the Client isn't already connected:
         if (!googleApiClient.isConnected()) {
-            new Thread(googleApiClient::blockingConnect).start();
+            googleApiClient.blockingConnect();
         }
 
         return fusedLocationProviderApi.getLastLocation(googleApiClient);

--- a/collect_app/src/test/java/org/odk/collect/android/location/client/GoogleFusedLocationClientTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/location/client/GoogleFusedLocationClientTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
@@ -123,8 +122,6 @@ public class GoogleFusedLocationClientTest {
 
     @Test
     public void requestingLocationUpdatesShouldUpdateCorrectListener() {
-        when(googleApiClient.isConnected()).thenReturn(true);
-
         client.start();
 
         TestLocationListener firstListener = new TestLocationListener();
@@ -173,13 +170,13 @@ public class GoogleFusedLocationClientTest {
     @Test
     public void getLastLocationShouldCallBlockingConnectIfNotConnected() {
         client.getLastLocation();
-        verify(googleApiClient, timeout(100)).blockingConnect();
+        verify(googleApiClient).blockingConnect();
 
         when(googleApiClient.isConnected()).thenReturn(true);
         client.start();
 
         client.getLastLocation();
-        verify(googleApiClient, timeout(100)).blockingConnect(); // 'verify' checks if called *once*.
+        verify(googleApiClient).blockingConnect(); // 'verify' checks if called *once*.
     }
 
     @Test


### PR DESCRIPTION
Closes #4155 

#### What has been done to verify that this works as intended?
I tested the app with hardcoded disconnecting GoogleApiClient and added tests. 

#### Why is this the best possible solution? Were any other approaches considered?
We just need to check if the client is connected before performing some operations.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing since it's difficult to reproduce.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)