### PR TITLE
Unsaved recent files should be deleted if a user ignores changes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/FormSaveViewModel.java
@@ -156,6 +156,9 @@ public class FormSaveViewModel extends ViewModel implements ProgressDialogFragme
             }
         }
 
+        for (String filePath : recentFiles.values()) {
+            mediaUtils.deleteMediaFile(filePath);
+        }
         clearMediaFiles();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -112,6 +112,10 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
 
     @Override
     public void setData(Object object) {
+        if (binaryName != null) {
+            deleteFile();
+        }
+
         File newFile;
         // get the file path and create a copy in the instance folder
         if (object instanceof Uri) {
@@ -129,11 +133,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
         }
 
         if (newFile.exists()) {
-            // when replacing an answer remove the current one.
-            if (binaryName != null && !binaryName.equals(newFile.getName())) {
-                deleteFile();
-            }
-
+            questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), newFile.getAbsolutePath());
             binaryName = newFile.getName();
             chosenFileNameTextView.setText(binaryName);
             answerLayout.setVisibility(VISIBLE);

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -433,6 +433,14 @@ public class FormSaveViewModelTest {
     }
 
     @Test
+    public void ignoreChanges_whenThereAreUnsavedFiles_shouldDeleteThoseFiles() {
+        viewModel.replaceAnswerFile("index", "blah1");
+        viewModel.ignoreChanges();
+
+        verify(mediaUtils).deleteMediaFile("blah1");
+    }
+
+    @Test
     public void replaceAnswerFile_whenAnswerFileHasAlreadyBeenReplaced_afterRecreatingViewModel_deletesPreviousReplacement() {
         viewModel.replaceAnswerFile("index", "blah1");
 


### PR DESCRIPTION
Closes #4248

#### What has been done to verify that this works as intended?
I tested the fix manually and added an automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix there is no better solution than removing recent files when a user ignores changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix which should just solve the problem, nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with media files.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)