### PR TITLE
Reorder strings to group by usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,10 @@ jobs:
       - store_test_results:
           path: collect_app/build/test-results
 
+      - run:
+          name: Assemble connected test build
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
+
   test_instrumented:
     <<: *android_config
     environment:

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserSettingsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/UserSettingsTest.java
@@ -31,6 +31,6 @@ public class UserSettingsTest {
                 .openUserSettings()
                 .assertTextDoesNotExist("Type")
                 .assertTextDoesNotExist("Submission transport")
-                .assertText(R.string.server);
+                .assertText(R.string.server_settings_title);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AdminSettingsPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AdminSettingsPage.java
@@ -54,7 +54,7 @@ public class AdminSettingsPage extends Page<AdminSettingsPage> {
     }
 
     public AdminSettingsPage uncheckServerOption() {
-        clickOnString(R.string.server);
+        clickOnString(R.string.server_settings_title);
         return this;
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/GeneralSettingsPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/GeneralSettingsPage.java
@@ -50,7 +50,7 @@ public class GeneralSettingsPage extends Page<GeneralSettingsPage> {
     }
 
     public ServerSettingsPage clickServerSettings() {
-        clickOnString(R.string.server);
+        clickOnString(R.string.server_settings_title);
         return new ServerSettingsPage(rule).assertOnPage();
     }
 
@@ -66,7 +66,7 @@ public class GeneralSettingsPage extends Page<GeneralSettingsPage> {
     }
 
     public GeneralSettingsPage checkIfServerOptionIsDisplayed() {
-        onView(withText(getTranslatedString(R.string.server))).check(matches(isDisplayed()));
+        onView(withText(getTranslatedString(R.string.server_settings_title))).check(matches(isDisplayed()));
         return this;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -898,14 +898,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case RequestCodes.AUDIO_CHOOSER:
             case RequestCodes.VIDEO_CHOOSER:
             case RequestCodes.IMAGE_CHOOSER:
-                /*
-                 * We have a saved image somewhere, but we really want it to be in:
-                 * /sdcard/odk/instances/[current instnace]/something.jpg so we move
-                 * it there before inserting it into the content provider. Once the
-                 * android image capture bug gets fixed, (read, we move on from
-                 * Android 1.6) we want to handle images the audio and video
-                 */
-
                 ProgressDialogFragment progressDialog = new ProgressDialogFragment();
                 progressDialog.setMessage(getString(R.string.please_wait));
                 progressDialog.show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceSyncTask.java
@@ -84,7 +84,7 @@ public class InstanceSyncTask extends AsyncTask<Void, String, String> {
                 File[] instanceFolders = instancesPath.listFiles();
                 if (instanceFolders == null || instanceFolders.length == 0) {
                     Timber.i("[%d] Empty instance folder. Stopping scan process.", instance);
-                    Timber.d(TranslationHandler.getString(Collect.getInstance(), R.string.instance_scan_completed));
+                    Timber.d("Instance scan completed");
                     return currentStatus;
                 }
 

--- a/collect_app/src/main/res/values/untranslated.xml
+++ b/collect_app/src/main/res/values/untranslated.xml
@@ -33,4 +33,6 @@ the specific language governing permissions and limitations under the License. -
     <string name="basemap_source_usgs" translatable="false">USGS</string>
     <string name="basemap_source_stamen" translatable="false">Stamen</string>
     <string name="basemap_source_carto" translatable="false">Carto</string>
+
+    <string name="google_drive" translatable="false">Google Drive</string>
 </resources>

--- a/collect_app/src/main/res/xml/user_settings_access_preferences.xml
+++ b/collect_app/src/main/res/xml/user_settings_access_preferences.xml
@@ -40,7 +40,7 @@
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:key="periodic_form_updates_check"
-            android:title="@string/periodic_form_updates_check_title"
+            android:title="@string/form_update_frequency_title"
             app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:key="automatic_update"

--- a/collect_app/src/main/res/xml/user_settings_access_preferences.xml
+++ b/collect_app/src/main/res/xml/user_settings_access_preferences.xml
@@ -8,13 +8,8 @@
         app:iconSpaceReserved="false">
         <CheckBoxPreference
             android:key="change_server"
-            android:title="@string/server"
+            android:title="@string/server_settings_title"
             app:iconSpaceReserved="false" />
-        <!--<org.odk.collect.android.preferences.ExtendedCheckboxPreference-->
-        <!--android:key="change_submission_transport"-->
-        <!--android:title="@string/submission_transport_admin_setting"-->
-        <!--android:dependency="change_server"-->
-        <!--/>-->
         <CheckBoxPreference
             android:key="change_app_theme"
             android:title="@string/app_theme"

--- a/strings/src/main/res/values-af/strings.xml
+++ b/strings/src/main/res/values-af/strings.xml
@@ -208,7 +208,6 @@
   <string name="survey_saving_finalizing_message">Finaliseer na SD kaart…</string>
   <string name="survey_saving_encrypting_message">Enkripteer data…</string>
   <string name="high_resolution_summary">Laat hoë-resolusie video opnames toe</string>
-  <string name="google_drive">Google Drive</string>
   <string name="go_drive">My Skyf</string>
   <string name="go_shared">Met my gedeel</string>
   <string name="modified_on_date_at_time">\'Verander op\' EEE, MMM dd, yyyy \'om\' HH:mm</string>

--- a/strings/src/main/res/values-am/strings.xml
+++ b/strings/src/main/res/values-am/strings.xml
@@ -176,8 +176,7 @@
   <string name="survey_saving_encrypting_message">ውሂብ በማመስጠር ላይ …</string>
   <string name="high_resolution_summary">ባለከፍተኛ ጥራት ቪዲዮ ቀረጻዎችን ያንቁ</string>
   <string name="server_platform_google_sheets">ጉግል Drive, ጉግል ሉሆች</string>
-  <string name="google_drive">ጉግል Drive</string>
-  <string name="go_drive">የእኔ Drive</string>
+    <string name="go_drive">የእኔ Drive</string>
   <string name="go_shared">ከእኔ ጋር የተጋሩ</string>
   <string name="no_google_account">ምንም የ Google መለያ አልተመረጠም!</string>
   <string name="google_set_account">Google ሉሆችን እንደ አገልጋይዎ መርጠዋል, እባክዎ ከመቀጠልዎ በፊት በአጠቃላይ ቅንብሮች ውስጥ ተዛማጅ የ Google መለያ ይምረጡ</string>

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -608,7 +608,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">إذن قراءة حالة الهاتف</string>
   <string name="read_phone_state_runtime_permission_denied_desc">لا يقوم ODK Collect بإجراء مكالمات ولكنه يحتاج إلى الوصول إلى بعض الخصائص المتعلقة بجهازك مثل رقم الهاتف ومعرف الجهاز.</string>
   <string name="form_update_category">تحديث الاستمارة</string>
-  <string name="periodic_form_updates_check_title">تحقق من وجود تحديثات الاستمارة بشكل دوري</string>
   <string name="every_fifteen_minutes">كل 15 دقيقة</string>
   <string name="every_one_hour">كل ساعة</string>
   <string name="every_six_hours">كل 6 ساعات</string>

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">تشفير البيانات</string>
   <string name="high_resolution_summary">تمكين تسجيلات الفيديو عالية الدقة</string>
   <string name="server_platform_google_sheets">محرك الجوجل، صفحات الجوجل</string>
-  <string name="google_drive">محرك الجوجل</string>
-  <string name="go_drive">المحرك الخاص بي</string>
+    <string name="go_drive">المحرك الخاص بي</string>
   <string name="go_shared">مشاركة معي</string>
   <string name="modified_on_date_at_time">\'تم التعديل ب \' yyyy, dd MMM, EEE  \'في الساعة\' mm:HH</string>
   <string name="google_sheets_url_hint">يجب أن تقوم الاستمارات بتعيين رابط للارسال. إذا لم يفعلوا ذلك، فسيتم استخدام عنوان الرابط هذا.</string>

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -436,7 +436,6 @@
   <string name="encrypted_form">استمارة مشفرة</string>
   <string name="deleted_form">استمارة محذوفة</string>
   <string name="exit">خروج</string>
-  <string name="instance_scan_completed">انتهت عملية البحث.</string>
   <string name="instance_scan_count">تم إضافة %1$d إستمارة</string>
   <string name="instance_sync">حدد الاستمارات كمنتهية عند الاستيراد</string>
   <string name="instance_sync_summary">يؤثر على الاستمارات المضافة مباشرة إلى مجلد النماذج.</string>

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -515,7 +515,6 @@
   <string name="use_device_language">استخدم لغة الجهاز</string>
   <string name="invalid_email_address">عنوان بريد إلكتروني غير صحيح!</string>
   <string name="sort_by">ترتيب حسب</string>
-  <string name="server">الخادم</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">اختر القيمة</string>
   <string name="edit_value">عدل القيمة</string>

--- a/strings/src/main/res/values-ca/strings.xml
+++ b/strings/src/main/res/values-ca/strings.xml
@@ -294,8 +294,7 @@
   <string name="encrypted_form">Formulari encriptat</string>
   <string name="deleted_form">Formulari esborrat</string>
   <string name="exit">Sortir</string>
-  <string name="instance_scan_completed">Escanejat finalitzat</string>
-  <string name="filter_the_list">Filtra la llista</string>
+    <string name="filter_the_list">Filtra la llista</string>
   <string name="language">Idioma</string>
   <string name="phone_number">Telèfon</string>
   <string name="email">Direcció email</string>

--- a/strings/src/main/res/values-ca/strings.xml
+++ b/strings/src/main/res/values-ca/strings.xml
@@ -216,8 +216,7 @@
   <string name="survey_saving_encrypting_message">Encriptant dades…</string>
   <string name="high_resolution_summary">Activant enregistrament de  vídeos HD</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">El meu disc</string>
+    <string name="go_drive">El meu disc</string>
   <string name="go_shared">Comparteix amb mi</string>
   <string name="modified_on_date_at_time">\'Modificat el\' EEE, dd-MMM-yyyy \'a les\' HH:mm</string>
   <string name="drive_get_file">Capturant %1$s i arxius multimedia.</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -603,7 +603,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Přečtěte si povolení k telefonu</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect neprovádí volání, ale potřebuje přístup k určitým vlastnostem vašeho zařízení, jako je například telefonní číslo a device ID.</string>
   <string name="form_update_category">Aktualizace formuláře</string>
-  <string name="periodic_form_updates_check_title">Pravidelná kontrola aktualizací formulářů</string>
   <string name="every_fifteen_minutes">Každých patnáct minut</string>
   <string name="every_one_hour">Každou hodinu</string>
   <string name="every_six_hours">Každých šest hodin</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">Šifruji data…</string>
   <string name="high_resolution_summary">Povolit vysoké rozlišení videonahrávek</string>
   <string name="server_platform_google_sheets">Disk Google, Tabulky Google</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Můj disk</string>
+    <string name="go_drive">Můj disk</string>
   <string name="go_shared">Sdíleno se mnou</string>
   <string name="modified_on_date_at_time">\'Upraveno v \' EEE, dd MMM, yyyy \'v\' HH:mm</string>
   <string name="google_sheets_url_hint">Formuláře musí obsahovat adresu URL pro podání. Pokud tomu tak není, použije se tato adresa URL.</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -510,7 +510,6 @@
   <string name="use_device_language">Použít jazyk zařízení</string>
   <string name="invalid_email_address">Neplatná emailová adresa!</string>
   <string name="sort_by">Seřazeno podle</string>
-  <string name="server">Server</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Vybrat hodnotu</string>
   <string name="edit_value">Upravit hodnotu</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -430,7 +430,6 @@
   <string name="encrypted_form">Šifrovaný formulář</string>
   <string name="deleted_form">Smazaný formulář</string>
   <string name="exit">Odejít</string>
-  <string name="instance_scan_completed">Dokončené skenování.</string>
   <string name="instance_scan_count">%1$d formulářů přidáno. </string>
   <string name="instance_sync">Dokončení formulářů při importu</string>
   <string name="instance_sync_summary">Ovlivňuje formuláře přidávané přímo do složky instance.</string>

--- a/strings/src/main/res/values-da/strings.xml
+++ b/strings/src/main/res/values-da/strings.xml
@@ -337,8 +337,7 @@
   <string name="reset_settings_button_reset">Nulstil</string>
   <string name="reset_in_progress">Nulstiller…</string>
   <string name="exit">Forlad</string>
-  <string name="instance_scan_completed">Afsluttede scanning.</string>
-  <string name="sort_by_name_asc">Navn, A-Z</string>
+    <string name="sort_by_name_asc">Navn, A-Z</string>
   <string name="sort_by_name_desc">Navn, A-Z</string>
   <string name="sort_by_date_asc">Dato - nyeste først</string>
   <string name="sort_by_date_desc">Dato - ældste først</string>

--- a/strings/src/main/res/values-da/strings.xml
+++ b/strings/src/main/res/values-da/strings.xml
@@ -228,8 +228,7 @@
   <string name="survey_saving_encrypting_message">Krypterer data…</string>
   <string name="high_resolution_summary">Aktivér højt-opløselige video-indstillnger</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Mit Drev (Google Drive)</string>
+    <string name="go_drive">Mit Drev (Google Drive)</string>
   <string name="go_shared">Delt med mig</string>
   <string name="google_sheets_url_hint">Formularer skal definere en webadresse til til indberetninger. Hvis ikke den bliver defineret , vil denne webadresse blive anvendt.</string>
   <string name="drive_get_file">Henter%1$s og mediefiler.</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -504,7 +504,6 @@
   <string name="use_device_language">Gerätesprache benutzen</string>
   <string name="invalid_email_address">Ungültige E-Mail-Adresse!</string>
   <string name="sort_by">Sortieren nach</string>
-  <string name="server">Server</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Wert auswählen</string>
   <string name="edit_value">Wert bearbeiten</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -424,7 +424,6 @@
   <string name="encrypted_form">Verschlüsseltes Formular</string>
   <string name="deleted_form">Formular gelöscht</string>
   <string name="exit">Beenden</string>
-  <string name="instance_scan_completed">Scan abgeschlossen.</string>
   <string name="instance_scan_count">%1$d Formular(e) hinzugefügt.</string>
   <string name="instance_sync">Formulare beim Import abschließen</string>
   <string name="instance_sync_summary">Betrifft Formulare, die direkt dem instances-Ordner hinzugefügt werden.</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -597,7 +597,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Berechtigung Telefonstatus abrufen</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect macht keine Telefonanrufe aber benötigt Zugriff auf bestimmte Eigenschaften Ihres Geräts, wie die Telefonnummer und Geräte-ID.</string>
   <string name="form_update_category">Formular-Update</string>
-  <string name="periodic_form_updates_check_title">Periodischer Formular-Update-Check</string>
   <string name="every_fifteen_minutes">Alle 15 Minuten</string>
   <string name="every_one_hour">Jede Stunde</string>
   <string name="every_six_hours">Alle 6 Stunden</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">Daten werden verschlüsselt…</string>
   <string name="high_resolution_summary">HD-Videoaufnahmen aktivieren</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">My Drive</string>
+    <string name="go_drive">My Drive</string>
   <string name="go_shared">Shared with Me</string>
   <string name="modified_on_date_at_time">\'Geändert am\' EEE, dd.MM.yyyy \'um\' HH:mm</string>
   <string name="google_sheets_url_hint">Formulare müssen eine Übermittlungs-URL setzen. Wenn nicht, wird diese URL verwendet.</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -505,7 +505,6 @@
   <string name="use_device_language">Usar el idioma del dispositivo</string>
   <string name="invalid_email_address">Email inválido</string>
   <string name="sort_by">Ordenar por</string>
-  <string name="server">Servidor</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Seleccionar valor</string>
   <string name="edit_value">Editar valor</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -598,7 +598,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Lea el permiso del estado del teléfono</string>
   <string name="read_phone_state_runtime_permission_denied_desc">La aplicación  no hace llamadas pero necesita acceso a ciertas propiedades del teléfono como el número telefónico y el IMEI.</string>
   <string name="form_update_category">Actualizar Formulario</string>
-  <string name="periodic_form_updates_check_title">Buscar actualizaciones de formularios</string>
   <string name="every_fifteen_minutes">Cada 15 minutos</string>
   <string name="every_one_hour">Cada hora</string>
   <string name="every_six_hours">Cada 6 horas</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -425,7 +425,6 @@
   <string name="encrypted_form">Formulario encriptado</string>
   <string name="deleted_form">Formulario borrado</string>
   <string name="exit">Salir</string>
-  <string name="instance_scan_completed">Terminado el escaneo.</string>
   <string name="instance_scan_count">%1$d formularios añadidos.</string>
   <string name="instance_sync">Finalizar formularios en importación</string>
   <string name="instance_sync_summary">Afecta los formularios agregados directamente a la carpeta de instances</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -246,8 +246,7 @@
   <string name="survey_saving_encrypting_message">Encriptando datos…</string>
   <string name="high_resolution_summary">Grabar vídeos en HD</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Mi Drive</string>
+    <string name="go_drive">Mi Drive</string>
   <string name="go_shared">Compartido conmigo</string>
   <string name="modified_on_date_at_time">\'Modificado el\' EEE, MMM dd, yyyy \'a las\' HH:mm</string>
   <string name="google_sheets_url_hint">Los formularios deben establecer una URL para envio. Si no lo hacen, se usará la siguiente URL</string>

--- a/strings/src/main/res/values-et/strings.xml
+++ b/strings/src/main/res/values-et/strings.xml
@@ -215,8 +215,7 @@
   <string name="survey_saving_encrypting_message">Andmete krüpteerimine</string>
   <string name="high_resolution_summary">Kõrge resolutiooniga videosalvestuse võimaldamine</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Minu Drive</string>
+    <string name="go_drive">Minu Drive</string>
   <string name="go_shared">Minuga jagatud</string>
   <string name="modified_on_date_at_time">\'Muudetud\' EEE, MMM dd, yyyy \'kell\' HH:mm</string>
   <string name="drive_get_file">Laen %1$s ja meediafailid.</string>

--- a/strings/src/main/res/values-fa/strings.xml
+++ b/strings/src/main/res/values-fa/strings.xml
@@ -230,8 +230,7 @@
   <string name="reset_layers_result">لایه های نقشه:: %s</string>
   <string name="deleted_form">حذف فورم</string>
   <string name="exit">خروج</string>
-  <string name="instance_scan_completed">اسکن تمام شد.</string>
-  <string name="instance_scan_count">%1$dفورم ها اضافه شدند.</string>
+    <string name="instance_scan_count">%1$dفورم ها اضافه شدند.</string>
   <string name="sort_by_name_asc">اسم، الف-ی</string>
   <string name="filter_the_list">فلتر لیست</string>
   <string name="language">زبان</string>

--- a/strings/src/main/res/values-fa/strings.xml
+++ b/strings/src/main/res/values-fa/strings.xml
@@ -162,8 +162,7 @@
   <string name="survey_saving_encrypting_message">رمزگذاری داده ها…</string>
   <string name="high_resolution_summary">فعال ساختن ظبط ویدیو با رزولوشن بالا</string>
   <string name="server_platform_google_sheets">گوگل درایو، گوگل شیت</string>
-  <string name="google_drive">گوگل درایو</string>
-  <string name="go_drive">درایو من</string>
+    <string name="go_drive">درایو من</string>
   <string name="go_shared">با من در اشتراک گذاشته شده است</string>
   <string name="odk_auto_note">نتایج ارسال خودکار ODK</string>
   <string name="odk_auto_download_notification_title">نتیاج دانلود خودکار ODK</string>

--- a/strings/src/main/res/values-fa/strings.xml
+++ b/strings/src/main/res/values-fa/strings.xml
@@ -259,7 +259,6 @@
   <string name="use_device_language">از زبان دستگاه استفاده کنید</string>
   <string name="invalid_email_address">آدرس ایمیل اعتبار ندارد</string>
   <string name="sort_by">دسته بندی بر اساس</string>
-  <string name="server">سرور</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">انتخاب مقدار</string>
   <string name="edit_value">ویرایش مقدار</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -424,7 +424,6 @@
   <string name="encrypted_form">Salattu lomake</string>
   <string name="deleted_form">Poistettu lomake</string>
   <string name="exit">Poistu</string>
-  <string name="instance_scan_completed">Skannaus valmis.</string>
   <string name="instance_scan_count">%1$d lomaketta lisätty.</string>
   <string name="instance_sync">Lomakkeet viimeistellään tuodessa</string>
   <string name="instance_sync_summary">Vaikuttaa lomakkeisiin jotka lisätään suoraan Instances -kansioon.</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -504,7 +504,6 @@
   <string name="use_device_language">Käytä laitteen oletuskieltä</string>
   <string name="invalid_email_address">Virheellinen sähköpostiosoite!</string>
   <string name="sort_by">Lajitteluperuste</string>
-  <string name="server">Palvelin</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Valitse arvo</string>
   <string name="edit_value">Muokkaa arvoa</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -597,7 +597,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Puhelimen tilan lukemisen käyttölupa</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect ei soita puheluita, mutta se tarvitsee tiedot joistakin laitteesi tiedoista, kuten puhelinnumero ja laitteen ID.</string>
   <string name="form_update_category">Lomakepäivitys</string>
-  <string name="periodic_form_updates_check_title">Ajastettu lomakepäivitysten tarkistus</string>
   <string name="every_fifteen_minutes">Vartin välein</string>
   <string name="every_one_hour">Tunnin välein</string>
   <string name="every_six_hours">Kuuden tunnin välein</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">Salataan dataa…</string>
   <string name="high_resolution_summary">Aktivoi korkean resoluution videotallennukset</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Oma Drive</string>
+    <string name="go_drive">Oma Drive</string>
   <string name="go_shared">Minun kanssani jaetut</string>
   <string name="modified_on_date_at_time">\'Muokattu\' EEE, dd MMM yyyy \'kello\' HH:mm</string>
   <string name="google_sheets_url_hint">Lomakkeiden täytyy asettaa URL lähetystä varten. Jos ei, käytetään tätä URL:ää.</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -504,7 +504,6 @@
   <string name="use_device_language">Utiliser la langue de l\'appareil</string>
   <string name="invalid_email_address">Adresse mail invalide!</string>
   <string name="sort_by">Trier par</string>
-  <string name="server">Serveur</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Choisir valeur</string>
   <string name="edit_value">Modifier valeur</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -424,7 +424,6 @@
   <string name="encrypted_form">Formulaires encryptés</string>
   <string name="deleted_form">Formulaire supprimé</string>
   <string name="exit">Sortir</string>
-  <string name="instance_scan_completed">Recherche terminée.</string>
   <string name="instance_scan_count">%1$d formulaires ajoutés.</string>
   <string name="instance_sync">Importer les formulaires enregistrés comme terminés</string>
   <string name="instance_sync_summary">Impacte sur les formulaires ajoutés directement au dossier instances.</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -597,7 +597,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Lire la permission de l\'état du téléphone</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect ne passe pas d\'appels, mais il doit accéder à certaines propriétés de votre périphérique, telles que le numéro de téléphone et l\'ID de périphérique.</string>
   <string name="form_update_category">Mise à jour d\'un fomulaire</string>
-  <string name="periodic_form_updates_check_title">Vérification périodique des mises à jour des formulaires</string>
   <string name="every_fifteen_minutes">Toutes les quinze minutes</string>
   <string name="every_one_hour">Toutes les heures</string>
   <string name="every_six_hours">Toutes les six heures</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">Chiffrement des données…</string>
   <string name="high_resolution_summary">Activer l\'option vidéos en haute résolution</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Mon Drive</string>
+    <string name="go_drive">Mon Drive</string>
   <string name="go_shared">Partagé avec moi</string>
   <string name="modified_on_date_at_time">\'Modifié\' EEE, MMM dd, yyyy \'à\' HH:mm</string>
   <string name="google_sheets_url_hint">Les formulaires doivent définir une URL de soumission. Si ce n\'est pas le cas, cette URL sera utilisée.</string>

--- a/strings/src/main/res/values-hi/strings.xml
+++ b/strings/src/main/res/values-hi/strings.xml
@@ -225,8 +225,7 @@
   <string name="survey_saving_encrypting_message">डेटा एन्क्रिप्ट कर रहा है…</string>
   <string name="high_resolution_summary">उच्च-रिज़ॉल्यूशन वीडियो रिकॉर्डिंग सक्षम करें</string>
   <string name="server_platform_google_sheets">गूगल ड्राइव, गूगल शीट्</string>
-  <string name="google_drive">गूगल ड्राइव</string>
-  <string name="go_drive">माई ड्राइव</string>
+    <string name="go_drive">माई ड्राइव</string>
   <string name="go_shared">मेरे साथ साझा किया हुआ </string>
   <string name="modified_on_date_at_time">EEE, MMM dd, yyyy \'पर संशोधित\' HH:mm \'पर\' </string>
   <string name="google_sheets_url_hint">फॉर्म को एक सबमिशन URL सेट करना होगा यदि नहीं तो इस URL का उपयोग किया जाएगा।</string>

--- a/strings/src/main/res/values-hi/strings.xml
+++ b/strings/src/main/res/values-hi/strings.xml
@@ -338,8 +338,7 @@
   <string name="encrypted_form">एन्क्रिप्ट किए गए फॉर्म</string>
   <string name="deleted_form">समाप्त फॉर्म</string>
   <string name="exit">बाहर आयें</string>
-  <string name="instance_scan_completed">स्कैनिंग समाप्त.</string>
-  <string name="instance_scan_count">%1$dफॉर्म जोड दिया.</string>
+    <string name="instance_scan_count">%1$dफॉर्म जोड दिया.</string>
   <string name="sort_by_name_asc">नाम, A-Z</string>
   <string name="sort_by_name_desc">नाम, Z-A</string>
   <string name="sort_by_date_asc">दिनांक, नयी पहले </string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">Mengenkripsi data…</string>
   <string name="high_resolution_summary">Mengaktifkan perekaman video beresolusi tinggi</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Drive saya</string>
+    <string name="go_drive">Drive saya</string>
   <string name="go_shared">Berbagi dengan saya</string>
   <string name="modified_on_date_at_time">\'Diubah pada tanggal\' EEE, dd MMM yyyy\', pukul\' HH:mm</string>
   <string name="google_sheets_url_hint">URL pengiriman harus ditetapkan pada formulir. Jika tidak, URL ini yang akan digunakan.</string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -498,7 +498,6 @@
   <string name="use_device_language">Gunakan bahasa perangkat</string>
   <string name="invalid_email_address">Alamat email tidak valid</string>
   <string name="sort_by">Urutkan dengan</string>
-  <string name="server">Server</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Pilih nilai</string>
   <string name="edit_value">Ubah nilai</string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -591,7 +591,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Izin untuk membaca status telepon</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect tidak akan melakukan panggilan telepon, tetapi ODK Collect memerlukan akses ke beberapa informasi mengenai perangkat Anda, seperti nomor telepon dan ID perangkat.</string>
   <string name="form_update_category">Pembaruan formulir</string>
-  <string name="periodic_form_updates_check_title">Pemeriksaan pembaruan formulir berkala</string>
   <string name="every_fifteen_minutes">Tiap 15 menit</string>
   <string name="every_one_hour">Tiap 1 jam</string>
   <string name="every_six_hours">Tiap 6 jam</string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -418,7 +418,6 @@
   <string name="encrypted_form">Formulir terenkripsi</string>
   <string name="deleted_form">Hapus formulir</string>
   <string name="exit">Keluar</string>
-  <string name="instance_scan_completed">Pemindaian selesai.</string>
   <string name="instance_scan_count">Formulir %1$d ditambahkan.</string>
   <string name="instance_sync">Selesaikan formulir saat impor</string>
   <string name="instance_sync_summary">Formulir yang rusak akan langsung ditambahkan ke berkas instance</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -242,8 +242,7 @@
   <string name="survey_saving_encrypting_message">Crittografia dati…</string>
   <string name="high_resolution_summary">Permetti la registrazione di video ad alta risoluzione</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">My Drive</string>
+    <string name="go_drive">My Drive</string>
   <string name="go_shared">Condiviso con Me</string>
   <string name="modified_on_date_at_time">\'Modificato il\' EEE, dd MMM yyyy \'alle\' HH:mm</string>
   <string name="google_sheets_url_hint">I moduli devono avere un URL di destinazione. Se non ne viene specificato uno, sarà utilizzato il seguente URL.</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -486,8 +486,6 @@
   <string name="use_device_language">Utilizza lingua del dispositivo</string>
   <string name="invalid_email_address">Indirizzo email invalido!</string>
   <string name="sort_by">Ordina per</string>
-  <string name="server">Server</string>
-  <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Selezione valore</string>
   <string name="edit_value">Modifica valore</string>
   <string name="no_value_selected">Nessun valore selezionato</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -408,7 +408,6 @@
   <string name="encrypted_form">Modulo crittografato</string>
   <string name="deleted_form">Modulo cancellato</string>
   <string name="exit">Esci</string>
-  <string name="instance_scan_completed">Scansione completata</string>
   <string name="instance_scan_count">%1$d moduli aggiunti.</string>
   <string name="instance_sync">Finalizza moduli per importazione</string>
   <string name="instance_sync_summary">Riguarda un modulo aggiunto direttamente alla cartella esempi</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -555,7 +555,6 @@
   <string name="get_accounts_runtime_permission_denied_desc">Senza questa autorizzazione Collect non può accedere al tuo account. Prova di nuovo quando hai autorizzato l\'accesso al tuo account</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect non effettua chiamate ma necessita di accedere ad alcune propietà del tuo dispositivo quali ad esempio il numero telefonico e l\'Identificativo del dispositivo.</string>
   <string name="form_update_category">Aggiornamento Modulo</string>
-  <string name="periodic_form_updates_check_title">Controllo periodico di aggiornamento questionari</string>
   <string name="every_fifteen_minutes">Ogni 15 minuti</string>
   <string name="every_one_hour">Ogni ora</string>
   <string name="every_six_hours">Ogni 6 ore</string>

--- a/strings/src/main/res/values-ja/strings.xml
+++ b/strings/src/main/res/values-ja/strings.xml
@@ -420,7 +420,6 @@
   <string name="encrypted_form">暗号化フォーム</string>
   <string name="deleted_form">削除済フォーム</string>
   <string name="exit">終了</string>
-  <string name="instance_scan_completed">スキャンが終了しました。</string>
   <string name="instance_scan_count">%1$d フォームを追加しました。</string>
   <string name="instance_sync">インポート時にフォームを確定済にする</string>
   <string name="instance_sync_summary">インスタンスフォルダーに直接追加されたフォームに影響します。</string>

--- a/strings/src/main/res/values-ja/strings.xml
+++ b/strings/src/main/res/values-ja/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">データを暗号化中…</string>
   <string name="high_resolution_summary">高解像度のビデオ録画を有効にします</string>
   <string name="server_platform_google_sheets">Google ドライブ, Google スプレッドシート</string>
-  <string name="google_drive">Google ドライブ</string>
-  <string name="go_drive">マイ ドライブ</string>
+    <string name="go_drive">マイ ドライブ</string>
   <string name="go_shared">私と共有</string>
   <string name="modified_on_date_at_time">yyyy/MM/dd HH:mm \'に変更しました\'</string>
   <string name="google_sheets_url_hint">フォームは送信 URL を設定する必要があります。 そうしない場合に、この URL が使用されます。</string>

--- a/strings/src/main/res/values-ja/strings.xml
+++ b/strings/src/main/res/values-ja/strings.xml
@@ -593,7 +593,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">電話の状態読み取りアクセス許可</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect は電話はかけませんが、電話番号やデバイス ID など、デバイスに関する特定のプロパティにアクセスする必要があります。</string>
   <string name="form_update_category">フォームの更新</string>
-  <string name="periodic_form_updates_check_title">定期的なフォームの更新チェック</string>
   <string name="every_fifteen_minutes">15 分ごと</string>
   <string name="every_one_hour">1 時間ごと</string>
   <string name="every_six_hours">6 時間ごと</string>

--- a/strings/src/main/res/values-ja/strings.xml
+++ b/strings/src/main/res/values-ja/strings.xml
@@ -500,7 +500,6 @@
   <string name="use_device_language">デバイスの言語を使用する</string>
   <string name="invalid_email_address">メールアドレスが無効です!</string>
   <string name="sort_by">並び順</string>
-  <string name="server">サーバー</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">値を選択</string>
   <string name="edit_value">値を編集</string>

--- a/strings/src/main/res/values-ka/strings.xml
+++ b/strings/src/main/res/values-ka/strings.xml
@@ -216,8 +216,7 @@
   <string name="survey_saving_validating_message">მიმდინარეობს პასუხების შემოწმება</string>
   <string name="survey_saving_collecting_message">მიმდინარეობს მონაცემთა შეგროვება</string>
   <string name="survey_saving_saving_message">მიმდინარეობს SD-ბარათზე შენახვა</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">ჩემი Drive</string>
+    <string name="go_drive">ჩემი Drive</string>
   <string name="notification_error">შეცდომა შეტყობინების ტექსტის ჩვენებისას</string>
   <string name="delete_after_send">გაგზავნის შემდგომ წაშლა</string>
   <string name="change_server_url">სერვერის ვებ-მისამართი</string>

--- a/strings/src/main/res/values-km/strings.xml
+++ b/strings/src/main/res/values-km/strings.xml
@@ -441,7 +441,6 @@
   <string name="use_device_language">ប្រើ​ប្រាស់​ភាសារបស់​ឧបករណ៍</string>
   <string name="invalid_email_address">អាសយដ្ឋាន​អ៊ីម៉េល​មិនត្រឹមត្រូវ!</string>
   <string name="sort_by">តំរៀបតាម</string>
-  <string name="server">ម៉ាស៊ីនម៉េ</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">ជ្រើសរើសតម្លៃ</string>
   <string name="edit_value">កែប្រែ​តម្លៃ</string>

--- a/strings/src/main/res/values-km/strings.xml
+++ b/strings/src/main/res/values-km/strings.xml
@@ -371,7 +371,6 @@
   <string name="encrypted_form">បម្លែងសំណុំបែបបទ​ជារហស្សលិខ</string>
   <string name="deleted_form">សំណុំបែបបទដែលបានលុប​</string>
   <string name="exit">ចាកចេញ</string>
-  <string name="instance_scan_completed">បញ្ចប់ការស្កេន.</string>
   <string name="instance_scan_count">%1$d សំណុំបែបបទបានបន្ថែម។</string>
   <string name="instance_sync">ទម្រង់បញ្ចប់ដែលនាំចូល</string>
   <string name="instance_sync_summary">ទម្រង់ដែលប៉ះពាល់ត្រូវបានបន្ថែមដោយផ្ទាល់ទៅកាន់ថតទម្រង់</string>

--- a/strings/src/main/res/values-km/strings.xml
+++ b/strings/src/main/res/values-km/strings.xml
@@ -239,8 +239,7 @@
   <string name="survey_saving_encrypting_message">កំពុងបម្លែង​ជារហស្សលិខទិន្នន័យ</string>
   <string name="high_resolution_summary">បើកការថតវីដេអូគុណភាពច្បាស់</string>
   <string name="server_platform_google_sheets">ថាស Google, សន្លឹក Google</string>
-  <string name="google_drive">ថាស Google</string>
-  <string name="go_drive">ថាសរបស់ខ្ញុំ</string>
+    <string name="go_drive">ថាសរបស់ខ្ញុំ</string>
   <string name="go_shared">ចែក​រំលែក​ជាមួយ​ខ្ញុំ</string>
   <string name="modified_on_date_at_time">\'កែប្រែនៅថ្ងៃ\' EEE, MMM dd, yyyy \'នៅម៉ោង\' HH:mm</string>
   <string name="google_sheets_url_hint">ទម្រង់​ត្រូវតែ​កំណត់ URLក្នុងការបញ្ជូន​។ ប្រសិន​មិន​បាន​កំណត់, URL នេះ​នឹង​ត្រូវ​បាន​ប្រើប្រាស់។</string>

--- a/strings/src/main/res/values-km/strings.xml
+++ b/strings/src/main/res/values-km/strings.xml
@@ -513,7 +513,6 @@
   <string name="storage_runtime_permission_denied_title">សិទ្ធិក្នុងការផ្ទុក</string>
   <string name="storage_runtime_permission_denied_desc">បើគ្មានការអនុញ្ញាតទាំងនេះ Collect មិនអាចចូលប្រើទម្រង់របស់អ្នក ឬរក្សាទុកចម្លើយ​បើក​កម្មវិធី​ឡើង​វិញ​នៅ​ពេល​អ្នក​រួចរាល់​ដើម្បី​ផ្តល់​សិទ្ធិ​ទាំងនេះ។</string>
   <string name="form_update_category">ទម្រង់សម្រាប់ធ្វើបច្ចុប្បន្នភាព</string>
-  <string name="periodic_form_updates_check_title">រយះពេល​ក្នុង​ការ​ពិនិត្យ​រក​ទម្រង់​ដែល​ធ្វើ​បច្ចុប្បន្នភាព</string>
   <string name="every_fifteen_minutes">រៀងរាល់ ១៥នាទី</string>
   <string name="every_one_hour">រៀងរាល់ម៉ោង</string>
   <string name="every_six_hours">រៀងរាល់ ៦ ម៉ោង</string>

--- a/strings/src/main/res/values-lo-rLA/strings.xml
+++ b/strings/src/main/res/values-lo-rLA/strings.xml
@@ -206,8 +206,7 @@
   <string name="survey_saving_finalizing_message">ກຳ​ລັງ​ເຮັດ​ໃຫ້ ກາດ​ຄວາມ​ຈຳ​ພາຍນອກ ສຳ​ເລັດ​ສົມ​ບູນ…</string>
   <string name="survey_saving_encrypting_message">​ກຳ​ລັງ​ເຂົ້າ​ລະ​ຫັດ​ຂໍ້​ມູນ…</string>
   <string name="high_resolution_summary">ເປີດ​ການ​ນຳ​ໃຊ້ ການ​ບັນ​ທຶກວີ​ດີ​ໂອ​ແບບ​ຄວາມ​ລະ​ອຽດ​ສູງ</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">ຊ້ອງຂອງຂ້ອຍ</string>
+    <string name="go_drive">ຊ້ອງຂອງຂ້ອຍ</string>
   <string name="go_shared">ແບ່ງກັບຂ້ອຍ</string>
   <string name="modified_on_date_at_time">\'ດັດແກ້ວັນທີ\' EEE, MMM dd, yyyy \'ເວລາ\' HH:mm</string>
   <string name="drive_get_file">ໄດ້ %1$s ຂອງເອກະສານ.</string>

--- a/strings/src/main/res/values-mr/strings.xml
+++ b/strings/src/main/res/values-mr/strings.xml
@@ -220,8 +220,7 @@
   <string name="survey_saving_encrypting_message">डेटा एन्क्रिप्ट करत आहे …</string>
   <string name="high_resolution_summary">उच्च-रिजोल्यूशन व्हिडिओ रेकॉर्डिंग सक्षम करा</string>
   <string name="server_platform_google_sheets">गूगल ड्राइव्ह, गूगल पत्रक</string>
-  <string name="google_drive">गूगल ड्राइव्ह</string>
-  <string name="go_drive">माझे ड्राइव्ह</string>
+    <string name="go_drive">माझे ड्राइव्ह</string>
   <string name="go_shared">माझ्यासह शेअर केलेले</string>
   <string name="modified_on_date_at_time">\'सुधारित\' वर EEE, d MMM, yyyy \'at\' HH: mm</string>
   <string name="google_sheets_url_hint">फॉर्म एक सबमिशन युरएल सेट करणे आवश्यक आहे नसल्यास, ही युरएल वापरली जाईल.</string>

--- a/strings/src/main/res/values-mr/strings.xml
+++ b/strings/src/main/res/values-mr/strings.xml
@@ -334,8 +334,7 @@
   <string name="encrypted_form">कूटबद्ध फॉर्म</string>
   <string name="deleted_form">फॉर्म हटविला</string>
   <string name="exit">निर्गमन करा</string>
-  <string name="instance_scan_completed">पूर्ण स्कॅनिंग</string>
-  <string name="instance_scan_count">%1$d  फॉर्म जोडले.</string>
+    <string name="instance_scan_count">%1$d  फॉर्म जोडले.</string>
   <string name="sort_the_list">सूची क्रमवारी लावा</string>
   <string name="filter_the_list">सूची फिल्टर करा</string>
   <string name="language">भाषा</string>

--- a/strings/src/main/res/values-ne-rNP/strings.xml
+++ b/strings/src/main/res/values-ne-rNP/strings.xml
@@ -234,8 +234,7 @@
   <string name="survey_saving_encrypting_message">तथ्यांक गुप्तिकृत गरिदैछ…</string>
   <string name="high_resolution_summary">उच्च स्तरीय भिडियो रेकर्ड गर्ने क्षमता सक्रिय गर्नुस् </string>
   <string name="server_platform_google_sheets">गुगल ड्राइभ, गुगल सिट्स</string>
-  <string name="google_drive">गुगल ड्राइभ</string>
-  <string name="go_drive">मेरो ड्राइभ</string>
+    <string name="go_drive">मेरो ड्राइभ</string>
   <string name="go_shared">म संग साझा गरिएको </string>
   <string name="modified_on_date_at_time">EEE, MMM dd, yyyy \'को\' HH:mm \'मा परिवर्तन गरिएको\'</string>
   <string name="google_sheets_url_hint">फारमहरु पठाउनको लागि URL सेट गर्नुपर्दछ । अन्यथा यही URL प्रयोग हुनेछ ।</string>

--- a/strings/src/main/res/values-nl/strings.xml
+++ b/strings/src/main/res/values-nl/strings.xml
@@ -239,8 +239,7 @@
   <string name="survey_saving_encrypting_message">Data versleutelen…</string>
   <string name="high_resolution_summary">Hoge resolutie video opnames toestaan</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Mijn Drive</string>
+    <string name="go_drive">Mijn Drive</string>
   <string name="go_shared">Gedeeld met mij</string>
   <string name="modified_on_date_at_time">\'Gewijzigd op\' EEE dd MMM yyyy \'om\' HH:mm</string>
   <string name="no_google_account">Geen Google account geselecteerd!</string>

--- a/strings/src/main/res/values-nl/strings.xml
+++ b/strings/src/main/res/values-nl/strings.xml
@@ -283,7 +283,6 @@
   <string name="encrypted_form">Versleuteld formulier</string>
   <string name="deleted_form">Verwijderd formulier</string>
   <string name="exit">Verlaten</string>
-  <string name="instance_scan_completed">Scannen voltooid.</string>
   <string name="instance_scan_count">%1$d formulieren toegevoegd.</string>
   <string name="sort_by_name_asc">Naam, A-Z</string>
   <string name="sort_by_name_desc">Naam, Z-A</string>

--- a/strings/src/main/res/values-nl/strings.xml
+++ b/strings/src/main/res/values-nl/strings.xml
@@ -316,7 +316,6 @@
   <string name="server_settings_title">Server</string>
   <string name="type">Type</string>
   <string name="sort_by">Sorteer op</string>
-  <string name="server">Server</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="image_size_large">Groot (3072px)</string>
   <string name="image_size_medium">Gemiddeld (2048px)</string>

--- a/strings/src/main/res/values-nl/strings.xml
+++ b/strings/src/main/res/values-nl/strings.xml
@@ -325,8 +325,7 @@
   <!--Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order-->
   <string name="no">Nee</string>
   <string name="form_update_category">Formulier update</string>
-  <string name="periodic_form_updates_check_title">Periodieke check op formulier updates</string>
-  <string name="every_fifteen_minutes">Elke vijftien minuten</string>
+    <string name="every_fifteen_minutes">Elke vijftien minuten</string>
   <string name="every_one_hour">Elk uur</string>
   <string name="every_six_hours">Elke zes uur</string>
   <string name="every_24_hours">Elke 24 uur</string>

--- a/strings/src/main/res/values-no/strings.xml
+++ b/strings/src/main/res/values-no/strings.xml
@@ -208,8 +208,7 @@
   <string name="survey_saving_encrypting_message">Krypterer data…</string>
   <string name="high_resolution_summary">Slå på høyoppløst videoopptak.</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Min Drive</string>
+    <string name="go_drive">Min Drive</string>
   <string name="go_shared">Delt med meg</string>
   <string name="modified_on_date_at_time">\'Endret den\' EEE, MMM dd, yyyy \'kl\' HH:mm</string>
   <string name="drive_get_file">Henter %1$s og mediafiler.</string>

--- a/strings/src/main/res/values-pl/strings.xml
+++ b/strings/src/main/res/values-pl/strings.xml
@@ -489,7 +489,6 @@
   <string name="use_device_language">Użyj języka urządzenia</string>
   <string name="invalid_email_address">Nieprawidłowy adres email!</string>
   <string name="sort_by">Sortuj według</string>
-  <string name="server">Serwer</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Wybierz wartość</string>
   <string name="edit_value">Edytuj wartość</string>

--- a/strings/src/main/res/values-pl/strings.xml
+++ b/strings/src/main/res/values-pl/strings.xml
@@ -582,7 +582,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Sprawdź uprawnienia dostępu do właściwości telefonu</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect nie wykonuje połączeń, ale wymaga dostępu do niektórych właściwości twojego urządzenia, w tym do numeru telefonu i numeru ID</string>
   <string name="form_update_category">Aktualizacja formularza</string>
-  <string name="periodic_form_updates_check_title">Cykliczne sprawdzenie możliwych aktualizacji</string>
   <string name="every_fifteen_minutes">Co piętnaście minut</string>
   <string name="every_one_hour">Co godzinę</string>
   <string name="every_six_hours">Co sześć godzin</string>

--- a/strings/src/main/res/values-pl/strings.xml
+++ b/strings/src/main/res/values-pl/strings.xml
@@ -419,7 +419,6 @@
   <string name="encrypted_form">Formularz zaszyfrowany</string>
   <string name="deleted_form">Formularz usunięty</string>
   <string name="exit">Wyjdź</string>
-  <string name="instance_scan_completed">Skanowanie zakończone.</string>
   <string name="instance_scan_count">Dodano %1$d formularzy.</string>
   <string name="instance_sync">Finalizuj formularze podczas importu</string>
   <string name="instance_sync_summary">Wpływa na formularze dodawane bezpośrednio do folderu formularzy.</string>

--- a/strings/src/main/res/values-pl/strings.xml
+++ b/strings/src/main/res/values-pl/strings.xml
@@ -241,8 +241,7 @@
   <string name="survey_saving_encrypting_message">Szyfruję dane…</string>
   <string name="high_resolution_summary">Włącz nagrywanie wideo wysokiej rozdzielczości</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Mój Dysk</string>
+    <string name="go_drive">Mój Dysk</string>
   <string name="go_shared">Dzielone ze Mną</string>
   <string name="modified_on_date_at_time">\'Zmieniony\' EEE, MMM dd, yyyy \'o\' HH:mm</string>
   <string name="google_sheets_url_hint">Formularze muszą ustawić URL przesyłania. Jeśli nie, ten adres URL zostanie użyty.</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -245,8 +245,7 @@ Escolher Imagem</string>
   <string name="survey_saving_encrypting_message">Criptografando dados…</string>
   <string name="high_resolution_summary">Ativar gravação de vídeos em alta resolução</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Meu Disco</string>
+    <string name="go_drive">Meu Disco</string>
   <string name="go_shared">Compartilhado comigo</string>
   <string name="modified_on_date_at_time">\'Modificado em\' EEE, MMM dd, yyyy \'às\' HH:mm</string>
   <string name="google_sheets_url_hint">Os formulários devem configurar um envio. Se não foram, esta URL será utilizada.</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -501,7 +501,6 @@ Escolher Imagem</string>
   <string name="use_device_language">Utilizar idioma do dispositivo</string>
   <string name="invalid_email_address">Endereço de e-mail inválido!</string>
   <string name="sort_by">Organizar por</string>
-  <string name="server">Servidor</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Selecione valor</string>
   <string name="edit_value">Edite valor</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -594,7 +594,6 @@ Escolher Imagem</string>
   <string name="read_phone_state_runtime_permission_denied_title">Permissão para acessar o estado do telefone</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect não faz chamadas, mas precisa desta permissão para acessar algumas propriedades sobre o seu dispositivo, como o número do telefone e o ID do dispositivo.</string>
   <string name="form_update_category">Atualização de formulários</string>
-  <string name="periodic_form_updates_check_title">Verificação periódica de formulários</string>
   <string name="every_fifteen_minutes">A cada 15 minutos</string>
   <string name="every_one_hour">A cada hora</string>
   <string name="every_six_hours">A cada 6 horas</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -421,7 +421,6 @@ Escolher Imagem</string>
   <string name="encrypted_form">Formulário encriptado</string>
   <string name="deleted_form">Formulário apagado</string>
   <string name="exit">Sair</string>
-  <string name="instance_scan_completed">Terminado o escaneamento.</string>
   <string name="instance_scan_count">%1$dformulários adicionados.</string>
   <string name="instance_sync">Finalizar formulários na importação</string>
   <string name="instance_sync_summary">Afeta formulários adicionados diretamente na pasta instances.</string>

--- a/strings/src/main/res/values-ro/strings.xml
+++ b/strings/src/main/res/values-ro/strings.xml
@@ -210,8 +210,7 @@
   <string name="survey_saving_encrypting_message">Criptez datele…</string>
   <string name="high_resolution_summary">Activați înregistrările video high-resolution</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Discul meu</string>
+    <string name="go_drive">Discul meu</string>
   <string name="go_shared">Partajate cu mine</string>
   <string name="modified_on_date_at_time">\'Modificat în\' EEE, dd MMM yyyy \'la\' HH:mm</string>
   <string name="drive_get_file">Preluare %1$s și fișiere media.</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -515,7 +515,6 @@
   <string name="record_audio_runtime_permission_denied_desc">Без данного разрешения Collect не сможет использовать микрофон. Попробуйте снова когда будете готовы предоставить доступ.</string>
   <string name="get_accounts_runtime_permission_denied_desc">Без данного разрешения Collect не сможет получить доступ к учётным записям. Попробуйте снова когда будете готовы предоставить доступ.</string>
   <string name="form_update_category">ОБНОВЛЕНИЕ БЛАНКОВ</string>
-  <string name="periodic_form_updates_check_title">Периодичность проверки обновлений</string>
   <string name="every_fifteen_minutes">Каждые ¼ часа</string>
   <string name="every_one_hour">Каждый 1 час</string>
   <string name="every_six_hours">Каждые 6 часов</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -367,7 +367,6 @@
   <string name="encrypted_form">Зашифрованный опрос</string>
   <string name="deleted_form">Удалённая форма</string>
   <string name="exit">Выйти</string>
-  <string name="instance_scan_completed">Сканирование завершено.</string>
   <string name="instance_scan_count">Добавлено опросников: %1$d шт.</string>
   <string name="instance_sync">Финализировать опросы при импорте</string>
   <string name="sort_by_name_asc">А-Я</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -436,7 +436,6 @@
   <string name="use_device_language">Использовать язык устройства</string>
   <string name="invalid_email_address">Неверный адрес почты!</string>
   <string name="sort_by">Сортировать по</string>
-  <string name="server">Сервер</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Выбрать значение</string>
   <string name="edit_value">Изменить значение</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -238,8 +238,7 @@
   <string name="survey_saving_encrypting_message">Шифрование данных…</string>
   <string name="high_resolution_summary">Разрешить запись видео высокого разрешения</string>
   <string name="server_platform_google_sheets">Google диск и таблицы</string>
-  <string name="google_drive">Google диск</string>
-  <string name="go_drive">Мой диск</string>
+    <string name="go_drive">Мой диск</string>
   <string name="go_shared">Доступные мне</string>
   <string name="modified_on_date_at_time">\'Изменено\' EEE, dd MMM yyyy \'в\' HH:mm</string>
   <string name="google_sheets_url_hint">В опроснике должен быть указан URL-выгрузки. Иначе, будет применён этот адрес.</string>

--- a/strings/src/main/res/values-sl/strings.xml
+++ b/strings/src/main/res/values-sl/strings.xml
@@ -233,8 +233,7 @@
   <string name="survey_saving_encrypting_message">Šifriram podatke…</string>
   <string name="high_resolution_summary">Omogoči video zapis visoke resolucije</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">My Drive</string>
+    <string name="go_drive">My Drive</string>
   <string name="go_shared">Deljeno z menoj</string>
   <string name="modified_on_date_at_time">\'Spremenjeno\' EEE, MMM dd,  yyyy \'ob\' HH:mm</string>
   <string name="google_sheets_url_hint">Obrazci morajo nastaviti URL za predložitev. Če ne, bo uporabljen ta URL.</string>

--- a/strings/src/main/res/values-sq/strings.xml
+++ b/strings/src/main/res/values-sq/strings.xml
@@ -328,7 +328,6 @@
   <string name="encrypted_form">Formular i koduar</string>
   <string name="deleted_form">Formular i fshirë</string>
   <string name="exit">Dil</string>
-  <string name="instance_scan_completed">Skanimi përfundoi</string>
   <string name="instance_scan_count">%1$d formë/a u shtuan.</string>
   <string name="instance_sync">Finalizo format në importim</string>
   <string name="sort_by_name_asc">Emër, A-Z</string>

--- a/strings/src/main/res/values-sq/strings.xml
+++ b/strings/src/main/res/values-sq/strings.xml
@@ -426,8 +426,7 @@
   <string name="location_runtime_permissions_denied_title">Lejo aksesin në vendndodhje</string>
   <string name="camera_runtime_permission_denied_title">Lejo aksesin në kamera</string>
   <string name="record_audio_runtime_permission_denied_title">Lejo aksesin në regjistrimin audio</string>
-  <string name="periodic_form_updates_check_title">Kontroll periodik për forma të rifreskuara</string>
-  <string name="every_fifteen_minutes">Çdo pesëmbëdhjetë minuta</string>
+    <string name="every_fifteen_minutes">Çdo pesëmbëdhjetë minuta</string>
   <string name="every_one_hour">Çdo një orë</string>
   <string name="every_six_hours">Çdo gjashtë orë</string>
   <string name="every_24_hours">Çdo 24 orë</string>

--- a/strings/src/main/res/values-sr/strings.xml
+++ b/strings/src/main/res/values-sr/strings.xml
@@ -238,8 +238,7 @@
   <string name="survey_saving_encrypting_message">Enkripcija podataka je u toku…</string>
   <string name="high_resolution_summary">Omogući snimanje video sadržaja visoke rezolucije</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">Moj Drive</string>
+    <string name="go_drive">Moj Drive</string>
   <string name="go_shared">Podijeljeno sa mnom</string>
   <string name="modified_on_date_at_time">\'Modifikovano na\' EEE, MMM dd, yyyy \'u\' HH:mm</string>
   <string name="google_sheets_url_hint">Formular mora podesiti URL za otpremanje. Ukoliko to nije slučaj, ovaj URL će biti korišćen.</string>

--- a/strings/src/main/res/values-sr/strings.xml
+++ b/strings/src/main/res/values-sr/strings.xml
@@ -468,7 +468,6 @@
   <string name="use_device_language">Koristi jezik uređaja</string>
   <string name="invalid_email_address">Pogrešna email adresa!</string>
   <string name="sort_by">Sortiraj na osnovu</string>
-  <string name="server">Server</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Odaberi vrijednost</string>
   <string name="edit_value">Izmijeni vrijednost</string>

--- a/strings/src/main/res/values-sr/strings.xml
+++ b/strings/src/main/res/values-sr/strings.xml
@@ -398,7 +398,6 @@
   <string name="encrypted_form">Formular pod enkripcijom</string>
   <string name="deleted_form">Obrisan formular</string>
   <string name="exit">Izađi</string>
-  <string name="instance_scan_completed">Završeno skeniranje.</string>
   <string name="instance_scan_count">%1$d dodatih formulara.</string>
   <string name="instance_sync">Finaliziraj formular pri unosu</string>
   <string name="instance_sync_summary">Odnosi se na fomrulare direktno dodate folderu instanci.</string>

--- a/strings/src/main/res/values-sr/strings.xml
+++ b/strings/src/main/res/values-sr/strings.xml
@@ -550,7 +550,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Dozvola za čitanje statusa telefona</string>
   <string name="read_phone_state_runtime_permission_denied_desc">Bez ovih dozvola Collect ne može da obavlja pozive ali mu je potreban pristup nekim djelovima uređaja poput broja telefona ili identifikacionog broja uređaja.</string>
   <string name="form_update_category">Ažuriranje formulara</string>
-  <string name="periodic_form_updates_check_title">Periodična provjera ažuriranja formulara</string>
   <string name="every_fifteen_minutes">Svakih 15 minuta</string>
   <string name="every_one_hour">Svakog sata</string>
   <string name="every_six_hours">Svakih 6 sati</string>

--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -528,7 +528,6 @@ Dela ODK Collect med dem.</string>
   <string name="record_audio_runtime_permission_denied_title">Behörigheter för att spela in ljud</string>
   <string name="read_phone_state_runtime_permission_denied_title">Behörigheter för att läsa telefonstatus</string>
   <string name="form_update_category">Uppdatera formulär</string>
-  <string name="periodic_form_updates_check_title">Periodisk kontroll av uppdaterade formulär</string>
   <string name="every_fifteen_minutes">Varje femtonde minut</string>
   <string name="every_one_hour">Varje timme</string>
   <string name="every_six_hours">Varje sjätte timme</string>

--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -453,7 +453,6 @@ Dela ODK Collect med dem.</string>
   <string name="use_device_language">Använd enhetens språk</string>
   <string name="invalid_email_address">Ogiltig e-postadress!</string>
   <string name="sort_by">Sorteringsordning</string>
-  <string name="server">Server</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Välj ett värde</string>
   <string name="edit_value">Redigera värde</string>

--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -240,8 +240,7 @@
   <string name="survey_saving_encrypting_message">Krypterar data…</string>
   <string name="high_resolution_summary">Tillåt högupplösta filminspelningar</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">My Drive</string>
+    <string name="go_drive">My Drive</string>
   <string name="go_shared">Delat med mig</string>
   <string name="modified_on_date_at_time">\'Ändrad\' yyyy-MM-dd (EEE) \'kl\' HH:mm</string>
   <string name="google_sheets_url_hint">Formulären måste ange en uppladdnings-URL. Om dem inte gör det används denna URL.</string>

--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -383,7 +383,6 @@ Dela ODK Collect med dem.</string>
   <string name="encrypted_form">Krypterat formulär</string>
   <string name="deleted_form">Raderat formulär</string>
   <string name="exit">Avsluta</string>
-  <string name="instance_scan_completed">Avslutat sökning</string>
   <string name="instance_scan_count">%1$d formulär tillagda.</string>
   <string name="instance_sync">Avsluta formulär vid import</string>
   <string name="instance_sync_summary">Påverkar formulär som lagts till direkt i mappen \'instances\'.</string>

--- a/strings/src/main/res/values-sw/strings.xml
+++ b/strings/src/main/res/values-sw/strings.xml
@@ -465,7 +465,6 @@
   <string name="use_device_language">Tumia lugha ya kifaa</string>
   <string name="invalid_email_address">Anwani ya barua pepe ni batili!</string>
   <string name="sort_by">Panga kwa</string>
-  <string name="server">Seva</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Chagua thamani</string>
   <string name="edit_value">Hariri thamani</string>

--- a/strings/src/main/res/values-sw/strings.xml
+++ b/strings/src/main/res/values-sw/strings.xml
@@ -395,7 +395,6 @@
   <string name="encrypted_form">Fomu yenye usimbaji fiche</string>
   <string name="deleted_form">Fomu iliyofutwa</string>
   <string name="exit">Toka</string>
-  <string name="instance_scan_completed">Malizika kukagua.</string>
   <string name="instance_scan_count">%1$dfomu zimeongezwa.</string>
   <string name="instance_sync">Kukamilisha fomu katika kuingiza</string>
   <string name="instance_sync_summary">Inaathiri fomu zilizowekwa moja kwa moja kwenye makabrasha ya mifano.</string>

--- a/strings/src/main/res/values-sw/strings.xml
+++ b/strings/src/main/res/values-sw/strings.xml
@@ -547,7 +547,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Soma ruhusa ya simu</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect haipigi simu lakini inahitaji kufikia taarifa fulani kuhusu kifaa chako kama namba ya simu na ya utambulisho wa kifaa.</string>
   <string name="form_update_category">Tolea jipya la fomu</string>
-  <string name="periodic_form_updates_check_title">Ukaguzi wa mara kwa mara wa matolea mapya ya  fomu</string>
   <string name="every_fifteen_minutes">Kila dakika kumi na tano</string>
   <string name="every_one_hour">Kila saa</string>
   <string name="every_six_hours">Kila masaa sita</string>

--- a/strings/src/main/res/values-sw/strings.xml
+++ b/strings/src/main/res/values-sw/strings.xml
@@ -241,8 +241,7 @@
   <string name="survey_saving_encrypting_message">Kuongeza usalama katika taarifa…</string>
   <string name="high_resolution_summary">Ruhusu kurekodi video zenye kiwango cha juu</string>
   <string name="server_platform_google_sheets">Hifadhi ya Google ,makaratasi ya google</string>
-  <string name="google_drive"> Hifadhi ya Google </string>
-  <string name="go_drive">Hifadhi yangu</string>
+    <string name="go_drive">Hifadhi yangu</string>
   <string name="go_shared">Imeshirikishwa na mimi</string>
   <string name="modified_on_date_at_time">\'Imerekebishwa\' EEE, MMM dd, yyyy \'katika\' HH:mm</string>
   <string name="google_sheets_url_hint">Fomu lazima iwe na URL ya uwasilishaji. Kama haina, hii URL itatumika.</string>

--- a/strings/src/main/res/values-te/strings.xml
+++ b/strings/src/main/res/values-te/strings.xml
@@ -245,8 +245,7 @@
   <string name="survey_saving_encrypting_message">డేటాను గుప్తీకరిస్తోంది…</string>
   <string name="high_resolution_summary">అధిక రిజల్యూషన్ ఉన్న వీడియో రికార్డింగ్‌ చేయడానికి వీలు కల్పించండి </string>
   <string name="server_platform_google_sheets">గూగుల్ డ్రైవ్, గూగుల్ షీట్స్</string>
-  <string name="google_drive">గూగుల్ డ్రైవ్</string>
-  <string name="go_drive">నా డ్రైవ్</string>
+    <string name="go_drive">నా డ్రైవ్</string>
   <string name="go_shared">నాతో పంచుకున్నవి </string>
   <string name="modified_on_date_at_time">\'సవరించిన తేదీ\' EEE, MMM dd, yyyy \'సమయం\' HH:mm </string>
   <string name="google_sheets_url_hint">ఫారమ్‌లు తప్పనిసరిగా సబ్మిషన్ URL ని సెట్ చేయాలి. లేకపోతే, ఈ URL ఉపయోగించబడుతుంది.</string>

--- a/strings/src/main/res/values-te/strings.xml
+++ b/strings/src/main/res/values-te/strings.xml
@@ -582,7 +582,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">ఫోన్ స్టేట్ అనుమతి చదవండి</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect ఎటువంటి కాల్స్ చేయదు. కాని దీనికి మీ పరికరం గురించిన ఫోన్ నంబర్, పరికరం ID వంటి కొంత సమాచారాన్ని సేకరించవలసి ఉంటుంది.</string>
   <string name="form_update_category">ఫారం నవీకరణ</string>
-  <string name="periodic_form_updates_check_title">ఫారంలో జరిగిన మార్పులను ఎంత సమయంలో చూడాలి</string>
   <string name="every_fifteen_minutes">ప్రతి పదిహేను నిమిషాలకు</string>
   <string name="every_one_hour">ప్రతి గంట</string>
   <string name="every_six_hours">ప్రతి ఆరు గంటలకు</string>

--- a/strings/src/main/res/values-te/strings.xml
+++ b/strings/src/main/res/values-te/strings.xml
@@ -416,7 +416,6 @@
   <string name="encrypted_form">గుప్తీకరించిన రూపం</string>
   <string name="deleted_form">తొలగించిన ఫారమ్</string>
   <string name="exit">నిష్క్రమించు</string>
-  <string name="instance_scan_completed">స్కానింగ్ పూర్తయింది.</string>
   <string name="instance_scan_count">%1$dఫారంలు జోడించబడ్డాయి.</string>
   <string name="instance_sync">దిగుమతులపై ఫారమ్‌లను ముగించండి</string>
   <string name="instance_sync_summary">ఇన్‌స్టాన్స్ ఫోల్డర్‌కు నేరుగా జోడించిన ఫారమ్‌లను ప్రభావితం చేస్తుంది.</string>

--- a/strings/src/main/res/values-te/strings.xml
+++ b/strings/src/main/res/values-te/strings.xml
@@ -489,7 +489,6 @@
   <string name="use_device_language">పరికర భాషను ఉపయోగించండి</string>
   <string name="invalid_email_address">చెల్లని ఇమెయిల్ చిరునామా!</string>
   <string name="sort_by">క్రమబద్ధీకరణ </string>
-  <string name="server">సర్వర్</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">ఎదేని విలువ ఎంచుకోండీ</string>
   <string name="edit_value">విలువ మార్చండి</string>

--- a/strings/src/main/res/values-th-rTH/strings.xml
+++ b/strings/src/main/res/values-th-rTH/strings.xml
@@ -214,8 +214,7 @@
   <string name="survey_saving_encrypting_message">กำลังเข้ารหัสข้อมูล</string>
   <string name="high_resolution_summary">เปิดใช้งานการบันทึกวีดีโอความละเอียดสูง</string>
   <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-  <string name="google_drive">Google Drive</string>
-  <string name="go_drive">My Drive</string>
+    <string name="go_drive">My Drive</string>
   <string name="go_shared">แบ่งปันกับฉัน</string>
   <string name="modified_on_date_at_time">\'แก้ไขเมื่อ\' EEE, MMM dd, yyy \'เวลา\' HH:mm</string>
   <string name="drive_get_file">ได้รับ %1$s และไฟล์ภาพและเสียง</string>

--- a/strings/src/main/res/values-th-rTH/strings.xml
+++ b/strings/src/main/res/values-th-rTH/strings.xml
@@ -305,7 +305,6 @@
   <string name="reset_layers_result">ชั้นข้อมูลแผนที่ :: %s</string>
   <string name="encrypted_form">แบบสำรวจเข้ารหัส</string>
   <string name="deleted_form">แบบสำรวจที่ถูกลบ</string>
-  <string name="instance_scan_completed">สแกนเสร็จสิ้น</string>
   <string name="sort_the_list">จัดเรียงรายการ</string>
   <string name="language">ภาษา</string>
   <string name="form_metadata_title">Metadata ของแบบสำรวจ</string>

--- a/strings/src/main/res/values-uk/strings.xml
+++ b/strings/src/main/res/values-uk/strings.xml
@@ -401,7 +401,6 @@
   <string name="encrypted_form">Зашифровані анкети</string>
   <string name="deleted_form">Видалені анкети</string>
   <string name="exit">Вийти</string>
-  <string name="instance_scan_completed">Завершені сканування.</string>
   <string name="instance_scan_count">%1$d анкет додано.</string>
   <string name="instance_sync">Завершувати форми під час імпорту</string>
   <string name="instance_sync_summary">Брати до уваги форми додані безпосередньо до директорії екземплярів.</string>

--- a/strings/src/main/res/values-uk/strings.xml
+++ b/strings/src/main/res/values-uk/strings.xml
@@ -471,7 +471,6 @@
   <string name="use_device_language">Використовувати мову пристрою</string>
   <string name="invalid_email_address">Некоректна електронна адреса!</string>
   <string name="sort_by">Сортувати за</string>
-  <string name="server">Сервер</string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">Обрати заначення</string>
   <string name="edit_value">Редагувати значення</string>

--- a/strings/src/main/res/values-uk/strings.xml
+++ b/strings/src/main/res/values-uk/strings.xml
@@ -553,7 +553,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">Сатус телефону</string>
   <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect не робить телефонних дзвінків але потребує доступу до певних властивостей вашого пристрою як то номер телефну та ID пристрою</string>
   <string name="form_update_category">Оновлення анкети</string>
-  <string name="periodic_form_updates_check_title">Періодична перерівка оновлень анкет</string>
   <string name="every_fifteen_minutes">Кожних п\'ятнадцять хвилин</string>
   <string name="every_one_hour">Щогодини</string>
   <string name="every_six_hours">Кожні шість годин</string>

--- a/strings/src/main/res/values-uk/strings.xml
+++ b/strings/src/main/res/values-uk/strings.xml
@@ -238,8 +238,7 @@
   <string name="survey_saving_encrypting_message">Шифрування даних…</string>
   <string name="high_resolution_summary">Дозволяє запис відео високої якості</string>
   <string name="server_platform_google_sheets">Google Диск, Google Сторінки</string>
-  <string name="google_drive">Google Диск</string>
-  <string name="go_drive">Мій диск</string>
+    <string name="go_drive">Мій диск</string>
   <string name="go_shared">Розділене зі мною</string>
   <string name="modified_on_date_at_time">\'Зімінено в\' EEE, dd MMM, yyyy \'at\' HH:mm</string>
   <string name="google_sheets_url_hint">URL для відправки має бути зазначено в анкетах. Інакше, буде використано цей URL.</string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -432,7 +432,6 @@
   <string name="use_device_language">ڈیوائس کی زبان استعمال کریں</string>
   <string name="invalid_email_address">غلط ای میل ایڈریس!</string>
   <string name="sort_by">بہ ترتیب</string>
-  <string name="server">سرور </string>
   <!--<string name="submission_transport_admin_setting">Submission transport</string>-->
   <string name="select_value">سلیکٹ ویلیو </string>
   <string name="edit_value">ایڈٹ ویلیو </string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -233,8 +233,7 @@
   <string name="survey_saving_encrypting_message">ڈیٹا انکرپٹ ہورہا ہے</string>
   <string name="high_resolution_summary">اعلی کوالٹی ویڈیو ریکارڈنگ کو فعال کریں</string>
   <string name="server_platform_google_sheets">گوگل ڈرائیو ، گوگل شیٹس </string>
-  <string name="google_drive">گوگل ڈرائیو </string>
-  <string name="go_drive">مائی ڈرائیو</string>
+    <string name="go_drive">مائی ڈرائیو</string>
   <string name="go_shared">میرے ساتھ شیئر کیا ہوا</string>
   <string name="modified_on_date_at_time"> EEE, MMM dd, yyyy\'کو\' HH:mm \'پر موڈیفائی کیا گیا\'</string>
   <string name="google_sheets_url_hint">فارم جمع کرانے کا یو آرال مقرر کرنا لازمی ہے. اگر مقررنہیں کرتے تو یہ یو آرال استعمال کیا جائے گا</string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -514,7 +514,6 @@
   <string name="read_phone_state_runtime_permission_denied_title">ریڈ فون اسٹیٹ پرمیشن</string>
   <string name="read_phone_state_runtime_permission_denied_desc">او ڈی کے کولیکٹ  کالز نہیں کرتا، لیکن یہ آپ کےڈیوائس  کے بارے میں مخصوص خصوصیات جیسے فون نمبر اور ڈیوائس آئی ڈٰی تک رسائی حاصل کرنے کی ضرورت ہے.</string>
   <string name="form_update_category">فارم اپ ڈیٹ</string>
-  <string name="periodic_form_updates_check_title">دورانیہ فارم اپ ڈیٹ چیک</string>
   <string name="every_fifteen_minutes">ہر پندرہ منٹ</string>
   <string name="every_one_hour">ہر گھنٹے </string>
   <string name="every_six_hours">ہر چھ گھنٹے </string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -362,7 +362,6 @@
   <string name="encrypted_form">انکرپٹڈ فارم</string>
   <string name="deleted_form">ڈیلیٹڈ فارم</string>
   <string name="exit">باہر نکلیں</string>
-  <string name="instance_scan_completed"> سکیننگ ختم</string>
   <string name="instance_scan_count">%1$dفارم شامل ہیں.</string>
   <string name="instance_sync">امپورٹ پر فارم کو حتمی شکل دیں</string>
   <string name="instance_sync_summary">افیکٹس فارمز براہ راست انسٹنسز فولڈر میں شامل کیا گئے.</string>

--- a/strings/src/main/res/values-zh/strings.xml
+++ b/strings/src/main/res/values-zh/strings.xml
@@ -193,8 +193,7 @@
   <string name="ext_import_completed_message">读取数据已完成！</string>
   <string name="survey_loading_reading_csv_message">正在读取CSV文件…</string>
   <string name="survey_saving_saving_message">正在保存至SD卡…</string>
-  <string name="google_drive">谷歌云盘</string>
-  <string name="no_google_account">无选中的谷歌账号！</string>
+    <string name="no_google_account">无选中的谷歌账号！</string>
   <string name="delete_after_send">发送后自动删除</string>
   <string name="change_server_url">服務器 URL</string>
   <string name="about_preferences">关于</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -87,7 +87,6 @@
     # FILL BLANK FORM
     ##############################################
     -->
-    <string name="instance_scan_completed">Finished scanning.</string>
     <string name="instance_scan_count">%1$d forms added.</string>
     <string name="finished_disk_scan">Finished scanning. All forms loaded.</string>
     <string name="xform_parse_error">XForm parse error for %1$s: %2$s is missing or invalid.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -823,8 +823,6 @@
     <string name="moving_backwards_enabled_title">Moving backwards enabled</string>
     <string name="moving_backwards_enabled_message">You may wish to review the following settings:\n\n\u2022 Edit Saved Form\n\u2022 Save Form\n\u2022 Go To Prompt\n\u2022 Constraint processing</string>
 
-    <string name="server">Server</string>
-
     <!-- Admin setting. When enabled, users are allowed to save forms while filling them. When disabled, users are only allowed to save forms when they reach their end -->
     <string name="save_mid">Save Form</string>
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -10,217 +10,277 @@
     License.
 -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation" tools:locale="en">
-    <string name="show_password">Show password</string>
-    <string name="activity_not_found">No activity found to handle: %s</string>
-    <string name="view_image">View Image</string>
-    <string name="annotate_image">Annotate Image</string>
-    <string name="signature_capture">Signature Capture</string>
-    <string name="view_video">View Video</string>
-    <string name="choose_audio">Choose Audio</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="enter_data">Fill Blank Form</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="enter_data_button">Fill Blank Form</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="review_data">Edit Saved Form</string>
+    <!-- Text for an action button on the main screen. A form count is provided in parentheses. -->
+    <string name="review_data_button">Edit Saved Form (%s)‎‎‎‎</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="send_data">Send Finalized Form</string>
+    <!-- Text for an action button on the main screen. A form count is provided in parentheses. -->
+    <string name="send_data_button">Send Finalized Form (%s)</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="view_sent_forms">View Sent Form</string>
+    <!-- Text for an action button on the main screen. A form count is provided in parentheses. -->
+    <string name="view_sent_forms_button">View Sent Form (%s)</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="get_forms">Get Blank Form</string>
+    <!-- Text for an action button on the main screen. -->
+    <string name="manage_files">Delete Saved Form</string>
+
+    <string name="version_number">Version: %s</string>
+    <string name="id_number">ID: %s</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="added_on_date_at_time">\'Added on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="saved_on_date_at_time">\'Saved on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="finalized_on_date_at_time">\'Finalized on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="sent_on_date_at_time">\'Sent on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="sending_failed_on_date_at_time">\'Sending failed on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="deleted_on_date_at_time">\'Deleted on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <string name="submission_deleted">Submission deleted</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="modified_on_date_at_time">\'Modified on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <string name="encrypted_form">Encrypted form</string>
+    <string name="deleted_form">Deleted form</string>
+
+    <string name="sort_the_list">Sort the list</string>
+    <string name="sort_by">Sort by</string>
+    <string name="sort_by_name_asc">Name, A-Z</string>
+    <string name="sort_by_name_desc">Name, Z-A</string>
+    <string name="sort_by_date_asc">Date, newest first</string>
+    <string name="sort_by_date_desc">Date, oldest first</string>
+    <string name="sort_by_status_asc">Status, finalized first</string>
+    <string name="sort_by_status_desc">Status, unfinalized first</string>
+    <string name="filter_the_list">Filter the list</string>
+    <!-- Displayed in search boxes for form lists or question types that involve search -->
+    <string name="search">Search</string>
+
+    <string name="no_items_display">Nothing available to display.</string>
+    <string name="no_items_display_forms">Nothing available to display.\n\nTry getting and filling out a blank form.</string>
+    <string name="no_items_display_sent_forms">Nothing available to display.\n\nTry sending finalized forms before viewing.</string>
+    <string name="no_items_display_instances">Nothing available to display.\n\nTry finalizing saved forms before sending.</string>
+
+    <string name="not_granted_permission">The activity you are trying to start requires a permission which is not granted.</string>
+    <string name="storage_runtime_permission_denied_title">Storage permissions</string>
+    <string name="storage_runtime_permission_denied_desc">Without these permissions Collect can\'t access your forms or save answers. Reopen the app when you are ready to grant them.</string>
+    <string name="location_runtime_permissions_denied_title">Location permissions</string>
+    <string name="location_runtime_permissions_denied_desc">Without these permissions Collect can\'t record your location. Please try again when you are ready to grant them.</string>
+    <string name="camera_runtime_permission_denied_title">Camera permission</string>
+    <string name="camera_runtime_permission_denied_desc">Without this permission Collect can\'t access the camera. Please try again when you are ready to grant it.</string>
+    <string name="record_audio_runtime_permission_denied_title">Record audio permission</string>
+    <string name="record_audio_runtime_permission_denied_desc">Without this permission Collect can\'t access the microphone. Please try again when you are ready to grant it.</string>
+    <string name="get_accounts_runtime_permission_denied_title">Get accounts permission</string>
+    <string name="get_accounts_runtime_permission_denied_desc">Without this permission Collect can\'t access accounts. Please try again when you are ready to grant it.</string>
+    <string name="read_phone_state_runtime_permission_denied_title">Read phone state permission</string>
+    <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect does not make calls but it needs to access certain properties about your device such as the phone number and device ID.</string>
+
+    <!--
+    ##############################################
+    # FILL BLANK FORM
+    ##############################################
+    -->
+    <string name="instance_scan_completed">Finished scanning.</string>
+    <string name="instance_scan_count">%1$d forms added.</string>
+    <string name="finished_disk_scan">Finished scanning. All forms loaded.</string>
+    <string name="xform_parse_error">XForm parse error for %1$s: %2$s is missing or invalid.</string>
+
+    <string name="loading_form">Loading Form</string>
+    <string name="survey_loading_reading_form_message">Reading form definition…</string>
+    <string name="survey_loading_reading_data_message">Reading survey data…</string>
+    <string name="survey_loading_reading_csv_message">Reading CSV files…</string>
+    <string name="parse_error">Sorry, unable to parse form.</string>
+    <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
+    <string name="parent_form_not_present">Unable to edit this saved form because the corresponding blank form is not present or was deleted.\n\nForm ID: %1$s</string>
+    <string name="cannot_edit_completed_form">This form cannot be edited once it has been marked as finalized. It may be encrypted.</string>
+
+    <!-- Displayed when loading a form if that form was previously filled but closed because of a crash or system failure -->
+    <string name="savepoint_used">Unsaved changes recovered from savepoint!</string>
+
+    <!-- Displayed in the form filling menu when a form definition specifies multiple languages -->
+    <string name="change_language">Change Language</string>
+    <!-- Text for button displayed in the form filling menu to see the form's table of contents -->
+    <string name="view_hierarchy">Go To Prompt</string>
+    <!-- Text for button displayed in the form filling menu to save the form -->
+    <string name="save_all_answers">Save Form</string>
+
+    <!-- Text of button from the form's table of contents to jump to the beginning of the form -->
+    <string name="jump_to_beginning">Go To Start</string>
+    <!-- Text of button from the form's table of contents to jump to the end of the form -->
+    <string name="jump_to_end">Go To End</string>
+    <!-- Text of button from the form's table of contents to navigate out of a group or a repeat -->
+    <string name="jump_to_previous">Go Up</string>
+    <!-- Displayed below group names in a form's table of contents -->
+    <string name="group_label">Group</string>
+    <!-- Displayed below repeat names in a form's table of contents -->
+    <string name="repeatable_group_label">Repeatable Group</string>
+    <string name="exit">Exit</string>
 
     <!-- This sentence is used in the dialog for adding repeats and will be completed by a singular noun usually. Examples would be ‘Add “observation”?’ or ‘Add “Reading”?’. If the phrase doesn’t make sense in your language you can add a word like “new”, being careful of gender/plural.-->
     <string name="add_repeat_question">Add \"%s\"?</string>
     <string name="add_repeat">Add</string>
     <string name="dont_add_repeat">Do not add</string>
-
     <string name="add_another_menu">Add another</string>
-    <string name="cancel">Cancel</string>
-    <string name="cancel_loading_form">Cancel</string>
-    <string name="cancel_location">Cancel</string>
-    <string name="canceling">Canceling</string>
-    <string name="cannot_edit_completed_form">This form cannot be edited once it has been marked as finalized. It may be encrypted.</string>
-    <string name="capture_audio">Record Sound</string>
-    <string name="capture_image">Take Picture</string>
-    <string name="capture_osm">Launch OpenMapKit</string>
-    <string name="recapture_osm">Redo OSM Tagging</string>
-    <string name="capture_video">Record Video</string>
-    <string name="change_language">Change Language</string>
-    <string name="change_password">ODK Password</string>
-    <string name="change_username">ODK Username</string>
+
+    <!-- Title of overlay menu displayed when long pressing on a question in a form -->
+    <string name="edit_prompt">Edit Prompt</string>
+
     <string name="clearanswer_confirm">Remove the response to \"%s\"?</string>
     <string name="clear_answer">Remove response</string>
     <string name="clear_answer_ask">Remove This Response?</string>
     <string name="clear_answer_no">Cancel</string>
-    <string name="data">Saved Forms</string>
-    <string name="data_saved_error">Sorry, form save failed!</string>
-    <string name="data_saved_ok">Form successfully saved!</string>
-    <string name="save_point_error">Error saving recovery point: %s</string>
-    <string name="default_completed">Default to finalized</string>
-    <string name="default_completed_summary">Mark form as finalized by default</string>
-    <string name="delete_confirm">Delete %s form(s)?</string>
-    <string name="delete_file">Delete Selected</string>
-    <string name="delete_no">Do Not Delete</string>
+    <string name="discard_answer">Remove response</string>
+    <string name="discard_group">Remove group</string>
+
     <string name="delete_repeat">Remove group</string>
     <string name="delete_repeat_ask">Remove This Group?</string>
     <string name="delete_repeat_confirm">Remove group \"%s\" and all of its sub-groups?</string>
     <string name="delete_repeat_no">Cancel</string>
-    <string name="delete_yes">Delete Forms</string>
-    <string name="discard_answer">Remove response</string>
-    <string name="discard_group">Remove group</string>
-    <string name="download">Get Selected</string>
-    <string name="download_forms_result">Download Results</string>
-    <string name="downloading_data">Connecting to Server</string>
-    <string name="do_not_change">Cancel</string>
-    <string name="do_not_exit">Cancel</string>
-    <string name="do_not_save">Ignore Changes</string>
-    <string name="enter_data">Fill Blank Form</string>
-    <string name="enter_data_button">Fill Blank Form</string>
-    <string name="error_occured">Error Occurred</string>
-    <string name="error_attaching_binary_file">An error occurred while attaching the media: %s</string>
-    <string name="fetching_file">Getting %1$s.\n\nForm %2$s of %3$s form(s).</string>
-    <string name="file_deleted_error">Sorry, %1$s of %2$s selected form(s) failed to delete!</string>
-    <string name="file_deleted_ok">%s form(s) successfully deleted!</string>
-    <string name="file_delete_in_progress">Sorry, a form delete action is already in progress!</string>
-    <string name="file_invalid">File: %s is invalid.</string>
-    <string name="file_missing">File: %s is missing.</string>
-    <string name="finished_disk_scan">Finished scanning. All forms loaded.</string>
-    <string name="forms">Blank Forms</string>
-    <string name="getting_location">Loading Location</string>
-    <string name="get_barcode">Get Barcode</string>
-    <string name="get_forms">Get Blank Form</string>
-    <string name="get_location">Record Location</string>
-    <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
+
     <string name="invalid_answer_error">Sorry, this response is invalid!</string>
+    <string name="required_answer_error">Sorry, this response is required!</string>
     <string name="invalid_space_in_answer_singular">Warning: underlying value %s has spaces</string>
     <string name="invalid_space_in_answer_plural">Warning: underlying values %s have spaces</string>
-    <string name="jump_to_beginning">Go To Start</string>
-    <string name="jump_to_end">Go To End</string>
-    <string name="jump_to_previous">Go Up</string>
-    <string name="loading_form">Loading Form</string>
-    <string name="load_remote_form_error">Form list download failed</string>
-    <string name="location_accuracy">Accuracy: %1$s m</string>
-    <string name="location_provider">Location provider: %s</string>
-    <string name="manage_files">Delete Saved Form</string>
-    <string name="mark_finished">Mark form as finalized</string>
-    <string name="noselect_error">Sorry, you have not selected any forms!</string>
-    <string name="no_connection">No network connection available</string>
-    <string name="no_items_display">Nothing available to display.</string>
-    <string name="no_items_display_forms">Nothing available to display.\n\nTry getting and filling out a blank form.</string>
-    <string name="no_items_display_sent_forms">Nothing available to display.\n\nTry sending finalized forms before viewing.</string>
-    <string name="no_items_display_instances">Nothing available to display.\n\nTry finalizing saved forms before sending.</string>
-    <string name="ok">OK</string>
-    <string name="parse_error">Sorry, unable to parse form.</string>
-    <string name="password">Password</string>
-    <string name="play_video">Play Video</string>
-    <string name="please_wait">Please wait a few moments.</string>
-    <string name="please_wait_long">Please wait. This could take a few minutes.</string>
-    <string name="quit_application">Exit %s</string>
-    <string name="quit_entry">Save Form and Exit</string>
-    <string name="refresh">Refresh</string>
-    <string name="group_label">Group</string>
-    <string name="repeatable_group_label">Repeatable Group</string>
-    <string name="replace_barcode">Replace Barcode</string>
-    <string name="required_answer_error">Sorry, this response is required!</string>
-    <string name="review_data">Edit Saved Form</string>
-    <string name="view_data">View Saved Form</string>
-    <string name="review_data_button">Edit Saved Form (%s)‎‎‎‎</string>
-    <string name="save_all_answers">Save Form</string>
+
+    <string name="too_complex_form">This form is too complex for this device. Try simplifying expressions or ask for help on the forum.</string>
+
+    <string name="survey_internal_error">Internal error: step to prompt failed.</string>
+
     <string name="save_enter_data_description">You are at the end of %s.</string>
-    <string name="saving_form">Saving Form</string>
-    <string name="sending_items">Sending %1$s of %2$s form(s)</string>
-    <string name="send_data">Send Finalized Form</string>
-    <string name="send_data_button">Send Finalized Form (%s)</string>
-    <string name="send_selected_data">Send Selected</string>
-    <string name="view_sent_forms">View Sent Form</string>
-    <string name="view_sent_forms_button">View Sent Form (%s)</string>
-    <string name="server_auth_credentials">Invalid username or password for server: %s</string>
-    <string name="server_requires_auth">Server Requires Authentication</string>
-    <string name="server_url">URL</string>
-    <string name="server_preferences">Server Settings</string>
-    <string name="trigger">OK. Please continue.</string>
-    <string name="uploading_data">Sending Form</string>
-    <string name="url_error">Sorry, invalid URL!</string>
-    <string name="username">Username</string>
-    <string name="view_hierarchy">Go To Prompt</string>
-    <string name="general_preferences">General Settings</string>
-    <string name="client">User interface</string>
-    <string name="show_splash_summary">Shows when application starts</string>
-    <string name="splash_path">Selected splash image</string>
-    <string name="default_splash_path">ODK Default</string>
-    <string name="select_another_image">Select another image</string>
-    <string name="use_odk_default">Use default image</string>
-    <string name="change_splash_path">Change image</string>
-    <string name="keep_changes">Save Changes</string>
-    <string name="change_formlist_url">Form list path (appended to URL)</string>
-    <string name="change_submission_url">Submission path (appended to URL)</string>
-    <string name="formlist_url">Form list path</string>
-    <string name="submission_url">Submission path</string>
-    <string name="font_size">Text font size</string>
-    <string name="change_font_size">Text font size</string>
-    <string name="form_download_progress">%1$s. Getting media files: %2$s of %3$s</string>
-    <string name="success">Success</string>
-    <string name="failures">Failures</string>
-    <string name="no_forms_uploaded">Sorry, no form was uploaded.</string>
-    <string name="upload_results">Upload Results</string>
-    <string name="xform_parse_error">XForm parse error for %1$s: %2$s is missing or invalid.</string>
-    <string name="choose_file">Choose File</string>
-    <string name="choose_sound">Choose Sound</string>
-    <string name="choose_video">Choose Video</string>
-    <string name="choose_image">Choose Image</string>
-    <string name="selected">Selected: </string>
-    <string name="select_answer">Select Answer</string>
     <string name="save_form_as">Name this form</string>
     <string name="save_as_error">Saved name must not be blank!</string>
-    <string name="edit_prompt">Edit Prompt</string>
-    <string name="selected_google_account_text">Google account</string>
-    <string name="font_size_extra_large">Extra Large</string>
-    <string name="font_size_large">Large</string>
-    <string name="font_size_medium">Medium</string>
-    <string name="font_size_small">Small</string>
-    <string name="font_size_extra_small">Extra Small</string>
-    <string name="change_view">Change View</string>
-    <string name="show_sent_and_unsent_forms">Show Sent and Unsent Forms</string>
-    <string name="show_unsent_forms">Show Unsent Forms</string>
-    <string name="added_on_date_at_time">\'Added on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
-    <string name="saved_on_date_at_time">\'Saved on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
-    <string name="finalized_on_date_at_time">\'Finalized on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
-    <string name="sent_on_date_at_time">\'Sent on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
-    <string name="sending_failed_on_date_at_time">\'Sending failed on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
-    <string name="deleted_on_date_at_time">\'Deleted on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
-    <string name="submission_deleted">Submission deleted</string>
-    <string name="version">Version:</string>
-    <string name="parent_form_not_present">Unable to edit this saved form because the corresponding blank form is not present or was deleted.\n\nForm ID: %1$s</string>
+    <string name="mark_finished">Mark form as finalized</string>
+    <string name="quit_entry">Save Form and Exit</string>
+
+    <string name="data_saved_error">Sorry, form save failed!</string>
+    <string name="data_saved_ok">Form successfully saved!</string>
+    <string name="save_point_error">Error saving recovery point: %s</string>
+
+    <!-- Dialog title when exiting a form. The name of the form will be included -->
+    <string name="quit_application">Exit %s</string>
+    <!-- Used when exiting a form filling session in which a form was not properly loaded. &lt; and &gt; surrounds the text so it will appear as <no form loaded> -->
+    <string name="no_form_loaded">&lt;no form loaded&gt;</string>
+    <string name="do_not_save">Ignore Changes</string>
+    <string name="keep_changes">Save Changes</string>
+
+    <string name="saving_form">Saving Form</string>
+    <string name="survey_saving_validating_message">Validating answers…</string>
+    <string name="survey_saving_collecting_message">Collecting data…</string>
+    <string name="survey_saving_saving_message">Saving to SD card…</string>
+    <string name="survey_saving_finalizing_message">Finalizing to SD card…</string>
+
+    <string name="survey_saving_encrypting_message">Encrypting data…</string>
+    <string name="not_exactly_one_record_for_this_instance">Not exactly one record for this instance!</string>
+    <string name="not_exactly_one_blank_form_for_this_form_id">Not exactly one blank form matches this jr_form_id.</string>
+    <string name="no_form_id_specified">No FormId specified???</string>
+    <string name="phone_does_not_support_rsa">Phone does not support RSA encryption.</string>
+    <string name="invalid_rsa_public_key">Invalid RSA public key.</string>
+    <string name="encryption_error_message">%s Form has not been saved as finalized.</string>
+
+    <!-- Displayed when form filling is attempted to be launched by intent but the intent URI is incorrect -->
+    <string name="bad_uri">Bad URI: %s</string>
+    <!-- Displayed when form filling is attempted to be launched by intent but the intent URI mime type is unknown -->
+    <string name="unrecognized_uri">Unrecognized URI: %s</string>
+
+    <!--
+    ##############################################
+    # FORM FEATURES
+    ##############################################
+    -->
+    <!-- Name of button displayed when a screen contains multiple questions populated by an external app: https://docs.getodk.org/launch-apps-from-collect/#launching-external-apps-to-populate-multiple-fields -->
     <string name="launch_app">Launch</string>
+    <string name="activity_not_found">No activity found to handle: %s</string>
     <string name="no_app">The requested application is missing. Please manually enter the reading.</string>
-    <string name="savepoint_used">Unsaved changes recovered from savepoint!</string>
+    <string name="null_intent_value">The external application did not provide expected information.</string>
+
+    <string name="launch_printer">Initiate Printing</string>
+    <string name="no_printer">The requested printer is not installed. Please install the printer.</string>
+
+    <string name="open_url">Open Url</string>
+
+    <string name="capture_osm">Launch OpenMapKit</string>
+    <string name="recapture_osm">Redo OSM Tagging</string>
+    <string name="edited_osm_file">Edited OSM XML File:</string>
+    <string name="invalid_osm_data">Something went wrong. We did not get valid OSM data.</string>
+    <string name="alert">Alert</string>
+    <string name="install_openmapkit">Please install OpenMapKit!</string>
+
+    <string name="get_barcode">Get Barcode</string>
+    <string name="replace_barcode">Replace Barcode</string>
+    <string name="barcode_scanner_prompt">Place the barcode inside the rectangle</string>
+
+    <string name="open_file">Open file</string>
+
+    <string name="rank_items">Rank items</string>
+
+    <string name="number_picker_title">Number Picker</string>
+    <string name="invalid_range_widget">This widget has invalid parameters!</string>
+
+    <string name="svg_file_does_not_exist">SVG file does not exist!</string>
+
+    <string name="capture_image">Take Picture</string>
+    <string name="choose_image">Choose Image</string>
+    <string name="selected_invalid_image">Selected file is not a valid image</string>
+    <string name="gdrive_connection_exception">This image is stored on Google Drive and cannot be accessed while you are offline.</string>
+    <string name="view_image">View Image</string>
+    <string name="take_picture_instruction">Tap the screen to take a picture</string>
+    <string name="error_front_camera_unavailable">Front camera not available on this device</string>
+    <string name="camera_error">This device doesn\'t support the Camera2 API.</string>
+    <string name="annotate_image">Annotate Image</string>
+    <!-- Dialog heading for saving annotated image -->
     <string name="save_and_close">Save and Close</string>
+    <string name="signature_capture">Signature Capture</string>
     <string name="sign_button">Gather Signature</string>
     <string name="markup_image">Markup Image</string>
     <string name="draw_image">Sketch Image</string>
     <string name="reset_image">Reset</string>
     <string name="set_color">Set Color</string>
-    <string name="admin_preferences">Admin Settings</string>
-    <string name="admin_access_settings">Tap for admin access to settings</string>
-    <string name="save_mid">Save Form</string>
-    <string name="enter_new_password">Enter new password</string>
-    <string name="admin_password">Admin Password</string>
-    <string name="admin_password_changed">Admin password successfully changed</string>
-    <string name="admin_password_disabled">Admin password disabled</string>
-    <string name="admin_password_incorrect">Sorry, password is incorrect!</string>
-    <string name="enter_admin_password">Enter Admin Password</string>
-    <string name="change_admin_password">Change Admin Password</string>
-    <string name="autosend">Auto send</string>
-    <string name="found_in_main">Uncheck to hide from Main Menu</string>
-    <string name="found_in_settings">Uncheck to hide from General Settings</string>
-    <string name="form_forward">Next</string>
-    <string name="form_backward">Back</string>
-    <string name="navigation">Navigation</string>
-    <string name="swipe_navigation">Use horizontal swipes</string>
-    <string name="buttons_navigation">Use forward/backward buttons</string>
-    <string name="swipe_buttons_navigation">Use swipes and buttons</string>
-    <string name="launch_printer">Initiate Printing</string>
-    <string name="no_printer">The requested printer is not installed. Please install the printer.</string>
-    <string name="constraint_behavior">Constraint processing behavior</string>
-    <string name="constraint_behavior_on_swipe">Validate upon forward swipe</string>
-    <string name="constraint_behavior_on_finalize">Defer validation until finalized</string>
-    <string name="view_change_location">View or Change Location</string>
-    <string name="change_location">Change Location</string>
-    <string name="open_url">Open Url</string>
-    <string name="get_bearing">Record Bearing</string>
-    <string name="replace_bearing">Replace Bearing</string>
-    <string name="getting_bearing">Loading Bearing</string>
-    <string name="accept_bearing">Record Bearing</string>
-    <string name="sdcard_unmounted">Collect cannot access the SD card. Perhaps it is mounted via USB? (Current state: %s)</string>
+
+    <string name="capture_video">Record Video</string>
+    <string name="choose_video">Choose Video</string>
+    <string name="view_video">View Video</string>
+    <string name="start_video_capture_instruction">Tap the screen to start recording</string>
+    <string name="stop_video_capture_instruction">Recording started. Tap again to stop</string>
+    <string name="play_video">Play Video</string>
+
+    <string name="choose_file">Choose File</string>
+
+    <string name="capture_audio">Record Sound</string>
+    <string name="choose_sound">Choose Sound</string>
+    <string name="choose_audio">Choose Audio</string>
+    <!-- Text for button that stops audio recording  -->
+    <string name="stop_recording">Stop</string>
+    <!-- Text to let the user know a recording is in progress  -->
+    <string name="recording">Recording…</string>
+    <!-- Title of Android Notification Channel for audio recording notifications  -->
+    <string name="recording_channel">Audio recording</string>
+    <!-- Text for button that plays audio clip  -->
+    <string name="play_audio">Play audio</string>
+    <!-- Text to let the user know a file is being saved  -->
+    <string name="saving_file">Saving file</string>
+    <!-- Text in dialog that instructs the user to stop recording audio before leaving the form -->
+    <string name="recording_warning">You must stop recording before leaving this screen.</string>
+
+    <string name="error_attaching_binary_file">An error occurred while attaching the media: %s</string>
+
+    <!-- Displayed in form questions for which the user needs to select a value -->
+    <string name="select_value">Select value</string>
+    <string name="select_answer">Select Answer</string>
+    <!-- Displayed in form questions for which the user needs to select a value -->
+    <string name="edit_value">Edit value</string>
+    <!-- Displayed in form questions for which the user needs to select a value -->
+    <string name="no_value_selected">No value selected</string>
+    <string name="selected">Selected: </string>
+
+    <string name="trigger">OK. Please continue.</string>
+
     <string name="ext_file_no_data_error">The file contains no data!</string>
     <string name="ext_conflicting_columns_error">Columns %s match!</string>
     <string name="ext_sortBy_numeric_error">Your sortby column should contain only numeric values. Conflicting value was \'%s\'.</string>
@@ -237,60 +297,107 @@
     <string name="ext_import_csv_missing_error">External data for %1$s has not been imported. Perhaps you forgot to include the %2$s.csv file with your form?</string>
     <string name="ext_search_generic_error">Syntax error in search() function: %s</string>
     <string name="ext_assign_value_error">Cannot assign the value at \'%s\'.</string>
-    <string name="fs_delete_media_path_if_file_error">Could not delete \'%s\'. Please delete the file manually and re-download the form.</string>
-    <string name="fs_create_media_folder_error">Could not create media folder \'%s\'.</string>
-    <string name="fs_file_copy_error">Could not copy \'%1$s\' over \'%2$s\'. Reason: %3$s</string>
-    <string name="survey_internal_error">Internal error: step to prompt failed.</string>
-    <string name="survey_multiple_forms_error">You have downloaded two different forms with the same form ID and version. Maybe they were the same form uploaded at different times or to different servers. In any case, you should delete one.</string>
-    <string name="survey_loading_reading_form_message">Reading form definition…</string>
-    <string name="survey_loading_reading_data_message">Reading survey data…</string>
-    <string name="survey_loading_reading_csv_message">Reading CSV files…</string>
-    <string name="survey_saving_validating_message">Validating answers…</string>
-    <string name="survey_saving_collecting_message">Collecting data…</string>
-    <string name="survey_saving_saving_message">Saving to SD card…</string>
-    <string name="survey_saving_finalizing_message">Finalizing to SD card…</string>
-    <string name="survey_saving_encrypting_message">Encrypting data…</string>
-    <string name="high_resolution_summary">Enable high-resolution video recordings</string>
-    <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
-    <string name="google_drive">Google Drive</string>
-    <string name="go_drive">My Drive</string>
-    <string name="go_shared">Shared with Me</string>
-    <string name="modified_on_date_at_time">\'Modified on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
-    <string name="google_sheets_url_hint">Forms must set a submission URL. If they don\'t, this URL will be used.</string>
-    <string name="drive_get_file">Getting %1$s and media files.</string>
-    <string name="no_google_account">No Google Account Selected!</string>
-    <string name="google_set_account">You have selected Google Sheets as your server, please select a corresponding Google account in the General Settings before continuing</string>
-    <string name="media_upload_error">Failed to upload media file that does not exist: %1$s</string>
-    <string name="odk_permissions_fail">ODK auto send permission failure, please make sure your have granted all required permissions</string>
-    <string name="odk_auto_note">ODK auto-send results</string>
-    <string name="odk_auto_download_notification_title">ODK auto-download results</string>
-    <string name="notification_error">Error displaying notification text</string>
-    <string name="delete_after_send">Delete after send</string>
-    <string name="delete_after_send_summary">Deletes finalized forms and media after sending to server</string>
-    <string name="change_server_url">Server URL</string>
-    <string name="google_search_browse">Search for forms. Or select \'My Drive\' below to browse.</string>
-    <string name="google_sheets_url">Fallback submission URL</string>
-    <string name="send_in_progress">Background send running, please try again shortly</string>
-    <string name="invalid_sheet_id">invalid sheet id: %1$s</string>
-    <string name="missing_submission_url">Missing submission URL</string>
-    <string name="google_sheets_access_denied">Access denied. Please make sure the spreadsheet owner has granted you edit permission.</string>
-    <string name="google_sheets_missing_columns">Spreadsheet is missing the following columns: %1$s</string>
-    <string name="password_error_whitespace">Leading or trailing whitespace not allowed in passwords</string>
-    <string name="username_error_whitespace">Leading or trailing whitespace not allowed in usernames</string>
-    <string name="google_play_services_error_occured">Unable to access Google Maps. Is Google Play Services installed?</string>
-    <string name="about_preferences">About</string>
-    <string name="tell_your_friends">Share ODK Collect</string>
-    <string name="tell_your_friends_msg">Are your colleagues still collecting data on paper? Share ODK Collect with them.</string>
-    <string name="leave_a_review">Leave a Play Store review</string>
-    <string name="leave_a_review_msg">Your (hopefully positive) review increases the visibility of the App in the Play Store.</string>
-    <!-- Geo string added in feature-geofeatures branch-->
 
-    <string name="maps">Maps</string>
+    <string name="parser_exception">XPathParser Exception: \"%s\"</string>
+
+    <string name="get_bearing">Record Bearing</string>
+    <string name="replace_bearing">Replace Bearing</string>
+    <string name="getting_bearing">Loading Bearing</string>
+    <string name="accept_bearing">Record Bearing</string>
+    <string name="bearing">Bearing: %.3f</string>
+    <string name="direction">Direction: %s</string>
+    <string name="bearing_lack_of_sensors">Bearing cannot be collected: device is missing accelerometer, magnetic field sensor or both.</string>
+
+    <string name="select_date">Select date</string>
+    <string name="select_time">Select time</string>
+    <string name="no_date_selected">No date selected</string>
+    <string name="no_time_selected">No time selected</string>
+
+    <string name="ethiopian_month_1">Meskerem</string>
+    <string name="ethiopian_month_2">Tikimt</string>
+    <string name="ethiopian_month_3">Hidar</string>
+    <string name="ethiopian_month_4">Tahsas</string>
+    <string name="ethiopian_month_5">Tir</string>
+    <string name="ethiopian_month_6">Yekatit</string>
+    <string name="ethiopian_month_7">Megabit</string>
+    <string name="ethiopian_month_8">Miazia</string>
+    <string name="ethiopian_month_9">Ginbot</string>
+    <string name="ethiopian_month_10">Senie</string>
+    <string name="ethiopian_month_11">Hamlie</string>
+    <string name="ethiopian_month_12">Nehasie</string>
+    <string name="ethiopian_month_13">Pagumien</string>
+    <string name="coptic_month_1">Thout</string>
+    <string name="coptic_month_2">Paopi</string>
+    <string name="coptic_month_3">Hathor</string>
+    <string name="coptic_month_4">Koiak</string>
+    <string name="coptic_month_5">Tobi</string>
+    <string name="coptic_month_6">Meshir</string>
+    <string name="coptic_month_7">Paremhat</string>
+    <string name="coptic_month_8">Parmouti</string>
+    <string name="coptic_month_9">Pashons</string>
+    <string name="coptic_month_10">Paoni</string>
+    <string name="coptic_month_11">Epip</string>
+    <string name="coptic_month_12">Mesori</string>
+    <string name="coptic_month_13">Pi Kogi Enavot</string>
+    <string name="islamic_month_1">Muharram</string>
+    <string name="islamic_month_2">Safar</string>
+    <string name="islamic_month_3">Rabi\' al-awwal</string>
+    <string name="islamic_month_4">Rabi\' al-thani</string>
+    <string name="islamic_month_5">Jumada al-awwal</string>
+    <string name="islamic_month_6">Jumada al-thani</string>
+    <string name="islamic_month_7">Rajab</string>
+    <string name="islamic_month_8">Sha\'ban</string>
+    <string name="islamic_month_9">Ramadan</string>
+    <string name="islamic_month_10">Shawwal</string>
+    <string name="islamic_month_11">Dhu al-Qidah</string>
+    <string name="islamic_month_12">Dhu al-Hijjah</string>
+    <string name="persian_month_1">Farvardin</string>
+    <string name="persian_month_2">Ordibehesht</string>
+    <string name="persian_month_3">Khordad</string>
+    <string name="persian_month_4">Tir</string>
+    <string name="persian_month_5">Mordad</string>
+    <string name="persian_month_6">Shahrivar</string>
+    <string name="persian_month_7">Mehr</string>
+    <string name="persian_month_8">Aban</string>
+    <string name="persian_month_9">Azar</string>
+    <string name="persian_month_10">Dey</string>
+    <string name="persian_month_11">Bahman</string>
+    <string name="persian_month_12">Esfand</string>
+    <!-- Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order -->
+    <string name="custom_date">%1$s (%2$s)</string>
+
+    <!-- Displayed when a form media file such as an image for a question label or an audio file for a choice is invalid -->
+    <string name="file_invalid">File: %s is invalid.</string>
+    <!-- Displayed when a form media file such as an image for a question label or an audio file for a choice is missing -->
+    <string name="file_missing">File: %s is missing.</string>
+
+    <!-- Heading for a dialog which prompts the user to identify themselves when making changes to data. See https://docs.getodk.org/form-audit-log/#enumerator-identification. -->
+    <string name="enter_identity">Enter identity</string>
+    <!-- Label for prompt for the user to identify themselves when making changes to data. See https://docs.getodk.org/form-audit-log/#enumerator-identification. -->
+    <string name="identity">Identity</string>
+    <!-- Explanation for prompt for the user to identify themselves when making changes to data. See https://docs.getodk.org/form-audit-log/#enumerator-identification. -->
+    <string name="enter_identity_description">This form requires you to identify yourself</string>
+    <!-- Action to close a full screen dialog -->
+    <string name="close">Close</string>
+
+    <!-- Heading for a dialog which prompts the user to describe why a change was made to data. See https://docs.getodk.org/form-audit-log/#change-tracking. -->
+    <string name="reason_for_changes">Reason for changes</string>
+    <!-- Label for prompt for the user to describe why a change was made to data. See https://docs.getodk.org/form-audit-log/#change-tracking. -->
+    <string name="reason">Reason</string>
+    <!-- Explanation for prompt for the user to describe why a change was made to data. See https://docs.getodk.org/form-audit-log/#change-tracking. -->
+    <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
+    <!-- Action to save the contents of a full screen dialog -->
+    <string name="save">Save</string>
 
     <!--
-      TODO(ping): Delete these openmap_* strings when we're ready to move on from OSMDroid.
-      These strings are only being used to preserve compatibility with pre-existing
-       tile caches, and are not shown in the UI.
+    ##############################################
+    # GEO
+    ##############################################
+    -->
+    <!--
+   TODO(ping): Delete these openmap_* strings when we're ready to move on from OSMDroid.
+   These strings are only being used to preserve compatibility with pre-existing
+    tile caches, and are not shown in the UI.
     -->
     <string name="openmap_usgs_topo">USGS National Map Topo</string>
     <string name="openmap_usgs_sat">USGS National Map Hybrid</string>
@@ -301,6 +408,7 @@
 
     <string name="basemap">Basemap</string>
     <string name="basemap_source">Source</string>
+    <string name="basemap_source_unavailable">Sorry, %s basemaps are not available on this device.  Please choose another basemap in General Settings &gt; Maps.</string>
     <string name="map_style_label">%s map style</string>
 
     <string name="streets">Streets</string>
@@ -311,6 +419,7 @@
     <string name="dark">Dark</string>
     <string name="outdoors">Outdoors</string>
     <string name="topographic">Topographic</string>
+    <string name="google_play_services_error_occured">Unable to access Google Maps. Is Google Play Services installed?</string>
 
     <string name="carto_map_style_positron">Positron</string>
     <string name="carto_map_style_dark_matter">Dark Matter</string>
@@ -320,6 +429,25 @@
     <string name="layer_data_caption">Above are all the layer files in %1$s that are supported by the %2$s basemap.</string>
     <string name="layer_data_file">Layer data file</string>
 
+    <string name="view_change_location">View or Change Location</string>
+    <string name="change_location">Change Location</string>
+    <string name="record_geopoint">Record a point</string>
+    <string name="location_accuracy">Accuracy: %1$s m</string>
+    <string name="location_provider">Location provider: %s</string>
+    <string name="getting_location">Loading Location</string>
+    <string name="get_location">Record Location</string>
+    <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
+    <string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$sm</string>
+    <string name="location_metadata">Satellites available: %1$d/24\n\nTime elapsed: %2$s</string>
+    <string name="google_play_services_not_available">This form wants to track your location but Google Play Services are not available.</string>
+    <string name="location_providers_disabled_dialog_message">This form wants to track your location but location providers are disabled. Please enable in Android settings.</string>
+    <!-- Action to go to Android settings. Displayed when location providers are disabled. -->
+    <string name="go_to_settings">Go to settings</string>
+    <!-- Label for a menu item that can be toggled to turn background location tracking on and off during form filling -->
+    <string name="track_location">Track location</string>
+    <string name="background_location_disabled">This form wants to track your location but tracking is disabled. Please enable in the %1$s menu above.</string>
+    <string name="background_location_enabled">This form tracks your location. You can disable tracking in the %1$s menu above.</string>
+
     <string name="save_point">Save GeoPoint</string>
     <string name="get_point">Start GeoPoint</string>
     <string name="geopoint_view_read_only">View GeoPoint</string>
@@ -327,6 +455,15 @@
     <string name="geotrace_view_read_only">View GeoTrace</string>
     <string name="get_shape">Start GeoShape</string>
     <string name="get_trace">Start GeoTrace</string>
+
+    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in W 18°48'8" -->
+    <string name="west">W %1$s%2$s%3$s</string>
+    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in E 18°48'8" -->
+    <string name="east">E %1$s%2$s%3$s</string>
+    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in S 18°48'8" -->
+    <string name="south">S %1$s%2$s%3$s</string>
+    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8" -->
+    <string name="north">N %1$s%2$s%3$s</string>
 
     <string name="geoshape_title">GeoShape</string>
     <string name="input_method">Input method</string>
@@ -374,53 +511,281 @@
     <string name="geoshape_view_change_location">View or Change GeoShape</string>
     <string name="geotrace_view_change_location">View or Change GeoTrace</string>
     <string name="geometry_status">Saved forms: %d (%d shown on map)</string>
-    <string name="bearing">Bearing: %.3f</string>
-    <string name="direction">Direction: %s</string>
-    <string name="select_odk_shortcut">Select ODK Shortcut</string>
-    <string name="bad_uri">Bad URI: %s</string>
-    <string name="unrecognized_uri">Unrecognized URI: %s</string>
-    <!-- &lt; and &gt; surrounds the text so it will appear as <no form loaded> -->
-    <string name="no_form_loaded">&lt;no form loaded&gt;</string>
-    <string name="settings_successfully_loaded_file_notification">Settings were successfully imported from a .settings file. This functionality will be removed in a future version. Please use QR code configuration instead.</string>
-    <string name="corrupt_settings_file_notification">Sorry, settings file is corrupt and should be deleted or replaced</string>
-    <string name="selected_invalid_image">Selected file is not a valid image</string>
-    <string name="edited_osm_file">Edited OSM XML File:</string>
-    <string name="invalid_osm_data">Something went wrong. We did not get valid OSM data.</string>
-    <string name="alert">Alert</string>
-    <string name="install_openmapkit">Please install OpenMapKit!</string>
-    <string name="go_back">Go back</string>
-    <string name="download_selected">Download Selected</string>
-    <string name="record_geopoint">Record a point</string>
-    <string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$sm</string>
-    <string name="parser_exception">XPathParser Exception: \"%s\"</string>
-    <string name="version_number">Version: %s</string>
-    <string name="id_number">ID: %s</string>
-    <string name="odk_website">Visit the ODK website</string>
-    <string name="odk_website_summary">ODK is used to collect data for social good in challenging environments.</string>
-    <string name="odk_forum">Join the ODK forum</string>
-    <string name="odk_forum_summary">Join the forum to get support, request features, contribute code/translations! </string>
-    <string name="all_open_source_licenses">Open source libraries/licenses</string>
-    <string name="all_open_source_licenses_msg">We stand on the shoulders of giants!</string>
+    <!-- Name of an action button -->
+    <string name="view_data">View Saved Form</string>
 
+    <!--
+    ##############################################
+    # SEND FINALIZED FORM
+    ##############################################
+    -->
+    <string name="uploading_data">Sending Form</string>
 
-    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in W 18°48'8" -->
-    <string name="west">W %1$s%2$s%3$s</string>
-    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in E 18°48'8" -->
-    <string name="east">E %1$s%2$s%3$s</string>
-    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in S 18°48'8" -->
-    <string name="south">S %1$s%2$s%3$s</string>
-    <!-- %1$s represents degrees, %2$s represents minutes and %3$s represents seconds as in N 18°48'8" -->
-    <string name="north">N %1$s%2$s%3$s</string>
-    <string name="gdrive_connection_exception">This image is stored on Google Drive and cannot be accessed while you are offline.</string>
-    <string name="not_exactly_one_record_for_this_instance">Not exactly one record for this instance!</string>
-    <string name="not_exactly_one_blank_form_for_this_form_id">Not exactly one blank form matches this jr_form_id.</string>
-    <string name="no_form_id_specified">No FormId specified???</string>
-    <string name="phone_does_not_support_rsa">Phone does not support RSA encryption.</string>
-    <string name="invalid_rsa_public_key">Invalid RSA public key.</string>
-    <string name="encryption_error_message">%s Form has not been saved as finalized.</string>
+    <string name="noselect_error">Sorry, you have not selected any forms!</string>
+    <string name="no_connection">No network connection available</string>
+
+    <string name="sending_items">Sending %1$s of %2$s form(s)</string>
+    <string name="send_selected_data">Send Selected</string>
+
+    <string name="server_auth_credentials">Invalid username or password for server: %s</string>
+    <string name="server_requires_auth">Server Requires Authentication</string>
+
+    <string name="no_forms_uploaded">Sorry, no form was uploaded.</string>
+
+    <string name="upload_results">Upload Results</string>
+
+    <!-- Name of option in Send Finalized Form menu to show only unsent forms (default) or show sent and unsent forms -->
+    <string name="change_view">Change View</string>
+    <string name="show_sent_and_unsent_forms">Show Sent and Unsent Forms</string>
+    <string name="show_unsent_forms">Show Unsent Forms</string>
+
+    <string name="media_upload_error">Failed to upload media file that does not exist: %1$s</string>
+
+    <string name="send_in_progress">Background send running, please try again shortly</string>
+
+    <string name="odk_permissions_fail">ODK auto send permission failure, please make sure your have granted all required permissions</string>
+    <string name="odk_auto_note">ODK auto-send results</string>
+    <string name="odk_auto_download_notification_title">ODK auto-download results</string>
+    <string name="notification_error">Error displaying notification text</string>
+
+    <!--
+    ##############################################
+    # GET BLANK FORM
+    ##############################################
+    -->
+    <string name="refresh">Refresh</string>
+    <string name="download">Get Selected</string>
+
+    <string name="download_forms_result">Download Results</string>
+    <string name="downloading_data">Connecting to Server</string>
+
+    <string name="fetching_file">Getting %1$s.\n\nForm %2$s of %3$s form(s).</string>
+    <string name="form_download_progress">%1$s. Getting media files: %2$s of %3$s</string>
+
+    <string name="version">Version:</string>
+
+    <string name="form_updates_available">Form updates available</string>
+    <string name="newer_version_of_a_form_info">This is an update to a form you have</string>
+    <string name="form_update_error">Form update failed</string>
+    <string name="form_update_succeeded">Form update succeeded</string>
+
+    <string name="report_to_project_lead">If you keep having this problem, report it to the person who asked you to collect data.</string>
+    <string name="unreachable_error">Collect can\'t reach the server at %s. Did you enter the URL correctly?</string>
+    <string name="security_error">Collect can\'t connect securely to the server at %s. Did you enter the URL correctly?</string>
+    <string name="failure">Failure</string>
+
+    <string name="load_remote_form_error">Form list download failed</string>
+
+    <!--
+    ##############################################
+    # DELETE SAVED FORM
+    ##############################################
+    -->
+    <!-- Title of a section in "Delete Saved Forms" for deleting filled/saved forms (as opposed to blank forms) -->
+    <string name="data">Saved Forms</string>
+    <!-- Title of a section in "Delete Saved Forms" for deleting blank forms (as opposed to filled/saved forms) -->
+    <string name="forms">Blank Forms</string>
+    <string name="delete_confirm">Delete %s form(s)?</string>
+    <string name="delete_file">Delete Selected</string>
+    <string name="delete_no">Do Not Delete</string>
+    <string name="delete_yes">Delete Forms</string>
+    <string name="file_deleted_error">Sorry, %1$s of %2$s selected form(s) failed to delete!</string>
+    <string name="form_delete_message">Deleting selected forms</string>
+    <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
+    <string name="file_deleted_ok">%s form(s) successfully deleted!</string>
+    <string name="file_delete_in_progress">Sorry, a form delete action is already in progress!</string>
+
+    <!--
+    ##############################################
+    # GENERAL SETTINGS
+    ##############################################
+    -->
+    <string name="general_preferences">General Settings</string>
+
+    <!-- Title of a settings section -->
+    <string name="server_settings_title">Server</string>
+    <!-- Title of a settings section -->
+    <string name="client">User interface</string>
+    <!-- Title of a settings section -->
+    <string name="maps">Maps</string>
+    <!-- Title of a settings section -->
+    <string name="form_management_preferences">Form management</string>
+    <!-- Title of a settings section -->
+    <string name="user_and_device_identity_title">User and device identity</string>
+    <!-- Title of a settings section only available in beta or development builds. -->
+    <string name="experimental">Experimental</string>
+
+    <string name="server_preferences">Server Settings</string>
+    <!-- Label for server type setting -->
+    <string name="type">Type</string>
+    <string name="server_url">URL</string>
+    <!-- Title of dialog for configuring server URL -->
+    <string name="change_server_url">Server URL</string>
+    <string name="url_error">Sorry, invalid URL!</string>
+    <string name="username">Username</string>
+    <string name="change_username">ODK Username</string>
+    <string name="password">Password</string>
+    <string name="change_password">ODK Password</string>
+    <string name="password_error_whitespace">Leading or trailing whitespace not allowed in passwords</string>
+    <string name="username_error_whitespace">Leading or trailing whitespace not allowed in usernames</string>
+    <string name="custom_server_paths">Custom server paths</string>
+    <string name="legacy_custom_server_paths_summary">Will be removed in a future version. Please use /formList and /submission on your server.</string>
+    <string name="change_formlist_url">Form list path (appended to URL)</string>
+    <string name="change_submission_url">Submission path (appended to URL)</string>
+    <string name="formlist_url">Form list path</string>
+    <string name="submission_url">Submission path</string>
+
+    <string name="server_platform_google_sheets">Google Drive, Google Sheets</string>
+    <string name="selected_google_account_text">Google account</string>
+    <!-- To use Google Drive, forms must set a submission URL. If they don't, this URL will be used. -->
+    <string name="google_sheets_url">Fallback submission URL</string>
+    <!-- Description for Fallback submission URL setting -->
+    <string name="google_sheets_url_hint">Forms must set a submission URL. If they don\'t, this URL will be used.</string>
+
+    <string name="app_theme">Theme</string>
+    <string name="theme_light">Light theme</string>
+    <string name="theme_dark">Dark theme</string>
+    <string name="theme_magenta">Magenta theme</string>
+
+    <string name="language">Language</string>
+    <string name="use_device_language">Use device language</string>
+
+    <string name="font_size">Text font size</string>
+    <string name="change_font_size">Text font size</string>
+    <string name="font_size_extra_large">Extra Large</string>
+    <string name="font_size_large">Large</string>
+    <string name="font_size_medium">Medium</string>
+    <string name="font_size_small">Small</string>
+    <string name="font_size_extra_small">Extra Small</string>
+
+    <string name="navigation">Navigation</string>
+    <string name="swipe_navigation">Use horizontal swipes</string>
+    <string name="buttons_navigation">Use forward/backward buttons</string>
+    <string name="swipe_buttons_navigation">Use swipes and buttons</string>
+    <!-- Text for navigation button showed at the bottom of a form that's being filled. Try to use a short word common for navigation. -->
+    <string name="form_forward">Next</string>
+    <!-- Text for navigation button showed at the bottom of a form that's being filled. Try to use a short word common for navigation. -->
+    <string name="form_backward">Back</string>
+
+    <string name="show_splash_title">Splash screen</string>
+    <string name="show_splash_summary">Shows when application starts</string>
+    <string name="splash_path">Selected splash image</string>
+    <string name="default_splash_path">ODK Default</string>
+    <string name="select_another_image">Select another image</string>
+    <string name="use_odk_default">Use default image</string>
+    <string name="change_splash_path">Change image</string>
+
+    <!-- Heading for the settings category about updating blank forms -->
+    <string name="form_update_category">Form update</string>
+    <!-- Name of the setting that defines how blank forms are updated from the server. -->
+    <string name="form_update_mode_title">Blank form update mode</string>
+    <!-- One of the possible settings values for "Blank form update mode". Manual update mode means forms have to be explicitly downloaded from Get Blank Forms. -->
+    <string name="manual">Manual</string>
+    <!-- One of the possible settings values for "Blank form update mode". "Previously downloaded" update mode means forms that have been manually downloaded will be kept up to date. -->
+    <string name="previously_downloaded_only">Previously downloaded forms only</string>
+    <!-- One of the possible settings values for "Blank form update mode". "Exactly match server" update mode means that new forms or form updates on the server will be downloaded and forms that the server doesn't know about will be removed. -->
+    <string name="match_exactly">Exactly match server</string>
+
+    <!-- Name of the setting that defines how often blank forms are updated from the server. -->
+    <string name="form_update_frequency_title">Automatic update frequency</string>
+    <string name="periodic_form_updates_check_title">Periodic form updates check</string>
+    <!-- Frequency for requesting blank form updates from the server -->
+    <string name="every_fifteen_minutes">Every fifteen minutes</string>
+    <!-- Frequency for requesting blank form updates from the server -->
+    <string name="every_one_hour">Every hour</string>
+    <!-- Frequency for requesting blank form updates from the server -->
+    <string name="every_six_hours">Every six hours</string>
+    <!-- Frequency for requesting blank form updates from the server -->
+    <string name="every_24_hours">Every 24 hours</string>
+    <!-- Name of setting that defines whether form updates should be automatically downloaded when in "previously downloaded forms only" download mode -->
+    <string name="automatic_download">Automatic download</string>
+    <string name="automatic_download_summary">Automatically download updated versions of forms</string>
+    <string name="hide_old_form_versions_setting_title">Hide old form versions</string>
+    <string name="hide_old_form_versions_setting_summary">Only the newest version will appear in Fill Blank Form</string>
+
+    <string name="form_submission_category">Form submission</string>
+    <string name="autosend_selector_title">Auto send</string>
+    <string name="autosend">Auto send</string>
+    <string name="off">Off</string>
+    <string name="wifi_autosend">Wifi only</string>
+    <string name="cellular_autosend">Cellular only</string>
+    <string name="wifi_cellular_autosend">Wifi or cellular</string>
+
+    <string name="delete_after_send">Delete after send</string>
+    <string name="delete_after_send_summary">Deletes finalized forms and media after sending to server</string>
+
+    <string name="form_filling_category">Form filling</string>
+
+    <string name="default_completed">Default to finalized</string>
+    <string name="default_completed_summary">Mark form as finalized by default</string>
+
+    <string name="constraint_behavior_title">Constraint processing</string>
+    <string name="constraint_behavior">Constraint processing behavior</string>
+    <string name="constraint_behavior_on_swipe">Validate upon forward swipe</string>
+    <string name="constraint_behavior_on_finalize">Defer validation until finalized</string>
+
+    <string name="high_resolution_title">High res video</string>
+    <string name="high_resolution_summary">Enable high-resolution video recordings</string>
+
+    <string name="image_size_title">Image size</string>
+    <string name="image_size_dialog_title">Maximum pixels of the long edge of the image</string>
+    <string name="image_size_large">Large (3072px)</string>
+    <string name="image_size_medium">Medium (2048px)</string>
+    <string name="image_size_small">Small (1024px)</string>
+    <string name="image_size_very_small">Very small (640px)</string>
+    <string name="image_size_original">Original size from camera (default)</string>
+
+    <!-- Name of setting for enabling guidance hints while filling forms. Guidance hints are meant for training or other specialized contexts. -->
+    <string name="guidance_hint_title">Show guidance for questions</string>
+    <string name="guidance_no">No</string>
+    <string name="guidance_yes">Yes - always shown</string>
+    <!-- Guidance hints can be displayed behind an icon that must be tapped to reveal the hint. -->
+    <string name="guidance_yes_collapsed">Yes - collapsed</string>
+
+    <!-- Title for setting to let the user switch between using Collect or another app (on the device) for recording audio -->
+    <string name="external_app_recording">Use external app for audio recording</string>
+
+    <string name="form_import_category">Form import</string>
+    <string name="instance_sync">Finalize forms on import</string>
+    <string name="instance_sync_summary">Affects forms added directly to instances folder.</string>
+
     <string name="analytics_preferences">Usage data</string>
     <string name="analytics">Collect anonymous usage data</string>
     <string name="analytics_summary">Anonymous usage data helps the ODK team prioritize fixes and features</string>
+
+    <string name="form_metadata_title">Form Metadata</string>
+    <string name="form_metadata">Form metadata</string>
+    <string name="form_metadata_summary">These values will be added to forms that have username, email and/or telephone preloaded fields to identify the person submitting data.</string>
+    <string name="user_defined">User-defined</string>
+    <string name="phone_number">Phone number</string>
+    <string name="email">Email address</string>
+    <string name="invalid_email_address">Invalid email address!</string>
+    <string name="device_defined">Device-defined</string>
+    <string name="device_id">Device ID</string>
+    <!-- Displayed when a device property such as the phone number is not available -->
+    <string name="preference_not_available">Not available</string>
+
+    <!--
+     ##############################################
+     # ADMIN SETTINGS
+     ##############################################
+     -->
+    <string name="admin_preferences">Admin Settings</string>
+    <string name="admin_access_settings">Tap for admin access to settings</string>
+    <string name="enter_new_password">Enter new password</string>
+    <string name="admin_password">Admin Password</string>
+    <string name="admin_password_changed">Admin password successfully changed</string>
+    <string name="admin_password_disabled">Admin password disabled</string>
+    <string name="admin_password_incorrect">Sorry, password is incorrect!</string>
+    <string name="enter_admin_password">Enter Admin Password</string>
+    <string name="change_admin_password">Change Admin Password</string>
+    <string name="show_password">Show password</string>
+    <string name="found_in_main">Uncheck to hide from Main Menu</string>
+    <string name="found_in_settings">Uncheck to hide from General Settings</string>
+    <string name="form_entry">Uncheck to hide from Form Entry</string>
+
+    <string name="app_configuration">App Configuration</string>
+    <string name="reset_settings_dialog">Reset application…</string>
     <string name="select_all">Select All</string>
     <string name="clear_all">Clear All</string>
     <string name="reset_settings">All settings (internal settings, saved settings)</string>
@@ -430,7 +795,6 @@
     <string name="reset_cache">Form load cache (.cache folder)</string>
     <string name="reset_osm_tiles">OSM tile cache (osmdroid folder)</string>
     <string name="reset_settings_dialog_title">Select what to reset</string>
-    <string name="reset_settings_dialog">Reset application…</string>
     <string name="reset_settings_button_reset">Reset</string>
     <string name="reset_in_progress">Resetting…</string>
     <string name="reset_app_state_result">Reset results</string>
@@ -441,35 +805,81 @@
     <string name="reset_layers_result">Map layers :: %s</string>
     <string name="reset_cache_result">Form load cache :: %s</string>
     <string name="reset_osm_tiles_result">OSM tile cache :: %s</string>
-    <string name="encrypted_form">Encrypted form</string>
-    <string name="deleted_form">Deleted form</string>
-    <string name="exit">Exit</string>
-    <string name="instance_scan_completed">Finished scanning.</string>
-    <string name="instance_scan_count">%1$d forms added.</string>
-    <string name="instance_sync">Finalize forms on import</string>
-    <string name="instance_sync_summary">Affects forms added directly to instances folder.</string>
-    <string name="sort_by_name_asc">Name, A-Z</string>
-    <string name="sort_by_name_desc">Name, Z-A</string>
-    <string name="sort_by_date_asc">Date, newest first</string>
-    <string name="sort_by_date_desc">Date, oldest first</string>
-    <string name="sort_by_status_asc">Status, finalized first</string>
-    <string name="sort_by_status_desc">Status, unfinalized first</string>
-    <string name="sort_the_list">Sort the list</string>
-    <string name="filter_the_list">Filter the list</string>
-    <string name="language">Language</string>
+
+    <string name="user_access_control">User Access Control</string>
+    <string name="main_menu_settings">Main Menu Settings</string>
+    <string name="main_menu_settings_summary">Tap to manage main menu items</string>
+    <string name="user_settings">User Settings</string>
+    <string name="user_setting_summary">Tap to manage general settings items</string>
+    <string name="form_entry_setting">Form Entry Settings</string>
+    <string name="form_entry_settings_summary">Tap to manage form entry items</string>
+
+    <!-- Name of a setting that determines whether users can navigate backwards in a form -->
+    <string name="moving_backwards_title">Moving backwards</string>
+    <string name="moving_backwards_disabled_title">Moving backwards disabled</string>
+    <string name="moving_backwards_disabled_message">Configure the device to prevent users from bypassing this setting?\n\nThe changes are:\n\u2022 Disable Edit Saved Form\n\u2022 Disable Save Form\n\u2022 Disable Go To Prompt\n\u2022 Set Constraint processing to Validate upon forward swipe</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    <string name="moving_backwards_enabled_title">Moving backwards enabled</string>
+    <string name="moving_backwards_enabled_message">You may wish to review the following settings:\n\n\u2022 Edit Saved Form\n\u2022 Save Form\n\u2022 Go To Prompt\n\u2022 Constraint processing</string>
+
+    <string name="server">Server</string>
+
+    <!-- Admin setting. When enabled, users are allowed to save forms while filling them. When disabled, users are only allowed to save forms when they reach their end -->
+    <string name="save_mid">Save Form</string>
+
+    <!--
+     ##############################################
+     # GOOGLE DRIVE, GOOGLE SHEETS
+     ##############################################
+     -->
+    <!-- Title of the screen that lists forms in user's Google Drive -->
+    <string name="go_drive">My Drive</string>
+    <!-- Title of the screen that lists forms shared with Google Drive user -->
+    <string name="go_shared">Shared with Me</string>
+    <!-- Button for navigating across Google Drive folders -->
+    <string name="download_selected">Download Selected</string>
+    <string name="go_back">Go back</string>
     <string name="google_auth_io_exception_msg">Unable to make API calls. If you are running a local build, please review the project readme.</string>
-    <string name="form_metadata_title">Form Metadata</string>
-    <string name="form_metadata">Form metadata</string>
-    <string name="form_metadata_summary">These values will be added to forms that have username, email and/or telephone preloaded fields to identify the person submitting data.</string>
-    <string name="phone_number">Phone number</string>
-    <string name="email">Email address</string>
-    <string name="user_defined">User-defined</string>
-    <string name="device_defined">Device-defined</string>
-    <string name="device_id">Device ID</string>
-    <string name="select_date">Select date</string>
-    <string name="select_time">Select time</string>
-    <string name="no_date_selected">No date selected</string>
-    <string name="no_time_selected">No time selected</string>
+    <string name="reading_files">Reading files</string>
+    <string name="drive_get_file">Getting %1$s and media files.</string>
+    <string name="no_google_account">No Google Account Selected!</string>
+    <string name="google_set_account">You have selected Google Sheets as your server, please select a corresponding Google account in the General Settings before continuing</string>
+    <string name="google_search_browse">Search for forms. Or select \'My Drive\' below to browse.</string>
+    <string name="invalid_sheet_id">invalid sheet id: %1$s</string>
+    <string name="missing_submission_url">Missing submission URL</string>
+    <string name="google_sheets_access_denied">Access denied. Please make sure the spreadsheet owner has granted you edit permission.</string>
+    <string name="google_sheets_missing_columns">Spreadsheet is missing the following columns: %1$s</string>
+    <string name="google_sheets_encrypted_message">Encrypted forms can\'t be submitted to Google Sheets.</string>
+    <string name="missing_google_account_dialog_desc">To submit forms via Google Sheets you have to set up your Google account in the Server settings.</string>
+    <!-- Text shown in dialog when a Google Sheets form upload was canceled before completion -->
+    <string name="instance_upload_cancelled">Instance upload canceled</string>
+    <string name="no_columns_to_upload">No columns found in the form to upload.</string>
+    <string name="missing_google_account_dialog_title">Google account not set</string>
+    <string name="multiple_media_folders_detected_notification">More than one media folder detected, please remove one and try again</string>
+
+    <!--
+     ##############################################
+     # ABOUT
+     ##############################################
+     -->
+    <string name="about_preferences">About</string>
+    <string name="tell_your_friends">Share ODK Collect</string>
+    <string name="tell_your_friends_msg">Are your colleagues still collecting data on paper? Share ODK Collect with them.</string>
+    <string name="leave_a_review">Leave a Play Store review</string>
+    <string name="leave_a_review_msg">Your (hopefully positive) review increases the visibility of the App in the Play Store.</string>
+    <string name="odk_website">Visit the ODK website</string>
+    <string name="odk_website_summary">ODK is used to collect data for social good in challenging environments.</string>
+    <string name="odk_forum">Join the ODK forum</string>
+    <string name="odk_forum_summary">Join the forum to get support, request features, contribute code/translations! </string>
+    <string name="all_open_source_licenses">Open source libraries/licenses</string>
+    <string name="all_open_source_licenses_msg">We stand on the shoulders of giants!</string>
+
+    <!--
+     ##############################################
+     # SETTINGS IMPORT
+     ##############################################
+     -->
     <string name="configure_via_qr_code">Configure via QR code</string>
     <string name="qr_code">QR code configuration</string>
     <string name="scan_qr_code_fragment_title">Scan</string>
@@ -484,192 +894,22 @@
     <string name="qrcode_without_passwords">QR code does not contain <b>admin</b> or <b>server</b> passwords. Tap to configure</string>
     <string name="qrcode_with_admin_password">Contains sensitive information: <b>admin</b> password</string>
     <string name="qrcode_with_server_password">Contains sensitive information: <b>server</b> password</string>
-    <string name="barcode_scanner_prompt">Place the barcode inside the rectangle</string>
     <string name="server_password">Server Password</string>
     <string name="include_password_dialog">Passwords Included in Code</string>
     <string name="generate">Generate</string>
     <string name="invalid_qrcode">QR code does not contain valid settings</string>
-    <string name="take_picture_instruction">Tap the screen to take a picture</string>
-    <string name="error_front_camera_unavailable">Front camera not available on this device</string>
-    <string name="camera_error">This device doesn\'t support the Camera2 API.</string>
-    <string name="invalid_range_widget">This widget has invalid parameters!</string>
-    <string name="form_entry_setting">Form Entry Settings</string>
-    <string name="form_entry_settings_summary">Tap to manage form entry items</string>
-    <string name="user_settings">User Settings</string>
-    <string name="user_setting_summary">Tap to manage general settings items</string>
-    <string name="main_menu_settings">Main Menu Settings</string>
-    <string name="main_menu_settings_summary">Tap to manage main menu items</string>
-    <string name="app_configuration">App Configuration</string>
-    <string name="user_access_control">User Access Control</string>
-    <string name="autosend_selector_title">Auto send</string>
-    <string name="off">Off</string>
-    <string name="guidance_no">No</string>
-    <string name="guidance_yes">Yes - always shown</string>
-    <string name="guidance_yes_collapsed">Yes - collapsed</string>
-    <string name="wifi_autosend">Wifi only</string>
-    <string name="cellular_autosend">Cellular only</string>
-    <string name="wifi_cellular_autosend">Wifi or cellular</string>
-    <string name="form_management_preferences">Form management</string>
-    <string name="form_submission_category">Form submission</string>
-    <string name="form_filling_category">Form filling</string>
-    <string name="high_resolution_title">High res video</string>
-    <string name="image_size_title">Image size</string>
-    <string name="form_import_category">Form import</string>
-    <string name="user_and_device_identity_title">User and device identity</string>
-    <string name="constraint_behavior_title">Constraint processing</string>
-    <string name="show_splash_title">Splash screen</string>
-    <string name="server_settings_title">Server</string>
-    <string name="type">Type</string>
-    <string name="form_entry">Uncheck to hide from Form Entry</string>
-    <string name="use_device_language">Use device language</string>
-    <string name="invalid_email_address">Invalid email address!</string>
-    <string name="sort_by">Sort by</string>
-    <string name="server">Server</string>
-    <!--
-        <string name="submission_transport_admin_setting">Submission transport</string>
-    -->
-    <string name="select_value">Select value</string>
-    <string name="edit_value">Edit value</string>
-    <string name="no_value_selected">No value selected</string>
-    <string name="form_delete_message">Deleting selected forms</string>
-    <string name="deleting_form_dialog_update_message">Deleting form: %1$d out of %2$d </string>
-    <string name="search">Search</string>
-    <string name="null_intent_value">The external application did not provide expected information.</string>
-    <string name="image_size_large">Large (3072px)</string>
-    <string name="image_size_medium">Medium (2048px)</string>
-    <string name="image_size_small">Small (1024px)</string>
-    <string name="image_size_very_small">Very small (640px)</string>
-    <string name="image_size_original">Original size from camera (default)</string>
-    <string name="image_size_dialog_title">Maximum pixels of the long edge of the image</string>
-    <string name="bearing_lack_of_sensors">Bearing cannot be collected: device is missing accelerometer, magnetic field sensor or both.</string>
-    <string name="ethiopian_month_1">Meskerem</string>
-    <string name="ethiopian_month_2">Tikimt</string>
-    <string name="ethiopian_month_3">Hidar</string>
-    <string name="ethiopian_month_4">Tahsas</string>
-    <string name="ethiopian_month_5">Tir</string>
-    <string name="ethiopian_month_6">Yekatit</string>
-    <string name="ethiopian_month_7">Megabit</string>
-    <string name="ethiopian_month_8">Miazia</string>
-    <string name="ethiopian_month_9">Ginbot</string>
-    <string name="ethiopian_month_10">Senie</string>
-    <string name="ethiopian_month_11">Hamlie</string>
-    <string name="ethiopian_month_12">Nehasie</string>
-    <string name="ethiopian_month_13">Pagumien</string>
-    <!-- Displays dates in specialized calendars with the Gregorian dates in parentheses. This is translated so right-to-left languages can specify the correct order -->
-    <string name="custom_date">%1$s (%2$s)</string>
-    <string name="coptic_month_1">Thout</string>
-    <string name="coptic_month_2">Paopi</string>
-    <string name="coptic_month_3">Hathor</string>
-    <string name="coptic_month_4">Koiak</string>
-    <string name="coptic_month_5">Tobi</string>
-    <string name="coptic_month_6">Meshir</string>
-    <string name="coptic_month_7">Paremhat</string>
-    <string name="coptic_month_8">Parmouti</string>
-    <string name="coptic_month_9">Pashons</string>
-    <string name="coptic_month_10">Paoni</string>
-    <string name="coptic_month_11">Epip</string>
-    <string name="coptic_month_12">Mesori</string>
-    <string name="coptic_month_13">Pi Kogi Enavot</string>
-    <string name="multiple_media_folders_detected_notification">More than one media folder detected, please remove one and try again</string>
-    <string name="islamic_month_1">Muharram</string>
-    <string name="islamic_month_2">Safar</string>
-    <string name="islamic_month_3">Rabi\' al-awwal</string>
-    <string name="islamic_month_4">Rabi\' al-thani</string>
-    <string name="islamic_month_5">Jumada al-awwal</string>
-    <string name="islamic_month_6">Jumada al-thani</string>
-    <string name="islamic_month_7">Rajab</string>
-    <string name="islamic_month_8">Sha\'ban</string>
-    <string name="islamic_month_9">Ramadan</string>
-    <string name="islamic_month_10">Shawwal</string>
-    <string name="islamic_month_11">Dhu al-Qidah</string>
-    <string name="islamic_month_12">Dhu al-Hijjah</string>
-    <string name="persian_month_1">Farvardin</string>
-    <string name="persian_month_2">Ordibehesht</string>
-    <string name="persian_month_3">Khordad</string>
-    <string name="persian_month_4">Tir</string>
-    <string name="persian_month_5">Mordad</string>
-    <string name="persian_month_6">Shahrivar</string>
-    <string name="persian_month_7">Mehr</string>
-    <string name="persian_month_8">Aban</string>
-    <string name="persian_month_9">Azar</string>
-    <string name="persian_month_10">Dey</string>
-    <string name="persian_month_11">Bahman</string>
-    <string name="persian_month_12">Esfand</string>
-    <string name="moving_backwards_title">Moving backwards</string>
-    <string name="moving_backwards_disabled_title">Moving backwards disabled</string>
-    <string name="moving_backwards_disabled_message">Configure the device to prevent users from bypassing this setting?\n\nThe changes are:\n\u2022 Disable Edit Saved Form\n\u2022 Disable Save Form\n\u2022 Disable Go To Prompt\n\u2022 Set Constraint processing to Validate upon forward swipe</string>
-    <string name="moving_backwards_enabled_title">Moving backwards enabled</string>
-    <string name="moving_backwards_enabled_message">You may wish to review the following settings:\n\n\u2022 Edit Saved Form\n\u2022 Save Form\n\u2022 Go To Prompt\n\u2022 Constraint processing</string>
-    <string name="yes">Yes</string>
-    <string name="no">No</string>
-    <string name="newer_version_of_a_form_info">This is an update to a form you have</string>
-    <string name="svg_file_does_not_exist">SVG file does not exist!</string>
-    <string name="start_video_capture_instruction">Tap the screen to start recording</string>
-    <string name="stop_video_capture_instruction">Recording started. Tap again to stop</string>
-    <string name="no_columns_to_upload">No columns found in the form to upload.</string>
-    <string name="storage_runtime_permission_denied_title">Storage permissions</string>
-    <string name="storage_runtime_permission_denied_desc">Without these permissions Collect can\'t access your forms or save answers. Reopen the app when you are ready to grant them.</string>
-    <string name="location_runtime_permissions_denied_title">Location permissions</string>
-    <string name="location_runtime_permissions_denied_desc">Without these permissions Collect can\'t record your location. Please try again when you are ready to grant them.</string>
-    <string name="camera_runtime_permission_denied_title">Camera permission</string>
-    <string name="camera_runtime_permission_denied_desc">Without this permission Collect can\'t access the camera. Please try again when you are ready to grant it.</string>
-    <string name="record_audio_runtime_permission_denied_title">Record audio permission</string>
-    <string name="record_audio_runtime_permission_denied_desc">Without this permission Collect can\'t access the microphone. Please try again when you are ready to grant it.</string>
-    <string name="get_accounts_runtime_permission_denied_title">Get accounts permission</string>
-    <string name="get_accounts_runtime_permission_denied_desc">Without this permission Collect can\'t access accounts. Please try again when you are ready to grant it.</string>
-    <string name="read_phone_state_runtime_permission_denied_title">Read phone state permission</string>
-    <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect does not make calls but it needs to access certain properties about your device such as the phone number and device ID.</string>
-    <string name="form_update_category">Form update</string>
-    <string name="periodic_form_updates_check_title">Periodic form updates check</string>
-    <string name="every_fifteen_minutes">Every fifteen minutes</string>
-    <string name="every_one_hour">Every hour</string>
-    <string name="every_six_hours">Every six hours</string>
-    <string name="every_24_hours">Every 24 hours</string>
-    <string name="form_updates_available">Form updates available</string>
-    <string name="automatic_download">Automatic download</string>
-    <string name="automatic_download_summary">Automatically download updated versions of forms</string>
-    <string name="guidance_hint_title">Show guidance for questions</string>
-    <string name="app_theme">Theme</string>
-    <string name="theme_light">Light theme</string>
-    <string name="theme_dark">Dark theme</string>
-    <string name="theme_magenta">Magenta theme</string>
-    <string name="cannot_create_directory">Cannot create directory: %s</string>
-    <string name="not_a_directory">%s exists, but is not a directory</string>
-    <string name="location_metadata">Satellites available: %1$d/24\n\nTime elapsed: %2$s</string>
-    <string name="instance_upload_cancelled">Instance upload canceled</string>
-    <string name="hide_old_form_versions_setting_title">Hide old form versions</string>
-    <string name="hide_old_form_versions_setting_summary">Only the newest version will appear in Fill Blank Form</string>
-    <string name="rank_items">Rank items</string>
-    <string name="loading_form_failed">An error occurred while loading the form. Please try again.</string>
-    <string name="missing_google_account_dialog_title">Google account not set</string>
-    <string name="missing_google_account_dialog_desc">To submit forms via Google Sheets you have to set up your Google account in the Server settings.</string>
-    <string name="notification_channel_name">General notifications</string>
-    <string name="corrupt_imported_preferences_error">Current settings are corrupt. From the admin settings, reset settings or import working ones.</string>
-    <string name="google_play_services_not_available">This form wants to track your location but Google Play Services are not available.</string>
-    <string name="location_providers_disabled_dialog_message">This form wants to track your location but location providers are disabled. Please enable in Android settings.</string>
-    <string name="go_to_settings">Go to settings</string>
-    <string name="track_location">Track location</string>
-    <string name="background_location_disabled">This form wants to track your location but tracking is disabled. Please enable in the %1$s menu above.</string>
-    <string name="background_location_enabled">This form tracks your location. You can disable tracking in the %1$s menu above.</string>
-    <string name="open_file">Open file</string>
-    <string name="google_sheets_encrypted_message">Encrypted forms can\'t be submitted to Google Sheets.</string>
-    <string name="number_picker_title">Number Picker</string>
-    <string name="too_complex_form">This form is too complex for this device. Try simplifying expressions or ask for help on the forum.</string>
-    <string name="reading_files">Reading files</string>
     <string name="qr_code_not_found">QR Code not found in the selected image</string>
-    <string name="not_granted_permission">The activity you are trying to start requires a permission which is not granted.</string>
-    <string name="basemap_source_unavailable">Sorry, %s basemaps are not available on this device.  Please choose another basemap in General Settings &gt; Maps.</string>
-    <string name="enter_identity">Enter identity</string>
-    <string name="identity">Identity</string>
-    <string name="enter_identity_description">This form requires you to identify yourself</string>
-    <string name="close">Close</string>
-    <string name="reason_for_changes">Reason for changes</string>
-    <string name="reason">Reason</string>
-    <string name="save">Save</string>
+    <string name="corrupt_imported_preferences_error">Current settings are corrupt. From the admin settings, reset settings or import working ones.</string>
     <string name="save_legacy_settings">Save legacy .settings file to disk</string>
     <string name="save_legacy_settings_warning">Will be removed in a future version. Please use the QR code above.</string>
-    <string name="reason_for_changes_description">You need to explain the reason for changes to this form</string>
+    <string name="settings_successfully_loaded_file_notification">Settings were successfully imported from a .settings file. This functionality will be removed in a future version. Please use QR code configuration instead.</string>
+    <string name="corrupt_settings_file_notification">Sorry, settings file is corrupt and should be deleted or replaced</string>
 
+    <!--
+     ##############################################
+     # SCOPED STORAGE MIGRATION
+     ##############################################
+     -->
     <string name="scoped_storage_banner_text">You must migrate Collect forms to private storage to comply with Android requirements. An automatic migration attempt failed. Please migrate manually.</string>
     <string name="scoped_storage_learn_more">Learn more and migrate</string>
     <string name="storage_migration_completed">Storage migration completed!</string>
@@ -679,6 +919,7 @@
     <string name="storage_migration_dialog_message3">If you use an external application integration such as OpenMapKit, please do not migrate yet.</string>
     <string name="storage_migration_more_details">More details</string>
     <string name="try_again">Try again</string>
+    <!-- Action to begin a storage migration -->
     <string name="migrate">Migrate</string>
     <string name="error">Error:</string>
     <string name="storage_migration_not_enough_space">You do not have enough space on your internal storage to migrate your data. Please free up some space and try again.</string>
@@ -687,40 +928,38 @@
     <string name="storage_migration_dialog_title">Storage migration</string>
     <string name="storage_migration_progress_msg">Migration in progress.\nThis may take a few seconds…</string>
 
-    <string name="preference_not_available">Not available</string>
-    <string name="custom_server_paths">Custom server paths</string>
-    <string name="legacy_custom_server_paths_summary">Will be removed in a future version. Please use /formList and /submission on your server.</string>
-    <string name="experimental">Experimental</string>
-    <string name="match_exactly">Exactly match server</string>
-    <string name="manual">Manual</string>
-    <string name="form_update_mode_title">Blank form update mode</string>
-    <string name="previously_downloaded_only">Previously downloaded forms only</string>
-    <string name="form_update_frequency_title">Automatic update frequency</string>
-    <string name="form_update_error">Form update failed</string>
-    <string name="report_to_project_lead">If you keep having this problem, report it to the person who asked you to collect data.</string>
-    <string name="unreachable_error">Collect can\'t reach the server at %s. Did you enter the URL correctly?</string>
-    <string name="security_error">Collect can\'t connect securely to the server at %s. Did you enter the URL correctly?</string>
-    <string name="failure">Failure</string>
-    <string name="form_update_succeeded">Form update succeeded</string>
+    <!--
+     ##############################################
+     # MISC
+     ##############################################
+     -->
+    <string name="ok">OK</string>
+    <!-- Used in many dialogs to dismiss the dialog without taking any action -->
+    <string name="cancel">Cancel</string>
 
-    <!-- Title for setting to let the user switch between using Collect or another app (on the device) for recording audio -->
-    <string name="external_app_recording">Use external app for audio recording</string>
+    <string name="cancel_loading_form">Cancel</string>
+    <string name="cancel_location">Cancel</string>
+    <string name="do_not_change">Cancel</string>
+    <string name="do_not_exit">Cancel</string>
+    <string name="canceling">Canceling</string>
 
-    <!-- Text for button that stops audio recording  -->
-    <string name="stop_recording">Stop</string>
+    <string name="notification_channel_name">General notifications</string>
 
-    <!-- Text to let the user know a recording is in progress  -->
-    <string name="recording">Recording…</string>
+    <string name="success">Success</string>
+    <string name="failures">Failures</string>
+    <string name="error_occured">Error Occurred</string>
 
-    <!-- Title of Android Notification Channel for audio recording notifications  -->
-    <string name="recording_channel">Audio recording</string>
+    <string name="please_wait">Please wait a few moments.</string>
+    <string name="please_wait_long">Please wait. This could take a few minutes.</string>
 
-    <!-- Text for button that plays audio clip  -->
-    <string name="play_audio">Play audio</string>
+    <string name="sdcard_unmounted">Collect cannot access the SD card. Perhaps it is mounted via USB? (Current state: %s)</string>
+    <string name="fs_delete_media_path_if_file_error">Could not delete \'%s\'. Please delete the file manually and re-download the form.</string>
+    <string name="fs_create_media_folder_error">Could not create media folder \'%s\'.</string>
+    <string name="fs_file_copy_error">Could not copy \'%1$s\' over \'%2$s\'. Reason: %3$s</string>
+    <string name="survey_multiple_forms_error">You have downloaded two different forms with the same form ID and version. Maybe they were the same form uploaded at different times or to different servers. In any case, you should delete one.</string>
 
-    <!-- Text to let the user know a file is being saved  -->
-    <string name="saving_file">Saving file</string>
+    <string name="cannot_create_directory">Cannot create directory: %s</string>
+    <string name="not_a_directory">%s exists, but is not a directory</string>
 
-    <!-- Text in dialog that instructs the user to stop recording audio before leaving the form -->
-    <string name="recording_warning">You must stop recording before leaving this screen.</string>
+    <string name="select_odk_shortcut">Select ODK Shortcut</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -688,7 +688,6 @@
 
     <!-- Name of the setting that defines how often blank forms are updated from the server. -->
     <string name="form_update_frequency_title">Automatic update frequency</string>
-    <string name="periodic_form_updates_check_title">Periodic form updates check</string>
     <!-- Frequency for requesting blank form updates from the server -->
     <string name="every_fifteen_minutes">Every fifteen minutes</string>
     <!-- Frequency for requesting blank form updates from the server -->


### PR DESCRIPTION
Closes #4072

@seadowg @grzesiek2010 I found when translating Central that it can really help translators to have related strings grouped together. I also think we've had a hard time verifying that language is consistent and that there are no duplicates because this file has been so disorganized. 

I have loosely organized strings based on the UI but I wasn't religious about it. For certain things like geo features or the new audio work @seadowg has been working on I left strings grouped by feature. I think that as long as we have some organization that lets us relatively quickly find related strings it doesn't have to be perfect.

Sections are preceded by a comment block like this:
```
    <!--
     ##############################################
     # SECTION NAME
     ##############################################
     -->
```
I did it this way so it would stand out visually and would be easy to search. For example searching for "# FILL" gets you right to the "Fill Blank Form" section.

The sections are:
- Fill blank form
- Form features
- Geo
- Send finalized form
- Get blank form
- Delete saved form
- General settings
- Admin settings
- Google Drive, Google Sheets
- About
- Settings import
- Scoped Storage Migration
- Misc

I also introduced line breaks between subgroups of related strings.

There were lots of changes I was tempted to make as I worked through this but I held back to hopefully make this not too controversial. I'll come back at the beginning of the next release cycle with some proposed wording changes.

#### What has been done to verify that this works as intended?
Ran lint to make sure the expected number of translations are there. Ran on a real device to spot check the string consolidation done in later commits.

#### Why is this the best possible solution? Were any other approaches considered?
I considered just adding the comments the forum poster had requested and moving on but this file has caused me enough pain that I wanted to take the time to clean it up some.

I considered splitting the initial commit up but I decided it wasn't very important because if any strings had gone missing the code wouldn't compile. It's going to be nearly impossible to verify the `strings.xml` diff but I think that's ok.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The biggest risk I can think of is that I somehow accidentally deleted or broke some of the text. I think anything like that with common strings would be caught in the regression pass. I'm not sure we need to QA this.

If someone has an actively-maintained fork in which some text is modified, this will be annoying. But it's easier to deal with than many of the recent refactors. Additionally, no maintainers of forks have been active members of the community recently. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
I don't think it really needs an explicit mention in developer docs but let me know if you'd prefer it.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)