### PR TITLE
Workaround paused recording Android bug

### DIFF
--- a/audiorecorder/build.gradle
+++ b/audiorecorder/build.gradle
@@ -58,4 +58,5 @@ dependencies {
     testImplementation 'androidx.test:core-ktx:1.3.0'
     testImplementation 'androidx.test:rules:1.3.0'
     testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation "org.mockito:mockito-core:3.6.28"
 }

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
@@ -77,15 +77,15 @@ internal open class AudioRecorderDependencyModule {
         return RecordingResourceRecorder(cacheDir) { output ->
             when (output) {
                 Output.AMR -> {
-                    AMRRecordingResource(MediaRecorder())
+                    AMRRecordingResource(MediaRecorder(), android.os.Build.VERSION.SDK_INT)
                 }
 
                 Output.AAC -> {
-                    AACRecordingResource(MediaRecorder(), 64)
+                    AACRecordingResource(MediaRecorder(), android.os.Build.VERSION.SDK_INT, 64)
                 }
 
                 Output.AAC_LOW -> {
-                    AACRecordingResource(MediaRecorder(), 24)
+                    AACRecordingResource(MediaRecorder(), android.os.Build.VERSION.SDK_INT, 24)
                 }
             }
         }

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/mediarecorder/MediaRecorderRecordingResource.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/mediarecorder/MediaRecorderRecordingResource.kt
@@ -1,9 +1,10 @@
 package org.odk.collect.audiorecorder.mediarecorder
 
+import android.annotation.SuppressLint
 import android.media.MediaRecorder
 import org.odk.collect.audiorecorder.recorder.RecordingResource
 
-internal abstract class MediaRecorderRecordingResource(private val mediaRecorder: MediaRecorder) : RecordingResource {
+internal abstract class MediaRecorderRecordingResource(private val mediaRecorder: MediaRecorder, private val sdk: Int) : RecordingResource {
 
     protected abstract fun beforePrepare(mediaRecorder: MediaRecorder)
 
@@ -22,13 +23,15 @@ internal abstract class MediaRecorderRecordingResource(private val mediaRecorder
     }
 
     override fun pause() {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        @SuppressLint("NewApi")
+        if (sdk >= android.os.Build.VERSION_CODES.N) {
             mediaRecorder.pause()
         }
     }
 
     override fun resume() {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+        @SuppressLint("NewApi")
+        if (sdk >= android.os.Build.VERSION_CODES.N) {
             mediaRecorder.resume()
         }
     }
@@ -46,7 +49,7 @@ internal abstract class MediaRecorderRecordingResource(private val mediaRecorder
     }
 }
 
-internal class AACRecordingResource(mediaRecorder: MediaRecorder, private val kbitRate: Int) : MediaRecorderRecordingResource(mediaRecorder) {
+internal class AACRecordingResource(mediaRecorder: MediaRecorder, sdk: Int, private val kbitRate: Int) : MediaRecorderRecordingResource(mediaRecorder, sdk) {
 
     override fun beforePrepare(mediaRecorder: MediaRecorder) {
         mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC)
@@ -57,7 +60,7 @@ internal class AACRecordingResource(mediaRecorder: MediaRecorder, private val kb
     }
 }
 
-internal class AMRRecordingResource(mediaRecorder: MediaRecorder) : MediaRecorderRecordingResource(mediaRecorder) {
+internal class AMRRecordingResource(mediaRecorder: MediaRecorder, sdk: Int) : MediaRecorderRecordingResource(mediaRecorder, sdk) {
 
     override fun beforePrepare(mediaRecorder: MediaRecorder) {
         mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC)
@@ -65,5 +68,10 @@ internal class AMRRecordingResource(mediaRecorder: MediaRecorder) : MediaRecorde
         mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB)
         mediaRecorder.setAudioSamplingRate(8000)
         mediaRecorder.setAudioEncodingBitRate(12200)
+    }
+
+    override fun stop() {
+        resume()
+        super.stop()
     }
 }

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/mediarecorder/AMRRecordingResourceTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/mediarecorder/AMRRecordingResourceTest.kt
@@ -1,0 +1,29 @@
+package org.odk.collect.audiorecorder.mediarecorder
+
+import android.media.MediaRecorder
+import org.junit.Test
+import org.mockito.Mockito.inOrder
+import org.mockito.Mockito.mock
+
+class AMRRecordingResourceTest {
+
+    /**
+     * Calls to stop() while paused hang which appears to be a problem in the Android
+     * framework. Resuming and the stopping does work however.
+     *
+     * @see <a href="https://gist.github.com/seadowg/e6cbab21e032fe2fcd9afb9b4f458ab9">Gist</a> for
+     * test demonstrating the issue in Android.
+     */
+    @Test
+    fun whenPaused_stop_callsResumeThenStopOnMediaRecorder() {
+        val mediaRecorder = mock(MediaRecorder::class.java)
+        val inOrder = inOrder(mediaRecorder)
+        val amrRecordingResource = AMRRecordingResource(mediaRecorder, android.os.Build.VERSION_CODES.N)
+
+        amrRecordingResource.pause()
+
+        amrRecordingResource.stop()
+        inOrder.verify(mediaRecorder).resume()
+        inOrder.verify(mediaRecorder).stop()
+    }
+}

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/mediarecorder/AMRRecordingResourceTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/mediarecorder/AMRRecordingResourceTest.kt
@@ -4,6 +4,8 @@ import android.media.MediaRecorder
 import org.junit.Test
 import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.only
+import org.mockito.Mockito.verify
 
 class AMRRecordingResourceTest {
 
@@ -11,19 +13,32 @@ class AMRRecordingResourceTest {
      * Calls to stop() while paused hang which appears to be a problem in the Android
      * framework. Resuming and the stopping does work however.
      *
-     * @see <a href="https://gist.github.com/seadowg/e6cbab21e032fe2fcd9afb9b4f458ab9">Gist</a> for
-     * test demonstrating the issue in Android.
+     * @see [Gist with test demonstrating problem](https://gist.github.com/seadowg/e6cbab21e032fe2fcd9afb9b4f458ab9)
+     * @see [Issue in Google's Android tracker](https://issuetracker.google.com/issues/178630865)
      */
     @Test
-    fun whenPaused_stop_callsResumeThenStopOnMediaRecorder() {
+    fun whenAPI24OrHigher_whenPaused_stop_callsResumeThenStopOnMediaRecorder() {
         val mediaRecorder = mock(MediaRecorder::class.java)
         val inOrder = inOrder(mediaRecorder)
-        val amrRecordingResource = AMRRecordingResource(mediaRecorder, android.os.Build.VERSION_CODES.N)
+        val amrRecordingResource = AMRRecordingResource(mediaRecorder, 24)
 
         amrRecordingResource.pause()
 
         amrRecordingResource.stop()
         inOrder.verify(mediaRecorder).resume()
         inOrder.verify(mediaRecorder).stop()
+    }
+
+    /**
+     * Pause/resume is not supported in API 23 and below so we need to check that we're not calling
+     * [MediaRecorder.pause] in [AMRRecordingResource.stop].
+     */
+    @Test
+    fun whenAPI23OrLower_stop_callsStopOnMediaRecorder() {
+        val mediaRecorder = mock(MediaRecorder::class.java)
+        val amrRecordingResource = AMRRecordingResource(mediaRecorder, 23)
+
+        amrRecordingResource.stop()
+        verify(mediaRecorder, only()).stop()
     }
 }


### PR DESCRIPTION
Hot fix for #4364

#### What has been done to verify that this works as intended?

Checked manually and wrote new tests.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only change here is to `voice-only` recordings, so we should focus any testing there. Good to check recording, pausing recordings etc on a few different devices if possible. We are now "resuming" recording before stopping for `voice-only` so it'd also be good to check that this doesn't introduce any artifacts into the recorded audio.

#### Do we need any specific form for testing your changes? If so, please attach one.

The `internal-audio-question.xml` form with a change to `voice-only` should do.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)