### PR TITLE
Use actual project ids from Firebase

### DIFF
--- a/collect_app/google-services.json
+++ b/collect_app/google-services.json
@@ -1,9 +1,9 @@
 {
   "project_info": {
     "project_number": "640412404956",
-    "firebase_url": "https://getodk-forks.firebaseio.com",
-    "project_id": "getodk-forks",
-    "storage_bucket": "getodk-forks.appspot.com"
+    "firebase_url": "https://opendatakit-forks.firebaseio.com",
+    "project_id": "opendatakit-forks",
+    "storage_bucket": "opendatakit-forks.appspot.com"
   },
   "client": [
     {

--- a/collect_app/src/debug/google-services.json
+++ b/collect_app/src/debug/google-services.json
@@ -1,9 +1,9 @@
 {
   "project_info": {
     "project_number": "462257085307",
-    "firebase_url": "https://getodk-debug.firebaseio.com",
-    "project_id": "getodk-debug",
-    "storage_bucket": "getodk-debug.appspot.com"
+    "firebase_url": "https://opendatakit-debug.firebaseio.com",
+    "project_id": "opendatakit-debug",
+    "storage_bucket": "opendatakit-debug.appspot.com"
   },
   "client": [
     {


### PR DESCRIPTION
Firebase has been sending emails about project ids not matching their end.

#### What has been done to verify that this works as intended?
I downloaded the `google-services.json` files from Firebase. I don't think there's really anything to do to verify this as everything has been working correctly, we're just getting angry emails.

#### Why is this the best possible solution? Were any other approaches considered?
No alternatives.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should not have any impact. Worst case would be if the files are wrong in some way analytics for forks and debug builds would be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)