### PR TITLE
Catch NPE from #4204

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -83,14 +83,14 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         try {
             formController.newRepeat();
         } catch (RuntimeException e) {
-            error.setValue(e.getCause() != null ? e.getCause().getMessage() : "Unknown issue occurred while adding a new group");
+            error.setValue(e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         }
         
         if (!formController.indexIsInFieldList()) {
             try {
                 formController.stepToNextScreenEvent();
             } catch (JavaRosaException e) {
-                error.setValue(e.getCause() != null ? e.getCause().getMessage() : "Unknown issue occurred while adding a new group");
+                error.setValue(e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -83,14 +83,14 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         try {
             formController.newRepeat();
         } catch (RuntimeException e) {
-            error.setValue(e.getCause().getMessage());
+            error.setValue(e.getCause() != null ? e.getCause().getMessage() : "Unknown issue occurred while adding a new group");
         }
         
         if (!formController.indexIsInFieldList()) {
             try {
                 formController.stepToNextScreenEvent();
             } catch (JavaRosaException e) {
-                error.setValue(e.getCause().getMessage());
+                error.setValue(e.getCause() != null ? e.getCause().getMessage() : "Unknown issue occurred while adding a new group");
             }
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -51,11 +51,22 @@ public class FormEntryViewModelTest {
     }
 
     @Test
-    public void addRepeat_whenThereIsAnErrorCreatingRepeat_setsErrorWithMessage() throws Exception {
+    public void addRepeat_whenThereIsAnErrorCreatingRepeat_setsErrorWithMessage() {
         doThrow(new RuntimeException(new IOException("OH NO"))).when(formController).newRepeat();
 
         viewModel.addRepeat(true);
         assertThat(viewModel.getError().getValue(), equalTo("OH NO"));
+    }
+
+    @Test
+    public void addRepeat_whenThereIsAnErrorCreatingRepeat_setsErrorWithoutCause() {
+        RuntimeException runtimeException = mock(RuntimeException.class);
+        when(runtimeException.getCause()).thenReturn(null);
+
+        doThrow(runtimeException).when(formController).newRepeat();
+
+        viewModel.addRepeat(true);
+        assertThat(viewModel.getError().getValue(), equalTo("Unknown issue occurred while adding a new group"));
     }
 
     @Test
@@ -64,6 +75,17 @@ public class FormEntryViewModelTest {
 
         viewModel.addRepeat(true);
         assertThat(viewModel.getError().getValue(), equalTo("OH NO"));
+    }
+
+    @Test
+    public void addRepeat_whenThereIsAnErrorSteppingToNextScreen_setsErrorWithoutCause() throws Exception {
+        JavaRosaException javaRosaException = mock(JavaRosaException.class);
+        when(javaRosaException.getCause()).thenReturn(null);
+
+        when(formController.stepToNextScreenEvent()).thenThrow(javaRosaException);
+
+        viewModel.addRepeat(true);
+        assertThat(viewModel.getError().getValue(), equalTo("Unknown issue occurred while adding a new group"));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -62,6 +62,7 @@ public class FormEntryViewModelTest {
     public void addRepeat_whenThereIsAnErrorCreatingRepeat_setsErrorWithoutCause() {
         RuntimeException runtimeException = mock(RuntimeException.class);
         when(runtimeException.getCause()).thenReturn(null);
+        when(runtimeException.getMessage()).thenReturn("Unknown issue occurred while adding a new group");
 
         doThrow(runtimeException).when(formController).newRepeat();
 
@@ -81,6 +82,7 @@ public class FormEntryViewModelTest {
     public void addRepeat_whenThereIsAnErrorSteppingToNextScreen_setsErrorWithoutCause() throws Exception {
         JavaRosaException javaRosaException = mock(JavaRosaException.class);
         when(javaRosaException.getCause()).thenReturn(null);
+        when(javaRosaException.getMessage()).thenReturn("Unknown issue occurred while adding a new group");
 
         when(formController.stepToNextScreenEvent()).thenThrow(javaRosaException);
 


### PR DESCRIPTION
Closes #4204

#### What has been done to verify that this works as intended?
I added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
There is no other solution we just need to catch null values that `exception.getCause()` might return.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Probably it doesn't require testing since we can't even reproduce the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)