### PR TITLE
Add analytics for audio prompt

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/Analytics.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/Analytics.java
@@ -1,7 +1,7 @@
 package org.odk.collect.android.analytics;
 
 public interface Analytics {
-
+    
     void logEvent(String category, String action);
 
     void logEvent(String category, String action, String label);

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/Analytics.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/Analytics.java
@@ -6,6 +6,8 @@ public interface Analytics {
 
     void logEvent(String category, String action, String label);
 
+    void logFormEvent(String event, String formId);
+
     void setAnalyticsCollectionEnabled(boolean isAnalyticsEnabled);
 
     void setUserProperty(String name, String value);

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -143,4 +143,6 @@ public class AnalyticsEvents {
      * should be a hash of the endpoint setting.
      */
     public static final String CUSTOM_ENDPOINT_SUB = "CustomEndpointSub";
+
+    public static final String AUDIO = "audio";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -144,5 +144,11 @@ public class AnalyticsEvents {
      */
     public static final String CUSTOM_ENDPOINT_SUB = "CustomEndpointSub";
 
-    public static final String AUDIO = "audio";
+    /**
+     * These events track how often recording vs choosing a file is used in audio questions. Should be
+     * sent with form ID so it's clear if a particular form/project is using a one workflow more than
+     * the other.
+     */
+    public static final String AUDIO_RECORD = "AudioRecord";
+    public static final String AUDIO_CHOOSE = "AudioChoose";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/FirebaseAnalytics.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/FirebaseAnalytics.java
@@ -31,6 +31,13 @@ public class FirebaseAnalytics implements Analytics {
         firebaseAnalytics.logEvent(category, bundle);
     }
 
+    @Override
+    public void logFormEvent(String event, String formId) {
+        Bundle bundle = new Bundle();
+        bundle.putString("form", formId);
+        firebaseAnalytics.logEvent(event, bundle);
+    }
+
     private void setupRemoteAnalytics() {
         boolean isAnalyticsEnabled = generalSharedPreferences.getBoolean(GeneralKeys.KEY_ANALYTICS, true);
         setAnalyticsCollectionEnabled(isAnalyticsEnabled);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -264,7 +264,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
      */
     private QuestionWidget configureWidgetForQuestion(FormEntryPrompt question, boolean readOnlyOverride) {
         QuestionWidget qw = WidgetFactory.createWidgetFromPrompt(question, getContext(),
-                readOnlyOverride, questionMediaManager, waitingForDataRegistry);
+                readOnlyOverride, questionMediaManager, waitingForDataRegistry, analytics);
         qw.setOnLongClickListener(this);
         qw.setValueChangedListener(this);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -32,6 +32,8 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.audio.AudioControllerView;
 import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.audio.Clip;
@@ -65,6 +67,7 @@ import static org.odk.collect.android.utilities.ApplicationConstants.RequestCode
 
 @SuppressLint("ViewConstructor")
 public class AudioWidget extends QuestionWidget implements FileWidget, BinaryDataReceiver {
+    private final Analytics analytics;
     AudioWidgetAnswerBinding binding;
     AudioControllerView audioController;
 
@@ -80,14 +83,16 @@ public class AudioWidget extends QuestionWidget implements FileWidget, BinaryDat
     private QuestionMediaManager questionMediaManager;
     private String binaryName;
 
-    public AudioWidget(Context context, QuestionDetails prompt, QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
+    public AudioWidget(Context context, QuestionDetails prompt, QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry, Analytics analytics) {
         this(context, prompt, new FileUtil(), new MediaUtil(), null, questionMediaManager,
-                waitingForDataRegistry, null, new ActivityAvailability(context));
+                waitingForDataRegistry, null, new ActivityAvailability(context), analytics);
     }
 
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     AudioWidget(Context context, QuestionDetails questionDetails, @NonNull FileUtil fileUtil, @NonNull MediaUtil mediaUtil, @NonNull AudioControllerView audioController,
-                QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry, AudioHelper audioHelper, ActivityAvailability activityAvailability) {
+                QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry, AudioHelper audioHelper, ActivityAvailability activityAvailability, Analytics analytics) {
         super(context, questionDetails);
+        this.analytics = analytics;
 
         if (audioHelper != null) {
             this.audioHelper = audioHelper;
@@ -250,6 +255,8 @@ public class AudioWidget extends QuestionWidget implements FileWidget, BinaryDat
     }
 
     private void onCaptureAudioButtonClicked() {
+        analytics.logEvent(AnalyticsEvents.AUDIO, "Record", getQuestionDetails().getFormAnalyticsID());
+
         getPermissionUtils().requestRecordAudioPermission((Activity) getContext(), new PermissionListener() {
             @Override
             public void granted() {
@@ -278,6 +285,8 @@ public class AudioWidget extends QuestionWidget implements FileWidget, BinaryDat
     }
 
     private void chooseSound() {
+        analytics.logEvent(AnalyticsEvents.AUDIO, "Choose", getQuestionDetails().getFormAnalyticsID());
+
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("audio/*");
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -255,7 +255,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, BinaryDat
     }
 
     private void onCaptureAudioButtonClicked() {
-        analytics.logEvent(AnalyticsEvents.AUDIO, "Record", getQuestionDetails().getFormAnalyticsID());
+        analytics.logFormEvent(AnalyticsEvents.AUDIO_RECORD, getQuestionDetails().getFormAnalyticsID());
 
         getPermissionUtils().requestRecordAudioPermission((Activity) getContext(), new PermissionListener() {
             @Override
@@ -285,7 +285,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, BinaryDat
     }
 
     private void chooseSound() {
-        analytics.logEvent(AnalyticsEvents.AUDIO, "Choose", getQuestionDetails().getFormAnalyticsID());
+        analytics.logFormEvent(AnalyticsEvents.AUDIO_CHOOSE, getQuestionDetails().getFormAnalyticsID());
 
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setType("audio/*");

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.analytics.Analytics;
-import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.CustomTabHelper;
@@ -151,7 +150,6 @@ public class WidgetFactory {
                 questionWidget = new OSMWidget(context, questionDetails, waitingForDataRegistry);
                 break;
             case Constants.CONTROL_AUDIO_CAPTURE:
-                analytics.logEvent(AnalyticsEvents.AUDIO_QUESTION, "Audio", questionDetails.getFormAnalyticsID());
                 questionWidget = new AudioWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry, analytics);
                 break;
             case Constants.CONTROL_VIDEO_CAPTURE:

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -18,6 +18,8 @@ import android.content.Context;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.CustomTabHelper;
@@ -60,7 +62,7 @@ public class WidgetFactory {
      * @param readOnlyOverride a flag to be ORed with JR readonly attribute.
      */
     public static QuestionWidget createWidgetFromPrompt(FormEntryPrompt prompt, Context context, boolean readOnlyOverride,
-                                                        QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
+                                                        QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry, Analytics analytics) {
 
         String appearance = WidgetAppearanceUtils.getSanitizedAppearanceHint(prompt);
         QuestionDetails questionDetails = new QuestionDetails(prompt, Collect.getCurrentFormIdentifierHash());
@@ -149,7 +151,8 @@ public class WidgetFactory {
                 questionWidget = new OSMWidget(context, questionDetails, waitingForDataRegistry);
                 break;
             case Constants.CONTROL_AUDIO_CAPTURE:
-                questionWidget = new AudioWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry);
+                analytics.logEvent(AnalyticsEvents.AUDIO_QUESTION, "Audio", questionDetails.getFormAnalyticsID());
+                questionWidget = new AudioWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry, analytics);
                 break;
             case Constants.CONTROL_VIDEO_CAPTURE:
                 questionWidget = new VideoWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.audio.AudioControllerView;
 import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.audio.Clip;
@@ -375,7 +376,7 @@ public class AudioWidgetTest {
 
     public AudioWidget createWidget(FormEntryPrompt prompt) {
         return new AudioWidget(widgetActivity, new QuestionDetails(prompt, "formAnalyticsID"), fileUtil,
-                mediaUtil, audioController, questionMediaManager, waitingForDataRegistry, audioHelper, activityAvailability);
+                mediaUtil, audioController, questionMediaManager, waitingForDataRegistry, audioHelper, activityAvailability, mock(Analytics.class));
     }
 
     private Clip getAnswerAudioClip(String instanceFolderPath, IAnswerData answer) {


### PR DESCRIPTION
This adds analytics to the Audio widget to track:

* How many forms include it
* How many enumerators/forms use Record vs Choose to answer the question

#### What has been done to verify that this works as intended?

Ran tests and manually tested audio widget.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot of choices made here! Just made changes to get the tracking in.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be no change.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)