### PR TITLE
Make sure screen reloads when preferences are changed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -151,7 +151,6 @@ import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PermissionUtils;
 import org.odk.collect.android.utilities.PlayServicesChecker;
-import org.odk.collect.android.utilities.QuestionFontSizeUtils;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.SnackbarUtils;
 import org.odk.collect.android.utilities.SoftKeyboardUtils;
@@ -356,7 +355,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * detection of location permissions changes while the activity is in the background.
      */
     private boolean locationPermissionsPreviouslyGranted;
-    private int questionFontSize;
 
     private BackgroundLocationViewModel backgroundLocationViewModel;
     private IdentityPromptViewModel identityPromptViewModel;
@@ -412,8 +410,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             swipeHandler.setBeenSwiped(true);
             onSwipeBackward();
         });
-
-        questionFontSize = QuestionFontSizeUtils.getQuestionFontSize();
 
         if (savedInstanceState == null) {
             mediaLoadingFragment = new MediaLoadingFragment();
@@ -2025,13 +2021,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         nextButton.setVisibility(formController.getEvent() != FormEntryController.EVENT_END_OF_FORM ? View.VISIBLE : View.GONE);
     }
 
-    private void adjustFontSize() {
-        if (questionFontSize != QuestionFontSizeUtils.getQuestionFontSize()) {
-            questionFontSize = QuestionFontSizeUtils.getQuestionFontSize();
-            onScreenRefresh();
-        }
-    }
-
     @Override
     protected void onStart() {
         super.onStart();
@@ -2082,7 +2071,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             onResumeWasCalledWithoutPermissions = true;
             return;
         }
-        adjustFontSize();
 
         String navigation = (String) GeneralSharedPreferences.getInstance().get(GeneralKeys.KEY_NAVIGATION);
         showNavigationButtons = navigation.contains(GeneralKeys.NAVIGATION_BUTTONS);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -762,7 +762,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         // If we're coming back from the hierarchy view, the user has either tapped the back
         // button or another question to jump to so we need to rebuild the view.
-        if (requestCode == RequestCodes.HIERARCHY_ACTIVITY) {
+        if (requestCode == RequestCodes.HIERARCHY_ACTIVITY || requestCode == RequestCodes.CHANGE_SETTINGS) {
             onScreenRefresh();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -114,7 +114,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
                 DialogUtils.showIfNotShowing(RecordingWarningDialogFragment.class, activity.getSupportFragmentManager());
             } else {
                 Intent pref = new Intent(activity, PreferencesActivity.class);
-                activity.startActivity(pref);
+                activity.startActivityForResult(pref, ApplicationConstants.RequestCodes.CHANGE_SETTINGS);
             }
 
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -96,6 +96,7 @@ public class ApplicationConstants {
         public static final int GEOSHAPE_CAPTURE = 20;
         public static final int GEOTRACE_CAPTURE = 21;
         public static final int ARBITRARY_FILE_CHOOSER = 22;
+        public static final int CHANGE_SETTINGS = 23;
 
         public static final int FORMS_UPLOADED_NOTIFICATION = 97;
         public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.formentry.backgroundlocation.BackgroundLocationVi
 import org.odk.collect.android.formentry.questions.AnswersProvider;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.preferences.PreferencesActivity;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.audiorecorder.recording.AudioRecorderViewModel;
 import org.robolectric.Robolectric;
@@ -142,6 +143,19 @@ public class FormEntryMenuDelegateTest {
     }
 
     @Test
+    public void onItemSelected_whenPreferences_startsPreferencesActivityWithChangeSettingsRequest() {
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_preferences));
+        ShadowActivity.IntentForResult nextStartedActivity = shadowOf(activity).getNextStartedActivityForResult();
+        assertThat(nextStartedActivity, not(nullValue()));
+        assertThat(nextStartedActivity.intent.getComponent().getClassName(), is(PreferencesActivity.class.getName()));
+        assertThat(nextStartedActivity.requestCode, is(ApplicationConstants.RequestCodes.CHANGE_SETTINGS));
+    }
+
+    @Test
     public void onItemSelected_whenPreferences_whenRecording_showsWarning() {
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
@@ -150,7 +164,7 @@ public class FormEntryMenuDelegateTest {
         when(audioRecorderViewModel.isRecording()).thenReturn(true);
 
         formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_preferences));
-        assertThat(shadowOf(activity).getNextStartedActivity(), is(nullValue()));
+        assertThat(shadowOf(activity).getNextStartedActivityForResult(), is(nullValue()));
 
         RecordingWarningDialogFragment dialog = getFragmentByClass(activity.getSupportFragmentManager(), RecordingWarningDialogFragment.class);
         assertThat(dialog, is(notNullValue()));


### PR DESCRIPTION
Closes #4212 

#### What has been done to verify that this works as intended?

New test and verified manually. There is one piece of tested code - comments inline.

#### Why is this the best possible solution? Were any other approaches considered?

I think it made sense to handle this generally rather than worrying about it for any new feature in form entry that can be configured.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The form "screen" will now reload whenever the user navigates to settings and back. It'd be good to check this doesn't create any problems (answers not retained for instance) and that there aren't any significant performance problems introduced.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)