### PR TITLE
Force storage migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ task checkInstrumented(type: GradleBuild) {
 ext {
     androidCompileSdk = 30
     androidMinSdk = 21
-    androidTargetSdk = 28
+    androidTargetSdk = 29
 
     fragmentVersion = '1.2.5'
     daggerVersion = '2.29.1'

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -200,6 +200,9 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
+            all {
+                maxHeapSize = "1024m"
+            }
         }
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalDataFileNotFoundTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalDataFileNotFoundTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.support.pages.FormEntryPage;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.ResetStateRule;
@@ -32,9 +34,11 @@ public class ExternalDataFileNotFoundTest {
 
     @Test
     public void questionsThatUseExternalFiles_ShouldDisplayFriendlyMessageWhenFilesAreMissing() {
+        String formsDirPath = new StoragePathProvider().getDirPath(StorageSubdirectory.FORMS);
+
         new FormEntryPage("externalDataQuestions", activityTestRule)
-                .assertText(activityTestRule.getActivity().getString(R.string.file_missing, "/storage/emulated/0/odk/forms/external_data_questions-media/fruits.csv"))
+                .assertText(activityTestRule.getActivity().getString(R.string.file_missing, formsDirPath + "/external_data_questions-media/fruits.csv"))
                 .swipeToNextQuestion()
-                .assertText(activityTestRule.getActivity().getString(R.string.file_missing, "/storage/emulated/0/odk/forms/external_data_questions-media/itemsets.csv"));
+                .assertText(activityTestRule.getActivity().getString(R.string.file_missing, formsDirPath + "/external_data_questions-media/itemsets.csv"));
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/AutomaticStorageMigrationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/AutomaticStorageMigrationTest.java
@@ -1,0 +1,28 @@
+package org.odk.collect.android.feature.storage;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.TestDependencies;
+import org.odk.collect.android.support.TestRuleChain;
+import org.odk.collect.android.support.pages.MainMenuPage;
+
+@RunWith(AndroidJUnit4.class)
+public class AutomaticStorageMigrationTest {
+
+    public CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public RuleChain copyFormChain = TestRuleChain.chain(false, new TestDependencies())
+            .around(rule);
+
+    @Test
+    public void when_storageMigrationNotPerformed_shouldBePerformedAutomatically() {
+        new MainMenuPage(rule)
+                .assertStorageMigrationCompletedBannerIsDisplayed();
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationCompletedBannerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationCompletedBannerTest.java
@@ -32,7 +32,7 @@ public class StorageMigrationCompletedBannerTest {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
             ))
-            .around(new ResetStateRule(true, new AppDependencyModule() {
+            .around(new ResetStateRule(new AppDependencyModule() {
                 @Provides
                 @Singleton
                 public StorageMigrationRepository providesStorageMigrationRepository() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/storage/StorageMigrationTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.activities.MainMenuActivity;
+import org.odk.collect.android.storage.StorageStateProvider;
 import org.odk.collect.android.support.CopyFormRule;
 import org.odk.collect.android.support.TestDependencies;
 import org.odk.collect.android.support.TestRuleChain;
@@ -15,11 +16,21 @@ import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.StorageMigrationDialogPage;
 
 import static java.util.Arrays.asList;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class StorageMigrationTest {
 
-    final TestDependencies testDependencies = new TestDependencies();
+    final TestDependencies testDependencies = new TestDependencies() {
+        @Override
+        public StorageStateProvider providesStorageStateProvider() {
+            StorageStateProvider storageStateProvider = spy(new StorageStateProvider());
+            when(storageStateProvider.shouldPerformAutomaticMigration()).thenReturn(false);
+            return storageStateProvider;
+        }
+    };
+
     final IntentsTestRule<MainMenuActivity> rule = new IntentsTestRule<>(MainMenuActivity.class);
 
     @Rule

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.instances.Instance;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.support.ActivityHelpers;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.CopyFormRule;
@@ -655,20 +657,22 @@ public class FillBlankFormTest {
 
     @Test
     public void missingFileMessage_shouldBeDisplayedIfExternalFIleIsMissing() {
+        String formsDirPath = new StoragePathProvider().getDirPath(StorageSubdirectory.FORMS);
+
         //TestCase55
         new MainMenuPage(rule)
                 .startBlankForm("search_and_select")
-                .assertText("File: /storage/emulated/0/odk/forms/search_and_select-media/nombre.csv is missing.")
-                .assertText("File: /storage/emulated/0/odk/forms/search_and_select-media/nombre2.csv is missing.")
+                .assertText("File: " + formsDirPath + "/search_and_select-media/nombre.csv is missing.")
+                .assertText("File: " + formsDirPath + "/search_and_select-media/nombre2.csv is missing.")
                 .swipeToEndScreen()
                 .clickSaveAndExit()
 
                 .startBlankForm("cascading select test")
                 .clickOnText("Texas")
                 .swipeToNextQuestion()
-                .assertText("File: /storage/emulated/0/odk/forms/select_one_external-media/itemsets.csv is missing.")
+                .assertText("File: " + formsDirPath + "/select_one_external-media/itemsets.csv is missing.")
                 .swipeToNextQuestion()
-                .assertText("File: /storage/emulated/0/odk/forms/select_one_external-media/itemsets.csv is missing.")
+                .assertText("File: " + formsDirPath + "/select_one_external-media/itemsets.csv is missing.")
                 .swipeToNextQuestion(3)
                 .swipeToEndScreen()
                 .clickSaveAndExit()
@@ -678,7 +682,7 @@ public class FillBlankFormTest {
                 .clickGoUpIcon()
                 .clickOnElementInHierarchy(14)
                 .clickOnQuestion("Source15")
-                .assertText("File: /storage/emulated/0/odk/forms/fieldlist-updates_nocsv-media/fruits.csv is missing.")
+                .assertText("File: " + formsDirPath + "/fieldlist-updates_nocsv-media/fruits.csv is missing.")
                 .swipeToEndScreen()
                 .clickSaveAndExit();
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
@@ -27,15 +27,11 @@ public class ResetStateRule implements TestRule {
     private AppDependencyModule appDependencyModule;
 
     public ResetStateRule() {
-        this(false, null);
-    }
-
-    public ResetStateRule(boolean useScopedStorage) {
-        this(useScopedStorage, null);
+        this(true, null);
     }
 
     public ResetStateRule(AppDependencyModule appDependencyModule) {
-        this(false, appDependencyModule);
+        this(true, appDependencyModule);
     }
 
     public ResetStateRule(boolean useScopedStorage, AppDependencyModule appDependencyModule) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
@@ -12,6 +12,8 @@ import org.junit.runners.model.Statement;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.preferences.PreferencesProvider;
+import org.odk.collect.android.provider.FormsProvider;
+import org.odk.collect.android.provider.InstanceProvider;
 import org.odk.collect.android.storage.StorageStateProvider;
 import org.odk.collect.android.utilities.ApplicationResetter;
 import org.odk.collect.android.utilities.MultiClickGuard;
@@ -94,6 +96,9 @@ public class ResetStateRule implements TestRule {
         } else {
             new StorageStateProvider().disableUsingScopedStorage();
         }
+
+        FormsProvider.recreateDatabaseHelper();
+        InstanceProvider.recreateDatabaseHelper();
     }
 
     private void resetDagger() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestRuleChain.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestRuleChain.java
@@ -13,11 +13,11 @@ public class TestRuleChain {
     }
 
     public static RuleChain chain() {
-        return chain(false, new TestDependencies());
+        return chain(true, new TestDependencies());
     }
 
     public static RuleChain chain(TestDependencies testDependencies) {
-        return chain(false, testDependencies);
+        return chain(true, testDependencies);
     }
 
     public static RuleChain chain(boolean useScopedStorage, TestDependencies testDependencies) {

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -78,7 +78,8 @@ the specific language governing permissions and limitations under the License.
         android:largeHeap="true"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:allowBackup="true">
+        android:allowBackup="true"
+        android:requestLegacyExternalStorage="true">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -290,6 +290,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
         setButtonsVisibility();
         invalidateOptionsMenu();
         setUpStorageMigrationBanner();
+        tryToPerformAutomaticMigration();
     }
 
     private void setButtonsVisibility() {
@@ -581,5 +582,14 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             storageMigrationBanner.setVisibility(View.GONE);
             storageMigrationRepository.clearResult();
         });
+    }
+
+    private void tryToPerformAutomaticMigration() {
+        if (storageStateProvider.shouldPerformAutomaticMigration()) {
+            StorageMigrationDialog dialog = showStorageMigrationDialog();
+            if (dialog != null) {
+                dialog.startStorageMigration();
+            }
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.java
@@ -33,6 +33,8 @@ import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.storage.StorageInitializer;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageStateProvider;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.PermissionUtils;
@@ -66,6 +68,12 @@ public class SplashScreenActivity extends Activity {
     @Inject
     GeneralSharedPreferences generalSharedPreferences;
 
+    @Inject
+    StorageStateProvider storageStateProvider;
+
+    @Inject
+    StoragePathProvider storagePathProvider;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -78,6 +86,7 @@ public class SplashScreenActivity extends Activity {
             public void granted() {
                 // must be at the beginning of any activity that can be called from an external intent
                 try {
+                    enableScopedStorageForFreshInstalls();
                     new StorageInitializer().createOdkDirsOnStorage();
                 } catch (RuntimeException e) {
                     DialogUtils.showDialog(DialogUtils.createErrorDialog(SplashScreenActivity.this,
@@ -178,5 +187,11 @@ public class SplashScreenActivity extends Activity {
         }
 
         new Handler().postDelayed(this::endSplashScreen, SPLASH_TIMEOUT);
+    }
+
+    private void enableScopedStorageForFreshInstalls() {
+        if (!storageStateProvider.isScopedStorageUsed() && !new File(storagePathProvider.getUnscopedStorageRootDirPath()).exists()) {
+            storageStateProvider.enableUsingScopedStorage();
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -269,6 +269,7 @@ public class AppDependencyModule {
     }
 
     @Provides
+    @Singleton
     public StorageStateProvider providesStorageStateProvider() {
         return new StorageStateProvider();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/storage/StorageStateProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/StorageStateProvider.java
@@ -13,6 +13,7 @@ import timber.log.Timber;
 import static org.odk.collect.android.preferences.MetaKeys.KEY_SCOPED_STORAGE_USED;
 
 public class StorageStateProvider {
+    private static long lastMigrationAttempt;
 
     private final SharedPreferences metaSharedPreferences;
 
@@ -75,5 +76,16 @@ public class StorageStateProvider {
             }
         }
         return length;
+    }
+
+    public boolean shouldPerformAutomaticMigration() {
+        return !isScopedStorageUsed() && !alreadyTriedToMigrateDataToday(System.currentTimeMillis());
+    }
+
+    public boolean alreadyTriedToMigrateDataToday(long currentTime) {
+        long oneDayPeriod = 86400000;
+        boolean result = currentTime - lastMigrationAttempt < oneDayPeriod;
+        lastMigrationAttempt = currentTime;
+        return result;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuButtonsVisibilityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuButtonsVisibilityTest.java
@@ -3,15 +3,21 @@ package org.odk.collect.android.activities;
 import android.view.View;
 import android.widget.Button;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
+import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
+import org.odk.collect.android.storage.StorageStateProvider;
+import org.odk.collect.android.support.RobolectricHelpers;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_DELETE_SAVED;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_EDIT_SAVED;
 import static org.odk.collect.android.preferences.AdminKeys.KEY_GET_BLANK;
@@ -22,6 +28,18 @@ import static org.odk.collect.android.preferences.AdminKeys.KEY_VIEW_SENT;
 public class MainMenuButtonsVisibilityTest {
 
     private MainMenuActivity mainMenuActivity;
+
+    @Before
+    public void setup() {
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public StorageStateProvider providesStorageStateProvider() {
+                StorageStateProvider storageStateProvider = spy(new StorageStateProvider());
+                when(storageStateProvider.shouldPerformAutomaticMigration()).thenReturn(false);
+                return storageStateProvider;
+            }
+        });
+    }
 
     @Test
     public void when_editSavedFormButtonIsEnabledInSettings_shouldBeVisible() {

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.java
@@ -23,6 +23,7 @@ import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.storage.StorageStateProvider;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.utilities.UserAgentProvider;
@@ -69,6 +70,8 @@ public class SplashScreenActivityTest {
             Assert.assertTrue("File " + dirName + "does not exist", dir.exists());
             Assert.assertTrue("File" + dirName + "does not exist", dir.isDirectory());
         }
+
+        assertThat(new StorageStateProvider().isScopedStorageUsed(), is(true));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/storage/StorageStateProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/storage/StorageStateProviderTest.java
@@ -1,0 +1,51 @@
+package org.odk.collect.android.storage;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.odk.collect.utilities.Clock;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class StorageStateProviderTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private Clock clock;
+
+    private StorageStateProvider storageStateProvider;
+
+    @Before
+    public void setup() {
+        when(clock.getCurrentTime()).thenReturn(90000000L);
+        storageStateProvider = spy(new StorageStateProvider(clock));
+        storageStateProvider.clearLastMigrationAttemptTime();
+    }
+
+    @Test
+    public void whenScopedStorageIsUsed_shouldNotPerformAutomaticMigration() {
+        when(storageStateProvider.isScopedStorageUsed()).thenReturn(true);
+        assertThat(storageStateProvider.shouldPerformAutomaticMigration(), is(false));
+    }
+
+    @Test
+    public void whenScopedStorageIsNotUsed_shouldPerformAutomaticMigrationAndRepeatItOnceADay() {
+        when(storageStateProvider.isScopedStorageUsed()).thenReturn(false);
+        assertThat(storageStateProvider.shouldPerformAutomaticMigration(), is(true));
+        when(clock.getCurrentTime()).thenReturn(90000000L + 86400000 - 1);
+        assertThat(storageStateProvider.shouldPerformAutomaticMigration(), is(false));
+        when(clock.getCurrentTime()).thenReturn(90000000L + 86400000);
+        assertThat(storageStateProvider.shouldPerformAutomaticMigration(), is(true));
+    }
+}

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -670,7 +670,7 @@
     <string name="save_legacy_settings_warning">Will be removed in a future version. Please use the QR code above.</string>
     <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
 
-    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage to comply with Android requirements. In Collect v1.29, <b>the migration will be forced on install</b>.</string>
+    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage to comply with Android requirements. The migration should have happened automatically. If you still see this message it indicates that something went wrong. Please try to perform migration manually.</string>
     <string name="scoped_storage_learn_more">Learn more and migrate</string>
     <string name="storage_migration_completed">Storage migration completed!</string>
     <string name="scoped_storage_dismiss">Dismiss</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -670,7 +670,7 @@
     <string name="save_legacy_settings_warning">Will be removed in a future version. Please use the QR code above.</string>
     <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
 
-    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage to comply with Android requirements. The migration should have happened automatically. If you still see this message it indicates that something went wrong. Please try to perform migration manually.</string>
+    <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage to comply with Android requirements. An automatic migration attempt failed. Please migrate manually.</string>
     <string name="scoped_storage_learn_more">Learn more and migrate</string>
     <string name="storage_migration_completed">Storage migration completed!</string>
     <string name="scoped_storage_dismiss">Dismiss</string>


### PR DESCRIPTION
Closes #3360

#### What has been done to verify that this works as intended?
I tested the changes manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is what we need to do because of google's policy.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
- fresh installs should start with scoped storage by default
- for other users migrations should happen automatically once they install and open the app for the first time
- if the automated migration fails the banner as in v1.28.x should be visible and allow users to perform migration manually
- if migration fails and users don't trigger it manually next attempt should take place automatically when such users open the app again after 24h or if the app was killed and reopened

We reuse the same code which performs migration so migration itself shouldn't be affected. During testing we don't need to test the process a lot. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)