### PR TITLE
Add logging

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -408,7 +408,7 @@ public class ServerFormDownloader implements FormDownloader {
                         try {
                             is.close();
                         } catch (Exception e) {
-                            Timber.e(e);
+                            Timber.w(e);
                         }
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -516,8 +516,10 @@ public class FormController {
         try {
             return formEntryController.saveAnswer(index, data, true);
         } catch (Exception e) {
+            String dataType = data != null ? data.getClass().toString() : null;
+            String ref = index != null ? index.getReference().toString() : null;
             Timber.w("Error saving answer of type %s with ref %s for index %s",
-                    data.getClass().toString(), index.getReference(), index);
+                    dataType, ref, index);
 
             throw new JavaRosaException(e);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -516,6 +516,9 @@ public class FormController {
         try {
             return formEntryController.saveAnswer(index, data, true);
         } catch (Exception e) {
+            Timber.w("Error saving answer of type %s with ref %s for index %s",
+                    data.getClass().toString(), index.getReference(), index);
+
             throw new JavaRosaException(e);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/PropertyManager.java
@@ -94,7 +94,7 @@ public class PropertyManager implements IPropertyManager {
             putProperty(PROPMGR_DEVICE_ID,     "",         deviceDetailsProvider.getDeviceId());
             putProperty(PROPMGR_PHONE_NUMBER,  SCHEME_TEL,          deviceDetailsProvider.getLine1Number());
         } catch (SecurityException e) {
-            Timber.e(e);
+            Timber.i(e);
         }
 
         // User-defined properties. Will replace any above with the same PROPMGR_ name.

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -183,8 +183,7 @@ public class SaveFormToDisk {
         FormInstance formInstance = formController.getFormDef().getInstance();
 
         // If FormEntryActivity was started with an instance, update that instance
-        if (Collect.getInstance().getContentResolver().getType(uri).equals(
-                InstanceColumns.CONTENT_ITEM_TYPE)) {
+        if (Collect.getInstance().getContentResolver().getType(uri).equals(InstanceColumns.CONTENT_ITEM_TYPE)) {
             // TODO: reduce geometry duplication across three branches with different database queries
             String geometryXpath = getGeometryXpathForInstance(uri);
             ContentValues geometryContentValues = extractGeometryContentValues(formInstance, geometryXpath);
@@ -200,8 +199,7 @@ public class SaveFormToDisk {
             } else {
                 Timber.w("Instance doesn't exist but we have its Uri!! %s", uri.toString());
             }
-        } else if (Collect.getInstance().getContentResolver().getType(uri).equals(
-                FormsColumns.CONTENT_ITEM_TYPE)) {
+        } else if (Collect.getInstance().getContentResolver().getType(uri).equals(FormsColumns.CONTENT_ITEM_TYPE)) {
             // If FormEntryActivity was started with a form, then either:
             // - it's the first time we're saving so we should create a new database row
             // - the user has used the manual 'save data' option so the database row already exists
@@ -231,7 +229,11 @@ public class SaveFormToDisk {
             } else {
                 Timber.i("No instance found, creating");
                 try (Cursor c = Collect.getInstance().getContentResolver().query(uri, null, null, null, null)) {
-                    // retrieve the form definition...
+                    // retrieve the form definition
+                    if (c.getCount() != 1) {
+                        Timber.w("No matching form found for %s", uri);
+                        Timber.w("Instance null: %s", instance == null);
+                    }
                     c.moveToFirst();
                     String formname = c.getString(c.getColumnIndex(FormsColumns.DISPLAY_NAME));
                     String submissionUri = null;
@@ -276,7 +278,6 @@ public class SaveFormToDisk {
         ContentValues values = new ContentValues();
 
         if (xpath == null) {
-            Timber.w("Geometry XPath is missing for instance %s!", instance);
             return null;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -124,7 +124,7 @@ public class FileUtils {
                 pfd.close();
             }
         } catch (IOException e) {
-            Timber.w(e);
+            Timber.e(e);
         }
     }
 
@@ -261,7 +261,7 @@ public class FileUtils {
                             sourceFile.getAbsolutePath());
                     errorMessage = actualCopy(sourceFile, destFile);
                 } catch (InterruptedException e) {
-                    Timber.e(e);
+                    Timber.i(e);
                 }
             }
             return errorMessage;
@@ -427,10 +427,10 @@ public class FileUtils {
         if (file != null && file.exists()) {
             // remove garbage
             if (!file.delete()) {
-                Timber.w("%s will be deleted upon exit.", file.getAbsolutePath());
+                Timber.d("%s will be deleted upon exit.", file.getAbsolutePath());
                 file.deleteOnExit();
             } else {
-                Timber.w("%s has been deleted.", file.getAbsolutePath());
+                Timber.d("%s has been deleted.", file.getAbsolutePath());
             }
         }
     }


### PR DESCRIPTION
The first commit is to try to get more information on [this exception](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/dacbfe39d324ac95ff15529a8b7841bf?time=last-ninety-days) (needs auth). It happens on form save, generally triggered by `onPause` but sometimes also by manually exiting out of the form. The user experience is that a dialog is shown with the `NullPointerException` message. I believe that in case of a manual exit out of the form, the user is forced to tap "OK" and then their data is lost rather than saved. When this is triggered by `onPause`, it's possible that there would be a later opportunity to save again. Either way, we don't want this happening. It seems pretty clear it only affects v1.28.x and I suspect a JavaRosa issue though I can't see what it would be. Hopefully getting more information on the shape of the reference that causes this problem will help.

The second commit is for troubleshooting [this exception](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/1923b875080051dec14f1ebfaa6d716f?time=last-ninety-days). On instance save, in the code path where this is the first time the instance is being saved, there can be a crash on attempt to get the blank form corresponding to the new instance. One possible issue I saw is that the field `uri` was updated when a local variable should have been used. This looks like a very safe change so I made it but can also revert if preferred. I also added logging.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)