### PR TITLE
Rework ResetStateRule 

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.java
@@ -21,6 +21,8 @@ public class FormFinalizingTest {
 
     private static final String FORM = "one-question.xml";
 
+    public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
+
     @Rule
     public RuleChain copyFormChain = RuleChain
             .outerRule(GrantPermissionRule.grant(
@@ -29,10 +31,9 @@ public class FormFinalizingTest {
                     Manifest.permission.READ_PHONE_STATE
             ))
             .around(new ResetStateRule())
-            .around(new CopyFormRule(FORM));
+            .around(new CopyFormRule(FORM))
+            .around(rule);
 
-    @Rule
-    public ActivityTestRule<MainMenuActivity> rule = new ActivityTestRule<>(MainMenuActivity.class);
 
     @Test
     public void fillingForm_andPressingSaveAndExit_finalizesForm() {


### PR DESCRIPTION
This fixes the build. The problem seemed to be that `ResetStateRule` was trying to clean up using `ApplicationResetter`. This meant that it needed the databases to exist for it to be able to delete records in it. Really we don't care as we're just trying to simulate an uninstall so instead it now just deletes the scoped and unscoped root dirs.

I had also had to make changes to a couple of tests that had problems revealed by the changes to to `ResetStateRule`.

#### What has been done to verify that this works as intended?

Ran locally and on test lab.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No just changes tests.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)