### PR TITLE
Make clicking recording notification return to app

### DIFF
--- a/audiorecorder/src/main/AndroidManifest.xml
+++ b/audiorecorder/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <application>
         <service android:name=".recording.internal.AudioRecorderService" />
+        <activity android:name=".recording.internal.ReturnToAppActivity" />
     </application>
 
 </manifest>

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.PRIORITY_LOW
 import org.odk.collect.audiorecorder.R
 import org.odk.collect.audiorecorder.getComponent
 import org.odk.collect.audiorecorder.recorder.Recorder
@@ -41,6 +42,7 @@ class AudioRecorderService : Service() {
                         .setContentTitle(getLocalizedString(R.string.recording))
                         .setSmallIcon(R.drawable.ic_baseline_mic_24)
                         .setContentIntent(PendingIntent.getActivity(this, 0, notificationIntent, 0))
+                        .setPriority(PRIORITY_LOW)
                         .build()
 
                     startForeground(NOTIFICATION_ID, notification)
@@ -66,7 +68,7 @@ class AudioRecorderService : Service() {
             val notificationChannel = NotificationChannel(
                 NOTIFICATION_CHANNEL,
                 getLocalizedString(R.string.recording_channel),
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_LOW
             )
 
             (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(notificationChannel)

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -2,6 +2,7 @@ package org.odk.collect.audiorecorder.recording.internal
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.Build
@@ -36,9 +37,12 @@ class AudioRecorderService : Service() {
 
                     setupNotificationChannel()
 
+                    val notificationIntent = Intent(this, ReturnToAppActivity::class.java)
+
                     val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL)
                         .setContentTitle(getLocalizedString(R.string.recording))
                         .setSmallIcon(R.drawable.ic_baseline_mic_24)
+                        .setContentIntent(PendingIntent.getActivity(this, 0, notificationIntent, 0))
                         .build()
 
                     startForeground(NOTIFICATION_ID, notification)

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -36,9 +36,7 @@ class AudioRecorderService : Service() {
                     recordingRepository.start(sessionId)
 
                     setupNotificationChannel()
-
                     val notificationIntent = Intent(this, ReturnToAppActivity::class.java)
-
                     val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL)
                         .setContentTitle(getLocalizedString(R.string.recording))
                         .setSmallIcon(R.drawable.ic_baseline_mic_24)

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivity.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivity.kt
@@ -1,0 +1,12 @@
+package org.odk.collect.audiorecorder.recording.internal
+
+import android.app.Activity
+import android.os.Bundle
+
+class ReturnToAppActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        finish()
+    }
+}

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivity.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivity.kt
@@ -3,6 +3,11 @@ package org.odk.collect.audiorecorder.recording.internal
 import android.app.Activity
 import android.os.Bundle
 
+/**
+ * This Activity will close as soon as it is started. This means it can be used as the content
+ * intent of a notification so clicking it will effectively return to the screen the user
+ * was last on (knowing what that Activity was).
+ */
 internal class ReturnToAppActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivity.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivity.kt
@@ -3,7 +3,7 @@ package org.odk.collect.audiorecorder.recording.internal
 import android.app.Activity
 import android.os.Bundle
 
-class ReturnToAppActivity : Activity() {
+internal class ReturnToAppActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
@@ -51,6 +51,7 @@ class AudioRecorderServiceTest {
         val notification = shadowOf(service.get()).lastForegroundNotification
         assertThat(notification, not(nullValue()))
         assertThat(shadowOf(notification).contentTitle, equalTo(application.getString(R.string.recording)))
+        assertThat(shadowOf(notification.contentIntent).savedIntent.component?.className, equalTo(ReturnToAppActivity::class.qualifiedName))
     }
 
     @Test

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivityTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/ReturnToAppActivityTest.kt
@@ -1,0 +1,19 @@
+package org.odk.collect.audiorecorder.recording.internal
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.launchActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReturnToAppActivityTest {
+
+    @Test
+    fun finishesImmediately() {
+        val scenario = launchActivity<ReturnToAppActivity>()
+        assertThat(scenario.state, equalTo(Lifecycle.State.DESTROYED))
+    }
+}


### PR DESCRIPTION
Closes #4151 
~~Blocked by #4190~~

#### What has been done to verify that this works as intended?

Drove out with tests after spiking out a working solution.

#### Why is this the best possible solution? Were any other approaches considered?

We could use Activity flags to deal with this but that seems less versatile as it means we need to know which Activity the recording is taking place in (from the user's perspective). Given that's already change once in the last couple of weeks I think going with this is the best idea.

I actually wasn't sure this would work, so I'm pretty happy it ended up being this simple.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to try and work out a way to break this. I couldn't!

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)