### PR TITLE
Catch ExternalDataException and display as a warning

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/ItemsWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/ItemsWidget.java
@@ -23,6 +23,7 @@ import org.javarosa.core.model.SelectChoice;
 import org.javarosa.xpath.expr.XPathFuncExpr;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.odk.collect.android.R;
+import org.odk.collect.android.exception.ExternalDataException;
 import org.odk.collect.android.fastexternalitemset.ItemsetDao;
 import org.odk.collect.android.fastexternalitemset.ItemsetDbAdapter;
 import org.odk.collect.android.external.ExternalDataUtil;
@@ -80,6 +81,8 @@ public abstract class ItemsWidget extends QuestionWidget {
             items = ExternalDataUtil.populateExternalChoices(getFormEntryPrompt(), xpathFuncExpr);
         } catch (FileNotFoundException e) {
             showWarning(getContext().getString(R.string.file_missing, e.getMessage()));
+        } catch (ExternalDataException e) {
+            showWarning(e.getMessage());
         }
     }
 


### PR DESCRIPTION
Closes #4310

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
No we catch the exception and display in the same way like other warnings. Thanks to that the exception will no longer be visible as a hard crash. This is the easiest solution for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The only change is that we catch `ExternalDataException` and display it as a warning not as a dialog. It's a safe change so we can test just that one scenario.

#### Do we need any specific form for testing your changes? If so, please attach one.
[form.zip](https://github.com/getodk/collect/files/5809090/form.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)