### PR TITLE
Downgraded commons-io dependency

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -231,7 +231,10 @@ dependencies {
     implementation 'com.github.chanmratekoko:myanmar-calendar:1.0.6.RC3'
     implementation 'bikramsambat:bikram-sambat:1.1.0'
     implementation "com.rarepebble:colorpicker:3.0.1"
-    implementation "commons-io:commons-io:2.8.0"
+
+    // Updating would require minSdkVersion >=26
+    implementation "commons-io:commons-io:2.6"
+
     implementation "net.sf.opencsv:opencsv:2.4"
     implementation("org.getodk:javarosa:3.0.2") {
         exclude group: 'joda-time'


### PR DESCRIPTION
Closes #4157

#### What has been done to verify that this works as intended?
I tested performing migration.

#### Why is this the best possible solution? Were any other approaches considered?
It looks like newer versions of commons-io use [java.nio.file.CopyOption](https://developer.android.com/reference/java/nio/file/CopyOption) which in android is available on API 26+ only.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We just need to test migration on various android versions.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)