### PR TITLE
Handle uris without granted read permission

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/IntentGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/IntentGroupTest.java
@@ -193,25 +193,6 @@ public class IntentGroupTest {
     }
 
     @Test
-    public void collect_shouldDisplayToastWhenPermissionNotGranted() {
-        assertImageWidgetWithoutAnswer();
-
-        Intent resultIntent = new Intent();
-
-        Uri uri = mock(Uri.class);
-        when(uri.getScheme()).thenThrow(new SecurityException());
-
-        resultIntent.putExtra("questionImage", uri);
-
-        intending(not(isInternal())).respondWith(new Instrumentation.ActivityResult(Activity.RESULT_OK, resultIntent));
-
-        onView(withText("This is buttonText")).perform(click());
-        onView(withText(R.string.read_file_permission_not_granted)).inRoot(withDecorView(not(is(activityTestRule.getActivity().getWindow().getDecorView())))).check(matches(isDisplayed()));
-
-        assertImageWidgetWithoutAnswer();
-    }
-
-    @Test
     public void collect_shouldNotCrashWhenAnyErrorIsThrownWhileReceivingAnswer() {
         assertImageWidgetWithoutAnswer();
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -858,15 +858,21 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     private void loadFile(Uri uri) {
-        if (permissionsProvider.isReadUriPermissionGranted(uri, getContentResolver())) {
-            ProgressDialogFragment progressDialog = new ProgressDialogFragment();
-            progressDialog.setMessage(getString(R.string.please_wait));
-            progressDialog.show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
+        permissionsProvider.requestReadUriPermission(this, uri, getContentResolver(), new PermissionListener() {
+            @Override
+            public void granted() {
+                ProgressDialogFragment progressDialog = new ProgressDialogFragment();
+                progressDialog.setMessage(getString(R.string.please_wait));
+                progressDialog.show(getSupportFragmentManager(), ProgressDialogFragment.COLLECT_PROGRESS_DIALOG_TAG);
 
-            mediaLoadingFragment.beginMediaLoadingTask(uri);
-        } else {
-            ToastUtils.showLongToast(R.string.read_file_permission_not_granted);
-        }
+                mediaLoadingFragment.beginMediaLoadingTask(uri);
+            }
+
+            @Override
+            public void denied() {
+
+            }
+        });
     }
 
     public QuestionWidget getWidgetWaitingForBinaryData() {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -64,6 +64,7 @@ import org.odk.collect.android.formentry.media.AudioHelperFactory;
 import org.odk.collect.android.formentry.media.PromptAutoplayer;
 import org.odk.collect.android.formentry.questions.QuestionTextSizeHelper;
 import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.permissions.PermissionsProvider;
 import org.odk.collect.android.preferences.PreferencesProvider;
@@ -530,16 +531,22 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
                                     } else {
                                         throw new RuntimeException("The value for " + key + " must be a URI but it is " + answer);
                                     }
-                                    if (permissionsProvider.isReadUriPermissionGranted(uri, getContext().getContentResolver())) {
-                                        File destFile = FileUtils.createDestinationMediaFile(formController.getInstanceFile().getParent(), ContentResolverHelper.getFileExtensionFromUri(uri));
-                                        //TODO might be better to use QuestionMediaManager in the future
-                                        FileUtils.saveAnswerFileFromUri(uri, destFile, getContext());
-                                        ((WidgetDataReceiver) questionWidget).setData(destFile);
+                                    permissionsProvider.requestReadUriPermission((Activity) getContext(), uri, getContext().getContentResolver(), new PermissionListener() {
+                                        @Override
+                                        public void granted() {
+                                            File destFile = FileUtils.createDestinationMediaFile(formController.getInstanceFile().getParent(), ContentResolverHelper.getFileExtensionFromUri(uri));
+                                            //TODO might be better to use QuestionMediaManager in the future
+                                            FileUtils.saveAnswerFileFromUri(uri, destFile, getContext());
+                                            ((WidgetDataReceiver) questionWidget).setData(destFile);
 
-                                        questionWidget.showAnswerContainer();
-                                    } else {
-                                        ToastUtils.showLongToast(R.string.read_file_permission_not_granted);
-                                    }
+                                            questionWidget.showAnswerContainer();
+                                        }
+
+                                        @Override
+                                        public void denied() {
+
+                                        }
+                                    });
                                 } catch (Exception | Error e) {
                                     Timber.w(e);
                                 }

--- a/collect_app/src/main/java/org/odk/collect/android/permissions/PermissionsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/permissions/PermissionsProvider.java
@@ -93,6 +93,21 @@ public class PermissionsProvider {
         }, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
+    public void requestReadStoragePermission(Activity activity, @NonNull PermissionListener action) {
+        requestPermissions(activity, new PermissionListener() {
+            @Override
+            public void granted() {
+                action.granted();
+            }
+
+            @Override
+            public void denied() {
+                showAdditionalExplanation(activity, R.string.storage_runtime_permission_denied_title,
+                        R.string.storage_runtime_permission_denied_desc, R.drawable.sd, action);
+            }
+        }, Manifest.permission.READ_EXTERNAL_STORAGE);
+    }
+
     public void requestCameraPermission(Activity activity, @NonNull PermissionListener action) {
         requestPermissions(activity, new PermissionListener() {
             @Override
@@ -259,6 +274,26 @@ public class PermissionsProvider {
             return true;
         } catch (SecurityException | NullPointerException e) {
             return false;
+        }
+    }
+
+    public void requestReadUriPermission(Activity activity, Uri uri, ContentResolver contentResolver, PermissionListener listener) {
+        try (Cursor ignored = contentResolver.query(uri, null, null, null, null)) {
+            listener.granted();
+        } catch (SecurityException e) {
+            requestReadStoragePermission(activity, new PermissionListener() {
+                @Override
+                public void granted() {
+                    listener.granted();
+                }
+
+                @Override
+                public void denied() {
+                    listener.denied();
+                }
+            });
+        } catch (Exception | Error e) {
+            listener.denied();
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/permissions/PermissionsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/permissions/PermissionsProvider.java
@@ -269,14 +269,6 @@ public class PermissionsProvider {
         DialogUtils.showDialog(alertDialog, activity);
     }
 
-    public boolean isReadUriPermissionGranted(Uri uri, ContentResolver contentResolver) {
-        try (Cursor cursor = contentResolver.query(uri, null, null, null, null)) {
-            return true;
-        } catch (SecurityException | NullPointerException e) {
-            return false;
-        }
-    }
-
     public void requestReadUriPermission(Activity activity, Uri uri, ContentResolver contentResolver, PermissionListener listener) {
         try (Cursor ignored = contentResolver.query(uri, null, null, null, null)) {
             listener.granted();

--- a/collect_app/src/test/java/org/odk/collect/android/permissions/PermissionsProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/permissions/PermissionsProviderTest.java
@@ -1,8 +1,6 @@
 package org.odk.collect.android.permissions;
 
 import android.Manifest;
-import android.content.ContentResolver;
-import android.net.Uri;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -139,24 +137,5 @@ public class PermissionsProviderTest {
         permissionsProvider = new PermissionsProvider(permissionsChecker, storageStateProvider);
 
         assertThat(permissionsProvider.isReadPhoneStatePermissionGranted(), is(false));
-    }
-
-    @Test
-    public void whenReadPermissionToFileGranted_shouldIsReadUriPermissionGrantedReturnTrue() {
-        permissionsProvider = new PermissionsProvider(permissionsChecker, storageStateProvider);
-        Uri uri = mock(Uri.class);
-        ContentResolver contentResolver = mock(ContentResolver.class);
-
-        assertThat(permissionsProvider.isReadUriPermissionGranted(uri, contentResolver), is(true));
-    }
-
-    @Test
-    public void whenReadPermissionToFileNotGranted_shouldIsReadUriPermissionGrantedReturnFalse() {
-        permissionsProvider = new PermissionsProvider(permissionsChecker, storageStateProvider);
-        Uri uri = mock(Uri.class);
-        ContentResolver contentResolver = mock(ContentResolver.class);
-        when(contentResolver.query(uri, null, null, null, null)).thenThrow(SecurityException.class);
-
-        assertThat(permissionsProvider.isReadUriPermissionGranted(uri, contentResolver), is(false));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/permissions/PermissionsProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/permissions/PermissionsProviderTest.java
@@ -1,15 +1,22 @@
 package org.odk.collect.android.permissions;
 
 import android.Manifest;
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.net.Uri;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.storage.StorageStateProvider;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class PermissionsProviderTest {
@@ -137,5 +144,46 @@ public class PermissionsProviderTest {
         permissionsProvider = new PermissionsProvider(permissionsChecker, storageStateProvider);
 
         assertThat(permissionsProvider.isReadPhoneStatePermissionGranted(), is(false));
+    }
+
+    @Test
+    public void whenRequestReadUriPermissionGranted_shouldGrantedBeCalled() {
+        permissionsProvider = new PermissionsProvider(permissionsChecker, storageStateProvider);
+
+        Activity activity = mock(Activity.class);
+        Uri uri = mock(Uri.class);
+        ContentResolver contentResolver = mock(ContentResolver.class);
+
+        PermissionListener permissionListener = mock(PermissionListener.class);
+        permissionsProvider.requestReadUriPermission(activity, uri, contentResolver, permissionListener);
+        verify(permissionListener).granted();
+    }
+
+    @Test
+    public void whenRequestReadUriPermissionNotGranted_shouldUserBeAskedToGrantReadStoragePermission() {
+        permissionsProvider = spy(new PermissionsProvider(permissionsChecker, storageStateProvider));
+
+        Activity activity = mock(Activity.class);
+        Uri uri = mock(Uri.class);
+        ContentResolver contentResolver = mock(ContentResolver.class);
+        when(contentResolver.query(uri, null, null, null, null)).thenThrow(SecurityException.class);
+
+        PermissionListener permissionListener = mock(PermissionListener.class);
+        permissionsProvider.requestReadUriPermission(activity, uri, contentResolver, permissionListener);
+        verify(permissionsProvider).requestReadStoragePermission(any(), any());
+    }
+
+    @Test
+    public void whenRequestReadUriPermissionThrowsAnyException_shouldDeniedBeCalled() {
+        permissionsProvider = new PermissionsProvider(permissionsChecker, storageStateProvider);
+
+        Activity activity = mock(Activity.class);
+        Uri uri = mock(Uri.class);
+        ContentResolver contentResolver = mock(ContentResolver.class);
+        when(contentResolver.query(uri, null, null, null, null)).thenThrow(RuntimeException.class);
+
+        PermissionListener permissionListener = mock(PermissionListener.class);
+        permissionsProvider.requestReadUriPermission(activity, uri, contentResolver, permissionListener);
+        verify(permissionListener).denied();
     }
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -81,7 +81,6 @@
     <string name="get_accounts_runtime_permission_denied_desc">Without this permission Collect can\'t access accounts. Please try again when you are ready to grant it.</string>
     <string name="read_phone_state_runtime_permission_denied_title">Read phone state permission</string>
     <string name="read_phone_state_runtime_permission_denied_desc">ODK Collect does not make calls but it needs to access certain properties about your device such as the phone number and device ID.</string>
-    <string name="read_file_permission_not_granted">Read permission to the file not granted.</string>
 
     <!--
     ##############################################


### PR DESCRIPTION
Closes #4360

#### What has been done to verify that this works as intended?
I tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
Seem like it's the only solution since if an external app doesn't grant read permission properly there is nothing we can do with it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test receiving media files in media widgets and intent groups. It doesn't require testing every single widget just one would be enough.
When it comes to the issue I was able to reproduce it using video widget and emulator api 23/25 so you can also try.

#### Do we need any specific form for testing your changes? If so, please attach one.
All widgets form and 
[externalForm (1).xlsx](https://github.com/getodk/collect/files/5888860/externalForm.1.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)