### PR TITLE
Stop pause/resume button causing multiclick problems

### DIFF
--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -44,17 +44,21 @@ internal class AudioRecorderService : Service() {
             }
 
             ACTION_PAUSE -> {
-                recorder.pause()
-                recordingRepository.setPaused(true)
+                if (recorder.isRecording()) {
+                    recorder.pause()
+                    recordingRepository.setPaused(true)
 
-                stopUpdates()
+                    stopUpdates()
+                }
             }
 
             ACTION_RESUME -> {
-                recorder.resume()
-                recordingRepository.setPaused(false)
+                if (recorder.isRecording()) {
+                    recorder.resume()
+                    recordingRepository.setPaused(false)
 
-                startUpdates()
+                    startUpdates()
+                }
             }
 
             ACTION_STOP -> {


### PR DESCRIPTION
Closes #4368

This blocks the pause/resume action from doing anything when a recording isn't in progress.

#### What has been done to verify that this works as intended?

Verified manually and added new tests.

#### Why is this the best possible solution? Were any other approaches considered?

We could block this at the UI side, but I really feel like it makes sense for the recording code to be as robust as it can be as we're using it in a few different places and looking to add more. More and more I regret not modelling the recording state internally with an ADT and defined transitions between states. That said it'd be harder to work with from the Java said if that had been the case 🤷‍♂️.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just trying to break recording should be the check here. @mmarciniak90 and @kkrawczyk123 have already had a go in reproducing the crash in question.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)