### PR TITLE
Build debug code up front in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,16 +43,6 @@ jobs:
       - attach_workspace:
           at: ~/work
 
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-      - run:
-          name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-
       - run:
           name: Run code quality checks
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 checkCode
@@ -67,16 +57,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
-
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-      - run:
-          name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Run async unit tests
@@ -108,16 +88,6 @@ jobs:
       - attach_workspace:
           at: ~/work
 
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-      - run:
-          name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-
       - run:
           name: Run app unit tests
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:testDebug
@@ -137,16 +107,6 @@ jobs:
       - attach_workspace:
           at: ~/work
 
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-      - run:
-          name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-
       - run:
           name: Assemble connected test build
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
@@ -158,16 +118,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
-
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
-      - run:
-          name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Assemble test build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,6 @@ jobs:
       - run:
           name: Run app unit tests
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:testDebug
-          no_output_timeout: 15m
 
       - store_artifacts:
           path: collect_app/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,20 +33,13 @@ jobs:
       - persist_to_workspace:
           root: ~/work
           paths:
-            - async/build
-            - audioclips/build
-            - audiorecorder/build
-            - collect_app/build
-            - material/build
-            - nbistubs/build
-            - strings/build
+            - .
 
   check_quality:
     <<: *android_config
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
-      - checkout
       - attach_workspace:
           at: ~/work
 
@@ -72,7 +65,6 @@ jobs:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
-      - checkout
       - attach_workspace:
           at: ~/work
 
@@ -113,7 +105,6 @@ jobs:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
-      - checkout
       - attach_workspace:
           at: ~/work
 
@@ -143,7 +134,6 @@ jobs:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
-      - checkout
       - attach_workspace:
           at: ~/work
 
@@ -166,7 +156,6 @@ jobs:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
-      - checkout
       - attach_workspace:
           at: ~/work
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Run code quality checks
@@ -57,6 +59,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Run async unit tests
@@ -87,6 +91,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Run app unit tests
@@ -106,6 +112,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Assemble connected test build
@@ -118,6 +126,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/work
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
 
       - run:
           name: Assemble test build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,8 @@ jobs:
       - run:
           name: Run app unit tests
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:testDebug
+          no_output_timeout: 15m
+          
       - store_artifacts:
           path: collect_app/build/reports
           destination: reports
@@ -165,7 +167,7 @@ jobs:
               --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
               --directories-to-pull /sdcard --timeout 20m
             fi
-          no_output_timeout: 60m
+          no_output_timeout: 25m
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run:
           name: Compile code
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 compileDebugSources
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug
       - persist_to_workspace:
           root: ~/work
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,21 +4,51 @@
 version: 2
 
 references:
-  workspace: &workspace
-               ~/work
-
   android_config: &android_config
-    working_directory: *workspace
+    working_directory: ~/work
     docker:
       - image: circleci/android:api-30
 
 jobs:
+  compile:
+    <<: *android_config
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
+      - run:
+          name: Download dependencies
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
+
+      - run:
+          name: Compile code
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 compileDebugSources
+      - persist_to_workspace:
+          root: ~/work
+          paths:
+            - async/build
+            - audioclips/build
+            - audiorecorder/build
+            - collect_app/build
+            - material/build
+            - nbistubs/build
+            - strings/build
+
   check_quality:
     <<: *android_config
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/work
 
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
@@ -43,6 +73,8 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/work
 
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
@@ -82,6 +114,8 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/work
 
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
@@ -97,7 +131,7 @@ jobs:
           name: Run app unit tests
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:testDebug
           no_output_timeout: 15m
-          
+
       - store_artifacts:
           path: collect_app/build/reports
           destination: reports
@@ -110,6 +144,8 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/work
 
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
@@ -131,6 +167,8 @@ jobs:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/work
 
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "collect_app/build.gradle" }}
@@ -173,10 +211,19 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - check_quality
-      - test_modules
-      - test_app
+      - compile
+      - check_quality:
+          requires:
+            - compile
+      - test_modules:
+          requires:
+            - compile
+      - test_app:
+          requires:
+            - compile
       - build_instrumented:
+          requires:
+            - compile
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
This adds an initial job to the CI pipeline that builds runs an `assembleDebug`. The output of this is then passed to the other jobs, so they don't have to recompile the (non-test) code. This should shorten the length of the `test_app` job as it won't have to build debug and test sources. It may also reduce the memory overhead, although it's unclear if that's related to the compilation work or not.

This shouldn't need QA as it's just changes to our CI config.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)