### PR TITLE
Scale icons on form entry and hierarchy screens to match others

### DIFF
--- a/collect_app/src/main/res/drawable/arrow_up.xml
+++ b/collect_app/src/main/res/drawable/arrow_up.xml
@@ -1,8 +1,8 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="36dp"
-    android:height="36dp"
-    android:viewportWidth="120.0"
-    android:viewportHeight="120.0">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
     <path
         android:fillColor="?attr/colorControlNormal"
         android:pathData="M95 52.771a1.902 1.902 0 0 0-0.52-1.263L61.226 16.9a1.685 1.685 0 0 0-2.452 0L25.512 51.508a1.927 1.927 0 0 0-0.393 2.022c0.27 0.695 0.912 1.15 1.623 1.148h16.9v48.494c0 1.021 0.783 1.849 1.75 1.85h29.216c0.967-0.001 1.75-0.829 1.75-1.85L76.35 54.678h16.908a1.707 1.707 0 0 0 1.257-0.562 1.91 1.91 0 0 0 0.493-1.345H95z" />

--- a/collect_app/src/main/res/drawable/ic_add_circle_24.xml
+++ b/collect_app/src/main/res/drawable/ic_add_circle_24.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="36dp"
-    android:height="36dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path

--- a/collect_app/src/main/res/drawable/ic_delete_menu_24.xml
+++ b/collect_app/src/main/res/drawable/ic_delete_menu_24.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="36dp"
-    android:height="36dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24">
     <path

--- a/collect_app/src/main/res/drawable/ic_menu_goto_24.xml
+++ b/collect_app/src/main/res/drawable/ic_menu_goto_24.xml
@@ -1,5 +1,8 @@
-<vector android:height="36dp" android:viewportHeight="24.0"
-    android:viewportWidth="24.0" android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
     <path
         android:fillColor="?attr/colorControlNormal"
         android:pathData="M17.164,20.342A2.248,2.248 129.812,0 0,20.342 20.342,2.248 2.248,50.188 0,0 20.342,17.164 2.248,2.248 0,0 0,17.164 17.164,2.248 2.248,0 0,0 17.164,20.342Z" />

--- a/collect_app/src/main/res/drawable/ic_save_menu_24.xml
+++ b/collect_app/src/main/res/drawable/ic_save_menu_24.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="36dp"
-    android:height="36dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportHeight="24"
     android:viewportWidth="24">
     <path

--- a/collect_app/src/main/res/menu/form_hierarchy_menu.xml
+++ b/collect_app/src/main/res/menu/form_hierarchy_menu.xml
@@ -5,14 +5,14 @@
 
     <item
         android:id="@+id/menu_delete_child"
-        android:icon="@drawable/ic_delete_menu"
+        android:icon="@drawable/ic_delete_menu_24"
         android:title="@string/delete_repeat"
         android:visible="false"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_add_repeat"
-        android:icon="@drawable/ic_add_circle"
+        android:icon="@drawable/ic_add_circle_24"
         android:title="@string/add_another_menu"
         android:visible="false"
         app:showAsAction="always" />

--- a/collect_app/src/main/res/menu/form_menu.xml
+++ b/collect_app/src/main/res/menu/form_menu.xml
@@ -16,19 +16,19 @@
     than title-->
     <item
         android:id="@+id/menu_add_repeat"
-        android:icon="@drawable/ic_add_circle"
+        android:icon="@drawable/ic_add_circle_24"
         android:title="@string/add_another_menu"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_save"
-        android:icon="@drawable/ic_save_menu"
+        android:icon="@drawable/ic_save_menu_24"
         android:title="@string/save_all_answers"
         app:showAsAction="always" />
 
     <item
         android:id="@+id/menu_goto"
-        android:icon="@drawable/ic_menu_goto"
+        android:icon="@drawable/ic_menu_goto_24"
         android:title="@string/view_hierarchy"
         app:showAsAction="always" />
 


### PR DESCRIPTION
All of the app bar icons are consistently 24dp except for the ones on the form entry activity and the up arrow in the hierarchy activity.

<table>
<tr>
	<th>master</th>
	<th>this PR</th>
</tr>
<tr>
	<td><img src="https://user-images.githubusercontent.com/967540/96543367-11812e00-1259-11eb-8e40-099174105b50.png"></td>
	<td><img src="https://user-images.githubusercontent.com/967540/96543352-09c18980-1259-11eb-83f9-6844a3ef635b.png">
</td>
</tr>
</table>

This also scales down the up arrow on the hierarchy view. I will separately post an issue with ideas for rethinking the southeast "jump" arrow that goes to the hierarchy view.

#### What has been done to verify that this works as intended?
Visual inspection.

#### Why is this the best possible solution? Were any other approaches considered?
I matched the other app bar icons we use. It seems strange to me to include the size in the resource but it seems to be the pattern across the code base and it seems to be common. Is this really the best way? Provided it is, I renamed the images to make that clear from the filename.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No behavior changes. There should be no risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)