### PR TITLE
Allow enumerator to toggle background recording

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.odk.collect.android.support.FileUtils.copyFileFromAssets;
 
@@ -90,5 +91,19 @@ public class BackgroundAudioRecordingTest {
                 .startBlankForm("One Question")
                 .assertContentDescriptionNotDisplayed(R.string.stop_recording)
                 .assertContentDescriptionNotDisplayed(R.string.pause_recording);
+    }
+
+    @Test
+    public void whenBackgroundAudioRecordingEnabled_uncheckingRecordAudio_andConfirming_endsAndDeletesRecording() {
+        rule.mainMenu()
+                .enableBackgroundAudioRecording()
+                .copyForm("one-question.xml")
+                .startBlankForm("One Question")
+                .clickOptionsIcon()
+                .clickRecordAudio()
+                .clickOk();
+
+        assertThat(stubAudioRecorderViewModel.isRecording(), is(false));
+        assertThat(stubAudioRecorderViewModel.getLastRecording(), is(nullValue()));
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -16,6 +16,8 @@ import org.odk.collect.android.support.TestDependencies;
 import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.FormEndPage;
 import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.support.pages.MainMenuPage;
+import org.odk.collect.android.support.pages.SaveOrIgnoreDialog;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.audiorecorder.testsupport.StubAudioRecorder;
 
@@ -94,8 +96,8 @@ public class BackgroundAudioRecordingTest {
     }
 
     @Test
-    public void whenBackgroundAudioRecordingEnabled_uncheckingRecordAudio_andConfirming_endsAndDeletesRecording() {
-        rule.mainMenu()
+    public void whenBackgroundAudioRecordingEnabled_uncheckingRecordAudio_endsAndDeletesRecording_andDisablesItForNextFormFill() {
+        FormEntryPage formEntryPage = rule.mainMenu()
                 .enableBackgroundAudioRecording()
                 .copyForm("one-question.xml")
                 .startBlankForm("One Question")
@@ -105,5 +107,12 @@ public class BackgroundAudioRecordingTest {
 
         assertThat(stubAudioRecorderViewModel.isRecording(), is(false));
         assertThat(stubAudioRecorderViewModel.getLastRecording(), is(nullValue()));
+
+        formEntryPage.closeSoftKeyboard()
+                .pressBack(new SaveOrIgnoreDialog<>("One Question", new MainMenuPage(rule), rule))
+                .clickIgnoreChanges()
+                .startBlankForm("One Question");
+
+        assertThat(stubAudioRecorderViewModel.isRecording(), is(false));
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveAsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveAsTest.java
@@ -1,0 +1,32 @@
+package org.odk.collect.android.feature.formentry;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.TestRuleChain;
+
+@RunWith(AndroidJUnit4.class)
+public class SaveAsTest {
+
+    public final CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public final RuleChain chain = TestRuleChain.chain()
+            .around(rule);
+
+    @Test
+    public void fillingFormNameAtEndOfForm_savesInstanceWithName() {
+        rule.mainMenu()
+                .copyForm("one-question.xml")
+                .startBlankForm("One Question")
+                .swipeToEndScreen()
+                .fillInFormName("My Favourite Form")
+                .clickSaveAndExit()
+                .clickSendFinalizedForm(1)
+                .assertText("My Favourite Form");
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.java
@@ -175,6 +175,7 @@ public class TrackChangesReasonTest {
                 .inputText("Nothing much!")
                 .clickSaveWithChangesReasonPrompt()
                 .enterReason("Bah")
-                .clickSave(new FormEntryPage("Track Changes Reason", rule));
+                .clickSave(new FormEntryPage("Track Changes Reason", rule))
+                .assertQuestion("What up?");
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.java
@@ -53,27 +53,10 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Track Changes Reason")
                 .clickGoToStart()
                 .inputText("Nothing much!")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExitWithChangesReasonPrompt()
                 .enterReason("Needed to be more exciting and less mysterious")
                 .clickSave();
-    }
-
-    @Test
-    public void openingAFormToEdit_andChangingAValue_andClickingSaveAndExit_andEnteringBlankReason_andClickingSave_remainsOnPrompt() {
-        new MainMenuPage(rule)
-                .startBlankForm("Track Changes Reason")
-                .inputText("Nothing much...")
-                .swipeToEndScreen()
-                .clickSaveAndExit()
-                .clickEditSavedForm()
-                .clickOnForm("Track Changes Reason")
-                .clickGoToStart()
-                .inputText("Nothing much!")
-                .swipeToNextQuestion()
-                .clickSaveAndExitWithChangesReasonPrompt()
-                .enterReason(" ")
-                .clickSaveWithValidationError();
     }
 
     @Test
@@ -87,7 +70,7 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Track Changes Reason")
                 .clickGoToStart()
                 .inputText("Nothing much!")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExitWithChangesReasonPrompt()
                 .closeSoftKeyboard()
                 .pressBack(new FormEntryPage("Track Changes Reason", rule))
@@ -105,7 +88,7 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Track Changes Reason")
                 .clickGoToStart()
                 .inputText("Nothing much!")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExitWithChangesReasonPrompt()
                 .closeSoftKeyboard()
                 .pressClose(new FormEntryPage("Track Changes Reason", rule))
@@ -123,7 +106,7 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Track Changes Reason")
                 .clickGoToStart()
                 .inputText("Nothing much!")
-                .swipeToNextQuestion()
+                .swipeToEndScreen()
                 .clickSaveAndExitWithChangesReasonPrompt()
                 .enterReason("Something")
                 .rotateToLandscape(new ChangesReasonPromptPage("Track Changes Reason", rule))
@@ -190,21 +173,8 @@ public class TrackChangesReasonTest {
                 .clickOnForm("Track Changes Reason")
                 .clickGoToStart()
                 .inputText("Nothing much!")
-                .clickSaveWithChangesReasonPrompt();
-    }
-
-    @Test
-    public void whenFormDoesNotHaveTrackChangesReason_openingToEdit_andChangingAValue_andClickingSaveAndExit_returnsToMainMenu() {
-        new MainMenuPage(rule)
-                .startBlankForm("Normal Form")
-                .inputText("Nothing much...")
-                .swipeToEndScreen()
-                .clickSaveAndExit()
-                .clickEditSavedForm()
-                .clickOnForm("Normal Form")
-                .clickGoToStart()
-                .inputText("Nothing much!")
-                .swipeToEndScreen()
-                .clickSaveAndExit();
+                .clickSaveWithChangesReasonPrompt()
+                .enterReason("Bah")
+                .clickSave(new FormEntryPage("Track Changes Reason", rule));
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/CancelRecordingDialog.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/CancelRecordingDialog.java
@@ -1,0 +1,26 @@
+package org.odk.collect.android.support.pages;
+
+import androidx.test.rule.ActivityTestRule;
+
+import org.odk.collect.android.R;
+
+public class CancelRecordingDialog extends Page<CancelRecordingDialog> {
+
+    private final String formName;
+
+    CancelRecordingDialog(String formName, ActivityTestRule rule) {
+        super(rule);
+        this.formName = formName;
+    }
+
+    @Override
+    public CancelRecordingDialog assertOnPage() {
+        assertText(R.string.stop_recording_confirmation);
+        return this;
+    }
+
+    public FormEntryPage clickOk() {
+        clickOKOnDialog();
+        return new FormEntryPage(formName, rule);
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ChangesReasonPromptPage.java
@@ -39,6 +39,11 @@ public class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
         return new MainMenuPage(rule).assertOnPage();
     }
 
+    public <D extends Page<D>> D clickSave(D destination) {
+        clickOnString(R.string.save);
+        return destination.assertOnPage();
+    }
+
     public <D extends Page<D>> D pressClose(D destination) {
         onView(withContentDescription(getTranslatedString(R.string.close))).perform(click());
         return destination.assertOnPage();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -48,6 +48,11 @@ public class FormEndPage extends Page<FormEndPage> {
         return new OkDialog(rule).assertOnPage();
     }
 
+    public ChangesReasonPromptPage clickSaveAndExitWithChangesReasonPrompt() {
+        onView(withId(R.id.save_exit_button)).perform(click());
+        return new ChangesReasonPromptPage(formName, rule).assertOnPage();
+    }
+
     public FormEndPage assertMarkFinishedIsSelected() {
         onView(withId(R.id.mark_finished)).check(matches(isChecked()));
         return this;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -75,4 +75,9 @@ public class FormEndPage extends Page<FormEndPage> {
     public FormEntryPage swipeToPreviousQuestion(String questionText, boolean isRequired) {
         return new FormEntryPage(formName, rule).swipeToPreviousQuestion(questionText, isRequired);
     }
+
+    public FormEndPage fillInFormName(String formName) {
+        inputText(formName);
+        return this;
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -201,11 +201,6 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public ChangesReasonPromptPage clickSaveAndExitWithChangesReasonPrompt() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return new ChangesReasonPromptPage(formName, rule).assertOnPage();
-    }
-
     public ChangesReasonPromptPage clickSaveWithChangesReasonPrompt() {
         onView(withId(R.id.menu_save)).perform(click());
         return new ChangesReasonPromptPage(formName, rule).assertOnPage();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -315,4 +315,9 @@ public class FormEntryPage extends Page<FormEntryPage> {
         assertText(R.string.recording_warning);
         return okDialog;
     }
+
+    public CancelRecordingDialog clickRecordAudio() {
+        clickOnString(R.string.record_audio);
+        return new CancelRecordingDialog(formName, rule);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1268,6 +1268,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         FormEndView endView = new FormEndView(this, formSaveViewModel.getFormName(), saveName, InstancesDaoHelper.isInstanceComplete(true), new FormEndView.Listener() {
             @Override
             public void onSaveAsChanged(String saveAs) {
+                // Seems like this is needed for rotation?
                 saveName = saveAs;
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -159,7 +159,6 @@ import org.odk.collect.android.widgets.utilities.ViewModelAudioPlayer;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.audioclips.AudioClipViewModel;
-import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 
 import java.io.File;
@@ -495,10 +494,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         waitingForDataRegistry = new FormControllerWaitingForDataRegistry();
         externalAppRecordingRequester = new ExternalAppRecordingRequester(this, activityAvailability, waitingForDataRegistry, permissionsProvider, formEntryViewModel);
-
-        if (preferencesProvider.getGeneralSharedPreferences().getBoolean("background_audio_recording", false)) {
-            audioRecorder.start("background", Output.AMR);
-        }
     }
 
     // Precondition: the instance directory must be ready so that the audit file can be created

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1731,6 +1731,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             case SAVED:
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
+
                 showShortToast(R.string.data_saved_ok);
 
                 if (result.getRequest().viewExiting()) {
@@ -1745,6 +1747,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             case SAVE_ERROR:
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
+
                 String message;
 
                 if (result.getMessage() != null) {
@@ -1760,6 +1764,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             case FINALIZE_ERROR:
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
+
                 showLongToast(String.format(getString(R.string.encryption_error_message),
                         result.getMessage()));
                 finishAndReturnInstance();
@@ -1768,6 +1774,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             case CONSTRAINT_ERROR: {
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
+                DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
+
                 onScreenRefresh();
 
                 // get constraint behavior preference value with appropriate default

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2360,7 +2360,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         }
 
-        audioRecorder.stop();
         finish();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -392,8 +392,8 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 formSaveViewModel,
                 formEntryViewModel,
                 audioRecorder,
-                backgroundLocationViewModel,
-                preferencesProvider);
+                backgroundLocationViewModel
+        );
 
         nextButton = findViewById(R.id.form_forward_button);
         nextButton.setOnClickListener(v -> {
@@ -1343,7 +1343,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             return false;
         }
 
-        if (audioRecorder.isRecording() && !preferencesProvider.getGeneralSharedPreferences().getBoolean("background_audio_recording", false)) {
+        if (audioRecorder.isRecording() && !formEntryViewModel.isBackgroundRecording()) {
             // We want the user to stop recording before changing screens
             DialogUtils.showIfNotShowing(RecordingWarningDialogFragment.class, getSupportFragmentManager());
             return false;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.java
@@ -1,0 +1,69 @@
+package org.odk.collect.android.formentry;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.TextWatcher;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.utilities.FormNameUtils;
+
+public class FormEndView extends FrameLayout {
+
+    private final Listener listener;
+    private final String formTitle;
+    private final String defaultInstanceName;
+
+    public FormEndView(Context context, String formTitle, String defaultInstanceName, boolean instanceComplete, Listener listener) {
+        super(context);
+        this.formTitle = formTitle;
+        this.defaultInstanceName = defaultInstanceName;
+        this.listener = listener;
+        init(context, instanceComplete);
+    }
+
+    private void init(Context context, boolean instanceComplete) {
+        inflate(context, R.layout.form_entry_end, this);
+
+        ((TextView) findViewById(R.id.description)).setText(context.getString(R.string.save_enter_data_description, formTitle));
+
+        EditText saveAs = findViewById(R.id.save_name);
+
+        // disallow carriage returns in the name
+        InputFilter returnFilter = (source, start, end, dest, dstart, dend) -> FormNameUtils.normalizeFormName(source.toString().substring(start, end), true);
+        saveAs.setFilters(new InputFilter[]{returnFilter});
+
+        saveAs.setText(defaultInstanceName);
+        saveAs.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void afterTextChanged(Editable s) {
+                listener.onSaveAsChanged(s.toString());
+            }
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+        });
+
+        final CheckBox markAsFinalized = findViewById(R.id.mark_finished);
+        markAsFinalized.setChecked(instanceComplete);
+
+        findViewById(R.id.save_exit_button).setOnClickListener(v -> {
+            listener.onSaveClicked(markAsFinalized.isChecked());
+        });
+    }
+
+    public interface Listener {
+        void onSaveAsChanged(String string);
+
+        void onSaveClicked(boolean markAsFinalized);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -8,6 +8,8 @@ import android.view.MenuItem;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.FormHierarchyActivity;
@@ -96,6 +98,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
 
         menu.findItem(R.id.menu_add_repeat).setVisible(formEntryViewModel.canAddRepeat());
         menu.findItem(R.id.menu_record_audio).setVisible(formEntryViewModel.hasBackgroundRecording());
+        menu.findItem(R.id.menu_record_audio).setChecked(formEntryViewModel.isBackgroundRecording());
     }
 
     @Override
@@ -136,7 +139,11 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
             return true;
         } else if (item.getItemId() == R.id.menu_record_audio) {
             if (formEntryViewModel.isBackgroundRecording()) {
-                formEntryViewModel.cancelBackgroundRecording();
+                new MaterialAlertDialogBuilder(activity)
+                        .setMessage(R.string.stop_recording_confirmation)
+                        .setPositiveButton(R.string.ok, (dialog, which) -> formEntryViewModel.cancelBackgroundRecording())
+                        .create()
+                        .show();
             } else {
                 formEntryViewModel.startBackgroundRecording();
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -147,6 +147,12 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
                         .create()
                         .show();
             } else {
+                new MaterialAlertDialogBuilder(activity)
+                        .setMessage(R.string.background_audio_recording_enabled_explanation)
+                        .setPositiveButton(R.string.ok, null)
+                        .create()
+                        .show();
+
                 formEntryViewModel.setBackgroundRecordingEnabled(true);
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -95,6 +95,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
         }
 
         menu.findItem(R.id.menu_add_repeat).setVisible(formEntryViewModel.canAddRepeat());
+        menu.findItem(R.id.menu_record_audio).setVisible(formEntryViewModel.hasBackgroundRecording());
     }
 
     @Override
@@ -130,6 +131,14 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
                 formEntryViewModel.openHierarchy();
                 Intent i = new Intent(activity, FormHierarchyActivity.class);
                 activity.startActivityForResult(i, ApplicationConstants.RequestCodes.HIERARCHY_ACTIVITY);
+            }
+
+            return true;
+        } else if (item.getItemId() == R.id.menu_record_audio) {
+            if (formEntryViewModel.isBackgroundRecording()) {
+                formEntryViewModel.cancelBackgroundRecording();
+            } else {
+                formEntryViewModel.startBackgroundRecording();
             }
 
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -19,7 +19,6 @@ import org.odk.collect.android.preferences.AdminKeys;
 import org.odk.collect.android.preferences.AdminSharedPreferences;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.PreferencesActivity;
-import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.MenuDelegate;
@@ -36,13 +35,12 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
     private final FormEntryViewModel formEntryViewModel;
     private final FormSaveViewModel formSaveViewModel;
     private final BackgroundLocationViewModel backgroundLocationViewModel;
-    private final PreferencesProvider preferencesProvider;
 
     @Nullable
     private FormController formController;
     private final AudioRecorder audioRecorder;
 
-    public FormEntryMenuDelegate(AppCompatActivity activity, AnswersProvider answersProvider, FormIndexAnimationHandler formIndexAnimationHandler, FormSaveViewModel formSaveViewModel, FormEntryViewModel formEntryViewModel, AudioRecorder audioRecorder, BackgroundLocationViewModel backgroundLocationViewModel, PreferencesProvider preferencesProvider) {
+    public FormEntryMenuDelegate(AppCompatActivity activity, AnswersProvider answersProvider, FormIndexAnimationHandler formIndexAnimationHandler, FormSaveViewModel formSaveViewModel, FormEntryViewModel formEntryViewModel, AudioRecorder audioRecorder, BackgroundLocationViewModel backgroundLocationViewModel) {
         this.activity = activity;
         this.answersProvider = answersProvider;
         this.formIndexAnimationHandler = formIndexAnimationHandler;
@@ -51,7 +49,6 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
         this.formEntryViewModel = formEntryViewModel;
         this.formSaveViewModel = formSaveViewModel;
         this.backgroundLocationViewModel = backgroundLocationViewModel;
-        this.preferencesProvider = preferencesProvider;
     }
 
     @Override
@@ -103,7 +100,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_add_repeat) {
-            if (audioRecorder.isRecording() && !preferencesProvider.getGeneralSharedPreferences().getBoolean("background_audio_recording", false)) {
+            if (audioRecorder.isRecording() && !formEntryViewModel.isBackgroundRecording()) {
                 DialogUtils.showIfNotShowing(RecordingWarningDialogFragment.class, activity.getSupportFragmentManager());
             } else {
                 formSaveViewModel.saveAnswersForScreen(answersProvider.getAnswers());
@@ -125,7 +122,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
             backgroundLocationViewModel.backgroundLocationPreferenceToggled();
             return true;
         } else if (item.getItemId() == R.id.menu_goto) {
-            if (audioRecorder.isRecording() && !preferencesProvider.getGeneralSharedPreferences().getBoolean("background_audio_recording", false)) {
+            if (audioRecorder.isRecording() && !formEntryViewModel.isBackgroundRecording()) {
                 DialogUtils.showIfNotShowing(RecordingWarningDialogFragment.class, activity.getSupportFragmentManager());
             } else {
                 formSaveViewModel.saveAnswersForScreen(answersProvider.getAnswers());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -98,7 +98,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
 
         menu.findItem(R.id.menu_add_repeat).setVisible(formEntryViewModel.canAddRepeat());
         menu.findItem(R.id.menu_record_audio).setVisible(formEntryViewModel.hasBackgroundRecording());
-        menu.findItem(R.id.menu_record_audio).setChecked(formEntryViewModel.isBackgroundRecording());
+        menu.findItem(R.id.menu_record_audio).setChecked(formEntryViewModel.isBackgroundRecordingEnabled());
     }
 
     @Override
@@ -138,14 +138,16 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
 
             return true;
         } else if (item.getItemId() == R.id.menu_record_audio) {
-            if (formEntryViewModel.isBackgroundRecording()) {
+            boolean enabled = !item.isChecked();
+
+            if (!enabled) {
                 new MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.stop_recording_confirmation)
-                        .setPositiveButton(R.string.ok, (dialog, which) -> formEntryViewModel.cancelBackgroundRecording())
+                        .setPositiveButton(R.string.ok, (dialog, which) -> formEntryViewModel.setBackgroundRecordingEnabled(false))
                         .create()
                         .show();
             } else {
-                formEntryViewModel.startBackgroundRecording();
+                formEntryViewModel.setBackgroundRecordingEnabled(true);
             }
 
             return true;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -39,6 +39,8 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     @Nullable
     private FormIndex jumpBackIndex;
 
+    private boolean backgroundRecordingEnabled = true;
+
     @SuppressWarnings("WeakerAccess")
     public FormEntryViewModel(Clock clock, Analytics analytics, PreferencesProvider preferencesProvider, AudioRecorder audioRecorder) {
         this.clock = clock;
@@ -196,6 +198,20 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
             return formController.getCurrentFormIdentifierHash();
         } else {
             return "";
+        }
+    }
+
+    public boolean isBackgroundRecordingEnabled() {
+        return backgroundRecordingEnabled;
+    }
+
+    public void setBackgroundRecordingEnabled(boolean enabled) {
+        backgroundRecordingEnabled = enabled;
+
+        if (!backgroundRecordingEnabled) {
+            audioRecorder.cleanUp();
+        } else {
+            startBackgroundRecording();
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -24,6 +24,7 @@ import org.odk.collect.utilities.Clock;
 import javax.inject.Inject;
 
 import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getRepeatGroupIndex;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_BACKGROUND_RECORDING;
 
 public class FormEntryViewModel extends ViewModel implements RequiresFormController {
 
@@ -39,8 +40,6 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     @Nullable
     private FormIndex jumpBackIndex;
 
-    private boolean backgroundRecordingEnabled = true;
-
     @SuppressWarnings("WeakerAccess")
     public FormEntryViewModel(Clock clock, Analytics analytics, PreferencesProvider preferencesProvider, AudioRecorder audioRecorder) {
         this.clock = clock;
@@ -53,7 +52,7 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     public void formLoaded(@NotNull FormController formController) {
         this.formController = formController;
 
-        if (hasBackgroundRecording() && backgroundRecordingEnabled) {
+        if (hasBackgroundRecording() && isBackgroundRecordingEnabled()) {
             startBackgroundRecording();
         }
     }
@@ -189,10 +188,6 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         audioRecorder.start("background", Output.AMR);
     }
 
-    public void cancelBackgroundRecording() {
-        audioRecorder.cleanUp();
-    }
-
     private String getFormIdentifierHash() {
         if (formController != null) {
             return formController.getCurrentFormIdentifierHash();
@@ -202,17 +197,17 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     }
 
     public boolean isBackgroundRecordingEnabled() {
-        return backgroundRecordingEnabled;
+        return preferencesProvider.getGeneralSharedPreferences().getBoolean(KEY_BACKGROUND_RECORDING, true);
     }
 
     public void setBackgroundRecordingEnabled(boolean enabled) {
-        backgroundRecordingEnabled = enabled;
-
-        if (!backgroundRecordingEnabled) {
+        if (!enabled) {
             audioRecorder.cleanUp();
         } else {
             startBackgroundRecording();
         }
+
+        preferencesProvider.getGeneralSharedPreferences().edit().putBoolean(KEY_BACKGROUND_RECORDING, enabled).apply();
     }
 
     public static class Factory implements ViewModelProvider.Factory {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -203,8 +203,6 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     public void setBackgroundRecordingEnabled(boolean enabled) {
         if (!enabled) {
             audioRecorder.cleanUp();
-        } else {
-            startBackgroundRecording();
         }
 
         preferencesProvider.getGeneralSharedPreferences().edit().putBoolean(KEY_BACKGROUND_RECORDING, enabled).apply();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -53,7 +53,7 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     public void formLoaded(@NotNull FormController formController) {
         this.formController = formController;
 
-        if (hasBackgroundRecording()) {
+        if (hasBackgroundRecording() && backgroundRecordingEnabled) {
             startBackgroundRecording();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -16,6 +16,7 @@ import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.utilities.Clock;
 
 import javax.inject.Inject;
@@ -26,6 +27,7 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
 
     private final Clock clock;
     private final Analytics analytics;
+    private final PreferencesProvider preferencesProvider;
     private final MutableLiveData<String> error = new MutableLiveData<>(null);
 
     @Nullable
@@ -35,9 +37,10 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     private FormIndex jumpBackIndex;
 
     @SuppressWarnings("WeakerAccess")
-    public FormEntryViewModel(Clock clock, Analytics analytics) {
+    public FormEntryViewModel(Clock clock, Analytics analytics, PreferencesProvider preferencesProvider) {
         this.clock = clock;
         this.analytics = analytics;
+        this.preferencesProvider = preferencesProvider;
     }
 
     @Override
@@ -164,6 +167,10 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         analytics.logFormEvent(event, getFormIdentifierHash());
     }
 
+    public boolean isBackgroundRecording() {
+        return preferencesProvider.getGeneralSharedPreferences().getBoolean("background_audio_recording", false);
+    }
+
     private String getFormIdentifierHash() {
         if (formController != null) {
             return formController.getCurrentFormIdentifierHash();
@@ -176,18 +183,20 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
 
         private final Clock clock;
         private final Analytics analytics;
+        private final PreferencesProvider preferencesProvider;
 
         @Inject
-        public Factory(Clock clock, Analytics analytics) {
+        public Factory(Clock clock, Analytics analytics, PreferencesProvider preferencesProvider) {
             this.clock = clock;
             this.analytics = analytics;
+            this.preferencesProvider = preferencesProvider;
         }
 
         @SuppressWarnings("unchecked")
         @NonNull
         @Override
         public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-            return (T) new FormEntryViewModel(clock, analytics);
+            return (T) new FormEntryViewModel(clock, analytics, preferencesProvider);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/ChangesReasonPromptDialogFragment.java
@@ -56,10 +56,7 @@ public class ChangesReasonPromptDialogFragment extends MaterialFullScreenDialogF
         });
 
         toolbar.setOnMenuItemClickListener(item -> {
-            if (viewModel.saveReason()) {
-                dismiss();
-            }
-
+            viewModel.resumeSave();
             return true;
         });
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -480,12 +480,12 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormSaveViewModel.FactoryFactory providesFormSaveViewModelFactoryFactory(Analytics analytics, Scheduler scheduler) {
+    public FormSaveViewModel.FactoryFactory providesFormSaveViewModelFactoryFactory(Analytics analytics, Scheduler scheduler, AudioRecorder audioRecorder) {
         return (owner, defaultArgs) -> new AbstractSavedStateViewModelFactory(owner, defaultArgs) {
             @NonNull
             @Override
             protected <T extends ViewModel> T create(@NonNull String key, @NonNull Class<T> modelClass, @NonNull SavedStateHandle handle) {
-                return (T) new FormSaveViewModel(handle, System::currentTimeMillis, new DiskFormSaver(), new MediaUtils(), analytics, scheduler);
+                return (T) new FormSaveViewModel(handle, System::currentTimeMillis, new DiskFormSaver(), new MediaUtils(), analytics, scheduler, audioRecorder);
             }
         };
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/GeneralKeys.java
@@ -11,140 +11,142 @@ import java.util.HashMap;
 
 public final class GeneralKeys {
     // server_preferences.xml
-    public static final String KEY_PROTOCOL                 = "protocol";
+    public static final String KEY_PROTOCOL = "protocol";
 
     // odk_server_preferences.xmll
-    public static final String KEY_SERVER_URL               = "server_url";
-    public static final String KEY_USERNAME                 = "username";
-    public static final String KEY_PASSWORD                 = "password";
+    public static final String KEY_SERVER_URL = "server_url";
+    public static final String KEY_USERNAME = "username";
+    public static final String KEY_PASSWORD = "password";
 
     // custom_server_paths_preferences.xmlreferences.xml
-    public static final String KEY_FORMLIST_URL             = "formlist_url";
-    public static final String KEY_SUBMISSION_URL           = "submission_url";
+    public static final String KEY_FORMLIST_URL = "formlist_url";
+    public static final String KEY_SUBMISSION_URL = "submission_url";
 
     // google_preferences.xml
-    public static final String KEY_SELECTED_GOOGLE_ACCOUNT  = "selected_google_account";
-    public static final String KEY_GOOGLE_SHEETS_URL        = "google_sheets_url";
+    public static final String KEY_SELECTED_GOOGLE_ACCOUNT = "selected_google_account";
+    public static final String KEY_GOOGLE_SHEETS_URL = "google_sheets_url";
 
     // user_interface_preferences.xml
-    public static final String KEY_APP_THEME                = "appTheme";
-    public static final String KEY_APP_LANGUAGE             = "app_language";
-    public static final String KEY_FONT_SIZE                = "font_size";
-    public static final String KEY_NAVIGATION               = "navigation";
-    public static final String KEY_SHOW_SPLASH              = "showSplash";
-    public static final String KEY_SPLASH_PATH              = "splashPath";
+    public static final String KEY_APP_THEME = "appTheme";
+    public static final String KEY_APP_LANGUAGE = "app_language";
+    public static final String KEY_FONT_SIZE = "font_size";
+    public static final String KEY_NAVIGATION = "navigation";
+    public static final String KEY_SHOW_SPLASH = "showSplash";
+    public static final String KEY_SPLASH_PATH = "splashPath";
 
     // map_preferences.xml
-    public static final String KEY_BASEMAP_SOURCE           = "basemap_source";
+    public static final String KEY_BASEMAP_SOURCE = "basemap_source";
 
     // basemap styles
-    public static final String KEY_GOOGLE_MAP_STYLE         = "google_map_style";
-    public static final String KEY_MAPBOX_MAP_STYLE         = "mapbox_map_style";
-    public static final String KEY_USGS_MAP_STYLE           = "usgs_map_style";
-    public static final String KEY_CARTO_MAP_STYLE          = "carto_map_style";
+    public static final String KEY_GOOGLE_MAP_STYLE = "google_map_style";
+    public static final String KEY_MAPBOX_MAP_STYLE = "mapbox_map_style";
+    public static final String KEY_USGS_MAP_STYLE = "usgs_map_style";
+    public static final String KEY_CARTO_MAP_STYLE = "carto_map_style";
 
-    public static final String KEY_REFERENCE_LAYER          = "reference_layer";
+    public static final String KEY_REFERENCE_LAYER = "reference_layer";
 
     // form_management_preferences.xml
     public static final String KEY_PERIODIC_FORM_UPDATES_CHECK = "periodic_form_updates_check";
-    public static final String KEY_AUTOMATIC_UPDATE         = "automatic_update";
-    public static final String KEY_HIDE_OLD_FORM_VERSIONS   = "hide_old_form_versions";
-    public static final String KEY_AUTOSEND                 = "autosend";
-    public static final String KEY_DELETE_AFTER_SEND        = "delete_send";
-    public static final String KEY_COMPLETED_DEFAULT        = "default_completed";
-    public static final String KEY_CONSTRAINT_BEHAVIOR      = "constraint_behavior";
-    public static final String KEY_HIGH_RESOLUTION          = "high_resolution";
-    public static final String KEY_IMAGE_SIZE               = "image_size";
-    public static final String KEY_GUIDANCE_HINT            = "guidance_hint";
-    public static final String KEY_INSTANCE_SYNC            = "instance_sync";
-    public static final String KEY_FORM_UPDATE_MODE         = "form_update_mode";
+    public static final String KEY_AUTOMATIC_UPDATE = "automatic_update";
+    public static final String KEY_HIDE_OLD_FORM_VERSIONS = "hide_old_form_versions";
+    public static final String KEY_AUTOSEND = "autosend";
+    public static final String KEY_DELETE_AFTER_SEND = "delete_send";
+    public static final String KEY_COMPLETED_DEFAULT = "default_completed";
+    public static final String KEY_CONSTRAINT_BEHAVIOR = "constraint_behavior";
+    public static final String KEY_HIGH_RESOLUTION = "high_resolution";
+    public static final String KEY_IMAGE_SIZE = "image_size";
+    public static final String KEY_GUIDANCE_HINT = "guidance_hint";
+    public static final String KEY_INSTANCE_SYNC = "instance_sync";
+    public static final String KEY_FORM_UPDATE_MODE = "form_update_mode";
 
     // identity_preferences.xml
-    public static final String KEY_ANALYTICS                = "analytics";
+    public static final String KEY_ANALYTICS = "analytics";
 
     // form_metadata_preferences.xml
-    public static final String KEY_METADATA_USERNAME        = "metadata_username";
-    public static final String KEY_METADATA_PHONENUMBER     = "metadata_phonenumber";
-    public static final String KEY_METADATA_EMAIL           = "metadata_email";
+    public static final String KEY_METADATA_USERNAME = "metadata_username";
+    public static final String KEY_METADATA_PHONENUMBER = "metadata_phonenumber";
+    public static final String KEY_METADATA_EMAIL = "metadata_email";
 
-    static final String KEY_FORM_METADATA                   = "form_metadata";
+    static final String KEY_FORM_METADATA = "form_metadata";
 
-    public static final String KEY_BACKGROUND_LOCATION      = "background_location";
+    public static final String KEY_BACKGROUND_LOCATION = "background_location";
+    public static final String KEY_BACKGROUND_RECORDING = "background_recording";
 
     // values
-    public static final String NAVIGATION_SWIPE             = "swipe";
-    public static final String NAVIGATION_BUTTONS           = "buttons";
-    public static final String NAVIGATION_BOTH              = "swipe_buttons";
+    public static final String NAVIGATION_SWIPE = "swipe";
+    public static final String NAVIGATION_BUTTONS = "buttons";
+    public static final String NAVIGATION_BOTH = "swipe_buttons";
     public static final String CONSTRAINT_BEHAVIOR_ON_SWIPE = "on_swipe";
-    private static final String AUTOSEND_OFF                = "off";
-    private static final String GUIDANCE_HINT_OFF           = "no";
-    static final String KEY_AUTOSEND_WIFI                   = "autosend_wifi";
-    static final String KEY_AUTOSEND_NETWORK                = "autosend_network";
+    private static final String AUTOSEND_OFF = "off";
+    private static final String GUIDANCE_HINT_OFF = "no";
+    static final String KEY_AUTOSEND_WIFI = "autosend_wifi";
+    static final String KEY_AUTOSEND_NETWORK = "autosend_network";
 
     // basemap section
-    public static final String CATEGORY_BASEMAP             = "category_basemap";
+    public static final String CATEGORY_BASEMAP = "category_basemap";
 
     // basemap source values
-    public static final String BASEMAP_SOURCE_GOOGLE        = "google";
-    public static final String BASEMAP_SOURCE_MAPBOX        = "mapbox";
-    public static final String BASEMAP_SOURCE_OSM           = "osm";
-    public static final String BASEMAP_SOURCE_USGS          = "usgs";
-    public static final String BASEMAP_SOURCE_STAMEN        = "stamen";
-    public static final String BASEMAP_SOURCE_CARTO         = "carto";
+    public static final String BASEMAP_SOURCE_GOOGLE = "google";
+    public static final String BASEMAP_SOURCE_MAPBOX = "mapbox";
+    public static final String BASEMAP_SOURCE_OSM = "osm";
+    public static final String BASEMAP_SOURCE_USGS = "usgs";
+    public static final String BASEMAP_SOURCE_STAMEN = "stamen";
+    public static final String BASEMAP_SOURCE_CARTO = "carto";
 
     // experimental
-    public static final String KEY_MAGENTA_THEME            = "magenta";
-    public static final String KEY_EXTERNAL_APP_RECORDING   = "external_app_recording";
+    public static final String KEY_MAGENTA_THEME = "magenta";
+    public static final String KEY_EXTERNAL_APP_RECORDING = "external_app_recording";
 
     private static HashMap<String, Object> getHashMap() {
         HashMap<String, Object> hashMap = new HashMap<>();
         // odk_server_preferences.xmll
-        hashMap.put(KEY_SERVER_URL,                 Collect.getInstance().getString(R.string.default_server_url));
-        hashMap.put(KEY_USERNAME,                   "");
-        hashMap.put(KEY_PASSWORD,                   "");
+        hashMap.put(KEY_SERVER_URL, Collect.getInstance().getString(R.string.default_server_url));
+        hashMap.put(KEY_USERNAME, "");
+        hashMap.put(KEY_PASSWORD, "");
         // form_management_preferences.xml
-        hashMap.put(KEY_AUTOSEND,                   AUTOSEND_OFF);
-        hashMap.put(KEY_GUIDANCE_HINT,              GUIDANCE_HINT_OFF);
-        hashMap.put(KEY_DELETE_AFTER_SEND,          false);
-        hashMap.put(KEY_COMPLETED_DEFAULT,          true);
-        hashMap.put(KEY_CONSTRAINT_BEHAVIOR,        CONSTRAINT_BEHAVIOR_ON_SWIPE);
-        hashMap.put(KEY_HIGH_RESOLUTION,            true);
-        hashMap.put(KEY_IMAGE_SIZE,                 "original_image_size");
-        hashMap.put(KEY_INSTANCE_SYNC,              true);
+        hashMap.put(KEY_AUTOSEND, AUTOSEND_OFF);
+        hashMap.put(KEY_GUIDANCE_HINT, GUIDANCE_HINT_OFF);
+        hashMap.put(KEY_DELETE_AFTER_SEND, false);
+        hashMap.put(KEY_COMPLETED_DEFAULT, true);
+        hashMap.put(KEY_CONSTRAINT_BEHAVIOR, CONSTRAINT_BEHAVIOR_ON_SWIPE);
+        hashMap.put(KEY_HIGH_RESOLUTION, true);
+        hashMap.put(KEY_IMAGE_SIZE, "original_image_size");
+        hashMap.put(KEY_INSTANCE_SYNC, true);
         hashMap.put(KEY_PERIODIC_FORM_UPDATES_CHECK, "every_fifteen_minutes");
-        hashMap.put(KEY_AUTOMATIC_UPDATE,           false);
-        hashMap.put(KEY_HIDE_OLD_FORM_VERSIONS,     true);
-        hashMap.put(KEY_BACKGROUND_LOCATION,        true);
-        hashMap.put(KEY_FORM_UPDATE_MODE,           "manual");
+        hashMap.put(KEY_AUTOMATIC_UPDATE, false);
+        hashMap.put(KEY_HIDE_OLD_FORM_VERSIONS, true);
+        hashMap.put(KEY_BACKGROUND_LOCATION, true);
+        hashMap.put(KEY_BACKGROUND_RECORDING, true);
+        hashMap.put(KEY_FORM_UPDATE_MODE, "manual");
         // form_metadata_preferences.xml
-        hashMap.put(KEY_METADATA_USERNAME,          "");
-        hashMap.put(KEY_METADATA_PHONENUMBER,       "");
-        hashMap.put(KEY_METADATA_EMAIL,             "");
+        hashMap.put(KEY_METADATA_USERNAME, "");
+        hashMap.put(KEY_METADATA_PHONENUMBER, "");
+        hashMap.put(KEY_METADATA_EMAIL, "");
         // google_preferences.xml
-        hashMap.put(KEY_SELECTED_GOOGLE_ACCOUNT,    "");
-        hashMap.put(KEY_GOOGLE_SHEETS_URL,          "");
+        hashMap.put(KEY_SELECTED_GOOGLE_ACCOUNT, "");
+        hashMap.put(KEY_GOOGLE_SHEETS_URL, "");
         // identity_preferences.xml
-        hashMap.put(KEY_ANALYTICS,                  true);
+        hashMap.put(KEY_ANALYTICS, true);
         // custom_server_paths_preferenceshs_preferences.xml
-        hashMap.put(KEY_FORMLIST_URL,               Collect.getInstance().getString(R.string.default_odk_formlist));
-        hashMap.put(KEY_SUBMISSION_URL,             Collect.getInstance().getString(R.string.default_odk_submission));
+        hashMap.put(KEY_FORMLIST_URL, Collect.getInstance().getString(R.string.default_odk_formlist));
+        hashMap.put(KEY_SUBMISSION_URL, Collect.getInstance().getString(R.string.default_odk_submission));
         // server_preferences.xml
-        hashMap.put(KEY_PROTOCOL,                   Collect.getInstance().getString(R.string.protocol_odk_default));
+        hashMap.put(KEY_PROTOCOL, Collect.getInstance().getString(R.string.protocol_odk_default));
         // user_interface_preferences.xml
-        hashMap.put(KEY_APP_THEME,                  Collect.getInstance().getString(R.string.app_theme_light));
-        hashMap.put(KEY_APP_LANGUAGE,               "");
-        hashMap.put(KEY_FONT_SIZE,                  String.valueOf(QuestionFontSizeUtils.DEFAULT_FONT_SIZE));
-        hashMap.put(KEY_NAVIGATION,                 NAVIGATION_BOTH);
-        hashMap.put(KEY_SHOW_SPLASH,                false);
-        hashMap.put(KEY_SPLASH_PATH,                Collect.getInstance().getString(R.string.default_splash_path));
-        hashMap.put(KEY_MAGENTA_THEME,              false);
-        hashMap.put(KEY_EXTERNAL_APP_RECORDING,     true);
+        hashMap.put(KEY_APP_THEME, Collect.getInstance().getString(R.string.app_theme_light));
+        hashMap.put(KEY_APP_LANGUAGE, "");
+        hashMap.put(KEY_FONT_SIZE, String.valueOf(QuestionFontSizeUtils.DEFAULT_FONT_SIZE));
+        hashMap.put(KEY_NAVIGATION, NAVIGATION_BOTH);
+        hashMap.put(KEY_SHOW_SPLASH, false);
+        hashMap.put(KEY_SPLASH_PATH, Collect.getInstance().getString(R.string.default_splash_path));
+        hashMap.put(KEY_MAGENTA_THEME, false);
+        hashMap.put(KEY_EXTERNAL_APP_RECORDING, true);
         // map_preferences.xml
-        hashMap.put(KEY_BASEMAP_SOURCE,             BASEMAP_SOURCE_GOOGLE);
-        hashMap.put(KEY_CARTO_MAP_STYLE,            "positron");
-        hashMap.put(KEY_USGS_MAP_STYLE,             "topographic");
-        hashMap.put(KEY_GOOGLE_MAP_STYLE,           String.valueOf(GoogleMap.MAP_TYPE_NORMAL));
-        hashMap.put(KEY_MAPBOX_MAP_STYLE,           Style.MAPBOX_STREETS);
+        hashMap.put(KEY_BASEMAP_SOURCE, BASEMAP_SOURCE_GOOGLE);
+        hashMap.put(KEY_CARTO_MAP_STYLE, "positron");
+        hashMap.put(KEY_USGS_MAP_STYLE, "topographic");
+        hashMap.put(KEY_GOOGLE_MAP_STYLE, String.valueOf(GoogleMap.MAP_TYPE_NORMAL));
+        hashMap.put(KEY_MAPBOX_MAP_STYLE, Style.MAPBOX_STREETS);
         return hashMap;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequester.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequester.java
@@ -85,6 +85,8 @@ public class InternalRecordingRequester implements RecordingRequester {
                 if (!session.getId().equals("background")) {
                     session.getFile().delete();
                 }
+
+                formSaveViewModel.resumeSave();
             }
         });
     }

--- a/collect_app/src/main/res/menu/form_menu.xml
+++ b/collect_app/src/main/res/menu/form_menu.xml
@@ -42,9 +42,9 @@
 
     <item
         android:id="@+id/menu_record_audio"
+        android:checkable="true"
         android:title="@string/record_audio"
         android:visible="false"
-        app:actionViewClass="android.widget.CheckBox"
         app:showAsAction="never" />
 
     <item

--- a/collect_app/src/main/res/menu/form_menu.xml
+++ b/collect_app/src/main/res/menu/form_menu.xml
@@ -41,6 +41,13 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_record_audio"
+        android:title="@string/record_audio"
+        android:visible="false"
+        app:actionViewClass="android.widget.CheckBox"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_languages"
         android:title="@string/change_language"
         app:showAsAction="never" />

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -119,6 +119,28 @@ public class FormEntryMenuDelegateTest {
     }
 
     @Test
+    public void onPrepare_whenRecordingInBackground_checksRecordAudio() {
+        when(formEntryViewModel.isBackgroundRecording()).thenReturn(true);
+
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        assertThat(menu.findItem(R.id.menu_record_audio).isChecked(), equalTo(true));
+    }
+
+    @Test
+    public void onPrepare_whenNotRecordingInBackground_unchecksRecordAudio() {
+        when(formEntryViewModel.isBackgroundRecording()).thenReturn(false);
+
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        assertThat(menu.findItem(R.id.menu_record_audio).isChecked(), equalTo(false));
+    }
+
+    @Test
     public void onPrepare_whenFormDoesNotHaveBackgroundRecording_hidesRecordAudio() {
         when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false);
 
@@ -277,18 +299,6 @@ public class FormEntryMenuDelegateTest {
 
         RecordingWarningDialogFragment dialog = getFragmentByClass(activity.getSupportFragmentManager(), RecordingWarningDialogFragment.class);
         assertThat(dialog, is(nullValue()));
-    }
-
-    @Test
-    public void onItemSelected_whenRecordAudio_whenRecordingInBackground_cancelBackgroundRecording() {
-        RoboMenu menu = new RoboMenu();
-        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
-        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
-
-        when(formEntryViewModel.isBackgroundRecording()).thenReturn(true);
-
-        formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_record_audio));
-        verify(formEntryViewModel).cancelBackgroundRecording();
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -119,8 +119,8 @@ public class FormEntryMenuDelegateTest {
     }
 
     @Test
-    public void onPrepare_whenRecordingInBackground_checksRecordAudio() {
-        when(formEntryViewModel.isBackgroundRecording()).thenReturn(true);
+    public void onPrepare_whenbackgroundRecodingEnabled_checksRecordAudio() {
+        when(formEntryViewModel.isBackgroundRecordingEnabled()).thenReturn(true);
 
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
@@ -131,7 +131,7 @@ public class FormEntryMenuDelegateTest {
 
     @Test
     public void onPrepare_whenNotRecordingInBackground_unchecksRecordAudio() {
-        when(formEntryViewModel.isBackgroundRecording()).thenReturn(false);
+        when(formEntryViewModel.isBackgroundRecordingEnabled()).thenReturn(false);
 
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
@@ -302,14 +302,14 @@ public class FormEntryMenuDelegateTest {
     }
 
     @Test
-    public void onItemSelected_whenRecordAudio_whenNotRecordingInBackground_startsBackgroundRecording() {
+    public void onItemSelected_whenRecordAudio_whenBackgroundRecordingDisabled_enablesBackgroundRecording() {
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
         formEntryMenuDelegate.onPrepareOptionsMenu(menu);
 
-        when(formEntryViewModel.isBackgroundRecording()).thenReturn(false);
+        when(formEntryViewModel.isBackgroundRecordingEnabled()).thenReturn(false);
 
         formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_record_audio));
-        verify(formEntryViewModel).startBackgroundRecording();
+        verify(formEntryViewModel).setBackgroundRecordingEnabled(true);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -302,7 +302,7 @@ public class FormEntryMenuDelegateTest {
     }
 
     @Test
-    public void onItemSelected_whenRecordAudio_whenBackgroundRecordingDisabled_enablesBackgroundRecording() {
+    public void onItemSelected_whenRecordAudio_whenBackgroundRecordingDisabled_enablesBackgroundRecording_andShowsDialog() {
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
         formEntryMenuDelegate.onPrepareOptionsMenu(menu);

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -14,7 +14,6 @@ import org.odk.collect.android.formentry.questions.AnswersProvider;
 import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.PreferencesActivity;
-import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.robolectric.Robolectric;
@@ -49,7 +48,6 @@ public class FormEntryMenuDelegateTest {
     private AnswersProvider answersProvider;
     private FormSaveViewModel formSaveViewModel;
     private AudioRecorder audioRecorder;
-    private PreferencesProvider preferencesProvider;
 
     @Before
     public void setup() {
@@ -64,8 +62,6 @@ public class FormEntryMenuDelegateTest {
 
         BackgroundLocationViewModel backgroundLocationViewModel = mock(BackgroundLocationViewModel.class);
 
-        preferencesProvider = new PreferencesProvider(activity);
-
         formEntryMenuDelegate = new FormEntryMenuDelegate(
                 activity,
                 answersProvider,
@@ -73,8 +69,7 @@ public class FormEntryMenuDelegateTest {
                 formSaveViewModel,
                 formEntryViewModel,
                 audioRecorder,
-                backgroundLocationViewModel,
-                preferencesProvider
+                backgroundLocationViewModel
         );
         formEntryMenuDelegate.formLoaded(formController);
     }
@@ -157,7 +152,7 @@ public class FormEntryMenuDelegateTest {
         formEntryMenuDelegate.onPrepareOptionsMenu(menu);
 
         when(audioRecorder.isRecording()).thenReturn(true);
-        preferencesProvider.getGeneralSharedPreferences().edit().putBoolean("background_audio_recording", true).apply();
+        when(formEntryViewModel.isBackgroundRecording()).thenReturn(true);
 
         formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_add_repeat));
         verify(formEntryViewModel).promptForNewRepeat();
@@ -253,7 +248,7 @@ public class FormEntryMenuDelegateTest {
         formEntryMenuDelegate.onPrepareOptionsMenu(menu);
 
         when(audioRecorder.isRecording()).thenReturn(true);
-        preferencesProvider.getGeneralSharedPreferences().edit().putBoolean("background_audio_recording", true).apply();
+        when(formEntryViewModel.isBackgroundRecording()).thenReturn(true);
 
         formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_goto));
         assertThat(shadowOf(activity).getNextStartedActivity(), is(notNullValue()));

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -108,6 +108,28 @@ public class FormEntryMenuDelegateTest {
     }
 
     @Test
+    public void onPrepare_whenFormHasBackgroundRecording_showsRecordAudio() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true);
+
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        assertThat(menu.findItem(R.id.menu_record_audio).isVisible(), equalTo(true));
+    }
+
+    @Test
+    public void onPrepare_whenFormDoesNotHaveBackgroundRecording_hidesRecordAudio() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false);
+
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        assertThat(menu.findItem(R.id.menu_record_audio).isVisible(), equalTo(false));
+    }
+
+    @Test
     public void onItemSelected_whenAddRepeat_callsPromptForNewRepeat() {
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
@@ -255,5 +277,29 @@ public class FormEntryMenuDelegateTest {
 
         RecordingWarningDialogFragment dialog = getFragmentByClass(activity.getSupportFragmentManager(), RecordingWarningDialogFragment.class);
         assertThat(dialog, is(nullValue()));
+    }
+
+    @Test
+    public void onItemSelected_whenRecordAudio_whenRecordingInBackground_cancelBackgroundRecording() {
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        when(formEntryViewModel.isBackgroundRecording()).thenReturn(true);
+
+        formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_record_audio));
+        verify(formEntryViewModel).cancelBackgroundRecording();
+    }
+
+    @Test
+    public void onItemSelected_whenRecordAudio_whenNotRecordingInBackground_startsBackgroundRecording() {
+        RoboMenu menu = new RoboMenu();
+        formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
+        formEntryMenuDelegate.onPrepareOptionsMenu(menu);
+
+        when(formEntryViewModel.isBackgroundRecording()).thenReturn(false);
+
+        formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_record_audio));
+        verify(formEntryViewModel).startBackgroundRecording();
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -13,7 +13,6 @@ import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.PreferencesProvider;
-import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.utilities.Clock;
 import org.robolectric.RobolectricTestRunner;
@@ -37,7 +36,6 @@ public class FormEntryViewModelTest {
     private FormIndex startingIndex;
     private AuditEventLogger auditEventLogger;
     private Clock clock;
-    private AudioRecorder audioRecorder;
 
     @Before
     public void setup() {
@@ -51,7 +49,7 @@ public class FormEntryViewModelTest {
 
         clock = mock(Clock.class);
 
-        audioRecorder = mock(AudioRecorder.class);
+        AudioRecorder audioRecorder = mock(AudioRecorder.class);
         viewModel = new FormEntryViewModel(clock, mock(Analytics.class), new PreferencesProvider(ApplicationProvider.getApplicationContext()), audioRecorder);
         viewModel.formLoaded(formController);
     }
@@ -134,11 +132,5 @@ public class FormEntryViewModelTest {
         when(clock.getCurrentTime()).thenReturn(12345L);
         viewModel.openHierarchy();
         verify(auditEventLogger).logEvent(AuditEvent.AuditEventType.HIERARCHY, true, 12345L);
-    }
-
-    @Test
-    public void setBackgroundRecordingEnabled_whenTrue_startsBackgroundRecording() {
-        viewModel.setBackgroundRecordingEnabled(true);
-        verify(audioRecorder).start("background", Output.AMR);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.formentry;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.TreeReference;
 import org.junit.Before;
@@ -10,6 +12,7 @@ import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
+import org.odk.collect.android.preferences.PreferencesProvider;
 import org.odk.collect.utilities.Clock;
 import org.robolectric.RobolectricTestRunner;
 
@@ -45,7 +48,7 @@ public class FormEntryViewModelTest {
 
         clock = mock(Clock.class);
 
-        viewModel = new FormEntryViewModel(clock, mock(Analytics.class));
+        viewModel = new FormEntryViewModel(clock, mock(Analytics.class), new PreferencesProvider(ApplicationProvider.getApplicationContext()));
         viewModel.formLoaded(formController);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.PreferencesProvider;
+import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.utilities.Clock;
 import org.robolectric.RobolectricTestRunner;
 
@@ -35,6 +36,7 @@ public class FormEntryViewModelTest {
     private FormIndex startingIndex;
     private AuditEventLogger auditEventLogger;
     private Clock clock;
+    private AudioRecorder audioRecorder;
 
     @Before
     public void setup() {
@@ -48,7 +50,8 @@ public class FormEntryViewModelTest {
 
         clock = mock(Clock.class);
 
-        viewModel = new FormEntryViewModel(clock, mock(Analytics.class), new PreferencesProvider(ApplicationProvider.getApplicationContext()));
+        audioRecorder = mock(AudioRecorder.class);
+        viewModel = new FormEntryViewModel(clock, mock(Analytics.class), new PreferencesProvider(ApplicationProvider.getApplicationContext()), audioRecorder);
         viewModel.formLoaded(formController);
     }
 
@@ -130,5 +133,11 @@ public class FormEntryViewModelTest {
         when(clock.getCurrentTime()).thenReturn(12345L);
         viewModel.openHierarchy();
         verify(auditEventLogger).logEvent(AuditEvent.AuditEventType.HIERARCHY, true, 12345L);
+    }
+
+    @Test
+    public void cancelBackgroundRecording_callsCleanUpOnAudioRecorder() {
+        viewModel.cancelBackgroundRecording();
+        verify(audioRecorder).cleanUp();
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.PreferencesProvider;
+import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.utilities.Clock;
 import org.robolectric.RobolectricTestRunner;
@@ -136,8 +137,8 @@ public class FormEntryViewModelTest {
     }
 
     @Test
-    public void cancelBackgroundRecording_callsCleanUpOnAudioRecorder() {
-        viewModel.cancelBackgroundRecording();
-        verify(audioRecorder).cleanUp();
+    public void setBackgroundRecordingEnabled_whenTrue_startsBackgroundRecording() {
+        viewModel.setBackgroundRecordingEnabled(true);
+        verify(audioRecorder).start("background", Output.AMR);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/QuitFormDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/QuitFormDialogFragmentTest.java
@@ -18,6 +18,7 @@ import org.odk.collect.android.formentry.saving.FormSaveViewModel;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.support.RobolectricHelpers;
 import org.odk.collect.async.Scheduler;
+import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowDialog;
 
@@ -39,7 +40,7 @@ public class QuitFormDialogFragmentTest {
     public void setup() {
         RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
             @Override
-            public FormSaveViewModel.FactoryFactory providesFormSaveViewModelFactoryFactory(Analytics analytics, Scheduler scheduler) {
+            public FormSaveViewModel.FactoryFactory providesFormSaveViewModelFactoryFactory(Analytics analytics, Scheduler scheduler, AudioRecorder audioRecorder) {
                 return (owner, defaultArgs) -> new ViewModelProvider.Factory() {
 
                     @NonNull

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -22,6 +22,7 @@ import org.odk.collect.android.support.MockFormEntryPromptBuilder;
 import org.odk.collect.android.tasks.SaveFormToDisk;
 import org.odk.collect.android.tasks.SaveToDiskResult;
 import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.testshared.FakeScheduler;
 import org.odk.collect.utilities.Result;
 import org.robolectric.Robolectric;
@@ -78,7 +79,7 @@ public class FormSaveViewModelTest {
         when(formController.getAuditEventLogger()).thenReturn(logger);
         when(logger.isChangeReasonRequired()).thenReturn(false);
 
-        viewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, analytics, scheduler);
+        viewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, analytics, scheduler, mock(AudioRecorder.class));
         viewModel.formLoaded(formController);
     }
 
@@ -416,7 +417,7 @@ public class FormSaveViewModelTest {
     public void deleteAnswerFile_whenAnswerFileHasAlreadyBeenDeleted_onRecreatingViewModel_actuallyDeletesNewFile() {
         viewModel.deleteAnswerFile("index", "blah1");
 
-        FormSaveViewModel restoredViewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null, scheduler);
+        FormSaveViewModel restoredViewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null, scheduler, mock(AudioRecorder.class));
         restoredViewModel.formLoaded(formController);
         restoredViewModel.deleteAnswerFile("index", "blah2");
 
@@ -447,7 +448,7 @@ public class FormSaveViewModelTest {
     public void replaceAnswerFile_whenAnswerFileHasAlreadyBeenReplaced_afterRecreatingViewModel_deletesPreviousReplacement() {
         viewModel.replaceAnswerFile("index", "blah1");
 
-        FormSaveViewModel restoredViewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null, scheduler);
+        FormSaveViewModel restoredViewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null, scheduler, mock(AudioRecorder.class));
         restoredViewModel.formLoaded(formController);
         restoredViewModel.replaceAnswerFile("index", "blah2");
 
@@ -522,7 +523,7 @@ public class FormSaveViewModelTest {
 
     @Test
     public void ignoreChanges_whenFormControllerNotSet_doesNothing() {
-        FormSaveViewModel viewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null, scheduler);
+        FormSaveViewModel viewModel = new FormSaveViewModel(savedStateHandle, () -> CURRENT_TIME, formSaver, mediaUtils, null, scheduler, mock(AudioRecorder.class));
         viewModel.ignoreChanges(); // Checks nothing explodes
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/FormSaveViewModelTest.java
@@ -358,37 +358,40 @@ public class FormSaveViewModelTest {
     }
 
     @Test
-    public void whenReasonRequiredToSave_saveReason_setsSaveResultState_toSaving() {
+    public void whenReasonRequiredToSave_resumeSave_setsSaveResultState_toSaving() {
         whenReasonRequiredToSave();
         viewModel.saveForm(Uri.parse("file://form"), false, "", false);
         LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
         viewModel.setReason("blah");
-        viewModel.saveReason();
+        viewModel.resumeSave();
         assertThat(saveResult.getValue().getState(), equalTo(SAVING));
     }
 
     @Test
-    public void saveReason_logsChangeReasonAuditEvent() {
+    public void whenReasonRequiredToSave_resumeSave_logsChangeReasonAuditEvent() {
+        whenReasonRequiredToSave();
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+
         viewModel.setReason("Blah");
-        viewModel.saveReason();
+        viewModel.resumeSave();
 
         verify(logger).logEvent(AuditEvent.AuditEventType.CHANGE_REASON, null, true, null, CURRENT_TIME, "Blah");
     }
 
     @Test
-    public void saveReason_whenReasonIsValid_returnsTrue() {
-        viewModel.setReason("Blah");
-        assertThat(viewModel.saveReason(), equalTo(true));
-    }
+    public void whenReasonRequiredToSave_resumeSave_whenReasonIsNotValid_doesNotSave() {
+        whenReasonRequiredToSave();
+        viewModel.saveForm(Uri.parse("file://form"), false, "", false);
+        LiveData<FormSaveViewModel.SaveResult> saveResult = viewModel.getSaveResult();
 
-    @Test
-    public void saveReason_whenReasonIsNotValid_returnsFalse() {
         viewModel.setReason("");
-        assertThat(viewModel.saveReason(), equalTo(false));
+        viewModel.resumeSave();
+        assertThat(saveResult.getValue().getState(), equalTo(CHANGE_REASON_REQUIRED));
 
         viewModel.setReason("  ");
-        assertThat(viewModel.saveReason(), equalTo(false));
+        viewModel.resumeSave();
+        assertThat(saveResult.getValue().getState(), equalTo(CHANGE_REASON_REQUIRED));
     }
 
     @Test

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -275,6 +275,12 @@
     <!-- Description text for button that that resumes recording sound -->
     <string name="resume_recording">Resume</string>
 
+    <!-- Text next to checkbox to allow the user to toggle audio recording on and off -->
+    <string name="record_audio">Record audio</string>
+
+    <!-- Text asking the user to confirm whether they want to stop recording or not (which deletes the recording file) -->
+    <string name="stop_recording_confirmation">This form requests background audio recording. Disabling it will stop recording and discard existing audio. Are you sure you want to proceed?</string>
+
     <!-- Title for dialog asking the user if they want to delete a file -->
     <string name="delete_answer_file_question">Delete file?</string>
 
@@ -990,6 +996,4 @@
     <string name="not_a_directory">%s exists, but is not a directory</string>
 
     <string name="select_odk_shortcut">Select ODK Shortcut</string>
-    <string name="record_audio">Record audio</string>
-    <string name="stop_recording_confirmation">Do you really want to stop recording?</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -281,6 +281,9 @@
     <!-- Text asking the user to confirm whether they want to stop recording or not (which deletes the recording file) -->
     <string name="stop_recording_confirmation">This form requests background audio recording. Disabling it will stop recording and discard existing audio. Are you sure you want to proceed?</string>
 
+    <!-- Text warning that user after they're reenabled background audio recording that it won't start again until they re-open the form -->
+    <string name="background_audio_recording_enabled_explanation">Recording will not begin immediately. You must re-open the form to record.</string>
+
     <!-- Title for dialog asking the user if they want to delete a file -->
     <string name="delete_answer_file_question">Delete file?</string>
 
@@ -996,5 +999,4 @@
     <string name="not_a_directory">%s exists, but is not a directory</string>
 
     <string name="select_odk_shortcut">Select ODK Shortcut</string>
-    <string name="background_audio_recording_enabled_explanation">Recording will not begin immediately. You must re-open the form to record.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -996,4 +996,5 @@
     <string name="not_a_directory">%s exists, but is not a directory</string>
 
     <string name="select_odk_shortcut">Select ODK Shortcut</string>
+    <string name="background_audio_recording_enabled_explanation">Recording will not begin immediately. You must re-open the form to record.</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -991,4 +991,5 @@
 
     <string name="select_odk_shortcut">Select ODK Shortcut</string>
     <string name="record_audio">Record audio</string>
+    <string name="stop_recording_confirmation">Do you really want to stop recording?</string>
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -990,4 +990,5 @@
     <string name="not_a_directory">%s exists, but is not a directory</string>
 
     <string name="select_odk_shortcut">Select ODK Shortcut</string>
+    <string name="record_audio">Record audio</string>
 </resources>


### PR DESCRIPTION
Closes #4343 

This also makes sure that the recording is saved **before** the form itself. This avoids any timing issues we might run into if the form saves before the recording can (and then the recording never will).

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It would be good to QA the [Change Reason Required feature](https://docs.getodk.org/form-audit-log/?highlight=audit#reason-for-changes)  as there were some changes under the hood to this area of the code. There are tests for this so hopefully we're covered.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)