### PR TITLE
Add pause/unpause to recording

### DIFF
--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
@@ -10,9 +10,9 @@ import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import org.odk.collect.async.CoroutineScheduler
 import org.odk.collect.async.Scheduler
-import org.odk.collect.audiorecorder.recorder.MediaRecorderRecorder
-import org.odk.collect.audiorecorder.recorder.RealMediaRecorderWrapper
 import org.odk.collect.audiorecorder.recorder.Recorder
+import org.odk.collect.audiorecorder.recorder.RecordingResourceRecorder
+import org.odk.collect.audiorecorder.recorder.resources.MediaRecorderRecordingResource
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModelFactory
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService
 import org.odk.collect.audiorecorder.recording.internal.RecordingRepository
@@ -65,7 +65,7 @@ internal open class AudioRecorderDependencyModule {
 
     @Provides
     open fun providesRecorder(application: Application): Recorder {
-        return MediaRecorderRecorder(application.cacheDir) { RealMediaRecorderWrapper(MediaRecorder()) }
+        return RecordingResourceRecorder(application.cacheDir) { MediaRecorderRecordingResource(MediaRecorder()) }
     }
 
     @Provides

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
@@ -10,9 +10,9 @@ import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import org.odk.collect.async.CoroutineScheduler
 import org.odk.collect.async.Scheduler
+import org.odk.collect.audiorecorder.mediarecorder.MediaRecorderRecordingResource
 import org.odk.collect.audiorecorder.recorder.Recorder
 import org.odk.collect.audiorecorder.recorder.RecordingResourceRecorder
-import org.odk.collect.audiorecorder.mediarecorder.MediaRecorderRecordingResource
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModelFactory
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService
 import org.odk.collect.audiorecorder.recording.internal.RecordingRepository

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
@@ -12,7 +12,7 @@ import org.odk.collect.async.CoroutineScheduler
 import org.odk.collect.async.Scheduler
 import org.odk.collect.audiorecorder.recorder.Recorder
 import org.odk.collect.audiorecorder.recorder.RecordingResourceRecorder
-import org.odk.collect.audiorecorder.recorder.resources.MediaRecorderRecordingResource
+import org.odk.collect.audiorecorder.mediarecorder.MediaRecorderRecordingResource
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModelFactory
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService
 import org.odk.collect.audiorecorder.recording.internal.RecordingRepository

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/mediarecorder/MediaRecorderRecordingResource.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/mediarecorder/MediaRecorderRecordingResource.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.audiorecorder.recorder.resources
+package org.odk.collect.audiorecorder.mediarecorder
 
 import android.media.MediaRecorder
 import org.odk.collect.audiorecorder.recorder.RecordingResource

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/Recorder.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/Recorder.kt
@@ -4,6 +4,8 @@ import java.io.File
 
 internal interface Recorder {
     fun start(output: Output)
+    fun pause()
+    fun resume()
     fun stop(): File
     fun cancel()
 

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/RecordingResource.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/RecordingResource.kt
@@ -1,0 +1,22 @@
+package org.odk.collect.audiorecorder.recorder
+
+/**
+ * Allows faking/stubbing/mocking with our interactions with Android's MediaRecorder. Could also
+ * wrap multiple implementations in the future.
+ */
+
+internal interface RecordingResource {
+    fun setAudioSource(audioSource: Int)
+    fun setOutputFormat(outputFormat: Int)
+    fun setOutputFile(path: String)
+    fun setAudioEncoder(audioEncoder: Int)
+    fun setAudioEncodingSampleRate(sampleRate: Int)
+    fun setAudioEncodingBitRate(bitRate: Int)
+    fun prepare()
+    fun start()
+    fun pause()
+    fun resume()
+    fun stop()
+    fun release()
+    fun getMaxAmplitude(): Int
+}

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/RecordingResourceRecorder.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/RecordingResourceRecorder.kt
@@ -3,13 +3,16 @@ package org.odk.collect.audiorecorder.recorder
 import android.media.MediaRecorder
 import java.io.File
 
-internal class MediaRecorderRecorder(private val cacheDir: File, private val mediaRecorderFactory: () -> MediaRecorderWrapper) : Recorder {
+internal class RecordingResourceRecorder(private val cacheDir: File, private val recordingResourceFactory: () -> RecordingResource) : Recorder {
 
-    private var mediaRecorder: MediaRecorderWrapper? = null
+    override val amplitude: Int
+        get() = recordingResource?.getMaxAmplitude() ?: 0
+
+    private var recordingResource: RecordingResource? = null
     private var file: File? = null
 
     override fun start(output: Output) {
-        mediaRecorder = mediaRecorderFactory().also {
+        recordingResource = recordingResourceFactory().also {
             it.setAudioSource(MediaRecorder.AudioSource.MIC)
 
             when (output) {
@@ -41,6 +44,14 @@ internal class MediaRecorderRecorder(private val cacheDir: File, private val med
         }
     }
 
+    override fun pause() {
+        recordingResource?.pause()
+    }
+
+    override fun resume() {
+        recordingResource?.resume()
+    }
+
     override fun stop(): File {
         stopAndReleaseMediaRecorder()
         return file!!
@@ -51,19 +62,16 @@ internal class MediaRecorderRecorder(private val cacheDir: File, private val med
         file?.delete()
     }
 
-    override val amplitude: Int
-        get() = mediaRecorder?.getMaxAmplitude() ?: 0
-
     override fun isRecording(): Boolean {
-        return mediaRecorder != null
+        return recordingResource != null
     }
 
     private fun stopAndReleaseMediaRecorder() {
-        mediaRecorder?.apply {
+        recordingResource?.apply {
             stop()
             release()
         }
 
-        mediaRecorder = null
+        recordingResource = null
     }
 }

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/resources/MediaRecorderRecordingResource.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recorder/resources/MediaRecorderRecordingResource.kt
@@ -1,27 +1,9 @@
-package org.odk.collect.audiorecorder.recorder
+package org.odk.collect.audiorecorder.recorder.resources
 
 import android.media.MediaRecorder
+import org.odk.collect.audiorecorder.recorder.RecordingResource
 
-/**
- * Allows faking/stubbing/mocking with our interactions with Android's MediaRecorder. Could also
- * wrap multiple implementations in the future.
- */
-
-internal interface MediaRecorderWrapper {
-    fun setAudioSource(audioSource: Int)
-    fun setOutputFormat(outputFormat: Int)
-    fun setOutputFile(path: String)
-    fun setAudioEncoder(audioEncoder: Int)
-    fun setAudioEncodingSampleRate(sampleRate: Int)
-    fun setAudioEncodingBitRate(bitRate: Int)
-    fun prepare()
-    fun start()
-    fun stop()
-    fun release()
-    fun getMaxAmplitude(): Int
-}
-
-class RealMediaRecorderWrapper(private val mediaRecorder: MediaRecorder) : MediaRecorderWrapper {
+internal class MediaRecorderRecordingResource(private val mediaRecorder: MediaRecorder) : RecordingResource {
 
     override fun setAudioSource(audioSource: Int) {
         mediaRecorder.setAudioSource(audioSource)
@@ -53,6 +35,18 @@ class RealMediaRecorderWrapper(private val mediaRecorder: MediaRecorder) : Media
 
     override fun start() {
         mediaRecorder.start()
+    }
+
+    override fun pause() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            mediaRecorder.pause()
+        }
+    }
+
+    override fun resume() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            mediaRecorder.resume()
+        }
     }
 
     override fun stop() {

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModel.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModel.kt
@@ -14,6 +14,8 @@ abstract class AudioRecorderViewModel : ViewModel() {
     abstract fun getCurrentSession(): LiveData<RecordingSession?>
 
     abstract fun start(sessionId: String, output: Output)
+    abstract fun pause()
+    abstract fun resume()
     abstract fun stop()
 
     /**
@@ -23,4 +25,4 @@ abstract class AudioRecorderViewModel : ViewModel() {
     abstract fun cleanUp()
 }
 
-data class RecordingSession(val id: String, val file: File?, val duration: Long, val amplitude: Int)
+data class RecordingSession(val id: String, val file: File?, val duration: Long, val amplitude: Int, val paused: Boolean = false)

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModel.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModel.kt
@@ -25,4 +25,4 @@ abstract class AudioRecorderViewModel : ViewModel() {
     abstract fun cleanUp()
 }
 
-data class RecordingSession(val id: String, val file: File?, val duration: Long, val amplitude: Int, val paused: Boolean = false)
+data class RecordingSession(val id: String, val file: File?, val duration: Long, val amplitude: Int, val paused: Boolean)

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -39,20 +39,18 @@ class AudioRecorderService : Service() {
                 val output = intent.getSerializableExtra(EXTRA_OUTPUT) as Output
 
                 if (!recorder.isRecording() && sessionId != null) {
-                    notification.show()
-
-                    recordingRepository.start(sessionId)
-                    recorder.start(output)
-                    durationUpdates = scheduler.repeat(
-                        {
-                            recordingRepository.setDuration(duration)
-                            duration += 1000
-                        },
-                        1000L
-                    )
-
-                    amplitudeUpdates = scheduler.repeat({ recordingRepository.setAmplitude(recorder.amplitude) }, 100L)
+                    startRecording(sessionId, output)
                 }
+            }
+
+            ACTION_PAUSE -> {
+                recorder.pause()
+                recordingRepository.setPaused(true)
+            }
+
+            ACTION_RESUME -> {
+                recorder.resume()
+                recordingRepository.setPaused(false)
             }
 
             ACTION_STOP -> {
@@ -65,6 +63,22 @@ class AudioRecorderService : Service() {
         }
 
         return START_STICKY
+    }
+
+    private fun startRecording(sessionId: String, output: Output) {
+        notification.show()
+
+        recordingRepository.start(sessionId)
+        recorder.start(output)
+        durationUpdates = scheduler.repeat(
+            {
+                recordingRepository.setDuration(duration)
+                duration += 1000
+            },
+            1000L
+        )
+
+        amplitudeUpdates = scheduler.repeat({ recordingRepository.setAmplitude(recorder.amplitude) }, 100L)
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
@@ -96,6 +110,8 @@ class AudioRecorderService : Service() {
 
     companion object {
         const val ACTION_START = "START"
+        const val ACTION_PAUSE = "PAUSE"
+        const val ACTION_RESUME = "RESUME"
         const val ACTION_STOP = "STOP"
         const val ACTION_CLEAN_UP = "CLEAN_UP"
 

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ForegroundServiceAudioRecorderViewModel.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ForegroundServiceAudioRecorderViewModel.kt
@@ -33,6 +33,14 @@ internal class ForegroundServiceAudioRecorderViewModel internal constructor(priv
         )
     }
 
+    override fun pause() {
+        TODO("Not yet implemented")
+    }
+
+    override fun resume() {
+        TODO("Not yet implemented")
+    }
+
     override fun stop() {
         application.startService(
             Intent(application, AudioRecorderService::class.java).apply { action = ACTION_STOP }

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ForegroundServiceAudioRecorderViewModel.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/ForegroundServiceAudioRecorderViewModel.kt
@@ -7,6 +7,8 @@ import org.odk.collect.audiorecorder.recorder.Output
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModel
 import org.odk.collect.audiorecorder.recording.RecordingSession
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService.Companion.ACTION_CLEAN_UP
+import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService.Companion.ACTION_PAUSE
+import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService.Companion.ACTION_RESUME
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService.Companion.ACTION_START
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService.Companion.ACTION_STOP
 import org.odk.collect.audiorecorder.recording.internal.AudioRecorderService.Companion.EXTRA_OUTPUT
@@ -34,11 +36,15 @@ internal class ForegroundServiceAudioRecorderViewModel internal constructor(priv
     }
 
     override fun pause() {
-        TODO("Not yet implemented")
+        application.startService(
+            Intent(application, AudioRecorderService::class.java).apply { action = ACTION_PAUSE }
+        )
     }
 
     override fun resume() {
-        TODO("Not yet implemented")
+        application.startService(
+            Intent(application, AudioRecorderService::class.java).apply { action = ACTION_RESUME }
+        )
     }
 
     override fun stop() {

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/RecordingRepository.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/RecordingRepository.kt
@@ -26,9 +26,15 @@ class RecordingRepository {
         }
     }
 
+    fun setPaused(paused: Boolean) {
+        _currentSession.value?.let {
+            _currentSession.value = it.copy(paused = paused)
+        }
+    }
+
     fun recordingReady(recording: File) {
         _currentSession.value?.let {
-            _currentSession.value = it.copy(file = recording)
+            _currentSession.value = it.copy(file = recording, paused = false)
         }
     }
 

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/RecordingRepository.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/RecordingRepository.kt
@@ -11,7 +11,7 @@ class RecordingRepository {
     val currentSession: LiveData<RecordingSession?> = _currentSession
 
     fun start(sessionId: String) {
-        _currentSession.value = RecordingSession(sessionId, null, 0, 0)
+        _currentSession.value = RecordingSession(sessionId, null, 0, 0, false)
     }
 
     fun setDuration(duration: Long) {

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/testsupport/StubAudioRecorderViewModel.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/testsupport/StubAudioRecorderViewModel.kt
@@ -31,7 +31,7 @@ class StubAudioRecorderViewModel(private val stubRecordingPath: String) : AudioR
         wasCleanedUp = false
         lastSession = sessionId
         isRecording = true
-        currentSession.value = RecordingSession(sessionId, null, 0, 0)
+        currentSession.value = RecordingSession(sessionId, null, 0, 0, false)
     }
 
     override fun pause() {

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/testsupport/StubAudioRecorderViewModel.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/testsupport/StubAudioRecorderViewModel.kt
@@ -34,6 +34,18 @@ class StubAudioRecorderViewModel(private val stubRecordingPath: String) : AudioR
         currentSession.value = RecordingSession(sessionId, null, 0, 0)
     }
 
+    override fun pause() {
+        currentSession.value?.let {
+            currentSession.value = it.copy(paused = true)
+        }
+    }
+
+    override fun resume() {
+        currentSession.value?.let {
+            currentSession.value = it.copy(paused = false)
+        }
+    }
+
     override fun stop() {
         isRecording = false
 
@@ -41,7 +53,7 @@ class StubAudioRecorderViewModel(private val stubRecordingPath: String) : AudioR
         File(stubRecordingPath).copyTo(newFile, overwrite = true)
         newFile.deleteOnExit()
         currentSession.value?.let {
-            currentSession.value = it.copy(file = newFile)
+            currentSession.value = it.copy(file = newFile, paused = false)
         }
 
         lastRecording = newFile
@@ -49,6 +61,7 @@ class StubAudioRecorderViewModel(private val stubRecordingPath: String) : AudioR
 
     override fun cleanUp() {
         isRecording = false
+
         currentSession.value = null
         wasCleanedUp = true
     }

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModelTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModelTest.kt
@@ -71,7 +71,7 @@ abstract class AudioRecorderViewModelTest {
     }
 
     @Test
-    fun getCurrentSession_afterStop_isRecordedFile() {
+    fun getCurrentSession_afterStop_hasRecordedFile() {
         val recording = liveDataTester.activate(viewModel.getCurrentSession())
         viewModel.start("session1", Output.AAC)
         viewModel.stop()
@@ -88,5 +88,60 @@ abstract class AudioRecorderViewModelTest {
 
         runBackground()
         assertThat(recording.value, equalTo(null))
+    }
+
+    @Test
+    fun getCurrentSession_whenRecording_isNotPaused() {
+        val session = liveDataTester.activate(viewModel.getCurrentSession())
+        viewModel.start("session", Output.AAC)
+
+        runBackground()
+        assertThat(session.value?.paused, equalTo(false))
+    }
+
+    @Test
+    fun getCurrentSession_afterStop_isNotPaused() {
+        val session = liveDataTester.activate(viewModel.getCurrentSession())
+
+        viewModel.start("session", Output.AAC)
+        viewModel.stop()
+
+        runBackground()
+        assertThat(session.value?.paused, equalTo(false))
+    }
+
+    @Test
+    fun getCurrentSession_afterPause_isPaused() {
+        val session = liveDataTester.activate(viewModel.getCurrentSession())
+
+        viewModel.start("session", Output.AAC)
+        viewModel.pause()
+
+        runBackground()
+        assertThat(session.value?.paused, equalTo(true))
+    }
+
+    @Test
+    fun getCurrentSession_afterPauseAndResume_isNotPaused() {
+        val session = liveDataTester.activate(viewModel.getCurrentSession())
+
+        viewModel.start("session", Output.AAC)
+        viewModel.pause()
+        viewModel.resume()
+
+        runBackground()
+        assertThat(session.value?.paused, equalTo(false))
+    }
+
+    @Test
+    fun getCurrentSession_afterPauseAndStop_isNotPaused() {
+        val session = liveDataTester.activate(viewModel.getCurrentSession())
+
+        viewModel.start("session", Output.AAC)
+        viewModel.pause()
+        viewModel.stop()
+
+        runBackground()
+        assertThat(session.value?.paused, equalTo(false))
     }
 }

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModelTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/AudioRecorderViewModelTest.kt
@@ -67,7 +67,7 @@ abstract class AudioRecorderViewModelTest {
         viewModel.start("session1", Output.AAC)
 
         runBackground()
-        assertThat(recording.value, equalTo(RecordingSession("session1", null, 0, 0)))
+        assertThat(recording.value, equalTo(RecordingSession("session1", null, 0, 0, false)))
     }
 
     @Test
@@ -77,7 +77,7 @@ abstract class AudioRecorderViewModelTest {
         viewModel.stop()
 
         runBackground()
-        assertThat(recording.value, equalTo(RecordingSession("session1", getLastRecordedFile(), 0, 0)))
+        assertThat(recording.value, equalTo(RecordingSession("session1", getLastRecordedFile(), 0, 0, false)))
     }
 
     @Test

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
@@ -196,6 +196,32 @@ class AudioRecorderServiceTest {
         assertThat(shadowOf(service.get()).isStoppedBySelf, equalTo(true))
     }
 
+    @Test
+    fun pauseAction_pausesRecorder() {
+        startService(createStartIntent("123"))
+
+        val pauseIntent = Intent(application, AudioRecorderService::class.java)
+        pauseIntent.action = AudioRecorderService.ACTION_PAUSE
+        startService(pauseIntent)
+
+        assertThat(recorder.paused, equalTo(true))
+    }
+
+    @Test
+    fun pauseAction_andThenResumeAction_resumesRecorder() {
+        startService(createStartIntent("123"))
+
+        val pauseIntent = Intent(application, AudioRecorderService::class.java)
+        pauseIntent.action = AudioRecorderService.ACTION_PAUSE
+        startService(pauseIntent)
+
+        val resumeIntent = Intent(application, AudioRecorderService::class.java)
+        resumeIntent.action = AudioRecorderService.ACTION_RESUME
+        startService(resumeIntent)
+
+        assertThat(recorder.paused, equalTo(false))
+    }
+
     private fun createStartIntent(sessionId: String): Intent {
         val intent = Intent(application, AudioRecorderService::class.java)
         intent.action = AudioRecorderService.ACTION_START

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
@@ -208,6 +208,17 @@ class AudioRecorderServiceTest {
     }
 
     @Test
+    fun pauseAction_stopsUpdates() {
+        startService(createStartIntent("123"))
+
+        val pauseIntent = Intent(application, AudioRecorderService::class.java)
+        pauseIntent.action = AudioRecorderService.ACTION_PAUSE
+        startService(pauseIntent)
+
+        assertThat(scheduler.isRepeatRunning(), equalTo(false))
+    }
+
+    @Test
     fun pauseAction_andThenResumeAction_resumesRecorder() {
         startService(createStartIntent("123"))
 
@@ -220,6 +231,21 @@ class AudioRecorderServiceTest {
         startService(resumeIntent)
 
         assertThat(recorder.paused, equalTo(false))
+    }
+
+    @Test
+    fun pauseAction_andThenResumeAction_startsUpdates() {
+        startService(createStartIntent("123"))
+
+        val pauseIntent = Intent(application, AudioRecorderService::class.java)
+        pauseIntent.action = AudioRecorderService.ACTION_PAUSE
+        startService(pauseIntent)
+
+        val resumeIntent = Intent(application, AudioRecorderService::class.java)
+        resumeIntent.action = AudioRecorderService.ACTION_RESUME
+        startService(resumeIntent)
+
+        assertThat(scheduler.isRepeatRunning(), equalTo(true))
     }
 
     private fun createStartIntent(sessionId: String): Intent {

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/support/FakeRecorder.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/support/FakeRecorder.kt
@@ -7,6 +7,13 @@ import java.io.File
 class FakeRecorder : Recorder {
 
     override var amplitude: Int = 0
+
+    private var _paused = false
+    val paused: Boolean
+        get() {
+            return _paused
+        }
+
     var file: File? = null
     lateinit var output: Output
 
@@ -29,6 +36,14 @@ class FakeRecorder : Recorder {
         cancelled = false
         this.output = output
         _recordings.add(Unit)
+    }
+
+    override fun pause() {
+        _paused = true
+    }
+
+    override fun resume() {
+        _paused = false
     }
 
     override fun stop(): File {

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
@@ -60,6 +60,11 @@ public class AudioRecordingControllerFragment extends Fragment {
                     binding.pauseRecording.setText(R.string.pause_recording);
                     binding.pauseRecording.setOnClickListener(v -> viewModel.pause());
                 }
+
+                // Pause not available before API 24
+                if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
+                    binding.pauseRecording.setVisibility(GONE);
+                }
             } else {
                 binding.getRoot().setVisibility(GONE);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
@@ -11,6 +11,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
+import org.odk.collect.android.R;
 import org.odk.collect.android.databinding.AudioRecordingControllerFragmentBinding;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModel;
@@ -26,7 +27,7 @@ public class AudioRecordingControllerFragment extends Fragment {
     @Inject
     AudioRecorderViewModelFactory audioRecorderViewModelFactory;
 
-    private AudioRecordingControllerFragmentBinding binding;
+    public AudioRecordingControllerFragmentBinding binding;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -46,7 +47,24 @@ public class AudioRecordingControllerFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         final AudioRecorderViewModel viewModel = new ViewModelProvider(requireActivity(), audioRecorderViewModelFactory).get(AudioRecorderViewModel.class);
 
-        viewModel.getCurrentSession().observe(getViewLifecycleOwner(), session -> binding.getRoot().setVisibility(session != null && session.getFile() == null ? VISIBLE : GONE));
+        viewModel.getCurrentSession().observe(getViewLifecycleOwner(), session -> {
+            if (session == null) {
+                binding.getRoot().setVisibility(GONE);
+            } else if (session.getFile() == null) {
+                binding.getRoot().setVisibility(VISIBLE);
+
+                if (session.getPaused()) {
+                    binding.pauseRecording.setText(R.string.resume_recording);
+                    binding.pauseRecording.setOnClickListener(v -> viewModel.resume());
+                } else {
+                    binding.pauseRecording.setText(R.string.pause_recording);
+                    binding.pauseRecording.setOnClickListener(v -> viewModel.pause());
+                }
+            } else {
+                binding.getRoot().setVisibility(GONE);
+            }
+        });
+
         binding.stopRecording.setOnClickListener(v -> viewModel.stop());
     }
 }

--- a/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
+++ b/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
@@ -14,23 +14,40 @@
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
-        android:layout_toStartOf="@id/stop_recording"
+        android:layout_marginStart="10dp"
+        android:layout_toStartOf="@id/buttons"
         android:drawablePadding="@dimen/margin_small"
         android:text="@string/recording"
         android:textColor="?colorOnPrimary"
         app:drawableStartCompat="@drawable/ic_baseline_mic_24"
         app:drawableTint="?colorOnPrimary" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/stop_recording"
-        style="@style/Widget.MaterialComponents.Button"
+    <LinearLayout
+        android:id="@+id/buttons"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
-        android:layout_marginStart="@dimen/margin_standard"
-        android:backgroundTint="?colorSecondary"
-        android:text="@string/stop_recording"
-        android:textColor="?colorOnSecondary"
-        app:icon="@drawable/ic_stop_black_24dp" />
+        android:orientation="horizontal">
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/pause_recording"
+            style="@style/Widget.MaterialComponents.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_standard"
+            android:backgroundTint="?colorSecondary"
+            android:text="@string/resume_recording"
+            app:icon="@drawable/ic_pause_24dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/stop_recording"
+            style="@style/Widget.MaterialComponents.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_standard"
+            android:backgroundTint="?colorSecondary"
+            android:text="@string/stop_recording"
+            android:textColor="?colorOnSecondary"
+            app:icon="@drawable/ic_stop_black_24dp" />
+    </LinearLayout>
 </RelativeLayout>

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="pause_recording">Pause</string>
+    <string name="resume_recording">Resume</string>
+</resources>

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
@@ -11,7 +11,6 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.audio;
 
 import android.app.Application;
 import android.content.Context;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.testing.FragmentScenario;
@@ -10,6 +11,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
@@ -18,6 +20,7 @@ import org.odk.collect.android.support.RobolectricHelpers;
 import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModelFactory;
 import org.odk.collect.audiorecorder.testsupport.StubAudioRecorderViewModel;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.io.IOException;
@@ -99,4 +102,21 @@ public class AudioRecordingControllerFragmentTest {
         });
     }
 
+    @Test
+    @Config(sdk = 23)
+    public void whenSDKOlderThan24_hidesPauseButton() {
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.pauseRecording.getVisibility(), is(View.GONE));
+        });
+    }
+
+    @Test
+    @Config(sdk = 24)
+    public void whenSDK24OrNewer_showsPauseButton() {
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.pauseRecording.getVisibility(), is(View.VISIBLE));
+        });
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequesterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequesterTest.java
@@ -84,7 +84,7 @@ public class InternalRecordingRequesterTest {
         requester.onIsRecordingChanged(listener);
         verify(listener).accept(false);
 
-        liveData.setValue(new RecordingSession("blah", null, 0, 0));
+        liveData.setValue(new RecordingSession("blah", null, 0, 0, false));
         verify(listener).accept(true);
     }
 
@@ -100,7 +100,7 @@ public class InternalRecordingRequesterTest {
 
         Consumer<String> listener = mock(Consumer.class);
         requester.onRecordingAvailable(prompt, listener);
-        sessionLiveData.setValue(new RecordingSession(prompt.getIndex().toString(), file, 0, 0));
+        sessionLiveData.setValue(new RecordingSession(prompt.getIndex().toString(), file, 0, 0, false));
         answerLiveData.setValue("copiedFile");
 
         verify(listener).accept("copiedFile");
@@ -117,7 +117,7 @@ public class InternalRecordingRequesterTest {
         requester.onRecordingAvailable(prompt, listener);
 
         File file = File.createTempFile("blah", ".mp3");
-        sessionLiveData.setValue(new RecordingSession("something else", file, 0, 0));
+        sessionLiveData.setValue(new RecordingSession("something else", file, 0, 0, false));
 
         verifyNoInteractions(listener);
         verifyNoInteractions(questionMediaManager);
@@ -132,7 +132,7 @@ public class InternalRecordingRequesterTest {
         Consumer<Pair<Long, Integer>> listener = mock(Consumer.class);
         requester.onRecordingInProgress(prompt, listener);
 
-        sessionLiveData.setValue(new RecordingSession(prompt.getIndex().toString(), null, 1200L, 25));
+        sessionLiveData.setValue(new RecordingSession(prompt.getIndex().toString(), null, 1200L, 25, false));
         verify(listener).accept(new Pair<>(1200L, 25));
     }
 
@@ -145,7 +145,7 @@ public class InternalRecordingRequesterTest {
         Consumer<Pair<Long, Integer>> listener = mock(Consumer.class);
         requester.onRecordingInProgress(prompt, listener);
 
-        sessionLiveData.setValue(new RecordingSession("something else", null, 1200L, 0));
+        sessionLiveData.setValue(new RecordingSession("something else", null, 1200L, 0, false));
         verifyNoInteractions(listener);
     }
 }


### PR DESCRIPTION
Closes #4234
~~Blocked by #4241~~

The interface isn't the greatest right now (switches between Pause/Resume with same icon) but will iterate on this when we do design polish.

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Just uses the Android `MediaRecorder` to pause so no big changes here. Annoyingly this doesn't work below API 24. Additional comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Definitely think we should leave QA on this until we have the "finished" (ready for release) feature set.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)