### PR TITLE
Revert Google Services to pick up correct config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath 'com.google.gms:google-services:4.3.4'
+        // Do not upgrade until https://github.com/google/play-services-plugins/issues/163 is addressed
+        classpath 'com.google.gms:google-services:4.3.3'
         classpath 'org.jacoco:org.jacoco.core:0.8.6'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
         classpath 'com.google.firebase:perf-plugin:1.3.1'


### PR DESCRIPTION
@grzesiek2010 discovered analytics and crash reports for the v1.29 beta were being sent to the wrong Firebase project. This is a fix in preparation for a new beta tomorrow.

#### What has been done to verify that this works as intended?
Did a release build and verified I could see the version appear in the StreamView for our main project in Firebase.

#### Why is this the best possible solution? Were any other approaches considered?
I traced the problem back to https://github.com/google/play-services-plugins/issues/163. The [changelog for v4.3.4](https://firebase.google.com/support/release-notes/android#google-services_plugin_v4-3-4) suggests it doesn't give us anything we need so I think our best bet is to downgrade the library. I also considered moving the `google-services.json` files we use but I'd rather not do that since we'll likely have to undo it again in the future and that will give us more opportunities for mistakes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only change should be that information is sent to the correct Firebase project. I think the biggest source of risk is that it's not really clear to me what went into the v4.3.4 point release and maybe there's another fix that would be helpful to us or maybe it ensures compatibility with other libs we upgraded. However, 4.3.3 worked fine in prior Collect releases so I think that's minimal. Also, the worst that would happen is probably that (some) events wouldn't make it to the project.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)