### PR TITLE
Fix crash when media file download fails

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormSource.java
@@ -19,6 +19,7 @@ public interface FormSource {
     @NotNull
     InputStream fetchForm(String formURL) throws FormSourceException;
 
+    @NotNull
     InputStream fetchMediaFile(String mediaFileURL) throws FormSourceException;
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormSource.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.forms;
 
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
 import java.io.InputStream;
@@ -15,6 +16,7 @@ public interface FormSource {
 
     ManifestFile fetchManifest(String manifestURL) throws FormSourceException;
 
+    @NotNull
     InputStream fetchForm(String formURL) throws FormSourceException;
 
     InputStream fetchMediaFile(String mediaFileURL) throws FormSourceException;

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
@@ -100,13 +100,27 @@ public class OpenRosaFormSource implements FormSource {
     }
 
     @Override
-    public @NotNull InputStream fetchForm(String formURL) throws FormSourceException {
-        return fetchFile(formURL);
+    @NotNull
+    public InputStream fetchForm(String formURL) throws FormSourceException {
+        InputStream formFile = mapException(() -> openRosaXMLFetcher.getFile(formURL, null));
+
+        if (formFile != null) {
+            return formFile;
+        } else {
+            throw new FormSourceException(FETCH_ERROR);
+        }
     }
 
     @Override
+    @NotNull
     public InputStream fetchMediaFile(String mediaFileURL) throws FormSourceException {
-        return mapException(() -> openRosaXMLFetcher.getFile(mediaFileURL, null));
+        InputStream mediaFile = mapException(() -> openRosaXMLFetcher.getFile(mediaFileURL, null));
+
+        if (mediaFile != null) {
+            return mediaFile;
+        } else {
+            throw new FormSourceException(FETCH_ERROR);
+        }
     }
 
     @Override
@@ -117,17 +131,6 @@ public class OpenRosaFormSource implements FormSource {
     @Override
     public void updateWebCredentialsUtils(WebCredentialsUtils webCredentialsUtils) {
         this.openRosaXMLFetcher.updateWebCredentialsUtils(webCredentialsUtils);
-    }
-
-    @NotNull
-    private InputStream fetchFile(String formURL) throws FormSourceException {
-        InputStream formFile = mapException(() -> openRosaXMLFetcher.getFile(formURL, null));
-
-        if (formFile != null) {
-            return formFile;
-        } else {
-            throw new FormSourceException(FETCH_ERROR);
-        }
     }
 
     private List<FormListItem> parseFormList(DocumentFetchResult result) throws FormSourceException {

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
@@ -100,7 +100,7 @@ public class OpenRosaFormSource implements FormSource {
     }
 
     @Override
-    public InputStream fetchForm(String formURL) throws FormSourceException {
+    public @NotNull InputStream fetchForm(String formURL) throws FormSourceException {
         return fetchFile(formURL);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
@@ -102,25 +102,13 @@ public class OpenRosaFormSource implements FormSource {
     @Override
     @NotNull
     public InputStream fetchForm(String formURL) throws FormSourceException {
-        InputStream formFile = mapException(() -> openRosaXMLFetcher.getFile(formURL, null));
-
-        if (formFile != null) {
-            return formFile;
-        } else {
-            throw new FormSourceException(FETCH_ERROR);
-        }
+        return mapException(() -> openRosaXMLFetcher.getFile(formURL, null));
     }
 
     @Override
     @NotNull
     public InputStream fetchMediaFile(String mediaFileURL) throws FormSourceException {
-        InputStream mediaFile = mapException(() -> openRosaXMLFetcher.getFile(mediaFileURL, null));
-
-        if (mediaFile != null) {
-            return mediaFile;
-        } else {
-            throw new FormSourceException(FETCH_ERROR);
-        }
+        return mapException(() -> openRosaXMLFetcher.getFile(mediaFileURL, null));
     }
 
     @Override
@@ -368,9 +356,16 @@ public class OpenRosaFormSource implements FormSource {
         return new ManifestFile(result.getHash(), files);
     }
 
+    @NotNull
     private <T> T mapException(Callable<T> callable) throws FormSourceException {
         try {
-            return callable.call();
+            T result = callable.call();
+
+            if (result != null) {
+                return result;
+            } else {
+                throw new FormSourceException(FETCH_ERROR, serverURL);
+            }
         } catch (UnknownHostException e) {
             throw new FormSourceException(UNREACHABLE, serverURL);
         } catch (SSLException e) {

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -241,8 +241,8 @@ public class ServerFormDownloaderTest {
                 true,
                 false,
                 new ManifestFile("", asList(
-                    new MediaFile("file1", "hash-1", "http://file1"),
-                    new MediaFile("file2", "hash-2", "http://file2")
+                        new MediaFile("file1", "hash-1", "http://file1"),
+                        new MediaFile("file2", "hash-2", "http://file2")
                 )));
 
         FormSource formSource = mock(FormSource.class);

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
@@ -33,6 +33,7 @@ import static org.odk.collect.android.forms.FormSourceException.Type.UNREACHABLE
 
 @RunWith(MockitoJUnitRunner.class)
 public class OpenRosaFormSourceTest {
+
     @Mock
     Analytics analytics;
 

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
@@ -133,6 +133,22 @@ public class OpenRosaFormSourceTest {
         }
     }
 
+    @Test
+    public void fetchMediaFile_whenThereIsAServerError_throwsFetchError() throws Exception {
+        OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
+        WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
+
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics);
+
+        try {
+            when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 500));
+            formListApi.fetchMediaFile("http://blah.com/mediaFile");
+            fail("No exception thrown!");
+        } catch (FormSourceException e) {
+            assertThat(e.getType(), is(FETCH_ERROR));
+        }
+    }
+
     private static String join(String... strings) {
         StringBuilder bob = new StringBuilder();
         for (String s : strings) {


### PR DESCRIPTION
Closes #4324 

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

The crash made a lot of sense given how `OkHttpConnection` is tested and behaved so really just needed to add a test to drive out accounting for the failure case in `OpenRosaFormSource`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just checking the issue is fixed is probably enough.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)