### PR TITLE
Always update formController for viewmodels when singleton is updated

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2300,7 +2300,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         formController.setLanguage(newLanguage);
                     } catch (Exception e) {
                         // if somehow we end up with a bad language, set it to the default
-                        Timber.e(e, "Ended up with a bad language. %s", newLanguage);
+                        Timber.i("Ended up with a bad language. %s", newLanguage);
                         formController.setLanguage(defaultLanguage);
                     }
                     Timber.i("Done in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -570,7 +570,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     formControllerAvailable(formController);
                     onScreenRefresh();
                 } else {
-                    Timber.d("Reloading form and restoring state.");
+                    Timber.w("Reloading form and restoring state.");
                     formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath);
                     showIfNotShowing(FormLoadingDialogFragment.class, getSupportFragmentManager());
                     formLoaderTask.execute(formPath);
@@ -581,6 +581,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             // Not a restart from a screen orientation change (or other).
             Collect.getInstance().setFormController(null);
+
             Intent intent = getIntent();
             if (intent != null) {
                 loadFromIntent(intent);
@@ -2282,6 +2283,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 t.destroy();
 
                 Collect.getInstance().setFormController(formController);
+                formControllerAvailable(formController);
+
                 backgroundLocationViewModel.formFinishedLoading();
                 Collect.getInstance().setExternalDataManager(task.getExternalDataManager());
 
@@ -2297,7 +2300,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         formController.setLanguage(newLanguage);
                     } catch (Exception e) {
                         // if somehow we end up with a bad language, set it to the default
-                        Timber.e("Ended up with a bad language. %s", newLanguage);
+                        Timber.e(e, "Ended up with a bad language. %s", newLanguage);
                         formController.setLanguage(defaultLanguage);
                     }
                     Timber.i("Done in %.3f seconds.", (System.currentTimeMillis() - start) / 1000F);
@@ -2337,8 +2340,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         showFormLoadErrorAndExit(getString(R.string.loading_form_failed));
                     }
 
-                    formControllerAvailable(formController);
-
                     identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                         if (!requiresIdentity) {
                             formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_START, true, System.currentTimeMillis());
@@ -2353,8 +2354,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                         // we've just loaded a saved form, so start in the hierarchy view
                         String formMode = reqIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
                         if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
-                            formControllerAvailable(formController);
-
                             identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                                 if (!requiresIdentity) {
                                     if (!allowMovingBackwards) {
@@ -2385,8 +2384,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             finish();
                         }
                     } else {
-                        formControllerAvailable(formController);
-
                         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
                             if (!requiresIdentity) {
                                 formController.getAuditEventLogger().logEvent(AuditEvent.AuditEventType.FORM_RESUME, true, System.currentTimeMillis());

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -146,6 +146,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
 
         if (errorMsg != null || formDef == null) {
+            Timber.w("No exception loading form but errorMsg set");
             return null;
         }
 
@@ -229,6 +230,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         String lastSavedSrc = FileUtils.getOrCreateLastSavedSrc(formXml);
         FormDef formDefFromXml = XFormUtils.getFormFromFormXml(formPath, lastSavedSrc);
         if (formDefFromXml == null) {
+            Timber.w("Error reading XForm file");
             errorMsg = "Error reading XForm file";
         } else {
             Timber.i("Loaded in %.3f seconds.",

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
@@ -29,15 +29,15 @@ public class ContentUriProvider {
     // https://stackoverflow.com/a/41309223/5479029
     public static Uri getUriForFile(@NonNull Context context, @NonNull String authority, @NonNull File file) {
         if (HUAWEI_MANUFACTURER.equalsIgnoreCase(Build.MANUFACTURER)) {
-            Timber.w(ContentUriProvider.class.getSimpleName(), "Using a Huawei device Increased likelihood of failure...");
+            Timber.w("%s: %s", ContentUriProvider.class.getSimpleName(), "Using a Huawei device Increased likelihood of failure...");
             try {
                 return FileProvider.getUriForFile(context, authority, file);
             } catch (IllegalArgumentException e) {
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-                    Timber.w(e, ContentUriProvider.class.getSimpleName(), "Returning Uri.fromFile to avoid Huawei 'external-files-path' bug for pre-N devices");
+                    Timber.w(e, "%s: %s", ContentUriProvider.class.getSimpleName(), "Returning Uri.fromFile to avoid Huawei 'external-files-path' bug for pre-N devices");
                     return Uri.fromFile(file);
                 } else {
-                    Timber.w(e, ContentUriProvider.class.getSimpleName(), "ANR Risk -- Copying the file the location cache to avoid Huawei 'external-files-path' bug for N+ devices");
+                    Timber.w(e, "%s: %s", ContentUriProvider.class.getSimpleName(), "ANR Risk -- Copying the file the location cache to avoid Huawei 'external-files-path' bug for N+ devices");
                     // Note: Periodically clear this cache
                     final File cacheFolder = new File(new StoragePathProvider().getDirPath(StorageSubdirectory.CACHE), HUAWEI_MANUFACTURER);
                     final File cacheLocation = new File(cacheFolder, file.getName());
@@ -47,10 +47,10 @@ public class ContentUriProvider {
                         in = new FileInputStream(file);
                         out = new FileOutputStream(cacheLocation); // appending output stream
                         IOUtils.copy(in, out);
-                        Timber.i(ContentUriProvider.class.getSimpleName(), "Completed Android N+ Huawei file copy. Attempting to return the cached file");
+                        Timber.i("%s: %s", ContentUriProvider.class.getSimpleName(), "Completed Android N+ Huawei file copy. Attempting to return the cached file");
                         return FileProvider.getUriForFile(context, authority, cacheLocation);
                     } catch (IOException e1) {
-                        Timber.e(e1, ContentUriProvider.class.getSimpleName(), "Failed to copy the Huawei file. Re-throwing exception");
+                        Timber.e(e1, "%s: %s", ContentUriProvider.class.getSimpleName(), "Failed to copy the Huawei file. Re-throwing exception");
                         throw new IllegalArgumentException("Huawei devices are unsupported for Android N", e1);
                     } finally {
                         IOUtils.closeQuietly(in);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDefCache.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDefCache.java
@@ -92,7 +92,7 @@ public class FormDefCache {
             } catch (Exception e) {
                 // New .formdef will be created from XML
                 Timber.w("Deserialization FAILED! Deleting cache file: %s", cachedForm.getAbsolutePath());
-                Timber.e(e);
+                Timber.w(e);
                 cachedForm.delete();
             }
         }


### PR DESCRIPTION
Closes #4327 

Some users are getting a crash that suggests their singleton `formController` is set but the `ViewModel`s don't know about it.

I searched for `Collect.getInstance().setFormController` and made sure that when it's called, `formControllerAvailable` is always called with the same value.

I also added commits improving logging that I saw while troubleshooting this.

#### What has been done to verify that this works as intended?
I can't reproduce the issue so all I have done is visual inspection.

#### Why is this the best possible solution? Were any other approaches considered?
It doesn't make sense that those two updates would be different so I think this is a change we have to make. I also updated some logging. The other approach I considered was passing in `formController` to `moveForward` and `moveBackward` and logging if the view model one is null but the one passed in is not. I think that would be fine and perhaps we can do that too but I think this change actually addresses the root cause.

I initially wanted to also null out the `ViewModel`s' `formController`s when `           Collect.getInstance().setFormController(null)` is called. However, that's not necessary for this fix and would probably require introducing new methods for those view models. It feels weird that there might be a stale form controller set but we can come back to it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I believe this to be very low risk. We are calling `formControllerAvailable` in more cases which seems it would always be positive.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)