### PR TITLE
Track usage of legacy formList API

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/Analytics.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/Analytics.java
@@ -1,12 +1,15 @@
 package org.odk.collect.android.analytics;
 
 public interface Analytics {
-
+    @Deprecated
     void logEvent(String category, String action);
 
+    @Deprecated
     void logEvent(String category, String action, String label);
 
-    void logFormEvent(String event, String formId);
+    void logFormEvent(String event, String formIdHash);
+
+    void logServerEvent(String event, String serverHash);
 
     void setAnalyticsCollectionEnabled(boolean isAnalyticsEnabled);
 

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -148,4 +148,9 @@ public class AnalyticsEvents {
      * should be a hash of the endpoint setting.
      */
     public static final String CUSTOM_ENDPOINT_SUB = "CustomEndpointSub";
+
+    /**
+     * Track usage of legacy Aggregate < 1 form list API code paths.
+     */
+    public static final String LEGACY_FORM_LIST = "LegacyFormList";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/FirebaseAnalytics.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/FirebaseAnalytics.java
@@ -16,6 +16,7 @@ public class FirebaseAnalytics implements Analytics {
         setupRemoteAnalytics();
     }
 
+    @Deprecated
     @Override
     public void logEvent(String category, String action) {
         Bundle bundle = new Bundle();
@@ -23,6 +24,7 @@ public class FirebaseAnalytics implements Analytics {
         firebaseAnalytics.logEvent(category, bundle);
     }
 
+    @Deprecated
     @Override
     public void logEvent(String category, String action, String label) {
         Bundle bundle = new Bundle();
@@ -35,6 +37,13 @@ public class FirebaseAnalytics implements Analytics {
     public void logFormEvent(String event, String formId) {
         Bundle bundle = new Bundle();
         bundle.putString("form", formId);
+        firebaseAnalytics.logEvent(event, bundle);
+    }
+
+    @Override
+    public void logServerEvent(String event, String serverHash) {
+        Bundle bundle = new Bundle();
+        bundle.putString("server", serverHash);
         firebaseAnalytics.logEvent(event, bundle);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -388,12 +388,12 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormSource providesFormAPI(GeneralSharedPreferences generalSharedPreferences, Context context, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils) {
+    public FormSource providesFormAPI(GeneralSharedPreferences generalSharedPreferences, Context context, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils, Analytics analytics) {
         SharedPreferences generalPrefs = generalSharedPreferences.getSharedPreferences();
         String serverURL = generalPrefs.getString(GeneralKeys.KEY_SERVER_URL, context.getString(R.string.default_server_url));
         String formListPath = generalPrefs.getString(GeneralKeys.KEY_FORMLIST_URL, context.getString(R.string.default_odk_formlist));
 
-        return new OpenRosaFormSource(serverURL, formListPath, openRosaHttpInterface, webCredentialsUtils);
+        return new OpenRosaFormSource(serverURL, formListPath, openRosaHttpInterface, webCredentialsUtils, analytics);
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
@@ -1,11 +1,15 @@
 package org.odk.collect.android.openrosa.api;
 
 import org.junit.Test;
-import org.odk.collect.android.openrosa.OpenRosaFormSource;
-import org.odk.collect.android.utilities.WebCredentialsUtils;
-import org.odk.collect.android.openrosa.HttpGetResult;
-import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.forms.FormSourceException;
+import org.odk.collect.android.openrosa.HttpGetResult;
+import org.odk.collect.android.openrosa.OpenRosaFormSource;
+import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.odk.collect.android.utilities.WebCredentialsUtils;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -27,14 +31,17 @@ import static org.odk.collect.android.forms.FormSourceException.Type.FETCH_ERROR
 import static org.odk.collect.android.forms.FormSourceException.Type.SECURITY_ERROR;
 import static org.odk.collect.android.forms.FormSourceException.Type.UNREACHABLE;
 
+@RunWith(MockitoJUnitRunner.class)
 public class OpenRosaFormSourceTest {
+    @Mock
+    Analytics analytics;
 
     @Test
     public void fetchFormList_removesTrailingSlashesFromUrl() throws Exception {
         OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
         WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
 
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils, analytics);
 
         when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(new ByteArrayInputStream(RESPONSE.getBytes()), Collections.emptyMap(), "", 200));
         formListApi.fetchFormList();
@@ -47,7 +54,7 @@ public class OpenRosaFormSourceTest {
         OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
         WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
 
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(UnknownHostException.class);
@@ -64,7 +71,7 @@ public class OpenRosaFormSourceTest {
         OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
         WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
 
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(SSLException.class);
@@ -81,7 +88,7 @@ public class OpenRosaFormSourceTest {
         OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
         WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
 
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 404));
@@ -98,7 +105,7 @@ public class OpenRosaFormSourceTest {
         OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
         WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
 
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(UnknownHostException.class);
@@ -115,7 +122,7 @@ public class OpenRosaFormSourceTest {
         OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
         WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
 
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 500));


### PR DESCRIPTION
Closes #4189

#### What has been done to verify that this works as intended?
Visual code inspection only.

#### Why is this the best possible solution? Were any other approaches considered?
I decided to add a new server logging method to match the form one. This should help us keep logging consistent moving forward. I also deprecated the category/action/label methods so we don't accidentally use them.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No change in behavior desired. Should be very safe.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)