### PR TITLE
3780 restore exif data after rotate or resize

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/ImageConverterTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/ImageConverterTest.java
@@ -43,12 +43,16 @@ import org.odk.collect.android.widgets.ImageWidget;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import timber.log.Timber;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.utilities.ApplicationConstants.Namespaces.XML_OPENROSA_NAMESPACE;
@@ -73,7 +77,7 @@ public class ImageConverterTest {
     @Test
     public void executeConversionWithoutAnySettings() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -84,7 +88,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly1() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(4000, 3000, null);
+        saveTestBitmap(4000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -95,7 +99,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly2() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, null);
+        saveTestBitmap(3000, 4000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -106,7 +110,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly3() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -117,7 +121,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly4() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "3000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -128,7 +132,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly5() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "4000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -139,7 +143,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly6() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2998"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -150,7 +154,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly7() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", ""), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -161,7 +165,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly8() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget("", "max-pixels", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -172,7 +176,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly9() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixel", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -183,7 +187,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly10() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2000.5"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -194,7 +198,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly11() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "0"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -205,7 +209,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormLevelOnly12() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "-2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -216,7 +220,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownSettingsLevelOnly1() {
         GeneralSharedPreferences.getInstance().save("image_size", "very_small");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -227,7 +231,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownSettingsLevelOnly2() {
         GeneralSharedPreferences.getInstance().save("image_size", "small");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -238,7 +242,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownSettingsLevelOnly3() {
         GeneralSharedPreferences.getInstance().save("image_size", "medium");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -249,7 +253,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownSettingsLevelOnly4() {
         GeneralSharedPreferences.getInstance().save("image_size", "large");
-        saveTestBitmap(3000, 3000, null);
+        saveTestBitmap(3000, 3000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -260,7 +264,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownSettingsLevelOnly5() {
         GeneralSharedPreferences.getInstance().save("image_size", "large");
-        saveTestBitmap(4000, 4000, null);
+        saveTestBitmap(4000, 4000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -271,7 +275,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormAndSettingsLevel1() {
         GeneralSharedPreferences.getInstance().save("image_size", "small");
-        saveTestBitmap(4000, 4000, null);
+        saveTestBitmap(4000, 4000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -282,7 +286,7 @@ public class ImageConverterTest {
     @Test
     public void scaleImageDownFormAndSettingsLevel2() {
         GeneralSharedPreferences.getInstance().save("image_size", "small");
-        saveTestBitmap(4000, 4000, null);
+        saveTestBitmap(4000, 4000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "650"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -292,8 +296,11 @@ public class ImageConverterTest {
 
     @Test
     public void rotateImage1() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(ExifInterface.TAG_ORIENTATION, String.valueOf(ExifInterface.ORIENTATION_ROTATE_90));
+
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, ExifInterface.ORIENTATION_ROTATE_90);
+        saveTestBitmap(3000, 4000, attributes);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -303,8 +310,11 @@ public class ImageConverterTest {
 
     @Test
     public void rotateImage2() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(ExifInterface.TAG_ORIENTATION, String.valueOf(ExifInterface.ORIENTATION_ROTATE_270));
+
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, ExifInterface.ORIENTATION_ROTATE_270);
+        saveTestBitmap(3000, 4000, attributes);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -314,8 +324,11 @@ public class ImageConverterTest {
 
     @Test
     public void rotateImage3() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(ExifInterface.TAG_ORIENTATION, String.valueOf(ExifInterface.ORIENTATION_ROTATE_180));
+
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, ExifInterface.ORIENTATION_ROTATE_180);
+        saveTestBitmap(3000, 4000, attributes);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -325,8 +338,11 @@ public class ImageConverterTest {
 
     @Test
     public void rotateImage4() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(ExifInterface.TAG_ORIENTATION, String.valueOf(ExifInterface.ORIENTATION_UNDEFINED));
+
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, ExifInterface.ORIENTATION_UNDEFINED);
+        saveTestBitmap(3000, 4000, attributes);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -337,7 +353,7 @@ public class ImageConverterTest {
     @Test
     public void rotateImage5() {
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, null);
+        saveTestBitmap(3000, 4000);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -347,8 +363,11 @@ public class ImageConverterTest {
 
     @Test
     public void rotateAndScaleDownImage() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(ExifInterface.TAG_ORIENTATION, String.valueOf(ExifInterface.ORIENTATION_ROTATE_90));
+
         GeneralSharedPreferences.getInstance().save("image_size", "original_image_size");
-        saveTestBitmap(3000, 4000, ExifInterface.ORIENTATION_ROTATE_90);
+        saveTestBitmap(3000, 4000, attributes);
         ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(XML_OPENROSA_NAMESPACE, "max-pixels", "2000"), Collect.getInstance());
 
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
@@ -358,25 +377,25 @@ public class ImageConverterTest {
 
     @Test
     public void scaleImageToNewWidthTest() {
-        saveTestBitmap(2000, 1000, null);
+        saveTestBitmap(2000, 1000);
         Bitmap image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
         image = ImageConverter.scaleImageToNewWidth(image, 500);
         assertEquals(500, image.getWidth());
         assertEquals(250, image.getHeight());
 
-        saveTestBitmap(1000, 2000, null);
+        saveTestBitmap(1000, 2000);
         image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
         image = ImageConverter.scaleImageToNewWidth(image, 500);
         assertEquals(500, image.getWidth());
         assertEquals(1000, image.getHeight());
 
-        saveTestBitmap(500, 400, null);
+        saveTestBitmap(500, 400);
         image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
         image = ImageConverter.scaleImageToNewWidth(image, 1000);
         assertEquals(1000, image.getWidth());
         assertEquals(800, image.getHeight());
 
-        saveTestBitmap(400, 500, null);
+        saveTestBitmap(400, 500);
         image = FileUtils.getBitmap(TEST_IMAGE_PATH, new BitmapFactory.Options());
         image = ImageConverter.scaleImageToNewWidth(image, 1000);
         assertEquals(1000, image.getWidth());
@@ -385,79 +404,74 @@ public class ImageConverterTest {
 
     @Test
     public void keepExifTest1AfterScaleAndRotation() {
-        String[] attributes = {
-                ExifInterface.TAG_APERTURE_VALUE,
-                ExifInterface.TAG_ARTIST,
-                ExifInterface.TAG_BITS_PER_SAMPLE,
-                ExifInterface.TAG_DATETIME,
-                ExifInterface.TAG_DATETIME_ORIGINAL,
-                ExifInterface.TAG_DATETIME_DIGITIZED,
-                ExifInterface.TAG_EXPOSURE_TIME,
-                ExifInterface.TAG_FLASH,
-                ExifInterface.TAG_FOCAL_LENGTH,
-                ExifInterface.TAG_GPS_ALTITUDE,
-                ExifInterface.TAG_GPS_ALTITUDE_REF,
-                ExifInterface.TAG_GPS_DATESTAMP,
-                ExifInterface.TAG_GPS_LATITUDE,
-                ExifInterface.TAG_GPS_LATITUDE_REF,
-                ExifInterface.TAG_GPS_LONGITUDE,
-                ExifInterface.TAG_GPS_LONGITUDE_REF,
-                ExifInterface.TAG_GPS_PROCESSING_METHOD,
-                ExifInterface.TAG_GPS_TIMESTAMP,
-                ExifInterface.TAG_MAKE,
-                ExifInterface.TAG_MODEL,
-                ExifInterface.TAG_SUBSEC_TIME,
-                ExifInterface.TAG_PIXEL_X_DIMENSION,
-                ExifInterface.TAG_PIXEL_Y_DIMENSION,
-                ExifInterface.TAG_WHITE_BALANCE
-        };
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(ExifInterface.TAG_ARTIST, ExifInterface.TAG_ARTIST);
+        attributes.put(ExifInterface.TAG_DATETIME, ExifInterface.TAG_DATETIME);
+        attributes.put(ExifInterface.TAG_DATETIME_ORIGINAL, ExifInterface.TAG_DATETIME_ORIGINAL);
+        attributes.put(ExifInterface.TAG_DATETIME_DIGITIZED, ExifInterface.TAG_DATETIME_DIGITIZED);
+        attributes.put(ExifInterface.TAG_GPS_ALTITUDE, dec2DMS(-17));
+        attributes.put(ExifInterface.TAG_GPS_ALTITUDE_REF, ExifInterface.TAG_GPS_ALTITUDE_REF);
+        attributes.put(ExifInterface.TAG_GPS_DATESTAMP, ExifInterface.TAG_GPS_DATESTAMP);
+        attributes.put(ExifInterface.TAG_GPS_LATITUDE, dec2DMS(25.165173));
+        attributes.put(ExifInterface.TAG_GPS_LATITUDE_REF, ExifInterface.TAG_GPS_LATITUDE_REF);
+        attributes.put(ExifInterface.TAG_GPS_LONGITUDE, dec2DMS(23.988174));
+        attributes.put(ExifInterface.TAG_GPS_LONGITUDE_REF, ExifInterface.TAG_GPS_LONGITUDE_REF);
+        attributes.put(ExifInterface.TAG_GPS_PROCESSING_METHOD, ExifInterface.TAG_GPS_PROCESSING_METHOD);
+        attributes.put(ExifInterface.TAG_MAKE, ExifInterface.TAG_MAKE);
+        attributes.put(ExifInterface.TAG_MODEL, ExifInterface.TAG_MODEL);
+        attributes.put(ExifInterface.TAG_SUBSEC_TIME, ExifInterface.TAG_SUBSEC_TIME);
 
-        String[] imageSizes = {"original_image_size", "large", "medium", "small", "very_small"};
+        saveTestBitmap(3000, 4000, attributes);
 
-        for (int i = 0; i < attributes.length; i++) {
-            String testExifTag = attributes[i];
-            String expectdExifValue = testExifTag + "_value";
-            for (int j = 0; j < imageSizes.length; j++) {
-                GeneralSharedPreferences.getInstance().save("image_size", imageSizes[j]);
-                saveTestBitmapExif(3000, 4000, ExifInterface.ORIENTATION_ROTATE_90, testExifTag, expectdExifValue);
-                ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
-                ExifInterface result = getTestImageExif();
-                assertNotNull(result);
-                assertEquals(expectdExifValue, result.getAttribute(testExifTag));
+        ImageConverter.execute(TEST_IMAGE_PATH, getTestImageWidget(), Collect.getInstance());
+        ExifInterface exifData = getTestImageExif();
+        assertNotNull(exifData);
+
+        for (String attributeName : attributes.keySet()) {
+            switch (attributeName) {
+                case ExifInterface.TAG_GPS_LATITUDE:
+                    assertThat(exifData.getAttribute(attributeName), is("25/1,9/1,54622/1000"));
+                    break;
+                case ExifInterface.TAG_GPS_LONGITUDE:
+                    assertThat(exifData.getAttribute(attributeName), is("23/1,59/1,17426/1000"));
+                    break;
+                case ExifInterface.TAG_GPS_ALTITUDE:
+                    assertThat(exifData.getAttribute(attributeName), is("17/1,0/1,0/1000"));
+                    break;
+                default:
+                    assertThat(exifData.getAttribute(attributeName), is(attributeName));
+                    break;
             }
         }
     }
 
-    private void saveTestBitmap(int width, int height, Integer orientation) {
-        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565);
-        FileUtils.saveBitmapToFile(bitmap, TEST_IMAGE_PATH);
-
-        if (orientation != null) {
-            try {
-                ExifInterface exifInterface = new ExifInterface(TEST_IMAGE_PATH);
-                exifInterface.setAttribute(ExifInterface.TAG_ORIENTATION, String.valueOf(orientation));
-                exifInterface.saveAttributes();
-            } catch (IOException e) {
-                Timber.w(e);
-            }
-        }
+    // https://stackoverflow.com/a/55252228/5479029
+    private String dec2DMS(double coord) {
+        coord = coord > 0 ? coord : -coord;
+        String out = (int) coord + "/1,";
+        coord = (coord % 1) * 60;
+        out = out + (int) coord + "/1,";
+        coord = (coord % 1) * 60000;
+        out = out + (int) coord + "/1000";
+        return out;
     }
 
-    private void saveTestBitmapExif(int width, int height, Integer orientation, String exifTag, String tagValue) {
+    private void saveTestBitmap(int width, int height) {
+        saveTestBitmap(width, height, new HashMap<>());
+    }
+
+    private void saveTestBitmap(int width, int height, Map<String, String> attributes) {
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565);
         FileUtils.saveBitmapToFile(bitmap, TEST_IMAGE_PATH);
 
-        if (exifTag != null && tagValue != null) {
-            try {
-                ExifInterface exifInterface = new ExifInterface(TEST_IMAGE_PATH);
-                exifInterface.setAttribute(exifTag, tagValue);
-                if (orientation != null) {
-                    exifInterface.setAttribute(ExifInterface.TAG_ORIENTATION, String.valueOf(orientation));
-                }
-                exifInterface.saveAttributes();
-            } catch (IOException e) {
-                Timber.w(e);
+        try {
+            ExifInterface exifInterface = new ExifInterface(TEST_IMAGE_PATH);
+            for (String attributeName : attributes.keySet()) {
+                exifInterface.setAttribute(attributeName, attributes.get(attributeName));
             }
+            exifInterface.saveAttributes();
+        } catch (IOException e) {
+            Timber.w(e);
         }
     }
 
@@ -472,7 +486,7 @@ public class ImageConverterTest {
     }
 
     private ImageWidget getTestImageWidget() {
-        return getTestImageWidget(new ArrayList<TreeElement>());
+        return getTestImageWidget(new ArrayList<>());
     }
 
     private ImageWidget getTestImageWidget(String namespace, String name, String value) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/ImageConverterTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/ImageConverterTest.java
@@ -385,7 +385,7 @@ public class ImageConverterTest {
 
     @Test
     public void keepExifTest1AfterScaleAndRotation() {
-        String[] attributes = new String[] {
+        String[] attributes = {
                 ExifInterface.TAG_APERTURE_VALUE,
                 ExifInterface.TAG_ARTIST,
                 ExifInterface.TAG_BITS_PER_SAMPLE,
@@ -412,7 +412,7 @@ public class ImageConverterTest {
                 ExifInterface.TAG_WHITE_BALANCE
         };
 
-        String[] imageSizes = new String[] {"original_image_size", "large", "medium", "small", "very_small"};
+        String[] imageSizes = {"original_image_size", "large", "medium", "small", "very_small"};
 
         for (int i = 0; i < attributes.length; i++) {
             String testExifTag = attributes[i];

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
@@ -55,7 +55,7 @@ public class ImageConverter {
         scaleDownImageIfNeeded(imagePath, questionWidget, context);
         
         try {
-            copyExif(exif, imagePath);
+            exif.saveAttributes();
         } catch (IOException e) {
             Timber.w(e);
         }
@@ -174,69 +174,6 @@ public class ImageConverter {
             Timber.w(e);
         }
         FileUtils.saveBitmapToFile(image, imagePath);
-    }
-
-    /**
-     * Copy an existing source exif to a new path.
-     * @param sourceExif : Source exif
-     * @param newPath    : path to which the exif is written to.
-     * @author Khuong Ninh (khuong.ninh@it-development.com)
-     */
-    public static void copyExif(ExifInterface sourceExif, String newPath) throws IOException {
-        if (sourceExif == null) {
-            return;
-        }
-
-        String[] attributes = new String[] {
-                ExifInterface.TAG_APERTURE_VALUE,
-                ExifInterface.TAG_ARTIST,
-                ExifInterface.TAG_BITS_PER_SAMPLE,
-                ExifInterface.TAG_DATETIME,
-                ExifInterface.TAG_DATETIME_ORIGINAL,
-                ExifInterface.TAG_DATETIME_DIGITIZED,
-                ExifInterface.TAG_EXPOSURE_TIME,
-                ExifInterface.TAG_FLASH,
-                ExifInterface.TAG_FOCAL_LENGTH,
-                ExifInterface.TAG_GPS_ALTITUDE,
-                ExifInterface.TAG_GPS_ALTITUDE_REF,
-                ExifInterface.TAG_GPS_DATESTAMP,
-                ExifInterface.TAG_GPS_LATITUDE,
-                ExifInterface.TAG_GPS_LATITUDE_REF,
-                ExifInterface.TAG_GPS_LONGITUDE,
-                ExifInterface.TAG_GPS_LONGITUDE_REF,
-                ExifInterface.TAG_GPS_PROCESSING_METHOD,
-                ExifInterface.TAG_GPS_TIMESTAMP,
-                ExifInterface.TAG_ISO_SPEED,
-                ExifInterface.TAG_MAKE,
-                ExifInterface.TAG_MODEL,
-                ExifInterface.TAG_ORIENTATION,
-                ExifInterface.TAG_SUBSEC_TIME,
-                ExifInterface.TAG_PIXEL_X_DIMENSION,
-                ExifInterface.TAG_PIXEL_Y_DIMENSION,
-                ExifInterface.TAG_WHITE_BALANCE
-        };
-
-        ExifInterface newExif = new ExifInterface(newPath);
-        for (int i = 0; i < attributes.length; i++) {
-            String value = sourceExif.getAttribute(attributes[i]);
-            if (!newExif.hasAttribute(attributes[i]) == false) {
-                if (value != null) {
-                    newExif.setAttribute(attributes[i], value);
-                }
-            }
-        }
-        newExif.saveAttributes();
-    }
-
-    /**
-     * Copy an existing source exif from one path to a new one.
-     * @param oldPath : Path where existing source exif data is stored.
-     * @param newPath : path to which the exif is written to.
-     * @author Khuong Ninh (khuong.ninh@it-development.com)
-     */
-    public static void copyExif(String oldPath, String newPath) throws IOException {
-        ExifInterface oldExif = new ExifInterface(oldPath);
-        copyExif(oldExif, newPath);
     }
 
     public static Bitmap scaleImageToNewWidth(Bitmap bitmap, int newWidth) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
@@ -40,7 +40,7 @@ public class ImageConverter {
     }
 
     /**
-     * Before proceed with scaling or rotating, make sure existing exif information is store/restored.
+     * Before proceed with scaling or rotating, make sure existing exif information is stored/restored.
      * @author Khuong Ninh (khuong.ninh@it-development.com)
      */
     public static void execute(String imagePath, QuestionWidget questionWidget, Context context) {
@@ -54,10 +54,12 @@ public class ImageConverter {
         rotateImageIfNeeded(imagePath);
         scaleDownImageIfNeeded(imagePath, questionWidget, context);
         
-        try {
-            exif.saveAttributes();
-        } catch (IOException e) {
-            Timber.w(e);
+        if (exif != null) {
+            try {
+                exif.saveAttributes();
+            } catch (IOException e) {
+                Timber.w(e);
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ImageConverter.java
@@ -39,6 +39,10 @@ public class ImageConverter {
     private ImageConverter() {
     }
 
+    /**
+     * Before proceed with scaling or rotating, make sure existing exif information is store/restored.
+     * @author Khuong Ninh (khuong.ninh@it-development.com)
+     */
     public static void execute(String imagePath, QuestionWidget questionWidget, Context context) {
         ExifInterface exif = null;
         try {
@@ -172,6 +176,12 @@ public class ImageConverter {
         FileUtils.saveBitmapToFile(image, imagePath);
     }
 
+    /**
+     * Copy an existing source exif to a new path.
+     * @param sourceExif : Source exif
+     * @param newPath    : path to which the exif is written to.
+     * @author Khuong Ninh (khuong.ninh@it-development.com)
+     */
     public static void copyExif(ExifInterface sourceExif, String newPath) throws IOException {
         if (sourceExif == null) {
             return;
@@ -209,9 +219,7 @@ public class ImageConverter {
         ExifInterface newExif = new ExifInterface(newPath);
         for (int i = 0; i < attributes.length; i++) {
             String value = sourceExif.getAttribute(attributes[i]);
-            if (newExif.hasAttribute(attributes[i])) {
-                Timber.w(" KHUONG DETECTED Detected %s : %s", attributes[i], value);
-            } else {
+            if (!newExif.hasAttribute(attributes[i]) == false) {
                 if (value != null) {
                     newExif.setAttribute(attributes[i], value);
                 }
@@ -220,6 +228,12 @@ public class ImageConverter {
         newExif.saveAttributes();
     }
 
+    /**
+     * Copy an existing source exif from one path to a new one.
+     * @param oldPath : Path where existing source exif data is stored.
+     * @param newPath : path to which the exif is written to.
+     * @author Khuong Ninh (khuong.ninh@it-development.com)
+     */
     public static void copyExif(String oldPath, String newPath) throws IOException {
         ExifInterface oldExif = new ExifInterface(oldPath);
         copyExif(oldExif, newPath);


### PR DESCRIPTION
Closes #3780

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
Use a form (with default imagewidget) to "capture image".
Tried with updating image size (for scaling) on settings as well as rotating the phone on capturing images.

Use exif viewer app (ExifTool) to view the exif information or
Submit the form to a server which can parse those exif information

#### Why is this the best possible solution? Were any other approaches considered?

It is simplest.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It avoids the exif data from being removed.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form with default image widget is enough as mentioned above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No. It's a bug fix. So I dont think we need any documentation


#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)