### PR TITLE
Change download analytics to only log when forms with same formid/version but different hashes are requested

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -72,9 +72,11 @@ public class AnalyticsEvents {
     public static final String SCOPED_STORAGE_MIGRATION = "ScopedStorageMigration";
 
     /**
-     * Track attempts to download a form with the same formid/version as one already on the device.
+     * Track attempts to download a form with the same formid/version but different contents as one
+     * already on the device. We know this happens in the case of Central drafts but it should
+     * otherwise be rare.
      */
-    public static final String DOWNLOAD_SAME_FORMID_VERSION = "DownloadSameFormidVersion";
+    public static final String DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH = "DownloadSameFormidVersionDifferentHash";
 
     /**
      * Track downloads initiated when there are no downloaded forms on the device. The action should

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
@@ -10,6 +10,7 @@ import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -44,10 +45,10 @@ public class DatabaseFormsRepository implements FormsRepository {
 
     @Nullable
     @Override
-    public Form getOneByFormIdAndVersion(String jrFormId, @Nullable String jrVersion) {
+    public Form getLatestByFormIdAndVersion(String jrFormId, @Nullable String jrVersion) {
         List<Form> all = getAllByFormIdAndVersion(jrFormId, jrVersion);
         if (!all.isEmpty()) {
-            return all.get(0);
+            return all.stream().max(Comparator.comparingLong(Form::getDate)).get();
         } else {
             return null;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 import timber.log.Timber;
 
 import static org.apache.commons.io.FileUtils.deleteDirectory;
-import static org.odk.collect.android.analytics.AnalyticsEvents.DOWNLOAD_SAME_FORMID_VERSION;
+import static org.odk.collect.android.analytics.AnalyticsEvents.DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH;
 import static org.odk.collect.utilities.PathUtils.getAbsoluteFilePath;
 
 public class ServerFormDownloader implements FormDownloader {
@@ -63,9 +63,11 @@ public class ServerFormDownloader implements FormDownloader {
             if (formOnDevice.isDeleted()) {
                 formsRepository.restore(formOnDevice.getId());
             } else {
-                String formIdentifier = formOnDevice.getDisplayName() + " " + formOnDevice.getId();
-                String formIdHash = FileUtils.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
-                analytics.logFormEvent(DOWNLOAD_SAME_FORMID_VERSION, formIdHash);
+                if (!getMd5HashWithoutPrefix(form.getHash()).equals(formOnDevice.getMD5Hash())) {
+                    String formIdentifier = formOnDevice.getDisplayName() + " " + formOnDevice.getId();
+                    String formIdHash = FileUtils.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
+                    analytics.logFormEvent(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, formIdHash);
+                }
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -62,12 +62,13 @@ public class ServerFormDownloader implements FormDownloader {
         if (formOnDevice != null) {
             if (formOnDevice.isDeleted()) {
                 formsRepository.restore(formOnDevice.getId());
-            } else {
-                if (!getMd5HashWithoutPrefix(form.getHash()).equals(formOnDevice.getMD5Hash()) && !form.getDownloadUrl().contains("/draft.xml")) {
-                    String formIdentifier = formOnDevice.getDisplayName() + " " + formOnDevice.getId();
-                    String formIdHash = FileUtils.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
-                    analytics.logFormEvent(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, formIdHash);
-                }
+            }
+        } else {
+            List<Form> allSameFormIdVersion = formsRepository.getAllByFormIdAndVersion(form.getFormId(), form.getFormVersion());
+            if (!allSameFormIdVersion.isEmpty() && !form.getDownloadUrl().contains("/draft.xml")) {
+                String formIdentifier = form.getFormName() + " " + form.getFormId();
+                String formIdHash = FileUtils.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
+                analytics.logFormEvent(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, formIdHash);
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -58,7 +58,7 @@ public class ServerFormDownloader implements FormDownloader {
 
     @Override
     public void downloadForm(ServerFormDetails form, @Nullable ProgressReporter progressReporter, @Nullable Supplier<Boolean> isCancelled) throws FormDownloadException, InterruptedException {
-        Form formOnDevice = formsRepository.getLatestByFormIdAndVersion(form.getFormId(), form.getFormVersion());
+        Form formOnDevice = formsRepository.getOneByMd5Hash(getMd5HashWithoutPrefix(form.getHash()));
         if (formOnDevice != null) {
             if (formOnDevice.isDeleted()) {
                 formsRepository.restore(formOnDevice.getId());

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -58,7 +58,7 @@ public class ServerFormDownloader implements FormDownloader {
 
     @Override
     public void downloadForm(ServerFormDetails form, @Nullable ProgressReporter progressReporter, @Nullable Supplier<Boolean> isCancelled) throws FormDownloadException, InterruptedException {
-        Form formOnDevice = formsRepository.getOneByFormIdAndVersion(form.getFormId(), form.getFormVersion());
+        Form formOnDevice = formsRepository.getLatestByFormIdAndVersion(form.getFormId(), form.getFormVersion());
         if (formOnDevice != null) {
             if (formOnDevice.isDeleted()) {
                 formsRepository.restore(formOnDevice.getId());

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -63,7 +63,7 @@ public class ServerFormDownloader implements FormDownloader {
             if (formOnDevice.isDeleted()) {
                 formsRepository.restore(formOnDevice.getId());
             } else {
-                if (!getMd5HashWithoutPrefix(form.getHash()).equals(formOnDevice.getMD5Hash())) {
+                if (!getMd5HashWithoutPrefix(form.getHash()).equals(formOnDevice.getMD5Hash()) && !form.getDownloadUrl().contains("/draft.xml")) {
                     String formIdentifier = formOnDevice.getDisplayName() + " " + formOnDevice.getId();
                     String formIdHash = FileUtils.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
                     analytics.logFormEvent(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, formIdHash);

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -11,7 +11,7 @@ public interface FormsRepository {
     Form get(Long id);
 
     @Nullable
-    Form getOneByFormIdAndVersion(String formId, @Nullable String version);
+    Form getLatestByFormIdAndVersion(String formId, @Nullable String version);
 
     @Nullable
     Form getOneByPath(String path);

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDeleter.java
@@ -21,7 +21,7 @@ public class InstanceDeleter {
         Instance instance = instancesRepository.get(id);
         instancesRepository.delete(id);
 
-        Form form = formsRepository.getOneByFormIdAndVersion(instance.getJrFormId(), instance.getJrVersion());
+        Form form = formsRepository.getLatestByFormIdAndVersion(instance.getJrFormId(), instance.getJrVersion());
         if (form != null && form.isDeleted()) {
             List<Instance> otherInstances = instancesRepository.getAllNotDeletedByFormIdAndVersion(form.getJrFormId(), form.getJrVersion());
             if (otherInstances.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.java
@@ -170,7 +170,7 @@ public class InstanceSubmitter {
      */
     @Deprecated
     public static boolean shouldFormBeSent(FormsRepository formsRepository, String jrFormId, String jrFormVersion, boolean isAutoSendAppSettingEnabled) {
-        Form form = formsRepository.getOneByFormIdAndVersion(jrFormId, jrFormVersion);
+        Form form = formsRepository.getLatestByFormIdAndVersion(jrFormId, jrFormVersion);
         if (form == null) {
             return false;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -28,8 +28,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 
 import org.odk.collect.android.database.FormDatabaseMigrator;
-import org.odk.collect.android.fastexternalitemset.ItemsetDbAdapter;
 import org.odk.collect.android.database.FormsDatabaseHelper;
+import org.odk.collect.android.fastexternalitemset.ItemsetDbAdapter;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.permissions.PermissionsProvider;
 import org.odk.collect.android.provider.FormsProviderAPI.FormsColumns;
@@ -37,6 +37,7 @@ import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.utilities.Clock;
 
 import java.io.File;
 import java.util.HashMap;
@@ -63,6 +64,9 @@ public class FormsProvider extends ContentProvider {
 
     @Inject
     PermissionsProvider permissionsProvider;
+
+    @Inject
+    Clock clock;
 
     private synchronized FormsDatabaseHelper getDbHelper() {
         // wrapper to test and reset/set the dbHelper based upon the attachment state of the device.
@@ -199,7 +203,7 @@ public class FormsProvider extends ContentProvider {
             filePath = form.getAbsolutePath(); // normalized
             values.put(FormsColumns.FORM_FILE_PATH, storagePathProvider.getFormDbPath(filePath));
 
-            Long now = System.currentTimeMillis();
+            Long now = clock.getCurrentTime();
 
             // Make sure that the necessary fields are all set
             if (!values.containsKey(FormsColumns.DATE)) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/InstanceUploaderUtils.java
@@ -98,7 +98,7 @@ public class InstanceUploaderUtils {
      * If the form explicitly sets the auto-delete property, then it overrides the preference.
      */
     public static boolean shouldFormBeDeleted(FormsRepository formsRepository, String jrFormId, String jrFormVersion, boolean isAutoDeleteAppSettingEnabled) {
-        Form form = formsRepository.getOneByFormIdAndVersion(jrFormId, jrFormVersion);
+        Form form = formsRepository.getLatestByFormIdAndVersion(jrFormId, jrFormVersion);
         if (form == null) {
             return false;
         }

--- a/collect_app/src/test/java/org/odk/collect/android/database/DatabaseFormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/DatabaseFormsRepositoryTest.java
@@ -6,10 +6,12 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.forms.FormsRepositoryTest;
+import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.support.RobolectricHelpers;
+import org.odk.collect.utilities.Clock;
 
 @RunWith(AndroidJUnit4.class)
 public class DatabaseFormsRepositoryTest extends FormsRepositoryTest {
@@ -26,6 +28,18 @@ public class DatabaseFormsRepositoryTest extends FormsRepositoryTest {
     @Override
     public FormsRepository buildSubject() {
         return new DatabaseFormsRepository();
+    }
+
+    @Override
+    public FormsRepository buildSubject(Clock clock) {
+        RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public Clock providesClock() {
+                return clock;
+            }
+        });
+
+        return buildSubject();
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -301,12 +301,13 @@ public class ServerFormDownloaderTest {
 
     @Test
     public void whenFormIsSoftDeleted_unDeletesForm() throws Exception {
-        Form form = buildForm("deleted-form", "version", getFormFilesPath())
+        String xform = createXForm("deleted-form", "version");
+
+        Form form = buildForm("deleted-form", "version", getFormFilesPath(), xform)
                 .deleted(true)
                 .build();
         formsRepository.save(form);
 
-        String xform = createXForm(form.getJrFormId(), form.getJrVersion());
         ServerFormDetails serverFormDetails = new ServerFormDetails(
                 form.getDisplayName(),
                 "http://downloadUrl",
@@ -326,7 +327,7 @@ public class ServerFormDownloaderTest {
     }
 
     @Test
-    public void whenMultipleFormsWithSameFormIdVersionDeleted_unDeletesFormWithSameHash() throws Exception {
+    public void whenMultipleFormsWithSameFormIdVersionDeleted_reDownloadUnDeletesFormWithSameHash() throws Exception {
         String xform = createXForm("deleted-form", "version", "A title");
         Form form = buildForm("deleted-form", "version", getFormFilesPath(), xform)
                 .deleted(true)

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -260,7 +260,7 @@ public class ServerFormDownloaderTest {
 
     @Test
     public void whenFormIsSoftDeleted_unDeletesForm() throws Exception {
-        Form form = buildForm(1L, "deleted-form", "version", getFormFilesPath())
+        Form form = buildForm("deleted-form", "version", getFormFilesPath())
                 .deleted(true)
                 .build();
         formsRepository.save(form);

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -20,14 +20,29 @@ public abstract class FormsRepositoryTest {
     public abstract String getFormFilesPath();
 
     @Test
-    public void getOneByFormIdAndVersion_whenFormHasNullVersion_returnsForm() {
+    public void getLatestByFormIdAndVersion_whenFormHasNullVersion_returnsForm() {
         FormsRepository formsRepository = buildSubject();
         formsRepository.save(buildForm(1L, "1", null, getFormFilesPath())
                 .build());
 
-        Form form = formsRepository.getOneByFormIdAndVersion("1", null);
+        Form form = formsRepository.getLatestByFormIdAndVersion("1", null);
         assertThat(form, notNullValue());
         assertThat(form.getId(), is(1L));
+    }
+
+    @Test
+    public void getLatestByFormIdAndVersion_whenMultipleExist_returnsLatest() {
+        FormsRepository formsRepository = buildSubject();
+        formsRepository.save(buildForm(1L, "1", "1", getFormFilesPath())
+                .build());
+        formsRepository.save(buildForm(2L, "1", "1", getFormFilesPath())
+                .build());
+        formsRepository.save(buildForm(3L, "1", "1", getFormFilesPath())
+                .build());
+
+        Form form = formsRepository.getLatestByFormIdAndVersion("1", "1");
+        assertThat(form, notNullValue());
+        assertThat(form.getId(), is(3L));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -22,7 +22,7 @@ public abstract class FormsRepositoryTest {
     @Test
     public void getLatestByFormIdAndVersion_whenFormHasNullVersion_returnsForm() {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "1", null, getFormFilesPath())
+        formsRepository.save(buildForm("1", null, getFormFilesPath())
                 .build());
 
         Form form = formsRepository.getLatestByFormIdAndVersion("1", null);
@@ -31,13 +31,15 @@ public abstract class FormsRepositoryTest {
     }
 
     @Test
-    public void getLatestByFormIdAndVersion_whenMultipleExist_returnsLatest() {
+    public void getLatestByFormIdAndVersion_whenMultipleExist_returnsLatest() throws InterruptedException {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "1", "1", getFormFilesPath())
+        formsRepository.save(buildForm("1", "1", getFormFilesPath())
                 .build());
-        formsRepository.save(buildForm(2L, "1", "1", getFormFilesPath())
+        Thread.sleep(2); // ensure that the in-memory inserts don't all get the same timestamp
+        formsRepository.save(buildForm("1", "1", getFormFilesPath())
                 .build());
-        formsRepository.save(buildForm(3L, "1", "1", getFormFilesPath())
+        Thread.sleep(2); // ensure that the in-memory inserts don't all get the same timestamp
+        formsRepository.save(buildForm("1", "1", getFormFilesPath())
                 .build());
 
         Form form = formsRepository.getLatestByFormIdAndVersion("1", "1");
@@ -48,13 +50,13 @@ public abstract class FormsRepositoryTest {
     @Test
     public void getAllByFormIdAndVersion_whenFormHasNullVersion_returnsAllMatchingForms() {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "1", null, getFormFilesPath())
+        formsRepository.save(buildForm("1", null, getFormFilesPath())
                 .build());
 
-        formsRepository.save(buildForm(2L, "1", null, getFormFilesPath())
+        formsRepository.save(buildForm("1", null, getFormFilesPath())
                 .build());
 
-        formsRepository.save(buildForm(3L, "1", "7", getFormFilesPath())
+        formsRepository.save(buildForm("1", "7", getFormFilesPath())
                 .build());
 
         List<Form> forms = formsRepository.getAllByFormIdAndVersion("1", null);
@@ -66,12 +68,12 @@ public abstract class FormsRepositoryTest {
     @Test
     public void getAllNotDeletedByFormId_doesNotReturnDeletedForms() {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "1", "deleted", getFormFilesPath())
+        formsRepository.save(buildForm("1", "deleted", getFormFilesPath())
                 .deleted(true)
                 .build()
         );
 
-        formsRepository.save(buildForm(2L, "1", "not-deleted", getFormFilesPath())
+        formsRepository.save(buildForm("1", "not-deleted", getFormFilesPath())
                 .deleted(false)
                 .build()
         );
@@ -84,20 +86,20 @@ public abstract class FormsRepositoryTest {
     @Test
     public void getAllNotDeletedByFormIdAndVersion_onlyReturnsNotDeletedFormsThatMatchVersion() {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "id", "1", getFormFilesPath())
+        formsRepository.save(buildForm("id", "1", getFormFilesPath())
                 .deleted(true)
                 .build()
         );
-        formsRepository.save(buildForm(2L, "id", "1", getFormFilesPath())
+        formsRepository.save(buildForm("id", "1", getFormFilesPath())
                 .deleted(false)
                 .build()
         );
 
-        formsRepository.save(buildForm(3L, "id", "2", getFormFilesPath())
+        formsRepository.save(buildForm("id", "2", getFormFilesPath())
                 .deleted(true)
                 .build()
         );
-        formsRepository.save(buildForm(4L, "id", "2", getFormFilesPath())
+        formsRepository.save(buildForm("id", "2", getFormFilesPath())
                 .deleted(false)
                 .build()
         );
@@ -110,7 +112,7 @@ public abstract class FormsRepositoryTest {
     @Test
     public void softDelete_marksDeletedAsTrue() {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "1", null, getFormFilesPath())
+        formsRepository.save(buildForm("1", null, getFormFilesPath())
                 .build());
 
         formsRepository.softDelete(1L);
@@ -120,7 +122,7 @@ public abstract class FormsRepositoryTest {
     @Test
     public void restore_marksDeletedAsFalse() {
         FormsRepository formsRepository = buildSubject();
-        formsRepository.save(buildForm(1L, "1", null, getFormFilesPath())
+        formsRepository.save(buildForm("1", null, getFormFilesPath())
                 .deleted(true)
                 .build());
 
@@ -131,7 +133,7 @@ public abstract class FormsRepositoryTest {
     @Test
     public void save_addsId() {
         FormsRepository formsRepository = buildSubject();
-        Form form = buildForm(null, "id", "version", getFormFilesPath()).build();
+        Form form = buildForm("id", "version", getFormFilesPath()).build();
 
         formsRepository.save(form);
         assertThat(formsRepository.getAll().get(0).getId(), notNullValue());
@@ -140,7 +142,7 @@ public abstract class FormsRepositoryTest {
     @Test
     public void save_addsHashBasedOnFormFile() {
         FormsRepository formsRepository = buildSubject();
-        Form form = buildForm(1L, "id", "version", getFormFilesPath()).build();
+        Form form = buildForm("id", "version", getFormFilesPath()).build();
         assertThat(form.getMD5Hash(), equalTo(null));
 
         formsRepository.save(form);

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -37,7 +37,10 @@ public abstract class FormsRepositoryTest {
 
     @Test
     public void getLatestByFormIdAndVersion_whenMultipleExist_returnsLatest() {
-        FormsRepository formsRepository = buildSubject(getMockClock());
+        Clock mockClock = mock(Clock.class);
+        when(mockClock.getCurrentTime()).thenReturn(2L, 3L, 1L);
+
+        FormsRepository formsRepository = buildSubject(mockClock);
         formsRepository.save(buildForm("1", "1", getFormFilesPath())
                 .build());
         formsRepository.save(buildForm("1", "1", getFormFilesPath())
@@ -152,11 +155,5 @@ public abstract class FormsRepositoryTest {
 
         String expectedHash = FileUtils.getMd5Hash(new File(form.getFormFilePath()));
         assertThat(formsRepository.get(1L).getMD5Hash(), equalTo(expectedHash));
-    }
-
-    public Clock getMockClock() {
-        Clock mockClock = mock(Clock.class);
-        when(mockClock.getCurrentTime()).thenReturn(2L, 3L, 1L);
-        return mockClock;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/forms/InMemFormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/InMemFormsRepositoryTest.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.forms;
 
 import org.junit.Before;
 import org.odk.collect.android.support.InMemFormsRepository;
+import org.odk.collect.utilities.Clock;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,6 +19,11 @@ public class InMemFormsRepositoryTest extends FormsRepositoryTest {
     @Override
     public FormsRepository buildSubject() {
         return new InMemFormsRepository();
+    }
+
+    @Override
+    public FormsRepository buildSubject(Clock clock) {
+        return new InMemFormsRepository(clock);
     }
 
     @Override

--- a/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
@@ -28,18 +28,17 @@ public class FormUtils {
                 "</h:html>";
     }
 
-    public static Form.Builder buildForm(Long id, String formId, String version, String formFilesPath) {
-        return buildForm(id, formId, version, formFilesPath, "blah");
+    public static Form.Builder buildForm(String formId, String version, String formFilesPath) {
+        return buildForm(formId, version, formFilesPath, "blah");
     }
 
-    public static Form.Builder buildForm(Long id, String formId, String version, String formFilesPath, String xform) {
+    public static Form.Builder buildForm(String formId, String version, String formFilesPath, String xform) {
         String fileName = formId + "-" + version + "-" + Math.random();
         File formFile = new File(formFilesPath + "/" + fileName + ".xml");
         FileUtils.write(formFile, xform.getBytes());
         String mediaPath = new File(formFilesPath + "/" + fileName + "-media").getAbsolutePath();
 
         return new Form.Builder()
-                .id(id)
                 .displayName("Test Form")
                 .formFilePath(formFile.getAbsolutePath())
                 .formMediaPath(mediaPath)

--- a/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/FormUtils.java
@@ -12,10 +12,14 @@ public class FormUtils {
     }
 
     public static String createXForm(String formId, String version) {
+        return createXForm(formId, version, "Form");
+    }
+
+    public static String createXForm(String formId, String version, String title) {
         return "<?xml version=\"1.0\"?>\n" +
                 "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:ev=\"http://www.w3.org/2001/xml-events\" xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:jr=\"http://openrosa.org/javarosa\" xmlns:orx=\"http://openrosa.org/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n" +
                 "    <h:head>\n" +
-                "        <h:title>Form</h:title>\n" +
+                "        <h:title>" + title + "</h:title>\n" +
                 "        <model>\n" +
                 "            <instance>\n" +
                 "                <data id=\"" + formId + "\" orx:version=\"" + version + "\">\n" +

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -72,13 +72,8 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Override
     public Uri save(Form form) {
-        if (form.getId() == null) {
-            form = new Form.Builder(form)
-                    .id(idCounter++)
-                    .build();
-        }
-
         form = new Form.Builder(form)
+                .id(idCounter++)
                 .date(System.currentTimeMillis())
                 .build();
 

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -8,6 +8,7 @@ import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -28,8 +29,14 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Nullable
     @Override
-    public Form getOneByFormIdAndVersion(String formId, @Nullable String version) {
-        return forms.stream().filter(f -> f.getJrFormId().equals(formId) && Objects.equals(f.getJrVersion(), version)).findFirst().orElse(null);
+    public Form getLatestByFormIdAndVersion(String formId, @Nullable String version) {
+        List<Form> candidates = getAllByFormIdAndVersion(formId, version);
+
+        if (!candidates.isEmpty()) {
+            return candidates.stream().max(Comparator.comparingLong(Form::getDate)).get();
+        } else {
+            return null;
+        }
     }
 
     @Nullable
@@ -70,6 +77,10 @@ public class InMemFormsRepository implements FormsRepository {
                     .id(idCounter++)
                     .build();
         }
+
+        form = new Form.Builder(form)
+                .date(System.currentTimeMillis())
+                .build();
 
         String formFilePath = form.getFormFilePath();
 

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.utilities.Clock;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -20,6 +21,16 @@ public class InMemFormsRepository implements FormsRepository {
 
     private final List<Form> forms = new ArrayList<>();
     private long idCounter = 1L;
+
+    private final Clock clock;
+
+    public InMemFormsRepository() {
+        this.clock = System::currentTimeMillis;
+    }
+
+    public InMemFormsRepository(Clock clock) {
+        this.clock = clock;
+    }
 
     @Nullable
     @Override
@@ -74,7 +85,7 @@ public class InMemFormsRepository implements FormsRepository {
     public Uri save(Form form) {
         form = new Form.Builder(form)
                 .id(idCounter++)
-                .date(System.currentTimeMillis())
+                .date(clock.getCurrentTime())
                 .build();
 
         String formFilePath = form.getFormFilePath();


### PR DESCRIPTION
The question we're trying to answer with this PR is whether we can make another attempt towards warning about or preventing downloads with the same formid/version and different hashes.

The `DownloadSameFormidVersion` event let us see that quite a lot of users download forms with the same formid and version. We suspect that these are typically identical forms and that people just select all in Get Blank Forms. This PR only logs analytics events when the form being downloaded has a different hash than the latest one with matching formid/version AND the download URL doesn't include `/draft.xml`. The latter condition is a rough way to avoid Central drafts since we know that Central draft workflows generally involve changing the form definition without changing the form version.

#### What has been done to verify that this works as intended?
Used the debugger to confirm that the analytics event is reached when the form hashes are different and not reached when the form hashes are the same. In doing this, I noticed that when we get a form by id and version, we really should always get the latest one downloaded. I verified that change by adding an automated test. I also verified that if the form hashes are different but a Central draft is being used, the analytics event is not reached.

I think this should probably go through brief QA because of the change to `FormRepository`.

#### Why is this the best possible solution? Were any other approaches considered?
I didn't really consider any alternatives other than not making the testing change to remove id parameters. I put it in here because I got tripped up trying to write a test to make sure the date was used for ordering rather than the database ID. It turns out there's no point in trying to manually set dates or ids when building `Form` objects because the database implementation ignores them. It felt better to remove that confusion.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think there are two ares of regression:
1. Ordering by date when matching a single form by formid and version. This gets used:
  - when deleting instances, to determine which form gets deleted when the last instance on the device is deleted. I think it would make more sense to delete all forms with matching formid/version but it seems like enough of an edge case that it's not a big deal.
  - when identifying whether instances of a form should be autosent or autodeleted.
2. Matching on hash instead of on formid/version to see if a form needs to be undeleted on form download. This affects cases where forms with the same formid/version and either the same or different contents as forms already on the device AND soft-deleted are downloaded. For a delete to be a soft delete, there need to still be instances matching the formid/version.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)