### PR TITLE
Set main instance name to null when editing saved form

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -396,6 +396,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
     }
 
+    // Copied from XFormParser.loadXmlInstance in order to set ExternalAnswerResolver for search()
     public static void importData(File instanceFile, FormEntryController fec) throws IOException, RuntimeException {
         // convert files into a byte array
         byte[] fileBytes = org.apache.commons.io.FileUtils.readFileToByteArray(instanceFile);
@@ -419,6 +420,11 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         XFormParser.setAnswerResolver(new ExternalAnswerResolver());
         templateRoot.populate(savedRoot, fec.getModel().getForm());
         XFormParser.setAnswerResolver(new DefaultAnswerResolver());
+
+        // FormInstanceParser.parseInstance is responsible for initial creation of instances. It explicitly sets the
+        // main instance name to null so we force this again on deserialization because some code paths rely on the main
+        // instance not having a name. Must be before the call on setRoot because setRoot also sets the root's name.
+        fec.getModel().getForm().getInstance().setName(null);
 
         // populated model to current form
         fec.getModel().getForm().getInstance().setRoot(templateRoot);


### PR DESCRIPTION
Closes #4181

#### What has been done to verify that this works as intended?
I started out writing a test in JavaRosa: https://github.com/getodk/javarosa/compare/master...lognaturel:constraints. However, the code that needs changing is copied in Collect so I'm not really sure where a test should ultimately live. I also tried the form [singleQ.xml.zip](https://github.com/getodk/collect/files/5427434/singleQ.xml.zip) with a single constraint.

#### Why is this the best possible solution? Were any other approaches considered?
This is a non-invasive change appropriate for bug fixing. The duplication between Collect and JavaRosa here is not ideal so I considered some rework but I don't think it's something we should do as part of a point release.

In https://github.com/getodk/javarosa/pull/578, we had identified that we had to reset the main instance name on form definition deserialization. We didn't consider that this was also necessary on form instance deserialization.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I can't think of any regression risk. This ensures that the main instance name is consistent before and after instance serialization.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with constraints. [singleQ.xml.zip](https://github.com/getodk/collect/files/5427434/singleQ.xml.zip) is a simple one. The user at https://forum.getodk.org/t/collect-v1-28-2-error-about-two-different-forms-with-same-formid-and-version-and-constraints-not-accepting-valid-values/30645 reports that they've seen the problem the first time they were filling a blank form. It would be worth trying for a bit to reproduce that though I don't think it would be related.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)