### PR TITLE
Ex arbitrary file widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -145,6 +145,7 @@ import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DestroyableLifecyleOwner;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FormNameUtils;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PlayServicesChecker;
@@ -350,6 +351,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     @Inject
     ActivityAvailability activityAvailability;
+
+    @Inject
+    ExternalAppIntentProvider externalAppIntentProvider;
 
     private final LocationProvidersReceiver locationProvidersReceiver = new LocationProvidersReceiver();
 
@@ -819,13 +823,16 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case RequestCodes.EX_STRING_CAPTURE:
             case RequestCodes.EX_INT_CAPTURE:
             case RequestCodes.EX_DECIMAL_CAPTURE:
-                Object externalValue = getValueFromExternalApp(intent);
+                Object externalValue = externalAppIntentProvider.getValueFromIntent(intent);
                 if (getCurrentViewIfODKView() != null) {
                     setWidgetData(externalValue);
                 }
                 break;
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
-                loadFile((Uri) getValueFromExternalApp(intent));
+                externalValue = externalAppIntentProvider.getValueFromIntent(intent);
+                if (externalValue instanceof Uri) {
+                    loadFile((Uri) externalValue);
+                }
                 break;
             case RequestCodes.EX_GROUP_CAPTURE:
                 try {
@@ -891,13 +898,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             }
         });
-    }
-
-    @Nullable
-    private Object getValueFromExternalApp(Intent intent) {
-        return intent.getExtras().containsKey("value")
-                ? intent.getExtras().get("value")
-                : null;
     }
 
     public QuestionWidget getWidgetWaitingForBinaryData() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -829,9 +829,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
                 break;
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
-                externalValue = externalAppIntentProvider.getValueFromIntent(intent);
-                if (externalValue instanceof Uri) {
-                    loadFile((Uri) externalValue);
+                if (intent.getClipData().getItemCount() > 0 && intent.getClipData().getItemAt(0) != null) {
+                    loadFile(intent.getClipData().getItemAt(0).getUri());
+                } else {
+                    setWidgetData(null);
                 }
                 break;
             case RequestCodes.EX_GROUP_CAPTURE:

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -819,15 +819,13 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case RequestCodes.EX_STRING_CAPTURE:
             case RequestCodes.EX_INT_CAPTURE:
             case RequestCodes.EX_DECIMAL_CAPTURE:
-            case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
-                String key = "value";
-                boolean exists = intent.getExtras().containsKey(key);
-                if (exists) {
-                    Object externalValue = intent.getExtras().get(key);
-                    if (getCurrentViewIfODKView() != null) {
-                        setWidgetData(externalValue);
-                    }
+                Object externalValue = getValueFromExternalApp(intent);
+                if (getCurrentViewIfODKView() != null) {
+                    setWidgetData(externalValue);
                 }
+                break;
+            case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
+                loadFile((Uri) getValueFromExternalApp(intent));
                 break;
             case RequestCodes.EX_GROUP_CAPTURE:
                 try {
@@ -893,6 +891,13 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             }
         });
+    }
+
+    @Nullable
+    private Object getValueFromExternalApp(Intent intent) {
+        return intent.getExtras().containsKey("value")
+                ? intent.getExtras().get("value")
+                : null;
     }
 
     public QuestionWidget getWidgetWaitingForBinaryData() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -829,7 +829,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
                 break;
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
-                if (intent.getClipData().getItemCount() > 0 && intent.getClipData().getItemAt(0) != null) {
+                if (intent.getClipData() != null
+                        && intent.getClipData().getItemCount() > 0
+                        && intent.getClipData().getItemAt(0) != null) {
                     loadFile(intent.getClipData().getItemAt(0).getUri());
                 } else {
                     setWidgetData(null);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -819,6 +819,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case RequestCodes.EX_STRING_CAPTURE:
             case RequestCodes.EX_INT_CAPTURE:
             case RequestCodes.EX_DECIMAL_CAPTURE:
+            case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
                 String key = "value";
                 boolean exists = intent.getExtras().containsKey(key);
                 if (exists) {

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -98,6 +98,7 @@ import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.AdminPasswordProvider;
 import org.odk.collect.android.utilities.AndroidUserAgent;
 import org.odk.collect.android.utilities.DeviceDetailsProvider;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileProvider;
 import org.odk.collect.android.utilities.FileUtil;
 import org.odk.collect.android.utilities.FormsDirDiskFormsSynchronizer;
@@ -513,5 +514,11 @@ public class AppDependencyModule {
     @Singleton
     public PermissionsChecker providesPermissionsChecker(Context context) {
         return new PermissionsChecker(context);
+    }
+
+    @Provides
+    @Singleton
+    public ExternalAppIntentProvider providesExternalAppIntentProvider() {
+        return new ExternalAppIntentProvider();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -96,7 +96,8 @@ public class ApplicationConstants {
         public static final int GEOSHAPE_CAPTURE = 20;
         public static final int GEOTRACE_CAPTURE = 21;
         public static final int ARBITRARY_FILE_CHOOSER = 22;
-        public static final int CHANGE_SETTINGS = 23;
+        public static final int EX_ARBITRARY_FILE_CHOOSER  = 23;
+        public static final int CHANGE_SETTINGS = 24;
 
         public static final int FORMS_UPLOADED_NOTIFICATION = 97;
         public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
@@ -1,0 +1,56 @@
+package org.odk.collect.android.utilities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import org.javarosa.form.api.FormEntryPrompt;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.exception.ExternalParamsException;
+import org.odk.collect.android.external.ExternalAppsUtils;
+
+import java.util.Map;
+
+public class ExternalAppIntentProvider {
+    // If an extra with this key is specified, it will be parsed as a URI and used as intent data
+    private static final String URI_KEY = "uri_data";
+
+    public Intent provideIntentToRunExternalApp(Context context, FormEntryPrompt formEntryPrompt, ActivityAvailability activityAvailability) throws ExternalParamsException, XPathSyntaxException {
+        String exSpec = formEntryPrompt.getAppearanceHint().replaceFirst("^ex[:]", "");
+        final String intentName = ExternalAppsUtils.extractIntentName(exSpec);
+        final Map<String, String> exParams = ExternalAppsUtils.extractParameters(exSpec);
+        final String errorString;
+        String v = formEntryPrompt.getSpecialFormQuestionText("noAppErrorString");
+        errorString = (v != null) ? v : context.getString(R.string.no_app);
+
+        Intent intent = new Intent(intentName);
+
+        // Use special "uri_data" key to set intent data. This must be done before checking if an
+        // activity is available to handle implicit intents.
+        if (exParams.containsKey(URI_KEY)) {
+            String uriValue = (String) ExternalAppsUtils.getValueRepresentedBy(exParams.get(URI_KEY),
+                    formEntryPrompt.getIndex().getReference());
+            intent.setData(Uri.parse(uriValue));
+            exParams.remove(URI_KEY);
+        }
+
+        if (!activityAvailability.isActivityAvailable(intent)) {
+            Intent launchIntent = Collect.getInstance().getPackageManager().getLaunchIntentForPackage(intentName);
+
+            if (launchIntent != null) {
+                // Make sure FLAG_ACTIVITY_NEW_TASK is not set because it doesn't work with startActivityForResult
+                launchIntent.setFlags(0);
+                intent = launchIntent;
+            }
+        }
+
+        if (activityAvailability.isActivityAvailable(intent)) {
+            ExternalAppsUtils.populateParameters(intent, exParams, formEntryPrompt.getIndex().getReference());
+            return intent;
+        } else {
+            throw new RuntimeException(errorString);
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.annotation.Nullable;
+
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.odk.collect.android.R;
@@ -16,8 +18,9 @@ import java.util.Map;
 public class ExternalAppIntentProvider {
     // If an extra with this key is specified, it will be parsed as a URI and used as intent data
     private static final String URI_KEY = "uri_data";
+    private static final String RETURNED_DATA_NAME = "value";
 
-    public Intent provideIntentToRunExternalApp(Context context, FormEntryPrompt formEntryPrompt, ActivityAvailability activityAvailability) throws ExternalParamsException, XPathSyntaxException {
+    public Intent getIntentToRunExternalApp(Context context, FormEntryPrompt formEntryPrompt, ActivityAvailability activityAvailability) throws ExternalParamsException, XPathSyntaxException {
         String exSpec = formEntryPrompt.getAppearanceHint().replaceFirst("^ex[:]", "");
         final String intentName = ExternalAppsUtils.extractIntentName(exSpec);
         final Map<String, String> exParams = ExternalAppsUtils.extractParameters(exSpec);
@@ -52,5 +55,12 @@ public class ExternalAppIntentProvider {
         } else {
             throw new RuntimeException(errorString);
         }
+    }
+
+    @Nullable
+    public Object getValueFromIntent(Intent intent) {
+        return intent.getExtras().containsKey(RETURNED_DATA_NAME)
+                ? intent.getExtras().get(RETURNED_DATA_NAME)
+                : null;
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.utilities;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -61,5 +62,12 @@ public class MediaUtils {
             ToastUtils.showLongToast(message);
             Timber.w(message);
         }
+    }
+
+    public void pickFile(Activity activity, String mimeType, int requestCode) {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(mimeType);
+        activity.startActivityForResult(intent, requestCode);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -34,8 +34,6 @@ import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
-import java.io.File;
-
 @SuppressLint("ViewConstructor")
 public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements FileWidget, WidgetDataReceiver {
     ArbitraryFileWidgetAnswerBinding binding;
@@ -44,10 +42,6 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
     private final MediaUtils mediaUtils;
 
     private final WaitingForDataRegistry waitingForDataRegistry;
-
-    public ArbitraryFileWidget(Context context, QuestionDetails prompt, QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
-        this(context, prompt, new MediaUtils(), questionMediaManager, waitingForDataRegistry);
-    }
 
     ArbitraryFileWidget(Context context, QuestionDetails questionDetails, @NonNull MediaUtils mediaUtils,
                         QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
@@ -59,19 +53,19 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
     @Override
     protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
         binding = ArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
-        fileName = prompt.getAnswerText();
+        setupAnswerFile(prompt.getAnswerText());
 
         if (prompt.isReadOnly()) {
             binding.arbitraryFileButton.setVisibility(GONE);
         } else {
             binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());
-            binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + fileName), null));
+            binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), answerFile, null));
         }
 
-        if (fileName != null && !fileName.isEmpty()) {
+        if (answerFile != null) {
             binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
-            binding.arbitraryFileAnswerText.setText(fileName);
+            binding.arbitraryFileAnswerText.setText(answerFile.getName());
             binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
         }
 
@@ -98,7 +92,7 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
 
     @Override
     protected void showAnswerText() {
-        binding.arbitraryFileAnswerText.setText(fileName);
+        binding.arbitraryFileAnswerText.setText(answerFile.getName());
         binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -21,22 +21,19 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import androidx.annotation.NonNull;
-import android.view.Gravity;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TextView;
+
+import android.util.TypedValue;
+import android.view.View;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
-import org.odk.collect.android.R;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.databinding.ArbitraryFileWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
-import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
@@ -44,11 +41,10 @@ import java.io.File;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.formentry.questions.WidgetViewUtils.createAnswerTextView;
-import static org.odk.collect.android.formentry.questions.WidgetViewUtils.createSimpleButton;
-
 @SuppressLint("ViewConstructor")
-public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, ButtonClickListener, WidgetDataReceiver {
+public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, WidgetDataReceiver {
+    ArbitraryFileWidgetAnswerBinding binding;
+
     @NonNull
     private final MediaUtils mediaUtils;
 
@@ -56,10 +52,6 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
     private final WaitingForDataRegistry waitingForDataRegistry;
 
     private String binaryName;
-
-    Button chooseFileButton;
-    TextView chosenFileNameTextView;
-    private LinearLayout answerLayout;
 
     public ArbitraryFileWidget(Context context, QuestionDetails prompt, QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
         this(context, prompt, new MediaUtils(), questionMediaManager, waitingForDataRegistry);
@@ -71,10 +63,28 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
         this.mediaUtils = mediaUtils;
         this.questionMediaManager = questionMediaManager;
         this.waitingForDataRegistry = waitingForDataRegistry;
+    }
 
-        binaryName = questionDetails.getPrompt().getAnswerText();
+    @Override
+    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
+        binding = ArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
+        binaryName = prompt.getAnswerText();
 
-        setUpLayout(context);
+        if (prompt.isReadOnly()) {
+            binding.arbitraryFileButton.setVisibility(GONE);
+        } else {
+            binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+            binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());
+            binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + binaryName), null));
+        }
+
+        if (binaryName != null && !binaryName.isEmpty()) {
+            binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+            binding.arbitraryFileAnswerText.setText(binaryName);
+            binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
+        }
+
+        return binding.getRoot();
     }
 
     @Override
@@ -91,16 +101,19 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
 
     @Override
     public void clearAnswer() {
-        answerLayout.setVisibility(GONE);
+        binding.arbitraryFileAnswerText.setVisibility(GONE);
         deleteFile();
 
         widgetValueChanged();
     }
 
-    @Override
-    public void onButtonClick(int buttonId) {
+    private void onButtonClick() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
-        performFileSearch();
+
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*"); // all file types
+        ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
     }
 
     @Override
@@ -114,8 +127,8 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
             if (newFile.exists()) {
                 questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), newFile.getAbsolutePath());
                 binaryName = newFile.getName();
-                chosenFileNameTextView.setText(binaryName);
-                answerLayout.setVisibility(VISIBLE);
+                binding.arbitraryFileAnswerText.setText(binaryName);
+                binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
                 widgetValueChanged();
             } else {
                 Timber.e("Inserting Arbitrary file FAILED");
@@ -127,42 +140,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, B
 
     @Override
     public void setOnLongClickListener(OnLongClickListener l) {
-        chooseFileButton.setOnLongClickListener(l);
-        answerLayout.setOnLongClickListener(l);
-    }
-
-    private void setUpLayout(Context context) {
-        LinearLayout widgetLayout = new LinearLayout(getContext());
-        widgetLayout.setOrientation(LinearLayout.VERTICAL);
-
-        chooseFileButton = createSimpleButton(getContext(), questionDetails.isReadOnly(), getContext().getString(R.string.choose_file), getAnswerFontSize(), this);
-        chooseFileButton.setEnabled(!questionDetails.isReadOnly());
-
-        answerLayout = new LinearLayout(getContext());
-        answerLayout.setOrientation(LinearLayout.HORIZONTAL);
-        answerLayout.setGravity(Gravity.CENTER);
-        answerLayout.setTag("ArbitraryFileWidgetAnswer");
-
-        ImageView attachmentImg = new ImageView(getContext());
-        attachmentImg.setImageResource(R.drawable.ic_attachment);
-        chosenFileNameTextView = createAnswerTextView(getContext(), binaryName, getAnswerFontSize());
-        chosenFileNameTextView.setGravity(Gravity.CENTER);
-
-        answerLayout.addView(attachmentImg);
-        answerLayout.addView(chosenFileNameTextView);
-        answerLayout.setVisibility(binaryName == null ? GONE : VISIBLE);
-        answerLayout.setOnClickListener(view -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + binaryName), null));
-
-        widgetLayout.addView(chooseFileButton);
-        widgetLayout.addView(answerLayout);
-
-        addAnswerView(widgetLayout, WidgetViewUtils.getStandardMargin(context));
-    }
-
-    private void performFileSearch() {
-        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*"); // all file types
-        ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
+        binding.arbitraryFileButton.setOnLongClickListener(l);
+        binding.arbitraryFileAnswerText.setOnLongClickListener(l);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -55,16 +55,17 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
         binding = ArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
         setupAnswerFile(prompt.getAnswerText());
 
+        binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+        binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+
         if (prompt.isReadOnly()) {
             binding.arbitraryFileButton.setVisibility(GONE);
         } else {
-            binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());
             binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), answerFile, null));
         }
 
         if (answerFile != null) {
-            binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.arbitraryFileAnswerText.setText(answerFile.getName());
             binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -19,7 +19,6 @@ package org.odk.collect.android.widgets;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import androidx.annotation.NonNull;
 
 import android.util.TypedValue;
@@ -109,11 +108,7 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, W
 
     private void onButtonClick() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
-
-        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*"); // all file types
-        ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
+        mediaUtils.pickFile((Activity) getContext(), "*/*", ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -24,8 +24,6 @@ import androidx.annotation.NonNull;
 import android.util.TypedValue;
 import android.view.View;
 
-import org.javarosa.core.model.data.IAnswerData;
-import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.databinding.ArbitraryFileWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -38,16 +36,13 @@ import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import java.io.File;
 
-import timber.log.Timber;
-
 @SuppressLint("ViewConstructor")
-public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, WidgetDataReceiver {
+public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements FileWidget, WidgetDataReceiver {
     ArbitraryFileWidgetAnswerBinding binding;
 
     @NonNull
     private final MediaUtils mediaUtils;
 
-    private final QuestionMediaManager questionMediaManager;
     private final WaitingForDataRegistry waitingForDataRegistry;
 
     private String binaryName;
@@ -58,9 +53,8 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, W
 
     ArbitraryFileWidget(Context context, QuestionDetails questionDetails, @NonNull MediaUtils mediaUtils,
                         QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
-        super(context, questionDetails);
+        super(context, questionDetails, mediaUtils, questionMediaManager, waitingForDataRegistry);
         this.mediaUtils = mediaUtils;
-        this.questionMediaManager = questionMediaManager;
         this.waitingForDataRegistry = waitingForDataRegistry;
     }
 
@@ -87,18 +81,6 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, W
     }
 
     @Override
-    public void deleteFile() {
-        questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(),
-                getInstanceFolder() + File.separator + binaryName);
-        binaryName = null;
-    }
-
-    @Override
-    public IAnswerData getAnswer() {
-        return binaryName != null ? new StringData(binaryName) : null;
-    }
-
-    @Override
     public void clearAnswer() {
         binding.arbitraryFileAnswerText.setVisibility(GONE);
         deleteFile();
@@ -112,30 +94,14 @@ public class ArbitraryFileWidget extends QuestionWidget implements FileWidget, W
     }
 
     @Override
-    public void setData(Object object) {
-        if (binaryName != null) {
-            deleteFile();
-        }
-
-        if (object instanceof File) {
-            File newFile = (File) object;
-            if (newFile.exists()) {
-                questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), newFile.getAbsolutePath());
-                binaryName = newFile.getName();
-                binding.arbitraryFileAnswerText.setText(binaryName);
-                binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
-                widgetValueChanged();
-            } else {
-                Timber.e("Inserting Arbitrary file FAILED");
-            }
-        } else {
-            Timber.e("FileWidget's setBinaryData must receive a File or Uri object.");
-        }
-    }
-
-    @Override
     public void setOnLongClickListener(OnLongClickListener l) {
         binding.arbitraryFileButton.setOnLongClickListener(l);
         binding.arbitraryFileAnswerText.setOnLongClickListener(l);
+    }
+
+    @Override
+    protected void showAnswerText() {
+        binding.arbitraryFileAnswerText.setText(binaryName);
+        binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -45,8 +45,6 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
 
     private final WaitingForDataRegistry waitingForDataRegistry;
 
-    private String binaryName;
-
     public ArbitraryFileWidget(Context context, QuestionDetails prompt, QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
         this(context, prompt, new MediaUtils(), questionMediaManager, waitingForDataRegistry);
     }
@@ -61,19 +59,19 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
     @Override
     protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
         binding = ArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
-        binaryName = prompt.getAnswerText();
+        fileName = prompt.getAnswerText();
 
         if (prompt.isReadOnly()) {
             binding.arbitraryFileButton.setVisibility(GONE);
         } else {
             binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());
-            binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + binaryName), null));
+            binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + fileName), null));
         }
 
-        if (binaryName != null && !binaryName.isEmpty()) {
+        if (fileName != null && !fileName.isEmpty()) {
             binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
-            binding.arbitraryFileAnswerText.setText(binaryName);
+            binding.arbitraryFileAnswerText.setText(fileName);
             binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
         }
 
@@ -84,7 +82,6 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
     public void clearAnswer() {
         binding.arbitraryFileAnswerText.setVisibility(GONE);
         deleteFile();
-
         widgetValueChanged();
     }
 
@@ -94,14 +91,14 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
     }
 
     @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        binding.arbitraryFileButton.setOnLongClickListener(l);
-        binding.arbitraryFileAnswerText.setOnLongClickListener(l);
+    public void setOnLongClickListener(OnLongClickListener listener) {
+        binding.arbitraryFileButton.setOnLongClickListener(listener);
+        binding.arbitraryFileAnswerText.setOnLongClickListener(listener);
     }
 
     @Override
     protected void showAnswerText() {
-        binding.arbitraryFileAnswerText.setText(binaryName);
+        binding.arbitraryFileAnswerText.setText(fileName);
         binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -58,12 +58,9 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
         binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
         binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
 
-        if (questionDetails.isReadOnly()) {
-            binding.arbitraryFileButton.setVisibility(GONE);
-        } else {
-            binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());
-            binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), answerFile, null));
-        }
+        binding.arbitraryFileButton.setVisibility(questionDetails.isReadOnly() ? GONE : VISIBLE);
+        binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());
+        binding.arbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), answerFile, null));
 
         if (answerFile != null) {
             binding.arbitraryFileAnswerText.setText(answerFile.getName());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -58,7 +58,7 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
         binding.arbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
         binding.arbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
 
-        if (prompt.isReadOnly()) {
+        if (questionDetails.isReadOnly()) {
             binding.arbitraryFileButton.setVisibility(GONE);
         } else {
             binding.arbitraryFileButton.setOnClickListener(v -> onButtonClick());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ArbitraryFileWidget.java
@@ -96,4 +96,9 @@ public class ArbitraryFileWidget extends BaseArbitraryFileWidget implements File
         binding.arbitraryFileAnswerText.setText(answerFile.getName());
         binding.arbitraryFileAnswerText.setVisibility(VISIBLE);
     }
+
+    @Override
+    protected void hideAnswerText() {
+        binding.arbitraryFileAnswerText.setVisibility(GONE);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -1,0 +1,71 @@
+package org.odk.collect.android.widgets;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.StringData;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.utilities.QuestionMediaManager;
+import org.odk.collect.android.widgets.interfaces.FileWidget;
+import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+
+import java.io.File;
+
+import timber.log.Timber;
+
+public abstract class BaseArbitraryFileWidget extends QuestionWidget implements FileWidget, WidgetDataReceiver  {
+    @NonNull
+    protected final MediaUtils mediaUtils;
+
+    private final QuestionMediaManager questionMediaManager;
+    protected final WaitingForDataRegistry waitingForDataRegistry;
+
+    protected String binaryName;
+
+    public BaseArbitraryFileWidget(Context context, QuestionDetails questionDetails, @NonNull MediaUtils mediaUtils,
+                                   QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
+        super(context, questionDetails);
+        this.mediaUtils = mediaUtils;
+        this.questionMediaManager = questionMediaManager;
+        this.waitingForDataRegistry = waitingForDataRegistry;
+    }
+
+    @Override
+    public IAnswerData getAnswer() {
+        return binaryName != null ? new StringData(binaryName) : null;
+    }
+
+    @Override
+    public void deleteFile() {
+        questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(),
+                getInstanceFolder() + File.separator + binaryName);
+        binaryName = null;
+    }
+
+    @Override
+    public void setData(Object object) {
+        if (binaryName != null) {
+            deleteFile();
+        }
+
+        if (object instanceof File) {
+            File newFile = (File) object;
+            if (newFile.exists()) {
+                questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), newFile.getAbsolutePath());
+                binaryName = newFile.getName();
+                showAnswerText();
+                widgetValueChanged();
+            } else {
+                Timber.e("Inserting Arbitrary file FAILED");
+            }
+        } else {
+            Timber.e("FileWidget's setBinaryData must receive a File or Uri object.");
+        }
+    }
+
+    protected abstract void showAnswerText();
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -24,7 +24,7 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
     private final QuestionMediaManager questionMediaManager;
     protected final WaitingForDataRegistry waitingForDataRegistry;
 
-    protected String binaryName;
+    protected String fileName;
 
     public BaseArbitraryFileWidget(Context context, QuestionDetails questionDetails, @NonNull MediaUtils mediaUtils,
                                    QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
@@ -36,19 +36,19 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
 
     @Override
     public IAnswerData getAnswer() {
-        return binaryName != null ? new StringData(binaryName) : null;
+        return fileName != null ? new StringData(fileName) : null;
     }
 
     @Override
     public void deleteFile() {
         questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(),
-                getInstanceFolder() + File.separator + binaryName);
-        binaryName = null;
+                getInstanceFolder() + File.separator + fileName);
+        fileName = null;
     }
 
     @Override
     public void setData(Object object) {
-        if (binaryName != null) {
+        if (fileName != null) {
             deleteFile();
         }
 
@@ -56,7 +56,7 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
             File newFile = (File) object;
             if (newFile.exists()) {
                 questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), newFile.getAbsolutePath());
-                binaryName = newFile.getName();
+                fileName = newFile.getName();
                 showAnswerText();
                 widgetValueChanged();
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -24,7 +24,7 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
     private final QuestionMediaManager questionMediaManager;
     protected final WaitingForDataRegistry waitingForDataRegistry;
 
-    protected String fileName;
+    protected File answerFile;
 
     public BaseArbitraryFileWidget(Context context, QuestionDetails questionDetails, @NonNull MediaUtils mediaUtils,
                                    QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry) {
@@ -36,34 +36,39 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
 
     @Override
     public IAnswerData getAnswer() {
-        return fileName != null ? new StringData(fileName) : null;
+        return answerFile != null ? new StringData(answerFile.getName()) : null;
     }
 
     @Override
     public void deleteFile() {
-        questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(),
-                getInstanceFolder() + File.separator + fileName);
-        fileName = null;
+        questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(), answerFile.getAbsolutePath());
+        answerFile = null;
     }
 
     @Override
     public void setData(Object object) {
-        if (fileName != null) {
+        if (answerFile != null) {
             deleteFile();
         }
 
         if (object instanceof File) {
-            File newFile = (File) object;
-            if (newFile.exists()) {
-                questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), newFile.getAbsolutePath());
-                fileName = newFile.getName();
+            answerFile = (File) object;
+            if (answerFile.exists()) {
+                questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), answerFile.getAbsolutePath());
                 showAnswerText();
                 widgetValueChanged();
             } else {
+                answerFile = null;
                 Timber.e("Inserting Arbitrary file FAILED");
             }
         } else {
             Timber.e("FileWidget's setBinaryData must receive a File or Uri object.");
+        }
+    }
+
+    protected void setupAnswerFile(String fileName) {
+        if (fileName != null && !fileName.isEmpty()) {
+            answerFile = new File(getInstanceFolder() + File.separator + fileName);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -43,6 +43,7 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
     public void deleteFile() {
         questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(), answerFile.getAbsolutePath());
         answerFile = null;
+        hideAnswerText();
     }
 
     @Override
@@ -73,4 +74,6 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
     }
 
     protected abstract void showAnswerText();
+
+    protected abstract void hideAnswerText();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -62,8 +62,8 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
                 answerFile = null;
                 Timber.e("Inserting Arbitrary file FAILED");
             }
-        } else {
-            Timber.e("FileWidget's setBinaryData must receive a File.");
+        } else if (object != null) {
+            Timber.e("FileWidget's setBinaryData must receive a File but received: %s", object.getClass());
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -62,7 +62,7 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
                 Timber.e("Inserting Arbitrary file FAILED");
             }
         } else {
-            Timber.e("FileWidget's setBinaryData must receive a File or Uri object.");
+            Timber.e("FileWidget's setBinaryData must receive a File.");
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -25,8 +25,6 @@ import java.io.File;
 
 import timber.log.Timber;
 
-import static android.content.Intent.ACTION_SENDTO;
-
 @SuppressLint("ViewConstructor")
 public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
     ExArbitraryFileWidgetAnswerBinding binding;
@@ -87,12 +85,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
             Intent intent = externalAppIntentProvider.provideIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
-            // ACTION_SENDTO used for sending text messages or emails doesn't require any results
-            if (ACTION_SENDTO.equals(intent.getAction())) {
-                getContext().startActivity(intent);
-            } else {
-                fireActivityForResult(intent);
-            }
+            fireActivityForResult(intent);
         } catch (Exception | Error e) {
             ToastUtils.showLongToast(e.getMessage());
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -21,8 +21,6 @@ import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
-import java.io.File;
-
 import timber.log.Timber;
 
 @SuppressLint("ViewConstructor")
@@ -43,19 +41,19 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
     @Override
     protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
         binding = ExArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
-        fileName = prompt.getAnswerText();
+        setupAnswerFile(prompt.getAnswerText());
 
         if (prompt.isReadOnly()) {
             binding.exArbitraryFileButton.setVisibility(GONE);
         } else {
             binding.exArbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.exArbitraryFileButton.setOnClickListener(v -> onButtonClick());
-            binding.exArbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + fileName), null));
+            binding.exArbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), answerFile, null));
         }
 
-        if (fileName != null && !fileName.isEmpty()) {
+        if (answerFile != null) {
             binding.exArbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
-            binding.exArbitraryFileAnswerText.setText(fileName);
+            binding.exArbitraryFileAnswerText.setText(answerFile.getName());
             binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
         }
 
@@ -77,7 +75,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
 
     @Override
     protected void showAnswerText() {
-        binding.exArbitraryFileAnswerText.setText(fileName);
+        binding.exArbitraryFileAnswerText.setText(answerFile.getName());
         binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -84,7 +84,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
     private void onButtonClick() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = externalAppIntentProvider.provideIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
             ToastUtils.showLongToast(e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -45,19 +45,19 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
     @Override
     protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
         binding = ExArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
-        binaryName = prompt.getAnswerText();
+        fileName = prompt.getAnswerText();
 
         if (prompt.isReadOnly()) {
             binding.exArbitraryFileButton.setVisibility(GONE);
         } else {
             binding.exArbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.exArbitraryFileButton.setOnClickListener(v -> onButtonClick());
-            binding.exArbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + binaryName), null));
+            binding.exArbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + fileName), null));
         }
 
-        if (binaryName != null && !binaryName.isEmpty()) {
+        if (fileName != null && !fileName.isEmpty()) {
             binding.exArbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
-            binding.exArbitraryFileAnswerText.setText(binaryName);
+            binding.exArbitraryFileAnswerText.setText(fileName);
             binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
         }
 
@@ -72,14 +72,14 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
     }
 
     @Override
-    public void setOnLongClickListener(OnLongClickListener l) {
-        binding.exArbitraryFileButton.setOnLongClickListener(l);
-        binding.exArbitraryFileAnswerText.setOnLongClickListener(l);
+    public void setOnLongClickListener(OnLongClickListener listener) {
+        binding.exArbitraryFileButton.setOnLongClickListener(listener);
+        binding.exArbitraryFileAnswerText.setOnLongClickListener(listener);
     }
 
     @Override
     protected void showAnswerText() {
-        binding.exArbitraryFileAnswerText.setText(binaryName);
+        binding.exArbitraryFileAnswerText.setText(fileName);
         binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -43,16 +43,17 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
         binding = ExArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
         setupAnswerFile(prompt.getAnswerText());
 
+        binding.exArbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+        binding.exArbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+
         if (prompt.isReadOnly()) {
             binding.exArbitraryFileButton.setVisibility(GONE);
         } else {
-            binding.exArbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.exArbitraryFileButton.setOnClickListener(v -> onButtonClick());
             binding.exArbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), answerFile, null));
         }
 
         if (answerFile != null) {
-            binding.exArbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
             binding.exArbitraryFileAnswerText.setText(answerFile.getName());
             binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -1,0 +1,109 @@
+package org.odk.collect.android.widgets;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.util.TypedValue;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
+import org.odk.collect.android.databinding.ExArbitraryFileWidgetAnswerBinding;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.ActivityAvailability;
+import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
+import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.utilities.QuestionMediaManager;
+import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+
+import java.io.File;
+
+import timber.log.Timber;
+
+import static android.content.Intent.ACTION_SENDTO;
+
+@SuppressLint("ViewConstructor")
+public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
+    ExArbitraryFileWidgetAnswerBinding binding;
+
+    private final ExternalAppIntentProvider externalAppIntentProvider;
+    private final ActivityAvailability activityAvailability;
+
+    public ExArbitraryFileWidget(Context context, QuestionDetails questionDetails, @NonNull MediaUtils mediaUtils,
+                                 QuestionMediaManager questionMediaManager, WaitingForDataRegistry waitingForDataRegistry,
+                                 ExternalAppIntentProvider externalAppIntentProvider, ActivityAvailability activityAvailability) {
+        super(context, questionDetails, mediaUtils, questionMediaManager, waitingForDataRegistry);
+        this.externalAppIntentProvider = externalAppIntentProvider;
+        this.activityAvailability = activityAvailability;
+    }
+
+    @Override
+    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
+        binding = ExArbitraryFileWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
+        binaryName = prompt.getAnswerText();
+
+        if (prompt.isReadOnly()) {
+            binding.exArbitraryFileButton.setVisibility(GONE);
+        } else {
+            binding.exArbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+            binding.exArbitraryFileButton.setOnClickListener(v -> onButtonClick());
+            binding.exArbitraryFileAnswerText.setOnClickListener(v -> mediaUtils.openFile(getContext(), new File(getInstanceFolder() + File.separator + binaryName), null));
+        }
+
+        if (binaryName != null && !binaryName.isEmpty()) {
+            binding.exArbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+            binding.exArbitraryFileAnswerText.setText(binaryName);
+            binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
+        }
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void clearAnswer() {
+        binding.exArbitraryFileAnswerText.setVisibility(GONE);
+        deleteFile();
+        widgetValueChanged();
+    }
+
+    @Override
+    public void setOnLongClickListener(OnLongClickListener l) {
+        binding.exArbitraryFileButton.setOnLongClickListener(l);
+        binding.exArbitraryFileAnswerText.setOnLongClickListener(l);
+    }
+
+    @Override
+    protected void showAnswerText() {
+        binding.exArbitraryFileAnswerText.setText(binaryName);
+        binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
+    }
+
+    private void onButtonClick() {
+        waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
+        try {
+            Intent intent = externalAppIntentProvider.provideIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            // ACTION_SENDTO used for sending text messages or emails doesn't require any results
+            if (ACTION_SENDTO.equals(intent.getAction())) {
+                getContext().startActivity(intent);
+            } else {
+                fireActivityForResult(intent);
+            }
+        } catch (Exception | Error e) {
+            ToastUtils.showLongToast(e.getMessage());
+        }
+    }
+
+    private void fireActivityForResult(Intent intent) {
+        try {
+            ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_ARBITRARY_FILE_CHOOSER);
+        } catch (SecurityException e) {
+            Timber.i(e);
+            ToastUtils.showLongToast(R.string.not_granted_permission);
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -80,6 +80,11 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
         binding.exArbitraryFileAnswerText.setVisibility(VISIBLE);
     }
 
+    @Override
+    protected void hideAnswerText() {
+        binding.exArbitraryFileAnswerText.setVisibility(GONE);
+    }
+
     private void onButtonClick() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -46,7 +46,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
         binding.exArbitraryFileButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
         binding.exArbitraryFileAnswerText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
 
-        if (prompt.isReadOnly()) {
+        if (questionDetails.isReadOnly()) {
             binding.exArbitraryFileButton.setVisibility(GONE);
         } else {
             binding.exArbitraryFileButton.setOnClickListener(v -> onButtonClick());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -180,7 +180,7 @@ public class ExStringWidget extends StringWidget implements WidgetDataReceiver, 
     public void onButtonClick(int buttonId) {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = new ExternalAppIntentProvider().provideIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = new ExternalAppIntentProvider().getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
             // ACTION_SENDTO used for sending text messages or emails doesn't require any results
             if (ACTION_SENDTO.equals(intent.getAction())) {
                 getContext().startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -127,7 +127,7 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
         helpTextView = setupHelpText(helpTextLayout.findViewById(R.id.help_text_view), formEntryPrompt);
         setupGuidanceTextAndLayout(helpTextLayout.findViewById(R.id.guidance_text_view), formEntryPrompt);
 
-        View answerView = onCreateAnswerView(context, getFormEntryPrompt(), getAnswerFontSize());
+        View answerView = onCreateAnswerView(context, questionDetails.getPrompt(), getAnswerFontSize());
         if (answerView != null) {
             addAnswerView(answerView);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -184,7 +184,7 @@ public class WidgetFactory {
                 if (appearance.startsWith(WidgetAppearanceUtils.EX)) {
                     questionWidget = new ExArbitraryFileWidget(context, questionDetails, new MediaUtils(), questionMediaManager, waitingForDataRegistry, new ExternalAppIntentProvider(), activityAvailability);
                 } else {
-                    questionWidget = new ArbitraryFileWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry);
+                    questionWidget = new ArbitraryFileWidget(context, questionDetails, new MediaUtils(), questionMediaManager, waitingForDataRegistry);
                 }
                 break;
             case Constants.CONTROL_IMAGE_CHOOSE:

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -30,6 +30,8 @@ import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.CustomTabHelper;
 import org.odk.collect.android.permissions.PermissionsProvider;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
+import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.items.LabelWidget;
@@ -179,7 +181,11 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_FILE_CAPTURE:
-                questionWidget = new ArbitraryFileWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry);
+                if (appearance.startsWith(WidgetAppearanceUtils.EX)) {
+                    questionWidget = new ExArbitraryFileWidget(context, questionDetails, new MediaUtils(), questionMediaManager, waitingForDataRegistry, new ExternalAppIntentProvider(), activityAvailability);
+                } else {
+                    questionWidget = new ArbitraryFileWidget(context, questionDetails, questionMediaManager, waitingForDataRegistry);
+                }
                 break;
             case Constants.CONTROL_IMAGE_CHOOSE:
                 if (appearance.equals(Appearances.SIGNATURE)) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -181,7 +181,7 @@ public class WidgetFactory {
                 }
                 break;
             case Constants.CONTROL_FILE_CAPTURE:
-                if (appearance.startsWith(WidgetAppearanceUtils.EX)) {
+                if (appearance.startsWith(Appearances.EX)) {
                     questionWidget = new ExArbitraryFileWidget(context, questionDetails, new MediaUtils(), questionMediaManager, waitingForDataRegistry, new ExternalAppIntentProvider(), activityAvailability);
                 } else {
                     questionWidget = new ArbitraryFileWidget(context, questionDetails, new MediaUtils(), questionMediaManager, waitingForDataRegistry);

--- a/collect_app/src/main/res/layout/arbitrary_file_widget_answer.xml
+++ b/collect_app/src/main/res/layout/arbitrary_file_widget_answer.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_standard">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/arbitrary_file_button"
+        style="@style/Widget.Collect.Button.WidgetAnswer"
+        android:text="@string/choose_file" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:id="@+id/arbitrary_file_answer_text"
+        style="@style/Widget.Collect.TextView.WidgetAnswer"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        android:drawableStart="@drawable/ic_attachment"
+        android:tag="ArbitraryFileWidgetAnswer"/>
+
+</LinearLayout>

--- a/collect_app/src/main/res/layout/ex_arbitrary_file_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_arbitrary_file_widget_answer.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_standard">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/ex_arbitrary_file_button"
+        style="@style/Widget.Collect.Button.WidgetAnswer"
+        android:text="@string/launch_app" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:id="@+id/ex_arbitrary_file_answer_text"
+        style="@style/Widget.Collect.TextView.WidgetAnswer"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        android:drawableStart="@drawable/ic_attachment" />
+</LinearLayout>

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android.widgets;
 
-import android.content.Intent;
 import android.view.View;
 
 import androidx.annotation.NonNull;
@@ -11,8 +10,8 @@ import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
 import org.odk.collect.android.widgets.support.FakeQuestionMediaManager;
@@ -22,6 +21,7 @@ import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget> {
@@ -61,8 +61,8 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
     public void buttonsShouldLaunchCorrectIntents() {
         stubAllRuntimePermissionsGranted(true);
 
-        Intent intent = getIntentLaunchedByClick(R.id.arbitrary_file_button);
-        assertActionEquals(Intent.ACTION_OPEN_DOCUMENT, intent);
+        getSpyWidget().binding.arbitraryFileButton.performClick();
+        verify(mediaUtils).pickFile(activity, "*/*", ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -61,7 +61,7 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
     public void buttonsShouldLaunchCorrectIntents() {
         stubAllRuntimePermissionsGranted(true);
 
-        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        Intent intent = getIntentLaunchedByClick(R.id.arbitrary_file_button);
         assertActionEquals(Intent.ACTION_OPEN_DOCUMENT, intent);
     }
 
@@ -69,14 +69,14 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getSpyWidget().chooseFileButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().binding.arbitraryFileButton.getVisibility(), is(View.GONE));
     }
 
     @Test
     public void whenReadOnlyOverrideOptionIsUsed_shouldAllClickableElementsBeDisabled() {
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
 
-        assertThat(getSpyWidget().chooseFileButton.getVisibility(), is(View.GONE));
+        assertThat(getSpyWidget().binding.arbitraryFileButton.getVisibility(), is(View.GONE));
     }
 
     public void prepareAnswerFile() {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -8,6 +8,7 @@ import org.javarosa.core.model.data.StringData;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.widgets.base.FileWidgetTest;
@@ -18,6 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_FONT_SIZE;
+import static org.odk.collect.android.utilities.QuestionFontSizeUtils.DEFAULT_FONT_SIZE;
 
 public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget> {
     @Mock
@@ -39,6 +42,20 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
     public ArbitraryFileWidget createWidget() {
         return new ArbitraryFileWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID", readOnlyOverride),
                 mediaUtils, new FakeQuestionMediaManager(), new FakeWaitingForDataRegistry());
+    }
+
+    @Test
+    public void whenFontSizeNotChanged_defaultFontSizeShouldBeUsed() {
+        assertThat((int) getWidget().binding.arbitraryFileButton.getTextSize(), is(DEFAULT_FONT_SIZE - 1));
+        assertThat((int) getWidget().binding.arbitraryFileAnswerText.getTextSize(), is(DEFAULT_FONT_SIZE - 1));
+    }
+
+    @Test
+    public void whenFontSizeChanged_CustomFontSizeShouldBeUsed() {
+        GeneralSharedPreferences.getInstance().save(KEY_FONT_SIZE, "30");
+
+        assertThat((int) getWidget().binding.arbitraryFileButton.getTextSize(), is(29));
+        assertThat((int) getWidget().binding.arbitraryFileAnswerText.getTextSize(), is(29));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -17,6 +17,7 @@ import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.preferences.GeneralKeys.KEY_FONT_SIZE;
@@ -93,6 +94,16 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
 
         ArbitraryFileWidget widget = getWidget();
         widget.clearAnswer();
+        assertThat(widget.binding.arbitraryFileAnswerText.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenSetDataCalledWithUnsupportedType_shouldAnswerBeRemoved() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ArbitraryFileWidget widget = getWidget();
+        widget.setData(null);
+        assertThat(widget.getAnswer(), is(nullValue()));
         assertThat(widget.binding.arbitraryFileAnswerText.getVisibility(), is(View.GONE));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -109,8 +109,13 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
 
     @Test
     public void whenReadOnlyOverrideOptionIsUsed_shouldAllClickableElementsBeDisabled() {
-        when(formEntryPrompt.isReadOnly()).thenReturn(true);
+        readOnlyOverride = true;
+        when(formEntryPrompt.isReadOnly()).thenReturn(false);
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
 
-        assertThat(getSpyWidget().binding.arbitraryFileButton.getVisibility(), is(View.GONE));
+        ArbitraryFileWidget widget = getWidget();
+        assertThat(widget.binding.arbitraryFileButton.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.arbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.binding.arbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -116,6 +116,7 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
         assertThat(widget.binding.arbitraryFileButton.getVisibility(), is(View.GONE));
         assertThat(widget.binding.arbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
         assertThat(widget.binding.arbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
+        assertThat(widget.binding.arbitraryFileAnswerText.hasOnClickListeners(), is(true));
     }
 
     @Test
@@ -128,5 +129,6 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
         assertThat(widget.binding.arbitraryFileButton.getVisibility(), is(View.GONE));
         assertThat(widget.binding.arbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
         assertThat(widget.binding.arbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
+        assertThat(widget.binding.arbitraryFileAnswerText.hasOnClickListeners(), is(true));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ArbitraryFileWidgetTest.java
@@ -73,7 +73,7 @@ public class ArbitraryFileWidgetTest extends FileWidgetTest<ArbitraryFileWidget>
     }
 
     @Test
-    public void whenClickingOnButton_shouldFilePickerByCalled() {
+    public void whenClickingOnButton_shouldFilePickerBeCalled() {
         getWidget().binding.arbitraryFileButton.performClick();
         verify(mediaUtils).pickFile(activity, "*/*", ApplicationConstants.RequestCodes.ARBITRARY_FILE_CHOOSER);
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -15,7 +15,6 @@ import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -42,10 +41,6 @@ import static org.robolectric.Shadows.shadowOf;
  */
 @RunWith(RobolectricTestRunner.class)
 public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
-
-    @Mock
-    File file;
-
     private String fileName;
 
     @NonNull
@@ -61,22 +56,10 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
         return new StringData(fileName);
     }
 
-    @Override
-    public Object createBinaryData(StringData answerData) {
-        return file;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();
         fileName = RandomString.make();
-    }
-
-    @Override
-    protected void prepareAnswerFile() {
-
-        when(file.exists()).thenReturn(true);
-        when(file.getName()).thenReturn(fileName);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
@@ -1,0 +1,104 @@
+package org.odk.collect.android.widgets;
+
+import android.content.Intent;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.odk.collect.android.exception.ExternalParamsException;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.ActivityAvailability;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
+import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.widgets.base.FileWidgetTest;
+import org.odk.collect.android.widgets.support.FakeQuestionMediaManager;
+import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
+
+public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWidget> {
+    @Mock
+    MediaUtils mediaUtils;
+
+    @Mock
+    ExternalAppIntentProvider externalAppIntentProvider;
+
+    @Override
+    public StringData getInitialAnswer() {
+        return new StringData("document.pdf");
+    }
+
+    @NonNull
+    @Override
+    public StringData getNextAnswer() {
+        return new StringData("document.xlsx");
+    }
+
+    @NonNull
+    @Override
+    public ExArbitraryFileWidget createWidget() {
+        return new ExArbitraryFileWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID", readOnlyOverride),
+                mediaUtils, new FakeQuestionMediaManager(), new FakeWaitingForDataRegistry(), externalAppIntentProvider, new ActivityAvailability(activity));
+    }
+
+    @Test
+    public void whenThereIsNoAnswer_shouldAnswerTextBeHidden() {
+        assertThat(getWidget().binding.exArbitraryFileAnswerText.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenThereIsAnswer_shouldAnswerTextBeDisplayed() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExArbitraryFileWidget widget = getWidget();
+        assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.binding.exArbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
+    }
+
+    @Test
+    public void whenClickingOnButton_shouldFilePickerByCalled() throws ExternalParamsException, XPathSyntaxException {
+        Intent intent = mock(Intent.class);
+        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
+        getWidget().binding.exArbitraryFileButton.performClick();
+        assertThat(shadowOf(activity).getNextStartedActivity(), is(intent));
+    }
+
+    @Test
+    public void whenClickingOnAnswer_shouldFileViewerByCalled() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExArbitraryFileWidget widget = getWidget();
+        widget.binding.exArbitraryFileAnswerText.performClick();
+        verify(mediaUtils).openFile(activity, widget.answerFile, null);
+    }
+
+    @Test
+    public void whenClearAnswerCall_shouldAnswerTextBeHidden() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExArbitraryFileWidget widget = getWidget();
+        widget.clearAnswer();
+        assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
+        when(formEntryPrompt.isReadOnly()).thenReturn(true);
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExArbitraryFileWidget widget = getWidget();
+        assertThat(widget.binding.exArbitraryFileButton.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.binding.exArbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.odk.collect.android.exception.ExternalParamsException;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -24,6 +25,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_FONT_SIZE;
+import static org.odk.collect.android.utilities.QuestionFontSizeUtils.DEFAULT_FONT_SIZE;
 import static org.robolectric.Shadows.shadowOf;
 
 public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWidget> {
@@ -49,6 +52,20 @@ public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWid
     public ExArbitraryFileWidget createWidget() {
         return new ExArbitraryFileWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID", readOnlyOverride),
                 mediaUtils, new FakeQuestionMediaManager(), new FakeWaitingForDataRegistry(), externalAppIntentProvider, new ActivityAvailability(activity));
+    }
+
+    @Test
+    public void whenFontSizeNotChanged_defaultFontSizeShouldBeUsed() {
+        assertThat((int) getWidget().binding.exArbitraryFileButton.getTextSize(), is(DEFAULT_FONT_SIZE - 1));
+        assertThat((int) getWidget().binding.exArbitraryFileAnswerText.getTextSize(), is(DEFAULT_FONT_SIZE - 1));
+    }
+
+    @Test
+    public void whenFontSizeChanged_CustomFontSizeShouldBeUsed() {
+        GeneralSharedPreferences.getInstance().save(KEY_FONT_SIZE, "30");
+
+        assertThat((int) getWidget().binding.exArbitraryFileButton.getTextSize(), is(29));
+        assertThat((int) getWidget().binding.exArbitraryFileAnswerText.getTextSize(), is(29));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
@@ -83,7 +83,7 @@ public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWid
     }
 
     @Test
-    public void whenClickingOnButton_shouldFilePickerByCalled() throws ExternalParamsException, XPathSyntaxException {
+    public void whenClickingOnButton_externalAppShouldBeLaunchedByIntent() throws ExternalParamsException, XPathSyntaxException {
         Intent intent = mock(Intent.class);
         when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
         getWidget().binding.exArbitraryFileButton.performClick();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
@@ -118,4 +118,16 @@ public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWid
         assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
         assertThat(widget.binding.exArbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
     }
+
+    @Test
+    public void whenReadOnlyOverrideOptionIsUsed_shouldAllClickableElementsBeDisabled() {
+        readOnlyOverride = true;
+        when(formEntryPrompt.isReadOnly()).thenReturn(false);
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExArbitraryFileWidget widget = getWidget();
+        assertThat(widget.binding.exArbitraryFileButton.getVisibility(), is(View.GONE));
+        assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.VISIBLE));
+        assertThat(widget.binding.exArbitraryFileAnswerText.getText(), is(getInitialAnswer().getDisplayText()));
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
@@ -21,6 +21,7 @@ import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -105,6 +106,16 @@ public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWid
 
         ExArbitraryFileWidget widget = getWidget();
         widget.clearAnswer();
+        assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenSetDataCalledWithUnsupportedType_shouldAnswerBeRemoved() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExArbitraryFileWidget widget = getWidget();
+        widget.setData(null);
+        assertThat(widget.getAnswer(), is(nullValue()));
         assertThat(widget.binding.exArbitraryFileAnswerText.getVisibility(), is(View.GONE));
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ImageWidgetTest.java
@@ -13,7 +13,6 @@ import net.bytebuddy.utility.RandomString;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
@@ -35,10 +34,6 @@ import static org.odk.collect.android.support.CollectHelpers.setupFakeReferenceM
  * @author James Knight
  */
 public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
-
-    @Mock
-    File file;
-
     private String fileName;
 
     @NonNull
@@ -54,22 +49,10 @@ public class ImageWidgetTest extends FileWidgetTest<ImageWidget> {
         return new StringData(fileName);
     }
 
-    @Override
-    public Object createBinaryData(StringData answerData) {
-        return file;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();
         fileName = RandomString.make();
-    }
-
-    @Override
-    protected void prepareAnswerFile() {
-
-        when(file.exists()).thenReturn(true);
-        when(file.getName()).thenReturn(fileName);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/SignatureWidgetTest.java
@@ -14,7 +14,6 @@ import net.bytebuddy.utility.RandomString;
 import org.javarosa.core.model.data.StringData;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.DrawActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -39,10 +38,6 @@ import static org.robolectric.Shadows.shadowOf;
  * @author James Knight
  */
 public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
-
-    @Mock
-    File file;
-
     private String fileName;
 
     @NonNull
@@ -58,21 +53,10 @@ public class SignatureWidgetTest extends FileWidgetTest<SignatureWidget> {
         return new StringData(fileName);
     }
 
-    @Override
-    public Object createBinaryData(StringData answerData) {
-        return file;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();
         fileName = RandomString.make();
-    }
-
-    @Override
-    protected void prepareAnswerFile() {
-        when(file.exists()).thenReturn(true);
-        when(file.getName()).thenReturn(fileName);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/VideoWidgetTest.java
@@ -20,8 +20,6 @@ import org.odk.collect.android.widgets.base.FileWidgetTest;
 import org.odk.collect.android.widgets.support.FakeQuestionMediaManager;
 import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
 
-import java.io.File;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,9 +30,6 @@ import static org.mockito.Mockito.when;
  * @author James Knight
  */
 public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
-    @Mock
-    File file;
-
     @Mock
     MediaUtils mediaUtils;
 
@@ -50,11 +45,6 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
     @Override
     public StringData getNextAnswer() {
         return new StringData(destinationName);
-    }
-
-    @Override
-    public Object createBinaryData(StringData answerData) {
-        return file;
     }
 
     @Before
@@ -106,10 +96,5 @@ public class VideoWidgetTest extends FileWidgetTest<VideoWidget> {
         assertThat(getSpyWidget().playButton.getVisibility(), is(View.VISIBLE));
         assertThat(getSpyWidget().playButton.isEnabled(), is(Boolean.FALSE));
         assertThat(getSpyWidget().playButton.getText(), is("Play Video"));
-    }
-
-    public void prepareAnswerFile() {
-        when(file.exists()).thenReturn(true);
-        when(file.getName()).thenReturn(destinationName);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/FileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/FileWidgetTest.java
@@ -11,6 +11,7 @@ import org.odk.collect.android.widgets.interfaces.FileWidget;
 
 import java.io.File;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +27,14 @@ public abstract class FileWidgetTest<W extends FileWidget> extends BinaryWidgetT
     }
 
     @Override
+    public Object createBinaryData(StringData answerData) {
+        File file = mock(File.class);
+        when(file.exists()).thenReturn(true);
+        when(file.getName()).thenReturn(answerData.getDisplayText());
+        return file;
+    }
+
+    @Override
     public void setUp() throws Exception {
         super.setUp();
 
@@ -35,8 +44,6 @@ public abstract class FileWidgetTest<W extends FileWidget> extends BinaryWidgetT
 
     @Test
     public void settingANewAnswerShouldCallDeleteMediaToRemoveTheOldFile() {
-        prepareAnswerFile();
-
         super.settingANewAnswerShouldRemoveTheOldAnswer();
 
         W widget = getSpyWidget();
@@ -49,25 +56,5 @@ public abstract class FileWidgetTest<W extends FileWidget> extends BinaryWidgetT
 
         W widget = getSpyWidget();
         verify(widget).deleteFile();
-    }
-
-    @Override
-    public void getAnswerShouldReturnCorrectAnswerAfterBeingSet() {
-        prepareAnswerFile();
-        super.getAnswerShouldReturnCorrectAnswerAfterBeingSet();
-    }
-
-    @Override
-    public void settingANewAnswerShouldRemoveTheOldAnswer() {
-        prepareAnswerFile();
-        super.settingANewAnswerShouldRemoveTheOldAnswer();
-    }
-
-    /**
-     * Override this to provide additional set-up prior to testing any set answer methods.
-     */
-    @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
-    protected void prepareAnswerFile() {
-        // Default implementation does nothing.
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
@@ -130,6 +130,8 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
 
     @Test
     public void callingClearShouldCallValueChangeListeners() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
         QuestionWidget widget = (QuestionWidget) getSpyWidget();
         WidgetValueChangedListener valueChangedListener = mockValueChangedListener(widget);
         widget.clearAnswer();


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested the fix manually and added (and improved) automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's a continuation of https://github.com/getodk/collect/pull/4188

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test widgets:
- **ExArbitraryFileWidget** - it's a completly new widget
- **ArbitraryFileWidget** - I had to refactor this widget to implement ExArbitraryFileWidget
- **ExStringWidgets** - I also touched these widgets to factor out the shared code so would be good to verify there is everything fine with them
and that should be enough when it comes to testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
[externalForm.xlsx](https://github.com/getodk/collect/files/5820990/externalForm.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
I'll file an issue for all the external binary widgets one we implement all of them.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)