### PR TITLE
Fix displaying recordings over an hour

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioControllerView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioControllerView.java
@@ -23,15 +23,20 @@ import android.widget.ImageButton;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.odk.collect.android.R;
 import org.odk.collect.android.databinding.AudioControllerLayoutBinding;
 
+import java.util.Locale;
+
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 
 public class AudioControllerView extends FrameLayout {
+
+    public static final int ONE_HOUR = 3600000;
+    public static final int ONE_MINUTE = 60000;
+    public static final int ONE_SECOND = 1000;
 
     public final AudioControllerLayoutBinding binding;
 
@@ -101,8 +106,16 @@ public class AudioControllerView extends FrameLayout {
         }
     }
 
-    private static String getTime(long seconds) {
-        return new DateTime(seconds, DateTimeZone.UTC).toString("mm:ss");
+    private static String getTime(long milliseconds) {
+        long hours = milliseconds / ONE_HOUR;
+        long minutes = (milliseconds % ONE_HOUR) / ONE_MINUTE;
+        long seconds = (milliseconds % ONE_MINUTE) / ONE_SECOND;
+
+        if (milliseconds < ONE_HOUR) {
+            return format(Locale.getDefault(), "%02d:%02d", minutes, seconds);
+        } else {
+            return format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds);
+        }
     }
 
     public void setPlaying(Boolean playing) {

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioControllerView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioControllerView.java
@@ -26,11 +26,8 @@ import android.widget.TextView;
 import org.odk.collect.android.R;
 import org.odk.collect.android.databinding.AudioControllerLayoutBinding;
 
-import java.util.Locale;
-
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.String.format;
 
 public class AudioControllerView extends FrameLayout {
 
@@ -106,18 +103,6 @@ public class AudioControllerView extends FrameLayout {
         }
     }
 
-    private static String getTime(long milliseconds) {
-        long hours = milliseconds / ONE_HOUR;
-        long minutes = (milliseconds % ONE_HOUR) / ONE_MINUTE;
-        long seconds = (milliseconds % ONE_MINUTE) / ONE_SECOND;
-
-        if (milliseconds < ONE_HOUR) {
-            return format(Locale.getDefault(), "%02d:%02d", minutes, seconds);
-        } else {
-            return format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds);
-        }
-    }
-
     public void setPlaying(Boolean playing) {
         this.playing = playing;
 
@@ -141,16 +126,15 @@ public class AudioControllerView extends FrameLayout {
     public void setDuration(Integer duration) {
         this.duration = duration;
 
-        totalDurationLabel.setText(getTime(duration));
+        totalDurationLabel.setText(LengthFormatter.formatLength((long) duration));
         seekBar.setMax(duration);
-
         setPosition(0);
     }
 
     private void renderPosition(Integer position) {
         this.position = position;
 
-        currentDurationLabel.setText(getTime(position));
+        currentDurationLabel.setText(LengthFormatter.formatLength((long) position));
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             seekBar.setProgress(position, true);

--- a/collect_app/src/main/java/org/odk/collect/android/audio/LengthFormatter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/LengthFormatter.java
@@ -1,0 +1,28 @@
+package org.odk.collect.android.audio;
+
+import java.util.Locale;
+
+import static java.lang.String.format;
+
+public class LengthFormatter {
+
+    public static final int ONE_HOUR = 3600000;
+    public static final int ONE_MINUTE = 60000;
+    public static final int ONE_SECOND = 1000;
+
+    private LengthFormatter() {
+        
+    }
+
+    public static String formatLength(long milliseconds) {
+        long hours = milliseconds / ONE_HOUR;
+        long minutes = (milliseconds % ONE_HOUR) / ONE_MINUTE;
+        long seconds = (milliseconds % ONE_MINUTE) / ONE_SECOND;
+
+        if (milliseconds < ONE_HOUR) {
+            return format(Locale.getDefault(), "%02d:%02d", minutes, seconds);
+        } else {
+            return format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds);
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioControllerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioControllerViewTest.java
@@ -34,37 +34,13 @@ public class AudioControllerViewTest {
 
     @Test
     public void setDuration_showsDurationInMinutesAndSeconds() {
-        view.setDuration(1000);
-        assertThat(view.binding.totalDuration.getText().toString(), equalTo("00:01"));
-
         view.setDuration(52000);
         assertThat(view.binding.totalDuration.getText().toString(), equalTo("00:52"));
-
-        view.setDuration(64000);
-        assertThat(view.binding.totalDuration.getText().toString(), equalTo("01:04"));
-    }
-
-    @Test
-    public void setDuration_whenHours_showsDurationInHoursMinutesAndSeconds() {
-        view.setDuration((60 * 60 * 1000) + 64000);
-        assertThat(view.binding.totalDuration.getText().toString(), equalTo("01:01:04"));
-    }
-
-    @Test
-    public void setDuration_when100Hours_showsDurationInHoursMinutesAndSeconds() {
-        view.setDuration(100 * 60 * 60 * 1000);
-        assertThat(view.binding.totalDuration.getText().toString(), equalTo("100:00:00"));
     }
 
     @Test
     public void setPosition_showsPositionInMinutesAndSeconds() {
         view.setDuration(65000);
-
-        view.setPosition(1000);
-        assertThat(view.binding.currentDuration.getText().toString(), equalTo("00:01"));
-
-        view.setPosition(52000);
-        assertThat(view.binding.currentDuration.getText().toString(), equalTo("00:52"));
 
         view.setPosition(64000);
         assertThat(view.binding.currentDuration.getText().toString(), equalTo("01:04"));

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioControllerViewTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioControllerViewTest.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android.audio;
+ package org.odk.collect.android.audio;
 
 import android.widget.SeekBar;
 
@@ -42,6 +42,18 @@ public class AudioControllerViewTest {
 
         view.setDuration(64000);
         assertThat(view.binding.totalDuration.getText().toString(), equalTo("01:04"));
+    }
+
+    @Test
+    public void setDuration_whenHours_showsDurationInHoursMinutesAndSeconds() {
+        view.setDuration((60 * 60 * 1000) + 64000);
+        assertThat(view.binding.totalDuration.getText().toString(), equalTo("01:01:04"));
+    }
+
+    @Test
+    public void setDuration_when100Hours_showsDurationInHoursMinutesAndSeconds() {
+        view.setDuration(100 * 60 * 60 * 1000);
+        assertThat(view.binding.totalDuration.getText().toString(), equalTo("100:00:00"));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/audio/LengthFormatterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/LengthFormatterTest.java
@@ -1,0 +1,27 @@
+package org.odk.collect.android.audio;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.odk.collect.android.audio.LengthFormatter.formatLength;
+
+public class LengthFormatterTest {
+
+    @Test
+    public void formatsToMinutesAndSeconds() {
+        assertThat(formatLength(1000), equalTo("00:01"));
+        assertThat(formatLength(52000), equalTo("00:52"));
+        assertThat(formatLength(64000), equalTo("01:04"));
+    }
+
+    @Test
+    public void whenHours_formatsToHoursMinutesAndSeconds() {
+        assertThat(formatLength((60 * 60 * 1000) + 64000), equalTo("01:01:04"));
+    }
+
+    @Test
+    public void when100Hours_showsDurationInHoursMinutesAndSeconds() {
+        assertThat(formatLength(100 * 60 * 60 * 1000), equalTo("100:00:00"));
+    }
+}


### PR DESCRIPTION
Closes #4143

#### What has been done to verify that this works as intended?

Added tests.

#### Why is this the best possible solution? Were any other approaches considered?

I was surprised I couldn't find a solution for this in JodaTime! Not a big deal to have a custom implementation of this as it doesn't need a lot of test coverage.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only part of the app that's changed is the audio widget and how it displays the position and duration.

#### Do we need any specific form for testing your changes? If so, please attach one.

Any form with an audio question will do!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)