### PR TITLE
Fix Margin for Buttons in Audio and Barcode Widget

### DIFF
--- a/collect_app/src/main/res/layout/audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/audio_widget_answer.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/capture_button"
         style="@style/Widget.Collect.Button.WidgetAnswer"
-        android:text="@string/capture_audio">
-    </org.odk.collect.android.views.MultiClickSafeButton>
+        android:text="@string/capture_audio" />
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/choose_button"
         style="@style/Widget.Collect.Button.WidgetAnswer"
-        android:text="@string/choose_sound">
-    </org.odk.collect.android.views.MultiClickSafeButton>
+        android:text="@string/choose_sound" />
 
 </LinearLayout>

--- a/collect_app/src/main/res/layout/barcode_widget_answer.xml
+++ b/collect_app/src/main/res/layout/barcode_widget_answer.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_standard">
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/barcode_button"


### PR DESCRIPTION
Closes #4162 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it. Margin is visible on Audio and Barcode Widget buttons.

<table>
  <tr>
    <td> <img src="https://user-images.githubusercontent.com/35730054/95573180-af4e4f00-0a48-11eb-8bd7-6a5a5feed51f.png"> </td>
    <td><img src="https://user-images.githubusercontent.com/35730054/95573183-b1181280-0a48-11eb-82ba-7fd045e8d93a.png"></td>
  </tr>
</table>

#### Why is this the best possible solution? Were any other approaches considered?
In my previous PR on reworking the Audio and Barcode Widget, I forgot to add padding to the widget container, hence the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form having Audio and Barcode Widget, AllWidgetsForm

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)