### PR TITLE
Expose more information in HEAD request error

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -148,12 +148,12 @@ public class InstanceServerUploader extends InstanceUploader {
                     }
                 }
             } else {
-                Timber.w("Status code on Head request: %d", headResult.getStatusCode());
                 if (headResult.getStatusCode() >= HttpsURLConnection.HTTP_OK
                         && headResult.getStatusCode() < HttpsURLConnection.HTTP_MULT_CHOICE) {
                     saveFailedStatusToDatabase(instance);
-                    throw new UploadException(FAIL + "Invalid status code on Head request. If "
-                            + "you have a web proxy, you may need to log in to your network.");
+                    throw new UploadException("Failed to send to " + uri + ". Is this an OpenRosa " +
+                            "submission endpoint? If you have a web proxy you may need to log in to " +
+                            "your network.\n\nHEAD request result status code: " + headResult.getStatusCode());
                 }
             }
         }


### PR DESCRIPTION
During some troubleshooting with a user, I discovered that there's a confusing message about a web proxy when there's an attempt to make a submission to a URL that exists but is not an OpenRosa submission endpoint. This is really only likely for people who specify a submission URL in their form because they need to remember to add the `/submission` to the address.

#### What has been done to verify that this works as intended?
1. Put a form on my device with `<submission action="https://test.central.getodk.org" method="post"/>`: 
[external_widgets.xml.zip](https://github.com/getodk/collect/files/5557879/external_widgets.xml.zip)
1. Finalized an instance, attempted to send it.
1. Verified that the error message is more useful.

#### Why is this the best possible solution? Were any other approaches considered?
This is a simple way to help direct users who make a form design mistake. I considered pulling the message out to be translated but I don't think it's common enough to be necessary. I think it also mostly targets project managers and form builders because a form with this error is very unlikely to make it out to production. 

I decided to move the actual status code to the user-facing message instead of leaving it buried in logs. There's nothing we as developers can do with this information so it should not go to Crashlytics.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This doesn't change any code structure and only modifies a message. It should be extremely safe and could probably even skip QA.

#### Do we need any specific form for testing your changes? If so, please attach one.
[external_widgets.xml.zip](https://github.com/getodk/collect/files/5557879/external_widgets.xml.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)