### PR TITLE
Fixed reading path from uri if _data column does not exist

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -59,6 +59,7 @@ import static org.odk.collect.android.utilities.FileUtils.deleteAndReport;
  * @author paulburke
  */
 public class MediaUtils {
+    private static Uri filePathUri;
 
     public void deleteMediaFile(String imageFile) {
         deleteAndReport(new File(imageFile));
@@ -106,6 +107,7 @@ public class MediaUtils {
      * @author paulburke
      */
     public String getPath(final Context context, final Uri uri) {
+        filePathUri = uri;
 
         // DocumentProvider
         if (DocumentsContract.isDocumentUri(context, uri)) {
@@ -319,6 +321,10 @@ public class MediaUtils {
                 final int column_index = cursor.getColumnIndexOrThrow(column);
                 return cursor.getString(column_index);
             }
+        } catch (IllegalArgumentException e) {
+            File file = new File(context.getCacheDir(), "tmp");
+            FileUtils.saveAnswerFileFromUri(filePathUri, file, context);
+            return file.getAbsolutePath();
         } finally {
             if (cursor != null) {
                 cursor.close();


### PR DESCRIPTION
Closes #4264

#### What has been done to verify that this works as intended?
I tested the fix hardcoding `thow new IllegalArgumentException()` and it worked well.

#### Why is this the best possible solution? Were any other approaches considered?
My solution is based on this answer https://gist.github.com/tatocaster/32aad15f6e0c50311626#gistcomment-2984840
and I reused the code I added in: https://github.com/getodk/collect/commit/ad1af29dd6cc6082fa22776512225defa2f66f8c#diff-1da6b8c0168e7752f609f209e9d0a7cf556eb7e402b7cc9fd9ee21cf1feedb6eR106

I wish such a solution worked for all cases but I'm too afraid to touch that code full of efferent cases for google drive, google photos etc.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing because we can't reproduce and the fix is safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)