### PR TITLE
Fixed centering texts in forms

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/StringUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/StringUtils.java
@@ -110,7 +110,7 @@ public class StringUtils {
     }
 
     public static CharSequence textToHtml(String text) {
-        return text == null ? "" : Html.fromHtml(markdownToHtml(text));
+        return text == null ? "" : trim(Html.fromHtml(markdownToHtml(text)));
     }
 
     public static String ellipsizeBeginning(String text) {
@@ -157,6 +157,26 @@ public class StringUtils {
         }
 
         return true;
+    }
+
+    private static CharSequence trim(CharSequence text) {
+        if (text == null || text.length() == 0) {
+            return text;
+        }
+
+        int len = text.length();
+        int start = 0;
+        int end = len - 1;
+        while (Character.isWhitespace(text.charAt(start)) && start < len) {
+            start++;
+        }
+        while (Character.isWhitespace(text.charAt(end)) && end > 0) {
+            end--;
+        }
+        if (end >= start) {
+            return text.subSequence(start, end + 1);
+        }
+        return text;
     }
 }
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/StringUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/StringUtilsTest.java
@@ -20,6 +20,12 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void textToHtml_shouldBeTrimmed() {
+        CharSequence observed = StringUtils.textToHtml("<p style=\"text-align:center\">Text</p>");
+        assertThat(observed.toString(), equalTo("Text"));
+    }
+
+    @Test
     public void markDownToHtmlEscapesBackslash() {
         String[][] tests = {
                 {"A\\_B\\_C", "A_B_C"},


### PR DESCRIPTION
Closes #4370

| Before  | After |
| ------------- | ------------- |
| ![Screenshot_1611920658](https://user-images.githubusercontent.com/3276264/106284428-7f1efc00-6243-11eb-9d52-4d61d8d648c4.png)  | ![Screenshot_1611924307](https://user-images.githubusercontent.com/3276264/106284437-80502900-6243-11eb-9acd-941d700af0bb.png)  |

#### What has been done to verify that this works as intended?
I added one test and also verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that in some case [Html.fromHtml()](https://developer.android.com/reference/android/text/Html#fromHtml(java.lang.String,%20int)) might return values with new lines at the end for example. See:
https://stackoverflow.com/questions/9589381/remove-extra-line-breaks-after-html-fromhtml/9974562

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix and we can just test the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes I think we should add info about centering in https://docs.getodk.org/form-styling/ so that it's clear for our users.
https://github.com/getodk/docs/issues/1315

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)