### PR TITLE
Downgrade mapbox-android-plugin-annotation

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -252,7 +252,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-crashlytics:17.2.2'
 
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.1'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.9.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 
     implementation("com.google.guava:guava:29.0-android")
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -252,6 +252,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-crashlytics:17.2.2'
 
     implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.1'
+
+    // Upgrading will require more changes in our codebase https://github.com/getodk/collect/issues/4305
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
 
     implementation("com.google.guava:guava:29.0-android")

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapFragment.java
@@ -783,11 +783,10 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
         }
 
         class ClickListener implements OnSymbolClickListener {
-            @Override public boolean onAnnotationClick(Symbol clickedSymbol) {
+            @Override public void onAnnotationClick(Symbol clickedSymbol) {
                 if (clickedSymbol.getId() == symbol.getId() && featureClickListener != null) {
                     featureClickListener.onFeature(featureId);
                 }
-                return true;
             }
         }
 
@@ -902,23 +901,21 @@ public class MapboxMapFragment extends org.odk.collect.android.geo.mapboxsdk.Map
         }
 
         class SymbolClickListener implements OnSymbolClickListener {
-            @Override public boolean onAnnotationClick(Symbol clickedSymbol) {
+            @Override public void onAnnotationClick(Symbol clickedSymbol) {
                 for (Symbol symbol : symbols) {
                     if (clickedSymbol.getId() == symbol.getId() && featureClickListener != null) {
                         featureClickListener.onFeature(featureId);
                         break;
                     }
                 }
-                return true;
             }
         }
 
         class LineClickListener implements OnLineClickListener {
-            @Override public boolean onAnnotationClick(Line clickedLine) {
+            @Override public void onAnnotationClick(Line clickedLine) {
                 if (clickedLine.getId() == line.getId() && featureClickListener != null) {
                     featureClickListener.onFeature(featureId);
                 }
-                return true;
             }
         }
 


### PR DESCRIPTION
Closes #4300
Closes #4302

#### What has been done to verify that this works as intended?
I confirmed that regression was caused by bumping mapbox-android-plugin-annotation to v9:0.9.0.

#### Why is this the best possible solution? Were any other approaches considered?
Another solution would be to just fix our code but we are in the middle of regression testing and the fix wouldn't be trivial so it's not a good time. It's better to downgrade to the version that was tested and worked well and file a separate issue to upgrade mapbox-android-plugin-annotation later.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
All widgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)