### PR TITLE
Make sure external recording is blocked when internal recording in progress

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequester.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequester.java
@@ -36,6 +36,13 @@ public class InternalRecordingRequester implements RecordingRequester {
     }
 
     @Override
+    public void onIsRecordingBlocked(Consumer<Boolean> isRecordingBlockedListener) {
+        viewModel.getCurrentSession().observe(lifecycleOwner, session -> {
+            isRecordingBlockedListener.accept(session != null && session.getFile() == null);
+        });
+    }
+
+    @Override
     public void requestRecording(FormEntryPrompt prompt) {
         permissionUtils.requestRecordAudioPermission(activity, new PermissionListener() {
             @Override
@@ -57,13 +64,6 @@ public class InternalRecordingRequester implements RecordingRequester {
         });
 
         formEntryViewModel.logFormEvent(AnalyticsEvents.AUDIO_RECORDING_INTERNAL);
-    }
-
-    @Override
-    public void onIsRecordingBlocked(Consumer<Boolean> isRecordingBlockedListener) {
-        viewModel.getCurrentSession().observe(lifecycleOwner, session -> {
-            isRecordingBlockedListener.accept(session != null && session.getFile() == null);
-        });
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RecordingRequester.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RecordingRequester.java
@@ -7,9 +7,9 @@ import org.javarosa.form.api.FormEntryPrompt;
 import java.util.function.Consumer;
 
 public interface RecordingRequester {
-    void requestRecording(FormEntryPrompt prompt);
-
     void onIsRecordingBlocked(Consumer<Boolean> isRecordingListener);
+
+    void requestRecording(FormEntryPrompt prompt);
 
     void onRecordingInProgress(FormEntryPrompt prompt, Consumer<Pair<Long, Integer>> durationListener);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RecordingRequesterFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RecordingRequesterFactory.java
@@ -39,9 +39,9 @@ public class RecordingRequesterFactory {
         if (audioQuality != null && (audioQuality.equals("normal") || audioQuality.equals("voice-only") || audioQuality.equals("low"))) {
             return new InternalRecordingRequester(activity, audioRecorderViewModel, permissionUtils, lifecycle, questionMediaManager, formEntryViewModel);
         } else if (audioQuality != null && audioQuality.equals("external")) {
-            return new ExternalAppRecordingRequester(activity, activityAvailability, waitingForDataRegistry, permissionUtils, formEntryViewModel);
+            return new ExternalAppRecordingRequester(activity, activityAvailability, waitingForDataRegistry, permissionUtils, formEntryViewModel, audioRecorderViewModel, lifecycle);
         } else if (externalRecorderPreferred) {
-            return new ExternalAppRecordingRequester(activity, activityAvailability, waitingForDataRegistry, permissionUtils, formEntryViewModel);
+            return new ExternalAppRecordingRequester(activity, activityAvailability, waitingForDataRegistry, permissionUtils, formEntryViewModel, audioRecorderViewModel, lifecycle);
         } else {
             return new InternalRecordingRequester(activity, audioRecorderViewModel, permissionUtils, lifecycle, questionMediaManager, formEntryViewModel);
         }


### PR DESCRIPTION
Closes #4285 

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to just check the issue is fixed and that external and internal recording still behave as expected.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)