### PR TITLE
Use JavaRosa v3.0.3 to fix bug in complex calculates

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -262,7 +262,7 @@ dependencies {
     implementation "com.rarepebble:colorpicker:3.0.1"
     implementation "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     implementation "net.sf.opencsv:opencsv:2.4"
-    implementation("org.getodk:javarosa:3.0.2") {
+    implementation("org.getodk:javarosa:3.0.3") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
See https://github.com/getodk/javarosa/issues/611 for description of bug and https://forum.getodk.org/t/repeats-and-calculations-inside-nested-repeats-behaving-differently-in-odk-1-27-3-vs-1-28-2/30694 for a user form.

#### What has been done to verify that this works as intended?
Wrote and ran JR test at https://github.com/getodk/javarosa/pull/612, interactively reviewed with @seadowg, ran with [complex_calc.xml.zip](https://github.com/getodk/collect/files/5436315/complex_calc.xml.zip).

#### Why is this the best possible solution? Were any other approaches considered?
It's the simplest.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Should be a safe bug fix.

#### Do we need any specific form for testing your changes? If so, please attach one.
[complex_calc.xml.zip](https://github.com/getodk/collect/files/5436317/complex_calc.xml.zip). This is a form with repeats. Each repeat has a question with text that represents 2*repeat position-4. Prior to the fix, it was showing 2*repeat position-.

There's also a user form at https://forum.getodk.org/t/repeats-and-calculations-inside-nested-repeats-behaving-differently-in-odk-1-27-3-vs-1-28-2/30694 but it's pretty complex. I ended up jumping to the section highlighted in the original writeup and then going backwards to fill needed answers.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)