### PR TITLE
Prevent crash when updating buttons on Main Menu

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -466,7 +466,8 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
                 Timber.w("Cannot update \"View Sent\" button label since the database is closed. Perhaps the app is running in the background?");
             }
         } catch (SQLiteDiskIOException e) {
-            Timber.e(e);
+            boolean migrationBeingPerformed = storageMigrationRepository.isMigrationBeingPerformed();
+            Timber.e(e, "Storage migration being peformed: %s", migrationBeingPerformed);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -270,7 +270,6 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     protected void onResume() {
         super.onResume();
 
-        countSavedForms();
         updateButtons();
         if (!storageMigrationRepository.isMigrationBeingPerformed()) {
             getContentResolver().registerContentObserver(InstanceColumns.CONTENT_URI, true, contentObserver);
@@ -423,6 +422,8 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     private void updateButtons() {
+        countSavedForms();
+
         try {
             if (finalizedCursor != null && !finalizedCursor.isClosed()) {
                 finalizedCursor.requery();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -374,50 +374,49 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     private void updateButtons() {
-        InstancesDao instancesDao = new InstancesDao();
+        if (!storageMigrationRepository.isMigrationBeingPerformed()) {
+            InstancesDao instancesDao = new InstancesDao();
 
-        int completedCount;
-        try (Cursor finalizedCursor = instancesDao.getFinalizedInstancesCursor()) {
-            completedCount = finalizedCursor != null ? finalizedCursor.getCount() : 0;
-        } catch (Exception e1) {
-            createErrorDialog(e1.getMessage(), EXIT);
-            return;
-        }
+            int completedCount;
+            try (Cursor finalizedCursor = instancesDao.getFinalizedInstancesCursor()) {
+                completedCount = finalizedCursor != null ? finalizedCursor.getCount() : 0;
+            } catch (Exception ignored) {
+                completedCount = 0;
+            }
 
-        try (Cursor savedCursor = instancesDao.getUnsentInstancesCursor()) {
-            savedCount = savedCursor != null ? savedCursor.getCount() : 0;
-        } catch (Exception e1) {
-            createErrorDialog(e1.getMessage(), EXIT);
-            return;
-        }
+            try (Cursor savedCursor = instancesDao.getUnsentInstancesCursor()) {
+                savedCount = savedCursor != null ? savedCursor.getCount() : 0;
+            } catch (Exception ignored) {
+                savedCount = 0;
+            }
 
-        int viewSentCount;
-        try (Cursor viewSentCursor = instancesDao.getSentInstancesCursor()) {
-            viewSentCount = viewSentCursor != null ? viewSentCursor.getCount() : 0;
-        } catch (Exception e1) {
-            createErrorDialog(e1.getMessage(), EXIT);
-            return;
-        }
+            int viewSentCount;
+            try (Cursor viewSentCursor = instancesDao.getSentInstancesCursor()) {
+                viewSentCount = viewSentCursor != null ? viewSentCursor.getCount() : 0;
+            } catch (Exception ignored) {
+                viewSentCount = 0;
+            }
 
-        if (completedCount > 0) {
-            sendDataButton.setText(
-                    getString(R.string.send_data_button, String.valueOf(completedCount)));
-        } else {
-            sendDataButton.setText(getString(R.string.send_data));
-        }
+            if (completedCount > 0) {
+                sendDataButton.setText(
+                        getString(R.string.send_data_button, String.valueOf(completedCount)));
+            } else {
+                sendDataButton.setText(getString(R.string.send_data));
+            }
 
-        if (savedCount > 0) {
-            reviewDataButton.setText(getString(R.string.review_data_button,
-                    String.valueOf(savedCount)));
-        } else {
-            reviewDataButton.setText(getString(R.string.review_data));
-        }
+            if (savedCount > 0) {
+                reviewDataButton.setText(getString(R.string.review_data_button,
+                        String.valueOf(savedCount)));
+            } else {
+                reviewDataButton.setText(getString(R.string.review_data));
+            }
 
-        if (viewSentCount > 0) {
-            viewSentFormsButton.setText(
-                    getString(R.string.view_sent_forms_button, String.valueOf(viewSentCount)));
-        } else {
-            viewSentFormsButton.setText(getString(R.string.view_sent_forms));
+            if (viewSentCount > 0) {
+                viewSentFormsButton.setText(
+                        getString(R.string.view_sent_forms_button, String.valueOf(viewSentCount)));
+            } else {
+                viewSentFormsButton.setText(getString(R.string.view_sent_forms));
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -19,6 +19,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.ContentObserver;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteDiskIOException;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -422,46 +423,50 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
     }
 
     private void updateButtons() {
-        if (finalizedCursor != null && !finalizedCursor.isClosed()) {
-            finalizedCursor.requery();
-            completedCount = finalizedCursor.getCount();
-            if (completedCount > 0) {
-                sendDataButton.setText(
-                        getString(R.string.send_data_button, String.valueOf(completedCount)));
+        try {
+            if (finalizedCursor != null && !finalizedCursor.isClosed()) {
+                finalizedCursor.requery();
+                completedCount = finalizedCursor.getCount();
+                if (completedCount > 0) {
+                    sendDataButton.setText(
+                            getString(R.string.send_data_button, String.valueOf(completedCount)));
+                } else {
+                    sendDataButton.setText(getString(R.string.send_data));
+                }
             } else {
                 sendDataButton.setText(getString(R.string.send_data));
+                Timber.w("Cannot update \"Send Finalized\" button label since the database is closed. Perhaps the app is running in the background?");
             }
-        } else {
-            sendDataButton.setText(getString(R.string.send_data));
-            Timber.w("Cannot update \"Send Finalized\" button label since the database is closed. Perhaps the app is running in the background?");
-        }
 
-        if (savedCursor != null && !savedCursor.isClosed()) {
-            savedCursor.requery();
-            savedCount = savedCursor.getCount();
-            if (savedCount > 0) {
-                reviewDataButton.setText(getString(R.string.review_data_button,
-                        String.valueOf(savedCount)));
+            if (savedCursor != null && !savedCursor.isClosed()) {
+                savedCursor.requery();
+                savedCount = savedCursor.getCount();
+                if (savedCount > 0) {
+                    reviewDataButton.setText(getString(R.string.review_data_button,
+                            String.valueOf(savedCount)));
+                } else {
+                    reviewDataButton.setText(getString(R.string.review_data));
+                }
             } else {
                 reviewDataButton.setText(getString(R.string.review_data));
+                Timber.w("Cannot update \"Edit Form\" button label since the database is closed. Perhaps the app is running in the background?");
             }
-        } else {
-            reviewDataButton.setText(getString(R.string.review_data));
-            Timber.w("Cannot update \"Edit Form\" button label since the database is closed. Perhaps the app is running in the background?");
-        }
 
-        if (viewSentCursor != null && !viewSentCursor.isClosed()) {
-            viewSentCursor.requery();
-            viewSentCount = viewSentCursor.getCount();
-            if (viewSentCount > 0) {
-                viewSentFormsButton.setText(
-                        getString(R.string.view_sent_forms_button, String.valueOf(viewSentCount)));
+            if (viewSentCursor != null && !viewSentCursor.isClosed()) {
+                viewSentCursor.requery();
+                viewSentCount = viewSentCursor.getCount();
+                if (viewSentCount > 0) {
+                    viewSentFormsButton.setText(
+                            getString(R.string.view_sent_forms_button, String.valueOf(viewSentCount)));
+                } else {
+                    viewSentFormsButton.setText(getString(R.string.view_sent_forms));
+                }
             } else {
                 viewSentFormsButton.setText(getString(R.string.view_sent_forms));
+                Timber.w("Cannot update \"View Sent\" button label since the database is closed. Perhaps the app is running in the background?");
             }
-        } else {
-            viewSentFormsButton.setText(getString(R.string.view_sent_forms));
-            Timber.w("Cannot update \"View Sent\" button label since the database is closed. Perhaps the app is running in the background?");
+        } catch (SQLiteDiskIOException e) {
+            Timber.e(e);
         }
     }
 


### PR DESCRIPTION
This reworks the main menu button code to not use deprecated Cursor requerying and Activity management. Instead, Cursors are just opened and closed as needed. 

I'd advise going through this commit by commit as the first two commits just add a way of preventing (and getting more info about) the crash where as the last two rework the code. If the rework is deemed to risky we could just go with the first two commits.

#### What has been done to verify that this works as intended?

Verified manually and ran tests. The button counts are actually tested in quite a lot of places (finalizing forms, sending forms etc) which I confirmed by killing the code and then running tests (~10 failures). It'd be good to look at further refactor and tests (probably pulling the counts out into a ViewModel and working out whether we need a content observer here or not for example) but that feels like a job for another day.

#### Why is this the best possible solution? Were any other approaches considered?

Comment inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just prevent the crash which we don't have repro for, so I think checking the button counts update as expected should be the focus.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)