### PR TITLE
Fixed multiclick issue that gives a possibility to open multiple dialogs with choices

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -146,6 +146,24 @@ public final class DialogUtils {
         }
     }
 
+    public static <T extends DialogFragment> void showIfNotShowing(T newDialog, Class<T> dialogClass, FragmentManager fragmentManager) {
+        if (fragmentManager.isStateSaved()) {
+            return;
+        }
+
+        String tag = dialogClass.getName();
+        T existingDialog = (T) fragmentManager.findFragmentByTag(tag);
+
+        if (existingDialog == null) {
+            newDialog.show(fragmentManager.beginTransaction(), tag);
+
+            // We need to execute this transaction. Otherwise a follow up call to this method
+            // could happen before the Fragment exists in the Fragment Manager and so the
+            // call to findFragmentByTag would return null and result in second dialog being show.
+            fragmentManager.executePendingTransactions();
+        }
+    }
+
     public static void dismissDialog(Class dialogClazz, FragmentManager fragmentManager) {
         DialogFragment existingDialog = (DialogFragment) fragmentManager.findFragmentByTag(dialogClazz.getName());
         if (existingDialog != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/DialogUtils.java
@@ -128,22 +128,7 @@ public final class DialogUtils {
     }
 
     public static <T extends DialogFragment> void showIfNotShowing(Class<T> dialogClass, @Nullable Bundle args, FragmentManager fragmentManager) {
-        if (fragmentManager.isStateSaved()) {
-            return;
-        }
-
-        String tag = dialogClass.getName();
-        T existingDialog = (T) fragmentManager.findFragmentByTag(tag);
-
-        if (existingDialog == null) {
-            T newDialog = createNewInstance(dialogClass, args);
-            newDialog.show(fragmentManager.beginTransaction(), tag);
-
-            // We need to execute this transaction. Otherwise a follow up call to this method
-            // could happen before the Fragment exists in the Fragment Manager and so the
-            // call to findFragmentByTag would return null and result in second dialog being show.
-            fragmentManager.executePendingTransactions();
-        }
+        showIfNotShowing(createNewInstance(dialogClass, args), dialogClass, fragmentManager);
     }
 
     public static <T extends DialogFragment> void showIfNotShowing(T newDialog, Class<T> dialogClass, FragmentManager fragmentManager) {

--- a/collect_app/src/main/java/org/odk/collect/android/views/MultiClickSafeTextInputEditText.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/MultiClickSafeTextInputEditText.java
@@ -1,0 +1,26 @@
+package org.odk.collect.android.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.textfield.TextInputEditText;
+
+import org.odk.collect.android.utilities.MultiClickGuard;
+
+public class MultiClickSafeTextInputEditText extends TextInputEditText {
+
+    public MultiClickSafeTextInputEditText(@NonNull Context context) {
+        super(context);
+    }
+
+    public MultiClickSafeTextInputEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean performClick() {
+        return MultiClickGuard.allowClick(getClass().getName()) && super.performClick();
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
@@ -11,6 +11,7 @@ import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
 import org.odk.collect.android.fragments.dialogs.SelectMultiMinimalDialog;
+import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.StringUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
@@ -46,7 +47,8 @@ public class SelectMultiMinimalWidget extends SelectMinimalWidget {
                 WidgetAppearanceUtils.isAutocomplete(getFormEntryPrompt()), getContext(), items,
                 getFormEntryPrompt(), getReferenceManager(),
                 getPlayColor(getFormEntryPrompt(), themeUtils), numColumns, noButtonsMode);
-        dialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), SelectMinimalDialog.class.getName());
+
+        DialogUtils.showIfNotShowing(dialog, SelectMinimalDialog.class, ((FormEntryActivity) getContext()).getSupportFragmentManager());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidget.java
@@ -12,6 +12,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
 import org.odk.collect.android.fragments.dialogs.SelectOneMinimalDialog;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
+import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.StringUtils;
 import org.odk.collect.android.utilities.WidgetAppearanceUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
@@ -48,7 +49,8 @@ public class SelectOneMinimalWidget extends SelectMinimalWidget {
                 WidgetAppearanceUtils.isAutocomplete(getFormEntryPrompt()), getContext(), items,
                 getFormEntryPrompt(), getReferenceManager(),
                 getPlayColor(getFormEntryPrompt(), themeUtils), numColumns, noButtonsMode);
-        dialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), SelectMinimalDialog.class.getName());
+
+        DialogUtils.showIfNotShowing(dialog, SelectMinimalDialog.class, ((FormEntryActivity) getContext()).getSupportFragmentManager());
     }
 
     @Override

--- a/collect_app/src/main/res/layout/select_minimal_widget_answer.xml
+++ b/collect_app/src/main/res/layout/select_minimal_widget_answer.xml
@@ -5,7 +5,7 @@
     android:paddingHorizontal="@dimen/margin_standard"
     android:paddingVertical="@dimen/margin_small">
 
-    <com.google.android.material.textfield.TextInputEditText
+    <org.odk.collect.android.views.MultiClickSafeTextInputEditText
         android:id="@+id/answer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -16,6 +16,5 @@
         android:drawableEnd="@drawable/ic_arrow_drop_down"
         android:cursorVisible="false"
         android:inputType="textMultiLine|textNoSuggestions"
-        android:saveEnabled="false">
-    </com.google.android.material.textfield.TextInputEditText>
+        android:saveEnabled="false"/>
 </FrameLayout>


### PR DESCRIPTION
Closes #4122

#### What has been done to verify that this works as intended?
I was able to reproduce the issue and verified that the fix works.

#### Why is this the best possible solution? Were any other approaches considered?
I used two of our mechanisms to protect from opening multiple dialogs. Once is `MultiClickGuard` class and another one is `DialogUtils.showIfNotShowing()`. Probably just one would be enough but I can't be sure so decided to add both.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe change that should just fix the issue, nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
[minimalTest.xlsx](https://github.com/getodk/collect/files/5482906/minimalTest.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)