### PR TITLE
Clean up ReferenceManager if form can't be parsed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMetadataParser.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMetadataParser.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import timber.log.Timber;
+
 import static org.odk.collect.android.utilities.FileUtils.LAST_SAVED_FILENAME;
 import static org.odk.collect.android.utilities.FileUtils.STUB_XML;
 import static org.odk.collect.android.utilities.FileUtils.write;
@@ -31,7 +33,16 @@ public class FormMetadataParser {
         referenceManager.addReferenceFactory(new FileReferenceFactory(mediaDir.getAbsolutePath()));
         referenceManager.addSessionRootTranslator(new RootTranslator("jr://file-csv/", "jr://file/"));
 
-        HashMap<String, String> metadata = FileUtils.getMetadataFromFormDefinition(file);
+        HashMap<String, String> metadata;
+        try {
+            metadata = FileUtils.getMetadataFromFormDefinition(file);
+        } catch (Exception e) {
+            referenceManager.reset();
+            tmpLastSaved.delete();
+            Timber.e(e);
+
+            throw e;
+        }
         referenceManager.reset();
         tmpLastSaved.delete();
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -176,8 +176,7 @@ public class ServerFormDownloader implements FormDownloader {
                     final long start = System.currentTimeMillis();
                     Timber.i("Parsing document %s", fileResult.file.getAbsolutePath());
 
-                    parsedFields = formMetadataParser
-                            .parse(fileResult.file, new File(tempMediaPath));
+                    parsedFields = formMetadataParser.parse(fileResult.file, new File(tempMediaPath));
 
                     Timber.i("Parse finished in %.3f seconds.",
                             (System.currentTimeMillis() - start) / 1000F);

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMetadataParserTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMetadataParserTest.java
@@ -103,7 +103,6 @@ public class FormMetadataParserTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.JUnitUseExpected")
     public void cleansUpReferenceManager() throws Exception {
         File formXml = File.createTempFile("form", ".xml");
         FileUtils.write(formXml, EXTERNAL_SECONDARY_INSTANCE.getBytes());
@@ -113,6 +112,27 @@ public class FormMetadataParserTest {
 
         FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
         formMetadataParser.parse(formXml, mediaDir);
+
+        try {
+            referenceManager.deriveReference("jr://file/external-data.xml");
+            fail("ReferenceManager still able to derive reference so hasn't been cleaned up!");
+        } catch (InvalidReferenceException ignored) {
+            // Pass
+        }
+    }
+
+    @Test
+    public void cleansUpReferenceManagerAfterFail() throws Exception {
+        File formXml = File.createTempFile("form", ".xml");
+
+        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+
+        try {
+            formMetadataParser.parse(formXml, mediaDir);
+            fail("Parse should have failed because file doesn't exist");
+        } catch (Exception e) {
+            // Expected
+        }
 
         try {
             referenceManager.deriveReference("jr://file/external-data.xml");

--- a/config/pmd-ruleset.xml
+++ b/config/pmd-ruleset.xml
@@ -22,6 +22,7 @@
         <exclude name="JUnitAssertionsShouldIncludeMessage" />
         <exclude name="JUnitTestContainsTooManyAsserts" />
         <exclude name="JUnitTestsShouldIncludeAssert" />
+        <exclude name="JUnitUseExpected" /> <!-- Favor using fail explicitly to test correct exception -->
         <exclude name="LiteralsFirstInComparisons" />
         <exclude name="LooseCoupling" />
         <exclude name="PositionLiteralsFirstInCaseInsensitiveComparisons" />


### PR DESCRIPTION
Closes #4315

#### What has been done to verify that this works as intended?

Confirmed that the test failed prior to the fix. Tried it with the form in the issue.

#### Why is this the best possible solution? Were any other approaches considered?

I think I previously had left this aside because it didn't seem very common and I felt like some refactoring was in order. However, #4332 highlights that users really do run into issues downloading form attachments and that can potentially result in this bad state. I also got a private support request about the issue and saw some missing file errors in Crashlytics that made me think other users were hitting this state.

Since I think this should go in a point release, I went for as safe and straightforward of a solution as possible. This means a little bit of redundancy but I think it's worth it for the simplicity. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is only intended to fix the bug. The code path changed affects all the different ways there are to download form definitions (manually, auto-update, match exactly).

#### Do we need any specific form for testing your changes? If so, please attach one.
See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)