### PR TITLE
Catch exceptions that might take place during opening uris

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
@@ -1,22 +1,15 @@
 package org.odk.collect.android.utilities;
 
-import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.browser.customtabs.CustomTabsService;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
 import androidx.browser.customtabs.CustomTabsSession;
 
 import org.odk.collect.android.activities.WebViewActivity;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by sanjeev on 17/3/17.
@@ -57,31 +50,6 @@ public class CustomTabHelper {
         CustomTabsClient.bindCustomTabsService(context, CUSTOM_TAB_PACKAGE_NAME, serviceConnection);
     }
 
-    /**
-     * Code from https://developer.chrome.com/multidevice/android/customtabs
-     * For more information see
-     * http://stackoverflow.com/a/33281092/137744
-     * https://medium.com/google-developers/best-practices-for-custom-tabs-5700e55143ee
-     */
-    private List<String> getPackageName(Context context) {
-        // Get default VIEW intent handler that can view a web url.
-        Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.test-url.com"));
-
-        // Get all apps that can handle VIEW intents.
-        PackageManager pm = context.getPackageManager();
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
-        List<String> packagesSupportingCustomTabs = new ArrayList<>();
-        for (ResolveInfo info : resolvedActivityList) {
-            Intent serviceIntent = new Intent();
-            serviceIntent.setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
-            serviceIntent.setPackage(info.activityInfo.packageName);
-            if (pm.resolveService(serviceIntent, 0) != null) {
-                packagesSupportingCustomTabs.add(info.activityInfo.packageName);
-            }
-        }
-        return packagesSupportingCustomTabs;
-    }
-
     // https://github.com/getodk/collect/issues/1221
     private Uri getNonNullUri(Uri url) {
         return url != null ? url : Uri.parse("");
@@ -92,21 +60,27 @@ public class CustomTabHelper {
     }
 
     public void openUri(Context context, Uri uri) {
-        if (!getPackageName(context).isEmpty()) {
-            //open in chrome custom tab
-            new CustomTabsIntent.Builder()
-                    .build()
-                    .launchUrl(context, uri);
-        } else {
+        try {
+            openUriInChromeTabs(context, uri);
+        } catch (Exception | Error e1) {
             try {
-                //open in external browser
-                context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
-            } catch (ActivityNotFoundException | SecurityException e) {
-                //open in webview
-                Intent intent = new Intent(context, WebViewActivity.class);
-                intent.putExtra(OPEN_URL, uri.toString());
-                context.startActivity(intent);
+                openUriInExternalBrowser(context, uri);
+            } catch (Exception | Error e2) {
+                openUriInWebView(context, uri);
             }
         }
     }
+
+    private void openUriInChromeTabs(Context context, Uri uri) {
+        new CustomTabsIntent.Builder().build().launchUrl(context, uri);
+    }
+
+    private void openUriInExternalBrowser(Context context, Uri uri) {
+        context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+    }
+
+    private void openUriInWebView(Context context, Uri uri) {
+        Intent intent = new Intent(context, WebViewActivity.class);
+        intent.putExtra(OPEN_URL, uri.toString());
+        context.startActivity(intent);    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
@@ -60,6 +60,7 @@ public class CustomTabHelper {
     }
 
     public void openUri(Context context, Uri uri) {
+        uri = uri.normalizeScheme();
         try {
             openUriInChromeTabs(context, uri);
         } catch (Exception | Error e1) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
@@ -83,5 +83,6 @@ public class CustomTabHelper {
     void openUriInWebView(Context context, Uri uri) {
         Intent intent = new Intent(context, WebViewActivity.class);
         intent.putExtra(OPEN_URL, uri.toString());
-        context.startActivity(intent);    }
+        context.startActivity(intent);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CustomTabHelper.java
@@ -72,15 +72,15 @@ public class CustomTabHelper {
         }
     }
 
-    private void openUriInChromeTabs(Context context, Uri uri) {
+    void openUriInChromeTabs(Context context, Uri uri) {
         new CustomTabsIntent.Builder().build().launchUrl(context, uri);
     }
 
-    private void openUriInExternalBrowser(Context context, Uri uri) {
+    void openUriInExternalBrowser(Context context, Uri uri) {
         context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
     }
 
-    private void openUriInWebView(Context context, Uri uri) {
+    void openUriInWebView(Context context, Uri uri) {
         Intent intent = new Intent(context, WebViewActivity.class);
         intent.putExtra(OPEN_URL, uri.toString());
         context.startActivity(intent);    }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/CustomTabHelperTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/CustomTabHelperTest.java
@@ -1,0 +1,33 @@
+package org.odk.collect.android.utilities;
+
+import android.net.Uri;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricTestRunner.class)
+public class CustomTabHelperTest extends TestCase {
+
+    @Test
+    public void uriShouldBeNormalized() {
+        CustomTabHelper customTabHelper = spy(new CustomTabHelper());
+        doNothing().when(customTabHelper).openUriInChromeTabs(any(), any());
+        doNothing().when(customTabHelper).openUriInWebView(any(), any());
+        doNothing().when(customTabHelper).openUriInExternalBrowser(any(), any());
+
+        Uri uri = mock(Uri.class);
+        customTabHelper.openUri(ApplicationProvider.getApplicationContext(), uri);
+        verify(uri).normalizeScheme();
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/CustomTabHelperTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/CustomTabHelperTest.java
@@ -4,8 +4,6 @@ import android.net.Uri;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -17,7 +15,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
-public class CustomTabHelperTest extends TestCase {
+public class CustomTabHelperTest {
 
     @Test
     public void uriShouldBeNormalized() {


### PR DESCRIPTION
Closes #4319

#### What has been done to verify that this works as intended?
I reviewed implemented changes and tested manually opening websites from Collect. 

#### Why is this the best possible solution? Were any other approaches considered?
Opening uris is tricky we were adding tr-catch blocks and looks like we need one more. In this case using try-catch is maybe even better because I removed [getPackageName()](https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-4319?expand=1#diff-61121fde4ced9fab134f17741cfed84d344268989cda8ab7faeef2ca0c387b48L66) which might be faulty and might be the cause of the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix we could even merge it without testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)