### PR TITLE
Don't compute choice list to get underlying value

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -56,7 +56,7 @@ public class AuditEventLogger {
      * Log a new event
      */
     public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
-                         boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
+                         boolean writeImmediatelyToDisk, @Nullable String questionAnswer, long currentTime, String changeReason) {
         if (!isAuditEnabled() || shouldBeIgnored(eventType)) {
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditUtils.java
@@ -21,8 +21,8 @@ public class AuditUtils {
             try {
                 FormEntryPrompt[] prompts = formController.getQuestionPrompts();
                 for (FormEntryPrompt question : prompts) {
-                    String answer = question.getAnswerValue() != null ? question.getAnswerValue().getDisplayText() : null;
-                    auditEventLogger.logEvent(AuditEvent.AuditEventType.QUESTION, question.getIndex(), true, answer, currentTime, null);
+                    auditEventLogger.logEvent(AuditEvent.AuditEventType.QUESTION, question.getIndex(), true,
+                            formController.getAnswerUnderlyingValue(question.getIndex()), currentTime, null);
                 }
             } catch (FormDesignException e) {
                 throw new RuntimeException(e.getMessage(), e);

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -525,6 +525,21 @@ public class FormController {
     }
 
     /**
+     * Return the raw model value at the given {@link FormIndex}. In particular, in the case of a
+     * select, this returns the selected choice(s)' value(s), NOT the label(s). This is exactly
+     * what gets written to XML on serialization.
+     *
+     * See FormEntryPrompt.getAnswerText for what appears to be the same behavior but possibly much
+     * slower because it may filter a choice list. The filtered list is unused.
+     */
+    @Nullable
+    public String getAnswerUnderlyingValue(FormIndex index) {
+        FormInstance instance = getInstance();
+        IAnswerData answerData = instance.resolveReference(index.getReference()).getValue();
+        return answerData == null ? null : answerData.getDisplayText();
+    }
+
+    /**
      * Navigates forward in the form.
      *
      * @return the next event that should be handled by a view.

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventLoggerTest.java
@@ -24,9 +24,6 @@ import org.junit.Test;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -234,20 +231,5 @@ public class AuditEventLoggerTest {
 
         auditEventLogger.flush(); // Triggers event writing
         assertEquals(21, testWriter.auditEvents.size());
-    }
-
-    private static class TestWriter implements AuditEventLogger.AuditEventWriter {
-
-        List<AuditEvent> auditEvents = new ArrayList<>();
-
-        @Override
-        public void writeEvents(List<AuditEvent> auditEvents) {
-            this.auditEvents.addAll(auditEvents);
-        }
-
-        @Override
-        public boolean isWriting() {
-            return false;
-        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditUtilsIntegrationTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditUtilsIntegrationTest.java
@@ -1,0 +1,162 @@
+package org.odk.collect.android.formentry.audit;
+
+import org.javarosa.core.model.SelectChoice;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.helper.Selection;
+import org.junit.Test;
+import org.odk.collect.android.javarosawrapper.FormController;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.odk.collect.android.javarosawrapper.FormControllerUtils.createFormController;
+
+public class AuditUtilsIntegrationTest {
+    @Test
+    public void exitingScreenWithStaticSelect_logsNewUnderlyingValue() throws Exception {
+        FormController formController = createFormController(STATIC_SELECT);
+        formController.stepToNextScreenEvent(); // go to first question
+
+        AuditConfig config = formController.getSubmissionMetadata().auditConfig;
+        TestWriter testWriter = new TestWriter();
+        AuditEventLogger eventLogger = new AuditEventLogger(config, testWriter, formController);
+
+        AuditUtils.logCurrentScreen(formController, eventLogger, 1L);
+
+        List<SelectChoice> level1Choices = formController.getQuestionPrompts()[0].getSelectChoices();
+        formController.answerQuestion(formController.getFormIndex(), new SelectOneData(new Selection(level1Choices.get(1))));
+
+        AuditUtils.logCurrentScreen(formController, eventLogger, 1L);
+
+        eventLogger.flush();
+        assertThat(testWriter.auditEvents.size(), is(1));
+        AuditEvent event = testWriter.auditEvents.get(0);
+        assertThat(event.getOldValue(), is(""));
+        assertThat(event.getNewValue(), is("b"));
+    }
+
+    @Test
+    public void exitingScreenWithDynamicSelect_logsNewUnderlyingValue() throws Exception {
+        FormController formController = createFormController(DYNAMIC_SELECT);
+
+        AuditConfig config = formController.getSubmissionMetadata().auditConfig;
+        TestWriter testWriter = new TestWriter();
+        AuditEventLogger eventLogger = new AuditEventLogger(config, testWriter, formController);
+
+        formController.stepToNextScreenEvent(); // go to dynamic select question
+
+        AuditUtils.logCurrentScreen(formController, eventLogger, 1L);
+
+        List<SelectChoice> level2Choices = formController.getQuestionPrompts()[0].getSelectChoices();
+        formController.answerQuestion(formController.getFormIndex(), new SelectOneData(new Selection(level2Choices.get(1))));
+
+        AuditUtils.logCurrentScreen(formController, eventLogger, 1L);
+
+        eventLogger.flush();
+        assertThat(testWriter.auditEvents.size(), is(1));
+        AuditEvent event = testWriter.auditEvents.get(0);
+        assertThat(event.getOldValue(), is(""));
+        assertThat(event.getNewValue(), is("bb"));
+    }
+
+    private static final String STATIC_SELECT = "<?xml version=\"1.0\"?>\n" +
+            "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:odk=\"http://www.opendatakit.org/xforms\">\n" +
+            "   <h:head>\n" +
+            "      <h:title>Static Select</h:title>\n" +
+            "      <model>\n" +
+            "         <instance>\n" +
+            "            <data id=\"static_select\">\n" +
+            "               <level1/>\n" +
+            "               <meta>\n" +
+            "                 <audit/>\n" +
+            "               </meta>\n" +
+            "            </data>\n" +
+            "          </instance>\n" +
+            "          <bind nodeset=\"/data/level1\" type=\"string\"/>\n" +
+            "          <bind nodeset=\"/data/meta/audit\" type=\"binary\" odk:track-changes=\"true\"/>\n" +
+            "        </model>\n" +
+            "    </h:head>\n" +
+            "    <h:body>\n" +
+            "        <select1 ref=\"/data/level1\">\n" +
+            "            <label>Level1</label>\n" +
+            "            <item>\n" +
+            "                <label>A</label>\n" +
+            "                <value>a</value>\n" +
+            "            </item>\n" +
+            "            <item>\n" +
+            "                <label>B</label>\n" +
+            "                <value>b</value>\n" +
+            "            </item>\n" +
+            "            <item>\n" +
+            "                <label>C</label>\n" +
+            "                <value>c</value>\n" +
+            "            </item>\n" +
+            "        </select1>\n" +
+            "    </h:body>\n" +
+            "</h:html>";
+
+    private static final String DYNAMIC_SELECT = "<?xml version=\"1.0\"?>\n" +
+            "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:odk=\"http://www.opendatakit.org/xforms\">\n" +
+            "   <h:head>\n" +
+            "      <h:title>Dynamic select</h:title>\n" +
+            "      <model odk:xforms-version=\"1.0.0\">\n" +
+            "         <instance>\n" +
+            "            <data id=\"dynamic_select\">\n" +
+            "               <level1>b</level1>\n" +
+            "               <level2/>\n" +
+            "               <meta>\n" +
+            "                 <audit/>\n" +
+            "               </meta>\n" +
+            "             </data>\n" +
+            "        </instance>\n" +
+            "        <instance id=\"level2\">\n" +
+            "            <root>\n" +
+            "                <item>\n" +
+            "                    <label>AA</label>\n" +
+            "                    <level1>a</level1>\n" +
+            "                    <name>aa</name>\n" +
+            "                </item>\n" +
+            "                <item>\n" +
+            "                    <label>AB</label>\n" +
+            "                    <level1>a</level1>\n" +
+            "                    <name>ab</name>\n" +
+            "                </item>\n" +
+            "                <item>\n" +
+            "                    <label>BA</label>\n" +
+            "                    <level1>b</level1>\n" +
+            "                    <name>ba</name>\n" +
+            "                </item>\n" +
+            "                <item>\n" +
+            "                    <label>BB</label>\n" +
+            "                    <level1>b</level1>\n" +
+            "                    <name>bb</name>\n" +
+            "                </item>\n" +
+            "                <item>\n" +
+            "                    <label>CA</label>\n" +
+            "                    <level1>c</level1>\n" +
+            "                    <name>ca</name>\n" +
+            "                </item>\n" +
+            "                <item>\n" +
+            "                    <label>CB</label>\n" +
+            "                    <level1>c</level1>\n" +
+            "                    <name>cb</name>\n" +
+            "                </item>\n" +
+            "            </root>\n" +
+            "         </instance>\n" +
+            "         <bind nodeset=\"/data/level1\" type=\"string\"/>\n" +
+            "         <bind nodeset=\"/data/level2\" type=\"string\"/>\n" +
+            "         <bind nodeset=\"/data/meta/audit\" type=\"binary\" odk:track-changes=\"true\"/>\n" +
+            "      </model>\n" +
+            "    </h:head>\n" +
+            "    <h:body>\n" +
+            "        <select1 ref=\"/data/level2\">\n" +
+            "            <label>Level2</label>\n" +
+            "            <itemset nodeset=\"instance('level2')/root/item[level1 =  /data/level1 ]\">\n" +
+            "                <value ref=\"name\"/>\n" +
+            "                <label ref=\"label\"/>\n" +
+            "            </itemset>\n" +
+            "        </select1>\n" +
+            "    </h:body>\n" +
+            "</h:html>";
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -7,6 +7,7 @@ import androidx.lifecycle.SavedStateHandle;
 
 import com.google.common.io.Files;
 
+import org.javarosa.core.model.FormIndex;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
@@ -137,6 +138,7 @@ public class FormSaveViewModelTest {
                 .withAnswerDisplayText("answer")
                 .build();
         when(formController.getQuestionPrompts()).thenReturn(Arrays.asList(prompt).toArray(new FormEntryPrompt[]{}));
+        when(formController.getAnswerUnderlyingValue(any(FormIndex.class))).thenReturn("answer");
 
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
@@ -166,6 +168,7 @@ public class FormSaveViewModelTest {
                 .withAnswerDisplayText("answer")
                 .build();
         when(formController.getQuestionPrompts()).thenReturn(Arrays.asList(prompt).toArray(new FormEntryPrompt[]{}));
+        when(formController.getAnswerUnderlyingValue(any(FormIndex.class))).thenReturn("answer");
 
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         whenFormSaverFinishes(SaveFormToDisk.SAVED);
@@ -195,6 +198,7 @@ public class FormSaveViewModelTest {
                 .withAnswerDisplayText("answer")
                 .build();
         when(formController.getQuestionPrompts()).thenReturn(Arrays.asList(prompt).toArray(new FormEntryPrompt[]{}));
+        when(formController.getAnswerUnderlyingValue(any(FormIndex.class))).thenReturn("answer");
 
         viewModel.saveForm(Uri.parse("file://form"), true, "", false);
         whenFormSaverFinishes(SaveFormToDisk.SAVED);

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/TestWriter.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/TestWriter.java
@@ -1,0 +1,19 @@
+package org.odk.collect.android.formentry.audit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestWriter implements AuditEventLogger.AuditEventWriter {
+
+    List<AuditEvent> auditEvents = new ArrayList<>();
+
+    @Override
+    public void writeEvents(List<AuditEvent> auditEvents) {
+        this.auditEvents.addAll(auditEvents);
+    }
+
+    @Override
+    public boolean isWriting() {
+        return false;
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerTest.java
@@ -5,11 +5,9 @@ import com.google.common.io.Files;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.util.XFormUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,6 +15,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.odk.collect.android.javarosawrapper.FormControllerUtils.createFormController;
 
 public class FormControllerTest {
 
@@ -89,7 +88,6 @@ public class FormControllerTest {
         assertThat(formController.getAuditEventLogger(), notNullValue());
     }
 
-
     //region indexIsInFieldList
     @Test
     public void questionInGroupWithoutFieldListAppearance_isNotInFieldList() throws IOException {
@@ -111,14 +109,6 @@ public class FormControllerTest {
         assertThat(formController.indexIsInFieldList(), is(true));
     }
     //endregion
-
-    @NotNull
-    private FormController createFormController(String xform) throws IOException {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(xform.getBytes());
-        final FormEntryModel fem = new FormEntryModel(XFormUtils.getFormFromInputStream(inputStream));
-        final FormEntryController formEntryController = new FormEntryController(fem);
-        return new FormController(Files.createTempDir(), formEntryController, File.createTempFile("instance", ""));
-    }
 
     private static final String ONE_QUESTION_REPEAT = "<?xml version=\"1.0\"?>\n" +
             "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:ev=\"http://www.w3.org/2001/xml-events\" xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:jr=\"http://openrosa.org/javarosa\" xmlns:orx=\"http://openrosa.org/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n" +

--- a/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerUtils.java
+++ b/collect_app/src/test/java/org/odk/collect/android/javarosawrapper/FormControllerUtils.java
@@ -1,0 +1,31 @@
+package org.odk.collect.android.javarosawrapper;
+
+import com.google.common.io.Files;
+
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.xform.util.XFormUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+
+public class FormControllerUtils {
+    private FormControllerUtils() {
+
+    }
+
+    // Replicates the essential functionality for loading a form. See FormLoaderTask.
+    @NotNull
+    public static FormController createFormController(String xform) throws IOException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(xform.getBytes());
+        final FormEntryModel fem = new FormEntryModel(XFormUtils.getFormFromInputStream(inputStream));
+        final FormEntryController formEntryController = new FormEntryController(fem);
+
+        // ensure all secondary instances get correct names. See FormLoaderTask.initializeForm
+        formEntryController.getModel().getForm().initialize(true, null);
+
+        return new FormController(Files.createTempDir(), formEntryController, File.createTempFile("instance", ""));
+    }
+}


### PR DESCRIPTION
Closes #4363

#### What has been done to verify that this works as intended?
Wrote and ran automated tests. Tried form from issue. Confirmed this halves the time to go to a question with a filtered choice list. @getodk/testers please confirm you also experience this on your device. https://drive.google.com/drive/u/0/folders/1QwX7E-u19jzXvzwkOpj2Y4X-xb9ihd1f is a good form for that (swiping to the settlement question).

#### Why is this the best possible solution? Were any other approaches considered?
There's a higher-level problem that choice lists get constantly recomputed whether anything that affects them has changed or not. I think we want to rethink how that works by e.g. caching `FormEntryPrompt`s instead of rebuilding them or caching the populated dynamic choices at another layer, etc. However, for this specific issue, I think it makes more sense that getting a node's underlying value would not require having a filtered choice list. There's just no use for it and it doesn't make sense.

I'm not completely happy with introducing a new method to `FormController` (`getAnswerUnderlyingValue`). However, I think it's the best place for it for now. I considered just making its calls inline in `AuditUtils` but I'd rather keep things that use JavaRosa classes in the `javarosawrapper` package and I like having a place for a longer comment. I'd like to replace `FormEntryPrompt.getAnswerText` but I'm not yet confident I understand the implications. We could introduce `getAnswerUnderlyingValue` in `FormEntryPrompt` and I'm happy to do that as a follow-up step that will require a JR update.

Test-wise, I like having an integration test for logging value changed audits. Prior to this we have no coverage at all. This brings a little bit of coverage to make sure new and old values are written, the `track-changes` attribute is respected, etc.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This feels low-risk to me. I think the tests give us pretty good coverage. The only code change is to registering a question value for the audit log. I think verifying various scenarios around that like setting a value for the first time, going back to a question and then leaving it again without changing the value, setting a value for the last question and then exiting the form would be sufficient. It should really only make a difference for select ones and select multiples but doing a quick check with e.g. strings would be good. Checking the actual audit log (e.g. on Central) would be good.

We've replaced code that computed the choice list and filtered out answer values that are no longer available choices with code that returns the raw answer value. However, I am quite confident that there's no way to change the answer without displaying the choice list which would also filter out answers that are no longer available. @getodk/testers something to experiment with is cases where you select some choice and then filter the list such that it is no longer available.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with a select one, a select multiple and a question of another type that requests an audit with `track-changes`.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)