### PR TITLE
Upgrade Gradle plugin to address ProGuard bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext.kotlin_version = '1.4.10'
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.google.gms:google-services:4.3.4'
         classpath 'org.jacoco:org.jacoco.core:0.8.6'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'

--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -13,6 +13,7 @@
 -keepclassmembers class * {
   @com.google.api.client.util.Key <fields>;
 }
+-keep class * extends androidx.fragment.app.Fragment{}
 
 -dontobfuscate
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -195,9 +195,7 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                     }
                 }
                 if (counter > 0) {
-                    currentStatus += String.format(
-                            TranslationHandler.getString(Collect.getInstance(), R.string.instance_scan_count),
-                            counter);
+                    currentStatus += TranslationHandler.getString(Collect.getInstance(), R.string.instance_scan_count, counter);
                 }
             }
         } finally {


### PR DESCRIPTION
Current `master` doesn't produce a working release build. Stacktrace on launch starts with 
`proguard android.view.InflateException: Binary XML file line #38: Error inflating class androidx.fragment.app.FragmentContainerView`

#### What has been done to verify that this works as intended?
Applied change, verified that release build launches.

#### Why is this the best possible solution? Were any other approaches considered?
I initially considered changing ProGuard rules but after finding https://issuetracker.google.com/issues/142601969, upgrading the Gradle plugin seems like the most robust solution that doesn't require us adding bad rules.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should only allow us to produce production builds.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)