### PR TITLE
Fixed: Collect crashes when user tries to download form via CollectTester if URL settings are not set

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/tasks/DownloadFormListTaskTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/tasks/DownloadFormListTaskTest.java
@@ -5,7 +5,10 @@ import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
 import org.odk.collect.android.tasks.DownloadFormListTask;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class DownloadFormListTaskTest {
@@ -17,7 +20,23 @@ public class DownloadFormListTaskTest {
 
         DownloadFormListTask task = new DownloadFormListTask(serverFormsDetailsFetcher);
         task.setAlternateCredentials(webCredentialsUtils, "https://test-server.com", "testUser", "testPassword");
-        verify(serverFormsDetailsFetcher).updateFormListApi("https://test-server.com", webCredentialsUtils);
+        verify(serverFormsDetailsFetcher).updateUrl("https://test-server.com");
+        verify(serverFormsDetailsFetcher).updateCredentials(webCredentialsUtils);
     }
 
+    @Test
+    public void whenAlternateCredentialsDoNotContainUrl_shouldNotUrlBeUpdated() {
+        ServerFormsDetailsFetcher serverFormsDetailsFetcher = mock(ServerFormsDetailsFetcher.class);
+        WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
+
+        DownloadFormListTask task = new DownloadFormListTask(serverFormsDetailsFetcher);
+
+        task.setAlternateCredentials(webCredentialsUtils, null, "testUser", "testPassword");
+        verify(serverFormsDetailsFetcher, never()).updateUrl(anyString());
+        verify(serverFormsDetailsFetcher).updateCredentials(webCredentialsUtils);
+
+        task.setAlternateCredentials(webCredentialsUtils, "", "testUser", "testPassword");
+        verify(serverFormsDetailsFetcher, never()).updateUrl(anyString());
+        verify(serverFormsDetailsFetcher, times(2)).updateCredentials(webCredentialsUtils);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -49,8 +49,11 @@ public class ServerFormsDetailsFetcher {
         this.diskFormsSynchronizer = diskFormsSynchronizer;
     }
 
-    public void updateFormListApi(String url, WebCredentialsUtils webCredentialsUtils) {
+    public void updateUrl(String url) {
         formSource.updateUrl(url);
+    }
+
+    public void updateCredentials(WebCredentialsUtils webCredentialsUtils) {
         formSource.updateWebCredentialsUtils(webCredentialsUtils);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormListTask.java
@@ -98,10 +98,15 @@ public class DownloadFormListTask extends AsyncTask<Void, String, Pair<List<Serv
 
     public void setAlternateCredentials(WebCredentialsUtils webCredentialsUtils, String url, String username, String password) {
         this.webCredentialsUtils = webCredentialsUtils;
+        serverFormsDetailsFetcher.updateCredentials(webCredentialsUtils);
+
         this.url = url;
+        if (url != null && !url.isEmpty()) {
+            serverFormsDetailsFetcher.updateUrl(url);
+        }
+
         this.username = username;
         this.password = password;
-        serverFormsDetailsFetcher.updateFormListApi(url, webCredentialsUtils);
     }
 
     private void setTemporaryCredentials() {


### PR DESCRIPTION
Closes #4253

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix, if we set alternate credentials which come from an external app we should not update url if it's not specified.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue and have no side effects so during testing we can focus on the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)