### PR TITLE
Fixed map icon button

### DIFF
--- a/collect_app/src/main/res/layout/form_chooser_list_item_map_button.xml
+++ b/collect_app/src/main/res/layout/form_chooser_list_item_map_button.xml
@@ -5,7 +5,6 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/map_button"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
-        android:background="?selectableItemBackground"
         android:focusable="false"
         android:clickable="false"
         android:layout_width="40sp"


### PR DESCRIPTION
Closes #4160 

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The issue appeared after bumping material dependencies in https://github.com/getodk/collect/pull/4117/
What's interesting the issue was visible only in the list of forms but media buttons (audio/video) which use the same style worked well. I compared both layout files and figured out that in map icon buttons we use additional background what I removed and everything seems fine.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix but it would be good to verify the fix on different devices.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)