### PR TITLE
Fixed creating multiple files for recording selfie videos

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -316,7 +316,7 @@ public class FieldListUpdateTest {
 
         // FormEntryActivity expects an image at a fixed path so copy the app logo there
         Bitmap icon = BitmapFactory.decodeResource(ApplicationProvider.getApplicationContext().getResources(), R.drawable.notes);
-        File tmpJpg = new File(new StoragePathProvider().getTmpFilePath());
+        File tmpJpg = new File(new StoragePathProvider().getTmpImageFilePath());
         tmpJpg.createNewFile();
         FileOutputStream fos = new FileOutputStream(tmpJpg);
         icon.compress(Bitmap.CompressFormat.JPEG, 90, fos);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -152,9 +152,9 @@ public class DrawActivity extends CollectAbstractActivity {
         if (extras == null) {
             loadOption = OPTION_DRAW;
             refImage = null;
-            savepointImage = new File(storagePathProvider.getTmpFilePath());
+            savepointImage = new File(storagePathProvider.getTmpImageFilePath());
             savepointImage.delete();
-            output = new File(storagePathProvider.getTmpFilePath());
+            output = new File(storagePathProvider.getTmpImageFilePath());
         } else {
             if (extras.getInt(SCREEN_ORIENTATION) == 1) {
                 setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
@@ -176,7 +176,7 @@ public class DrawActivity extends CollectAbstractActivity {
                     FileUtils.copyFile(refImage, savepointImage);
                 }
             } else {
-                savepointImage = new File(storagePathProvider.getTmpFilePath());
+                savepointImage = new File(storagePathProvider.getTmpImageFilePath());
                 savepointImage.delete();
                 if (refImage != null && refImage.exists()) {
                     FileUtils.copyFile(refImage, savepointImage);
@@ -186,7 +186,7 @@ public class DrawActivity extends CollectAbstractActivity {
             if (uri != null) {
                 output = new File(uri.getPath());
             } else {
-                output = new File(storagePathProvider.getTmpFilePath());
+                output = new File(storagePathProvider.getTmpImageFilePath());
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -152,7 +152,7 @@ public class DrawActivity extends CollectAbstractActivity {
         if (extras == null) {
             loadOption = OPTION_DRAW;
             refImage = null;
-            savepointImage = new File(storagePathProvider.getTmpDrawFilePath());
+            savepointImage = new File(storagePathProvider.getTmpFilePath());
             savepointImage.delete();
             output = new File(storagePathProvider.getTmpFilePath());
         } else {
@@ -176,7 +176,7 @@ public class DrawActivity extends CollectAbstractActivity {
                     FileUtils.copyFile(refImage, savepointImage);
                 }
             } else {
-                savepointImage = new File(storagePathProvider.getTmpDrawFilePath());
+                savepointImage = new File(storagePathProvider.getTmpFilePath());
                 savepointImage.delete();
                 if (refImage != null && refImage.exists()) {
                     FileUtils.copyFile(refImage, savepointImage);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -854,8 +854,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                  */
                 // The intent is empty, but we know we saved the image to the temp
                 // file
-                ImageConverter.execute(storagePathProvider.getTmpFilePath(), getWidgetWaitingForBinaryData(), this);
-                File fi = new File(storagePathProvider.getTmpFilePath());
+                ImageConverter.execute(storagePathProvider.getTmpImageFilePath(), getWidgetWaitingForBinaryData(), this);
+                File fi = new File(storagePathProvider.getTmpImageFilePath());
 
                 String instanceFolder = formController.getInstanceFile()
                         .getParent();

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2Fragment.java
@@ -856,7 +856,7 @@ public class Camera2Fragment extends Fragment
             byte[] bytes = new byte[buffer.remaining()];
             buffer.get(bytes);
 
-            CameraUtils.savePhoto(new StoragePathProvider().getTmpFilePath(), bytes);
+            CameraUtils.savePhoto(new StoragePathProvider().getTmpImageFilePath(), bytes);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -48,8 +48,8 @@ import android.view.ViewGroup;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.dialogs.ErrorDialog;
+import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.MultiClickGuard;
-import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
 import java.io.File;
@@ -500,7 +500,7 @@ public class Camera2VideoFragment extends Fragment
         mediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
         mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         if (nextVideoAbsolutePath == null || nextVideoAbsolutePath.isEmpty()) {
-            nextVideoAbsolutePath = CameraUtils.getVideoFilePath();
+            nextVideoAbsolutePath = new StoragePathProvider().getTmpVideoFilePath();
         }
         mediaRecorder.setOutputFile(nextVideoAbsolutePath);
         mediaRecorder.setVideoEncodingBitRate(10000000);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -500,7 +500,7 @@ public class Camera2VideoFragment extends Fragment
         mediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
         mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
         if (nextVideoAbsolutePath == null || nextVideoAbsolutePath.isEmpty()) {
-            nextVideoAbsolutePath = CameraUtils.getVideoFilePath(getActivity());
+            nextVideoAbsolutePath = CameraUtils.getVideoFilePath();
         }
         mediaRecorder.setOutputFile(nextVideoAbsolutePath);
         mediaRecorder.setVideoEncodingBitRate(10000000);

--- a/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.java
@@ -79,11 +79,11 @@ public class StoragePathProvider {
                 : getUnscopedStorageRootDirPath();
     }
 
-    public String getTmpFilePath() {
+    public String getTmpImageFilePath() {
         return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmp.jpg";
     }
 
-    public String getTmpVideoPath() {
+    public String getTmpVideoFilePath() {
         return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmp.mp4";
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.java
@@ -87,6 +87,10 @@ public class StoragePathProvider {
         return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmpDraw.jpg";
     }
 
+    public String getTmpVideoPath() {
+        return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmp.mp4";
+    }
+
     public String getInstanceDbPath(String filePath) {
         return getDbPath(getDirPath(StorageSubdirectory.INSTANCES), filePath);
     }

--- a/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.java
@@ -83,10 +83,6 @@ public class StoragePathProvider {
         return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmp.jpg";
     }
 
-    public String getTmpDrawFilePath() {
-        return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmpDraw.jpg";
-    }
-
     public String getTmpVideoPath() {
         return getDirPath(StorageSubdirectory.CACHE) + File.separator + "tmp.mp4";
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
@@ -77,6 +77,6 @@ public class CameraUtils {
     }
 
     public static String getVideoFilePath() {
-        return new StoragePathProvider().getTmpVideoPath();
+        return new StoragePathProvider().getTmpVideoFilePath();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
@@ -23,7 +23,6 @@ import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
 
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -74,9 +73,5 @@ public class CameraUtils {
         } catch (IOException e) {
             Timber.e(e);
         }
-    }
-
-    public static String getVideoFilePath() {
-        return new StoragePathProvider().getTmpVideoFilePath();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
@@ -25,6 +25,7 @@ import android.hardware.camera2.CameraManager;
 import android.view.Surface;
 
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -123,10 +124,8 @@ public class CameraUtils {
             Timber.e(e);
         }
     }
-  
-    public static String getVideoFilePath(Context context) {
-        final File dir = context.getExternalFilesDir(null);
-        return (dir == null ? "" : (dir.getAbsolutePath() + "/"))
-                + System.currentTimeMillis() + ".mp4";
+
+    public static String getVideoFilePath() {
+        return new StoragePathProvider().getTmpVideoPath();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CameraUtils.java
@@ -16,13 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-import android.app.Activity;
 import android.content.Context;
 import android.hardware.Camera;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
-import android.view.Surface;
 
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.storage.StoragePathProvider;
@@ -34,36 +32,6 @@ import java.io.IOException;
 import timber.log.Timber;
 
 public class CameraUtils {
-
-    public static Camera getCameraInstance(Activity activity, int cameraId) {
-        Camera camera = Camera.open(cameraId);
-        camera.setDisplayOrientation(90);
-
-        // Set the rotation of the camera which the output picture need.
-        Camera.Parameters parameters = camera.getParameters();
-        int rotation = getRotationInt(activity.getWindowManager().getDefaultDisplay().getRotation());
-        parameters.setRotation(calcCameraRotation(cameraId, rotation));
-        camera.setParameters(parameters);
-
-        return camera;
-    }
-
-    private static int getRotationInt(int rotation) {
-        switch (rotation) {
-            case Surface.ROTATION_0:
-                return 0;
-            case Surface.ROTATION_90:
-                return 90;
-            case Surface.ROTATION_180:
-                return 180;
-            case Surface.ROTATION_270:
-                return 270;
-            default:
-                Timber.e(new IllegalArgumentException(), "Invalid rotation");
-                return -1;
-        }
-    }
-
     public static int getFrontCameraId() {
         for (int camNo = 0; camNo < Camera.getNumberOfCameras(); camNo++) {
             Camera.CameraInfo camInfo = new Camera.CameraInfo();
@@ -96,23 +64,6 @@ public class CameraUtils {
             Timber.e(e);
         }
         return false; // No front-facing camera found
-    }
-
-    /**
-     * Calculates the front camera rotation
-     * <p>
-     * This calculation is applied to the output JPEG either via Exif Orientation tag
-     * or by actually transforming the bitmap. (Determined by vendor camera API implementation)
-     * <p>
-     * Note: This is not the same calculation as the display orientation
-     *
-     * @param screenOrientationDegrees Screen orientation in degrees
-     * @return Number of degrees to rotate image in order for it to view correctly.
-     */
-    public static int calcCameraRotation(int cameraId, int screenOrientationDegrees) {
-        Camera.CameraInfo camInfo = new Camera.CameraInfo();
-        Camera.getCameraInfo(cameraId, camInfo);
-        return (camInfo.orientation + screenOrientationDegrees) % 360;
     }
 
     public static void savePhoto(String path, byte[] data) {

--- a/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
@@ -60,7 +60,7 @@ public class DrawView extends View {
         bitmapPaint = new Paint(Paint.DITHER_FLAG);
         currentPath = new Path();
         offscreenPath = new Path();
-        backgroundBitmapFile = new File(new StoragePathProvider().getTmpFilePath());
+        backgroundBitmapFile = new File(new StoragePathProvider().getTmpImageFilePath());
 
         paint = new Paint();
         paint.setAntiAlias(true);

--- a/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/DrawView.java
@@ -60,7 +60,7 @@ public class DrawView extends View {
         bitmapPaint = new Paint(Paint.DITHER_FLAG);
         currentPath = new Path();
         offscreenPath = new Path();
-        backgroundBitmapFile = new File(new StoragePathProvider().getTmpDrawFilePath());
+        backgroundBitmapFile = new File(new StoragePathProvider().getTmpFilePath());
 
         paint = new Paint();
         paint.setAntiAlias(true);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -187,7 +187,7 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
         try {
             Uri uri = ContentUriProvider.getUriForFile(getContext(),
                     BuildConfig.APPLICATION_ID + ".provider",
-                    new File(new StoragePathProvider().getTmpFilePath()));
+                    new File(new StoragePathProvider().getTmpImageFilePath()));
             // if this gets modified, the onActivityResult in
             // FormEntyActivity will also need to be updated.
             intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -230,7 +230,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
             if (binaryName != null) {
                 i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(getFile()));
             }
-            i.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(new StoragePathProvider().getTmpFilePath())));
+            i.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(new StoragePathProvider().getTmpImageFilePath())));
             i = addExtrasToIntent(i);
             launchActivityForResult(i, requestCode, stringResourceId);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -174,7 +174,7 @@ public class ImageWidget extends BaseImageWidget implements ButtonClickListener 
             try {
                 Uri uri = ContentUriProvider.getUriForFile(getContext(),
                         BuildConfig.APPLICATION_ID + ".provider",
-                        new File(new StoragePathProvider().getTmpFilePath()));
+                        new File(new StoragePathProvider().getTmpImageFilePath()));
                 // if this gets modified, the onActivityResult in
                 // FormEntyActivity will also need to be updated.
                 intent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, uri);


### PR DESCRIPTION
Closes #4268 

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that we created a new tmp file for every recording https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-4268?expand=1#diff-f63fc4d1f7f735577c9fb1d0cb030deff5c0c4693005671cd7352cdf8a359a85L129 which we didn't remove. I decided to use the same solution we have for image files where we create a reusable tmp file in cache directory https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-4268?expand=1#diff-305ec7a913eed2277d0af06a536383d929631be636da49be48e21df4bfb625d4R87

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
With the fix the app should use a reusable tmp file for recording selfie videos instead of creating a new file in the app directory.
It's a safe and isolate change so we can test just the behavior described in the issue.

I also implemented code improvements touching the DrawWidget so please make sure answers are saved witout regression (no need to test changing colors or something just saving output images)

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with selfie video widget like the demo All widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)