### PR TITLE
Make sure form is created in correct place during download

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -511,8 +511,7 @@ public class ServerFormDownloader implements FormDownloader {
                         } else {
                             // exists, and the hash is the same
                             // no need to download it again
-                            Timber.i("Skipping media file fetch -- file hashes identical: %s",
-                                    finalMediaFile.getAbsolutePath());
+                            Timber.i("Skipping media file fetch -- file hashes identical: %s", finalMediaFile.getAbsolutePath());
                         }
                     }
                     //  } catch (Exception e) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -158,6 +158,7 @@ public class ServerFormDownloader implements FormDownloader {
                 // do not download additional forms.
                 throw e;
             } catch (FormSourceException | IOException e) {
+                cleanUp(fileResult, tempMediaPath);
                 return false;
             }
 

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -1,7 +1,9 @@
 package org.odk.collect.android.forms;
 
 import org.junit.Test;
+import org.odk.collect.android.utilities.FileUtils;
 
+import java.io.File;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -109,5 +111,17 @@ public abstract class FormsRepositoryTest {
 
         formsRepository.restore(1L);
         assertThat(formsRepository.get(1L).isDeleted(), is(false));
+    }
+
+    @Test
+    public void save_addsHashBasedOnFormFile() {
+        FormsRepository formsRepository = buildSubject();
+        Form form = buildForm(1L, "id", "version", getFormFilesPath()).build();
+        assertThat(form.getMD5Hash(), equalTo(null));
+
+        formsRepository.save(form);
+
+        String expectedHash = FileUtils.getMd5Hash(new File(form.getFormFilePath()));
+        assertThat(formsRepository.get(1L).getMD5Hash(), equalTo(expectedHash));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -114,6 +114,15 @@ public abstract class FormsRepositoryTest {
     }
 
     @Test
+    public void save_addsId() {
+        FormsRepository formsRepository = buildSubject();
+        Form form = buildForm(null, "id", "version", getFormFilesPath()).build();
+
+        formsRepository.save(form);
+        assertThat(formsRepository.getAll().get(0).getId(), notNullValue());
+    }
+
+    @Test
     public void save_addsHashBasedOnFormFile() {
         FormsRepository formsRepository = buildSubject();
         Form form = buildForm(1L, "id", "version", getFormFilesPath()).build();

--- a/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
@@ -28,11 +28,11 @@ public class FormUtils {
                 "</h:html>";
     }
 
-    public static Form.Builder buildForm(long id, String formId, String version, String formFilesPath) {
+    public static Form.Builder buildForm(Long id, String formId, String version, String formFilesPath) {
         return buildForm(id, formId, version, formFilesPath, "blah");
     }
 
-    public static Form.Builder buildForm(long id, String formId, String version, String formFilesPath, String xform) {
+    public static Form.Builder buildForm(Long id, String formId, String version, String formFilesPath, String xform) {
         String fileName = formId + "-" + version + "-" + Math.random();
         File formFile = new File(formFilesPath + "/" + fileName + ".xml");
         FileUtils.write(formFile, xform.getBytes());

--- a/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
@@ -44,7 +44,6 @@ public class FormUtils {
                 .formFilePath(formFile.getAbsolutePath())
                 .formMediaPath(mediaPath)
                 .jrFormId(formId)
-                .jrVersion(version)
-                .md5Hash(FileUtils.getMd5Hash(formFile));
+                .jrVersion(version);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -4,7 +4,9 @@ import android.net.Uri;
 
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
+import org.odk.collect.android.utilities.FileUtils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -62,7 +64,12 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Override
     public Uri save(Form form) {
-        forms.add(form);
+        String hash = FileUtils.getMd5Hash(new File(form.getFormFilePath()));
+        forms.add(new Form.Builder(form)
+                .md5Hash(hash)
+                .build()
+        );
+
         return null;
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -64,11 +64,17 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Override
     public Uri save(Form form) {
-        String hash = FileUtils.getMd5Hash(new File(form.getFormFilePath()));
-        forms.add(new Form.Builder(form)
-                .md5Hash(hash)
-                .build()
-        );
+        String formFilePath = form.getFormFilePath();
+
+        if (formFilePath != null) {
+            String hash = FileUtils.getMd5Hash(new File(formFilePath));
+            forms.add(new Form.Builder(form)
+                    .md5Hash(hash)
+                    .build()
+            );
+        } else {
+            forms.add(form);
+        }
 
         return null;
     }

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toList;
 public class InMemFormsRepository implements FormsRepository {
 
     private final List<Form> forms = new ArrayList<>();
+    private long idCounter = 1L;
 
     @Nullable
     @Override
@@ -64,6 +65,12 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Override
     public Uri save(Form form) {
+        if (form.getId() == null) {
+            form = new Form.Builder(form)
+                    .id(idCounter++)
+                    .build();
+        }
+
         String formFilePath = form.getFormFilePath();
 
         if (formFilePath != null) {


### PR DESCRIPTION
Closes #4332

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

~~I'm going to take the afternoon to try and improve the solution further as I'm not a fan of the fact that we have to clean up in the error case here. I think this solution is good enough to go in a point release though, so I don't want to wait on that (or worry about any changes/refactoring adding risk).~~

~~It looks like the original problem stems from the fact that the form file is created in Collect's forms dir rather than in the temp dir created for download which is too early. Really instead the form file should be created in the temp dir and then copied at the end. In that world we could avoid problems like this as the temp dir is always cleaned up.~~

EDIT: I ended up having to do all this anyway.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to check downloading forms with and without media files works as expected (in failure cases as well). I think paying special attention to the end state of the forms directory is important as well. 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)