### PR TITLE
External audio widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -832,6 +832,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
             case RequestCodes.EX_VIDEO_CHOOSER:
             case RequestCodes.EX_IMAGE_CHOOSER:
+            case RequestCodes.EX_AUDIO_CHOOSER:
                 if (intent.getClipData() != null
                         && intent.getClipData().getItemCount() > 0
                         && intent.getClipData().getItemAt(0) != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/ExternalAppsUtils.java
@@ -132,17 +132,16 @@ public class ExternalAppsUtils {
         }
     }
 
-    public static Object getValueRepresentedBy(String text, TreeReference reference)
-            throws XPathSyntaxException {
-        FormDef formDef = Collect.getInstance().getFormController().getFormDef();
-        FormInstance formInstance = formDef.getInstance();
-        EvaluationContext evaluationContext = new EvaluationContext(formDef.getEvaluationContext(),
-                reference);
-
+    public static Object getValueRepresentedBy(String text, TreeReference reference) throws XPathSyntaxException {
         if (text.startsWith("'")) {
             // treat this as a constant parameter but not require an ending quote
             return text.endsWith("'") ? text.substring(1, text.length() - 1) : text.substring(1);
-        } else if (text.startsWith("/")) {
+        }
+
+        FormDef formDef = Collect.getInstance().getFormController().getFormDef();
+        FormInstance formInstance = formDef.getInstance();
+        EvaluationContext evaluationContext = new EvaluationContext(formDef.getEvaluationContext(), reference);
+        if (text.startsWith("/")) {
             // treat this is an xpath
             XPathPathExpr pathExpr = XPathReference.getPathExpr(text);
             XPathNodeset xpathNodeset = pathExpr.eval(formInstance, evaluationContext);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ApplicationConstants.java
@@ -99,7 +99,8 @@ public class ApplicationConstants {
         public static final int EX_ARBITRARY_FILE_CHOOSER  = 23;
         public static final int EX_VIDEO_CHOOSER  = 24;
         public static final int EX_IMAGE_CHOOSER  = 25;
-        public static final int CHANGE_SETTINGS = 26;
+        public static final int EX_AUDIO_CHOOSER  = 26;
+        public static final int CHANGE_SETTINGS = 27;
 
         public static final int FORMS_UPLOADED_NOTIFICATION = 97;
         public static final int FORMS_DOWNLOADED_NOTIFICATION = 98;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ExternalAppIntentProvider.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.utilities;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 
 import androidx.annotation.Nullable;
@@ -9,7 +10,6 @@ import androidx.annotation.Nullable;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import org.odk.collect.android.R;
-import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.ExternalParamsException;
 import org.odk.collect.android.external.ExternalAppsUtils;
 
@@ -20,7 +20,7 @@ public class ExternalAppIntentProvider {
     private static final String URI_KEY = "uri_data";
     private static final String RETURNED_DATA_NAME = "value";
 
-    public Intent getIntentToRunExternalApp(Context context, FormEntryPrompt formEntryPrompt, ActivityAvailability activityAvailability) throws ExternalParamsException, XPathSyntaxException {
+    public Intent getIntentToRunExternalApp(Context context, FormEntryPrompt formEntryPrompt, ActivityAvailability activityAvailability, PackageManager packageManager) throws ExternalParamsException, XPathSyntaxException {
         String exSpec = formEntryPrompt.getAppearanceHint().replaceFirst("^ex[:]", "");
         final String intentName = ExternalAppsUtils.extractIntentName(exSpec);
         final Map<String, String> exParams = ExternalAppsUtils.extractParameters(exSpec);
@@ -40,7 +40,7 @@ public class ExternalAppIntentProvider {
         }
 
         if (!activityAvailability.isActivityAvailable(intent)) {
-            Intent launchIntent = Collect.getInstance().getPackageManager().getLaunchIntentForPackage(intentName);
+            Intent launchIntent = packageManager.getLaunchIntentForPackage(intentName);
 
             if (launchIntent != null) {
                 // Make sure FLAG_ACTIVITY_NEW_TASK is not set because it doesn't work with startActivityForResult

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -78,4 +78,8 @@ public class MediaUtils {
     public boolean isImageFile(File file) {
         return ContentResolverHelper.getMimeType(file).startsWith("image");
     }
+
+    public boolean isAudioFile(File file) {
+        return ContentResolverHelper.getMimeType(file).startsWith("audio");
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -91,8 +91,8 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 recordingInProgress = true;
                 updateVisibilities();
 
-                binding.recordingDuration.setText(formatLength(session.first));
-                binding.waveform.addAmplitude(session.second);
+                binding.audioPlayer.recordingDuration.setText(formatLength(session.first));
+                binding.audioPlayer.waveform.addAmplitude(session.second);
             } else {
                 recordingInProgress = false;
                 updateVisibilities();
@@ -108,7 +108,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
         binding.chooseButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
 
         binding.captureButton.setOnClickListener(v -> {
-            binding.waveform.clear();
+            binding.audioPlayer.waveform.clear();
             recordingRequester.requestRecording(getFormEntryPrompt());
         });
         binding.chooseButton.setOnClickListener(v -> audioFileRequester.requestFile(getFormEntryPrompt()));
@@ -165,21 +165,21 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
         if (recordingInProgress) {
             binding.captureButton.setVisibility(GONE);
             binding.chooseButton.setVisibility(GONE);
-            binding.recordingDuration.setVisibility(VISIBLE);
-            binding.waveform.setVisibility(VISIBLE);
-            binding.audioController.setVisibility(GONE);
+            binding.audioPlayer.recordingDuration.setVisibility(VISIBLE);
+            binding.audioPlayer.waveform.setVisibility(VISIBLE);
+            binding.audioPlayer.audioController.setVisibility(GONE);
         } else if (getAnswer() == null) {
             binding.captureButton.setVisibility(VISIBLE);
             binding.chooseButton.setVisibility(VISIBLE);
-            binding.recordingDuration.setVisibility(GONE);
-            binding.waveform.setVisibility(GONE);
-            binding.audioController.setVisibility(GONE);
+            binding.audioPlayer.recordingDuration.setVisibility(GONE);
+            binding.audioPlayer.waveform.setVisibility(GONE);
+            binding.audioPlayer.audioController.setVisibility(GONE);
         } else {
             binding.captureButton.setVisibility(GONE);
             binding.chooseButton.setVisibility(GONE);
-            binding.recordingDuration.setVisibility(GONE);
-            binding.waveform.setVisibility(GONE);
-            binding.audioController.setVisibility(VISIBLE);
+            binding.audioPlayer.recordingDuration.setVisibility(GONE);
+            binding.audioPlayer.waveform.setVisibility(GONE);
+            binding.audioPlayer.audioController.setVisibility(VISIBLE);
         }
 
         if (questionDetails.isReadOnly()) {
@@ -196,10 +196,10 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
         if (binaryName != null) {
             Clip clip = new Clip("audio:" + getFormEntryPrompt().getIndex().toString(), getAudioFile().getAbsolutePath());
 
-            audioPlayer.onPlayingChanged(clip.getClipID(), binding.audioController::setPlaying);
-            audioPlayer.onPositionChanged(clip.getClipID(), binding.audioController::setPosition);
-            binding.audioController.setDuration(getDurationOfFile(clip.getURI()));
-            binding.audioController.setListener(new AudioControllerView.Listener() {
+            audioPlayer.onPlayingChanged(clip.getClipID(), binding.audioPlayer.audioController::setPlaying);
+            audioPlayer.onPositionChanged(clip.getClipID(), binding.audioPlayer.audioController::setPosition);
+            binding.audioPlayer.audioController.setDuration(getDurationOfFile(clip.getURI()));
+            binding.audioPlayer.audioController.setListener(new AudioControllerView.Listener() {
                 @Override
                 public void onPlayClicked() {
                     audioPlayer.play(clip);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.databinding.ExArbitraryFileWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.ActivityAvailability;
@@ -88,7 +89,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
     private void onButtonClick() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
             ToastUtils.showLongToast(e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -1,0 +1,223 @@
+package org.odk.collect.android.widgets;
+
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.media.MediaMetadataRetriever;
+import android.util.TypedValue;
+import android.view.View;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.audio.AudioControllerView;
+import org.odk.collect.android.dao.helpers.ContentResolverHelper;
+import org.odk.collect.android.databinding.ExAudioWidgetAnswerBinding;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.ActivityAvailability;
+import org.odk.collect.android.utilities.ApplicationConstants;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
+import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.utilities.QuestionMediaManager;
+import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
+import org.odk.collect.android.widgets.interfaces.FileWidget;
+import org.odk.collect.android.widgets.utilities.AudioPlayer;
+import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.audioclips.Clip;
+
+import java.io.File;
+
+import timber.log.Timber;
+
+@SuppressLint("ViewConstructor")
+public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetDataReceiver {
+    ExAudioWidgetAnswerBinding binding;
+
+    private final AudioPlayer audioPlayer;
+    private final WaitingForDataRegistry waitingForDataRegistry;
+    private final QuestionMediaManager questionMediaManager;
+    private final MediaUtils mediaUtils;
+    private final ExternalAppIntentProvider externalAppIntentProvider;
+    private final ActivityAvailability activityAvailability;
+
+    File answerFile;
+
+    public ExAudioWidget(Context context, QuestionDetails questionDetails, QuestionMediaManager questionMediaManager,
+                         AudioPlayer audioPlayer, WaitingForDataRegistry waitingForDataRegistry, MediaUtils mediaUtils,
+                         ExternalAppIntentProvider externalAppIntentProvider, ActivityAvailability activityAvailability) {
+        super(context, questionDetails);
+
+        this.audioPlayer = audioPlayer;
+        this.waitingForDataRegistry = waitingForDataRegistry;
+        this.questionMediaManager = questionMediaManager;
+        this.mediaUtils = mediaUtils;
+        this.externalAppIntentProvider = externalAppIntentProvider;
+        this.activityAvailability = activityAvailability;
+
+        updateVisibilities();
+        updatePlayerMedia();
+    }
+
+    @Override
+    protected View onCreateAnswerView(Context context, FormEntryPrompt prompt, int answerFontSize) {
+        setupAnswerFile(prompt.getAnswerText());
+
+        binding = ExAudioWidgetAnswerBinding.inflate(((Activity) context).getLayoutInflater());
+
+        binding.launchExternalAppButton.setTextSize(TypedValue.COMPLEX_UNIT_DIP, answerFontSize);
+        binding.launchExternalAppButton.setOnClickListener(view -> launchExternalApp());
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void deleteFile() {
+        audioPlayer.stop();
+        questionMediaManager.deleteAnswerFile(getFormEntryPrompt().getIndex().toString(), answerFile.getAbsolutePath());
+        answerFile = null;
+    }
+
+    @Override
+    public void clearAnswer() {
+        deleteFile();
+        updateVisibilities();
+        widgetValueChanged();
+    }
+
+    @Override
+    public IAnswerData getAnswer() {
+        return answerFile != null ? new StringData(answerFile.getName()) : null;
+    }
+
+    @Override
+    public void setData(Object object) {
+        if (answerFile != null) {
+            clearAnswer();
+        }
+
+        if (object instanceof File && mediaUtils.isAudioFile((File) object)) {
+            answerFile = (File) object;
+            if (answerFile.exists()) {
+                questionMediaManager.replaceAnswerFile(getFormEntryPrompt().getIndex().toString(), answerFile.getAbsolutePath());
+                updateVisibilities();
+                updatePlayerMedia();
+                widgetValueChanged();
+            } else {
+                Timber.e("Inserting Audio file FAILED");
+            }
+        } else if (object != null) {
+            if (object instanceof File) {
+                ToastUtils.showLongToast(R.string.invalid_file_type);
+                mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
+                Timber.e("ExAudioWidget's setBinaryData must receive a audio file but received: %s", ContentResolverHelper.getMimeType((File) object));
+            } else {
+                Timber.e("ExAudioWidget's setBinaryData must receive a audio file but received: %s", object.getClass());
+            }
+        }
+    }
+
+    @Override
+    public void setOnLongClickListener(OnLongClickListener l) {
+        binding.launchExternalAppButton.setOnLongClickListener(l);
+    }
+
+    @Override
+    public void cancelLongPress() {
+        super.cancelLongPress();
+        binding.launchExternalAppButton.cancelLongPress();
+    }
+
+    private void updateVisibilities() {
+        if (answerFile == null) {
+            binding.launchExternalAppButton.setVisibility(VISIBLE);
+            binding.audioPlayer.recordingDuration.setVisibility(GONE);
+            binding.audioPlayer.waveform.setVisibility(GONE);
+            binding.audioPlayer.audioController.setVisibility(GONE);
+        } else {
+            binding.launchExternalAppButton.setVisibility(GONE);
+            binding.audioPlayer.recordingDuration.setVisibility(GONE);
+            binding.audioPlayer.waveform.setVisibility(GONE);
+            binding.audioPlayer.audioController.setVisibility(VISIBLE);
+        }
+
+        if (questionDetails.isReadOnly()) {
+            binding.launchExternalAppButton.setVisibility(GONE);
+        }
+    }
+
+    private void updatePlayerMedia() {
+        if (answerFile != null) {
+            Clip clip = new Clip("audio:" + getFormEntryPrompt().getIndex().toString(), answerFile.getAbsolutePath());
+
+            audioPlayer.onPlayingChanged(clip.getClipID(), binding.audioPlayer.audioController::setPlaying);
+            audioPlayer.onPositionChanged(clip.getClipID(), binding.audioPlayer.audioController::setPosition);
+            binding.audioPlayer.audioController.setDuration(getDurationOfFile(clip.getURI()));
+            binding.audioPlayer.audioController.setListener(new AudioControllerView.Listener() {
+                @Override
+                public void onPlayClicked() {
+                    audioPlayer.play(clip);
+                }
+
+                @Override
+                public void onPauseClicked() {
+                    audioPlayer.pause();
+                }
+
+                @Override
+                public void onPositionChanged(Integer newPosition) {
+                    analytics.logFormEvent(AnalyticsEvents.AUDIO_PLAYER_SEEK, questionDetails.getFormAnalyticsID());
+                    audioPlayer.setPosition(clip.getClipID(), newPosition);
+                }
+
+                @Override
+                public void onRemoveClicked() {
+                    new MaterialAlertDialogBuilder(getContext())
+                            .setTitle(R.string.delete_answer_file_question)
+                            .setMessage(R.string.answer_file_delete_warning)
+                            .setPositiveButton(R.string.delete_answer_file, (dialog, which) -> clearAnswer())
+                            .setNegativeButton(R.string.cancel, null)
+                            .show();
+                }
+            });
+
+        }
+    }
+
+    private Integer getDurationOfFile(String uri) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        retriever.setDataSource(uri);
+        String durationString = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+        return durationString != null ? Integer.parseInt(durationString) : 0;
+    }
+
+    private void launchExternalApp() {
+        waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
+        try {
+            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            fireActivityForResult(intent);
+        } catch (Exception | Error e) {
+            ToastUtils.showLongToast(e.getMessage());
+        }
+    }
+
+    private void fireActivityForResult(Intent intent) {
+        try {
+            ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_AUDIO_CHOOSER);
+        } catch (SecurityException e) {
+            Timber.i(e);
+            ToastUtils.showLongToast(R.string.not_granted_permission);
+        }
+    }
+
+    private void setupAnswerFile(String fileName) {
+        if (fileName != null && !fileName.isEmpty()) {
+            answerFile = new File(getInstanceFolder() + File.separator + fileName);
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -15,6 +15,7 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AudioControllerView;
 import org.odk.collect.android.dao.helpers.ContentResolverHelper;
 import org.odk.collect.android.databinding.ExAudioWidgetAnswerBinding;
@@ -199,7 +200,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
     private void launchExternalApp() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
             ToastUtils.showLongToast(e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
@@ -13,6 +13,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.helpers.ContentResolverHelper;
 import org.odk.collect.android.databinding.ExImageWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -133,7 +134,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
     private void launchExternalApp() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
             ToastUtils.showLongToast(e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -29,6 +29,7 @@ import android.widget.Toast;
 
 import org.javarosa.core.model.data.StringData;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.external.ExternalAppsUtils;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
@@ -180,7 +181,7 @@ public class ExStringWidget extends StringWidget implements WidgetDataReceiver, 
     public void onButtonClick(int buttonId) {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = new ExternalAppIntentProvider().getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = new ExternalAppIntentProvider().getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             // ACTION_SENDTO used for sending text messages or emails doesn't require any results
             if (ACTION_SENDTO.equals(intent.getAction())) {
                 getContext().startActivity(intent);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
@@ -11,6 +11,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.dao.helpers.ContentResolverHelper;
 import org.odk.collect.android.databinding.ExVideoWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -128,7 +129,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
     private void launchExternalApp() {
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         try {
-            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability);
+            Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
             ToastUtils.showLongToast(e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -206,7 +206,12 @@ public class WidgetFactory {
             case Constants.CONTROL_AUDIO_CAPTURE:
                 RecordingRequester recordingRequester = recordingRequesterProvider.create(prompt, useExternalRecorder);
                 GetContentAudioFileRequester audioFileRequester = new GetContentAudioFileRequester(context, activityAvailability, waitingForDataRegistry, formEntryViewModel);
-                questionWidget = new AudioWidget(context, questionDetails, questionMediaManager, audioPlayer, recordingRequester, audioFileRequester, new AudioRecorderRecordingStatusHandler(audioRecorder, viewLifecycle));
+
+                if (appearance.startsWith(Appearances.EX)) {
+                    questionWidget = new ExAudioWidget(context, questionDetails, questionMediaManager, audioPlayer, waitingForDataRegistry, new MediaUtils(), new ExternalAppIntentProvider(), activityAvailability);
+                } else {
+                    questionWidget = new AudioWidget(context, questionDetails, questionMediaManager, audioPlayer, recordingRequester, audioFileRequester, new AudioRecorderRecordingStatusHandler(audioRecorder, viewLifecycle));
+                }
                 break;
             case Constants.CONTROL_VIDEO_CAPTURE:
                 if (appearance.startsWith(Appearances.EX)) {

--- a/collect_app/src/main/res/layout/audio_controller_layout.xml
+++ b/collect_app/src/main/res/layout/audio_controller_layout.xml
@@ -39,7 +39,6 @@ limitations under the License.
             android:layout_height="wrap_content"
             android:layout_above="@id/seekBar"
             android:layout_alignParentStart="true"
-            android:layout_marginStart="@dimen/margin_standard"
             android:textColor="?colorOnSurface"
             android:textSize="@dimen/text_size_small"
             android:textStyle="bold"
@@ -51,7 +50,6 @@ limitations under the License.
             android:layout_height="wrap_content"
             android:layout_above="@id/seekBar"
             android:layout_alignParentEnd="true"
-            android:layout_marginEnd="@dimen/margin_standard"
             android:textColor="?colorOnSurface"
             android:textSize="@dimen/text_size_small"
             android:textStyle="bold"
@@ -63,14 +61,15 @@ limitations under the License.
             android:layout_height="wrap_content"
             android:layout_below="@+id/play"
             android:minHeight="24dp"
-            android:padding="@dimen/margin_standard"
+            android:paddingVertical="@dimen/margin_standard"
+            android:paddingStart="0dp"
+            android:paddingEnd="0dp"
             android:thumbOffset="3dp" />
     </RelativeLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_standard"
         android:orientation="horizontal">
 
         <com.google.android.material.button.MaterialButton
@@ -78,7 +77,6 @@ limitations under the License.
             style="@style/Widget.MaterialComponents.Button.OutlinedButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
             android:text="@string/delete_answer_file"
             android:textColor="?colorError"
             app:icon="@drawable/ic_baseline_delete_outline_24"

--- a/collect_app/src/main/res/layout/audio_player_layout.xml
+++ b/collect_app/src/main/res/layout/audio_player_layout.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/recording_duration"
+        style="@style/TextAppearance.Collect.Headline5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/margin_standard"
+        android:textColor="?colorSecondary"
+        tools:text="00:07" />
+
+    <org.odk.collect.android.audio.Waveform
+        android:layout_marginTop="@dimen/margin_small"
+        android:id="@+id/waveform"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        android:layout_marginHorizontal="@dimen/margin_standard" />
+
+    <org.odk.collect.android.audio.AudioControllerView
+        android:id="@+id/audio_controller"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/collect_app/src/main/res/layout/audio_player_layout.xml
+++ b/collect_app/src/main/res/layout/audio_player_layout.xml
@@ -19,8 +19,7 @@
         android:layout_marginTop="@dimen/margin_small"
         android:id="@+id/waveform"
         android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:layout_marginHorizontal="@dimen/margin_standard" />
+        android:layout_height="80dp" />
 
     <org.odk.collect.android.audio.AudioControllerView
         android:id="@+id/audio_controller"

--- a/collect_app/src/main/res/layout/audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/audio_widget_answer.xml
@@ -2,20 +2,17 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="@dimen/margin_standard">
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/capture_button"
         style="@style/Widget.Collect.Button.WidgetAnswer"
-        android:layout_marginHorizontal="@dimen/margin_standard"
-        android:layout_marginTop="@dimen/margin_standard"
         android:text="@string/capture_audio" />
 
     <org.odk.collect.android.views.MultiClickSafeButton
         android:id="@+id/choose_button"
         style="@style/Widget.Collect.Button.WidgetAnswer"
-        android:layout_marginHorizontal="@dimen/margin_standard"
-        android:layout_marginTop="@dimen/margin_extra_small"
         android:text="@string/choose_sound" />
 
     <include

--- a/collect_app/src/main/res/layout/audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/audio_widget_answer.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -20,26 +18,8 @@
         android:layout_marginTop="@dimen/margin_extra_small"
         android:text="@string/choose_sound" />
 
-    <TextView
-        android:id="@+id/recording_duration"
-        style="@style/TextAppearance.Collect.Headline5"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/margin_standard"
-        android:textColor="?colorSecondary"
-        tools:text="00:07" />
-
-    <org.odk.collect.android.audio.Waveform
-        android:layout_marginTop="@dimen/margin_small"
-        android:id="@+id/waveform"
-        android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:layout_marginHorizontal="@dimen/margin_standard" />
-
-    <org.odk.collect.android.audio.AudioControllerView
-        android:id="@+id/audio_controller"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+    <include
+        android:id="@+id/audio_player"
+        layout="@layout/audio_player_layout"/>
 
 </LinearLayout>

--- a/collect_app/src/main/res/layout/ex_audio_widget_answer.xml
+++ b/collect_app/src/main/res/layout/ex_audio_widget_answer.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_standard">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/launch_external_app_button"
+        style="@style/Widget.Collect.Button.WidgetAnswer"
+        android:text="@string/launch_app" />
+
+    <include
+        android:id="@+id/audio_player"
+        layout="@layout/audio_player_layout"/>
+</LinearLayout>

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppIntentProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ExternalAppIntentProviderTest.java
@@ -1,0 +1,121 @@
+package org.odk.collect.android.utilities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+
+import org.javarosa.core.model.FormIndex;
+import org.javarosa.form.api.FormEntryPrompt;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
+import org.odk.collect.android.exception.ExternalParamsException;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class ExternalAppIntentProviderTest {
+    private Context context;
+    private ActivityAvailability activityAvailability;
+    private FormEntryPrompt formEntryPrompt;
+    private PackageManager packageManager;
+    private ExternalAppIntentProvider externalAppIntentProvider;
+
+    @Before
+    public void setup() {
+        context = mock(Context.class);
+        activityAvailability = mock(ActivityAvailability.class);
+        formEntryPrompt = mock(FormEntryPrompt.class);
+        packageManager = mock(PackageManager.class);
+        externalAppIntentProvider = new ExternalAppIntentProvider();
+
+        when(context.getString(R.string.no_app)).thenReturn("The requested application is missing. Please manually enter the reading.");
+        when(formEntryPrompt.getIndex()).thenReturn(mock(FormIndex.class));
+    }
+
+    @Test
+    public void whenExternalActivityNotAvailable_shouldExceptionBeThrown() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider()");
+
+        assertThrows(RuntimeException.class, () -> externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager));
+    }
+
+    @Test
+    public void whenNoCustomErrorMessageSpecified_shouldDefaultOneBeReturned() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider()");
+
+        Exception exception = assertThrows(RuntimeException.class, () -> externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager));
+        assertThat(exception.getMessage(), is("The requested application is missing. Please manually enter the reading."));
+    }
+
+    @Test
+    public void whenCustomErrorMessageSpecified_shouldThatMessageReturned() {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider()");
+        when(formEntryPrompt.getSpecialFormQuestionText("noAppErrorString")).thenReturn("Custom error message");
+
+        Exception exception = assertThrows(RuntimeException.class, () -> externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager));
+        assertThat(exception.getMessage(), is("Custom error message"));
+    }
+
+    @Test
+    public void intentAction_shouldBeSetProperly() throws ExternalParamsException, XPathSyntaxException {
+        when(activityAvailability.isActivityAvailable(any())).thenReturn(true);
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider()");
+
+        Intent resultIntent = externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager);
+        assertThat(resultIntent.getAction(), is("com.example.collectanswersprovider"));
+    }
+
+    @Test
+    public void whenNoParamsSpecified_shouldIntentHaveNoExtras() throws ExternalParamsException, XPathSyntaxException {
+        when(activityAvailability.isActivityAvailable(any())).thenReturn(true);
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider()");
+
+        Intent resultIntent = externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager);
+        assertThat(resultIntent.getExtras(), nullValue());
+    }
+
+    @Test
+    public void whenParamsSpecified_shouldIntentHaveExtras() throws ExternalParamsException, XPathSyntaxException {
+        when(activityAvailability.isActivityAvailable(any())).thenReturn(true);
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider(param1='value1', param2='value2')");
+
+        Intent resultIntent = externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager);
+        assertThat(resultIntent.getExtras().keySet().size(), is(2));
+        assertThat(resultIntent.getExtras().getString("param1"), is("value1"));
+        assertThat(resultIntent.getExtras().getString("param2"), is("value2"));
+    }
+
+    @Test
+    public void whenParamsContainUri_shouldThatUriBeAddedAsIntentData() throws ExternalParamsException, XPathSyntaxException {
+        when(activityAvailability.isActivityAvailable(any())).thenReturn(true);
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider(param1='value1', uri_data='file:///tmp/android.txt')");
+
+        Intent resultIntent = externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager);
+        assertThat(resultIntent.getData().toString(), is("file:///tmp/android.txt"));
+        assertThat(resultIntent.getExtras().keySet().size(), is(1));
+        assertThat(resultIntent.getExtras().getString("param1"), is("value1"));
+    }
+
+    @Test
+    public void whenSpecifiedIntentCanNotBeLaunched_shouldTryToLaunchTheMainExternalAppActivity() throws ExternalParamsException, XPathSyntaxException {
+        when(formEntryPrompt.getAppearanceHint()).thenReturn("ex:com.example.collectanswersprovider()");
+        Intent intent = mock(Intent.class);
+        when(packageManager.getLaunchIntentForPackage("com.example.collectanswersprovider")).thenReturn(intent);
+        when(activityAvailability.isActivityAvailable(intent)).thenReturn(true);
+
+        Intent resultIntent = externalAppIntentProvider.getIntentToRunExternalApp(context, formEntryPrompt, activityAvailability, packageManager);
+        assertThat(resultIntent, is(intent));
+        assertThat(resultIntent.getFlags(), is(0));
+
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AudioWidgetTest.java
@@ -74,9 +74,9 @@ public class AudioWidgetTest {
     public void whenPromptDoesNotHaveAnswer_showsButtons() {
         AudioWidget widget = createWidget(promptWithAnswer(null));
 
-        assertThat(widget.binding.audioController.getVisibility(), is(GONE));
-        assertThat(widget.binding.recordingDuration.getVisibility(), is(GONE));
-        assertThat(widget.binding.waveform.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.recordingDuration.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.waveform.getVisibility(), is(GONE));
         assertThat(widget.binding.captureButton.getVisibility(), is(VISIBLE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(VISIBLE));
     }
@@ -87,9 +87,9 @@ public class AudioWidgetTest {
 
         assertThat(widget.binding.captureButton.getVisibility(), is(GONE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(GONE));
-        assertThat(widget.binding.waveform.getVisibility(), is(GONE));
-        assertThat(widget.binding.recordingDuration.getVisibility(), is(GONE));
-        assertThat(widget.binding.audioController.getVisibility(), is(VISIBLE));
+        assertThat(widget.binding.audioPlayer.waveform.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.recordingDuration.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(VISIBLE));
     }
 
     @Test
@@ -146,7 +146,7 @@ public class AudioWidgetTest {
         widget.clearAnswer();
 
         assertThat(widget.getAnswer(), nullValue());
-        assertThat(widget.binding.audioController.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(GONE));
     }
 
     @Test
@@ -254,7 +254,7 @@ public class AudioWidgetTest {
 
         assertThat(widget.binding.captureButton.getVisibility(), is(GONE));
         assertThat(widget.binding.captureButton.getVisibility(), is(GONE));
-        assertThat(widget.binding.audioController.getVisibility(), is(VISIBLE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(VISIBLE));
     }
 
     @Test
@@ -286,7 +286,7 @@ public class AudioWidgetTest {
 
         recordingRequester.setAmplitude(prompt.getIndex().toString(), 11);
         widget.binding.captureButton.performClick();
-        assertThat(widget.binding.waveform.getLatestAmplitude(), nullValue());
+        assertThat(widget.binding.audioPlayer.waveform.getLatestAmplitude(), nullValue());
     }
 
     @Test
@@ -310,9 +310,9 @@ public class AudioWidgetTest {
         recordingRequester.setDuration(prompt.getIndex().toString(), 0);
         assertThat(widget.binding.captureButton.getVisibility(), is(GONE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(GONE));
-        assertThat(widget.binding.audioController.getVisibility(), is(GONE));
-        assertThat(widget.binding.recordingDuration.getVisibility(), is(VISIBLE));
-        assertThat(widget.binding.waveform.getVisibility(), is(VISIBLE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.recordingDuration.getVisibility(), is(VISIBLE));
+        assertThat(widget.binding.audioPlayer.waveform.getVisibility(), is(VISIBLE));
     }
 
     @Test
@@ -321,10 +321,10 @@ public class AudioWidgetTest {
         AudioWidget widget = createWidget(prompt);
 
         recordingRequester.setDuration(prompt.getIndex().toString(), 0);
-        assertThat(widget.binding.recordingDuration.getText(), is("00:00"));
+        assertThat(widget.binding.audioPlayer.recordingDuration.getText(), is("00:00"));
 
         recordingRequester.setDuration(prompt.getIndex().toString(), 42000);
-        assertThat(widget.binding.recordingDuration.getText(), is("00:42"));
+        assertThat(widget.binding.audioPlayer.recordingDuration.getText(), is("00:42"));
     }
 
     @Test
@@ -333,10 +333,10 @@ public class AudioWidgetTest {
         AudioWidget widget = createWidget(prompt);
 
         recordingRequester.setAmplitude(prompt.getIndex().toString(), 5);
-        assertThat(widget.binding.waveform.getLatestAmplitude(), is(5));
+        assertThat(widget.binding.audioPlayer.waveform.getLatestAmplitude(), is(5));
 
         recordingRequester.setAmplitude(prompt.getIndex().toString(), 67);
-        assertThat(widget.binding.waveform.getLatestAmplitude(), is(67));
+        assertThat(widget.binding.audioPlayer.waveform.getLatestAmplitude(), is(67));
     }
 
     @Test
@@ -347,9 +347,9 @@ public class AudioWidgetTest {
         recordingRequester.setDuration(prompt.getIndex().toString(), 5);
         recordingRequester.reset();
 
-        assertThat(widget.binding.audioController.getVisibility(), is(GONE));
-        assertThat(widget.binding.recordingDuration.getVisibility(), is(GONE));
-        assertThat(widget.binding.waveform.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.recordingDuration.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.waveform.getVisibility(), is(GONE));
         assertThat(widget.binding.captureButton.getVisibility(), is(VISIBLE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(VISIBLE));
     }
@@ -363,7 +363,7 @@ public class AudioWidgetTest {
         Clip expectedClip = getExpectedClip(prompt, audioFile.getName());
         widget.setData(audioFile);
 
-        AudioControllerView audioController = widget.binding.audioController;
+        AudioControllerView audioController = widget.binding.audioPlayer.audioController;
         assertThat(audioController.getVisibility(), is(VISIBLE));
         audioController.binding.play.performClick();
         assertThat(audioPlayer.getCurrentClip(), is(expectedClip));
@@ -388,7 +388,7 @@ public class AudioWidgetTest {
         AudioWidget widget = createWidget(prompt);
         widget.setData(audioFile);
 
-        AudioControllerView audioController = widget.binding.audioController;
+        AudioControllerView audioController = widget.binding.audioPlayer.audioController;
         assertThat(audioController.binding.currentDuration.getText().toString(), is("00:00"));
 
         audioPlayer.setPosition(expectedClip.getClipID(), 42000);
@@ -406,14 +406,14 @@ public class AudioWidgetTest {
         AudioWidget widget = createWidget(prompt);
         widget.setData(audioFile);
 
-        AudioControllerView audioController = widget.binding.audioController;
+        AudioControllerView audioController = widget.binding.audioPlayer.audioController;
         assertThat(audioController.binding.totalDuration.getText().toString(), is("05:22"));
     }
 
     @Test
     public void clickingRemove_andConfirming_clearsAnswer() {
         AudioWidget widget = createWidget(promptWithAnswer(new StringData("blah.mp3")));
-        widget.binding.audioController.binding.remove.performClick();
+        widget.binding.audioPlayer.audioController.binding.remove.performClick();
 
         AlertDialog dialog = (AlertDialog) getLatestDialog();
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick();
@@ -424,7 +424,7 @@ public class AudioWidgetTest {
     @Test
     public void clickingRemove_andCancelling_doesNothing() {
         AudioWidget widget = createWidget(promptWithAnswer(new StringData("blah.mp3")));
-        widget.binding.audioController.binding.remove.performClick();
+        widget.binding.audioPlayer.audioController.binding.remove.performClick();
 
         AlertDialog dialog = (AlertDialog) getLatestDialog();
         dialog.getButton(AlertDialog.BUTTON_NEGATIVE).performClick();
@@ -435,12 +435,12 @@ public class AudioWidgetTest {
     @Test
     public void clickingRemove_andConfirming_hidesAudioControllerAndShowsButtons() {
         AudioWidget widget = createWidget(promptWithAnswer(new StringData("blah.mp3")));
-        widget.binding.audioController.binding.remove.performClick();
+        widget.binding.audioPlayer.audioController.binding.remove.performClick();
 
         AlertDialog dialog = (AlertDialog) getLatestDialog();
         dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick();
 
-        assertThat(widget.binding.audioController.getVisibility(), is(GONE));
+        assertThat(widget.binding.audioPlayer.audioController.getVisibility(), is(GONE));
         assertThat(widget.binding.captureButton.getVisibility(), is(VISIBLE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(VISIBLE));
     }
@@ -448,7 +448,7 @@ public class AudioWidgetTest {
     @Test
     public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
         AudioWidget widget = createWidget(promptWithReadOnlyAndAnswer(new StringData("blah.mp3")));
-        widget.binding.audioController.binding.remove.performClick();
+        widget.binding.audioPlayer.audioController.binding.remove.performClick();
 
         assertThat(widget.binding.captureButton.getVisibility(), is(View.GONE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(View.GONE));
@@ -457,7 +457,7 @@ public class AudioWidgetTest {
     @Test
     public void whenReadOnlyOverrideOptionIsUsed_shouldAllClickableElementsBeDisabled() {
         AudioWidget widget = createWidget(promptWithAnswer(new StringData("blah.mp3")), true);
-        widget.binding.audioController.binding.remove.performClick();
+        widget.binding.audioPlayer.audioController.binding.remove.performClick();
 
         assertThat(widget.binding.captureButton.getVisibility(), is(View.GONE));
         assertThat(widget.binding.chooseButton.getVisibility(), is(View.GONE));

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExArbitraryFileWidgetTest.java
@@ -86,7 +86,7 @@ public class ExArbitraryFileWidgetTest extends FileWidgetTest<ExArbitraryFileWid
     @Test
     public void whenClickingOnButton_externalAppShouldBeLaunchedByIntent() throws ExternalParamsException, XPathSyntaxException {
         Intent intent = mock(Intent.class);
-        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
+        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any(), any())).thenReturn(intent);
         getWidget().binding.exArbitraryFileButton.performClick();
         assertThat(shadowOf(activity).getNextStartedActivity(), is(intent));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExAudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExAudioWidgetTest.java
@@ -1,0 +1,190 @@
+package org.odk.collect.android.widgets;
+
+import android.content.Intent;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+import org.javarosa.core.model.data.StringData;
+import org.javarosa.xpath.parser.XPathSyntaxException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.odk.collect.android.exception.ExternalParamsException;
+import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.preferences.GeneralSharedPreferences;
+import org.odk.collect.android.utilities.ActivityAvailability;
+import org.odk.collect.android.utilities.ExternalAppIntentProvider;
+import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.android.widgets.base.FileWidgetTest;
+import org.odk.collect.android.widgets.support.FakeQuestionMediaManager;
+import org.odk.collect.android.widgets.support.FakeWaitingForDataRegistry;
+import org.odk.collect.android.widgets.utilities.AudioPlayer;
+import org.robolectric.shadows.ShadowToast;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.preferences.GeneralKeys.KEY_FONT_SIZE;
+import static org.odk.collect.android.utilities.QuestionFontSizeUtils.DEFAULT_FONT_SIZE;
+import static org.robolectric.Shadows.shadowOf;
+
+public class ExAudioWidgetTest extends FileWidgetTest<ExAudioWidget> {
+    @Mock
+    MediaUtils mediaUtils;
+
+    @Mock
+    ExternalAppIntentProvider externalAppIntentProvider;
+
+    @Mock
+    AudioPlayer audioPlayer;
+
+    @Before
+    public void setup() {
+        when(mediaUtils.isAudioFile(any())).thenReturn(true);
+    }
+
+    @Override
+    public StringData getInitialAnswer() {
+        return new StringData("audio1.mp3");
+    }
+
+    @NonNull
+    @Override
+    public StringData getNextAnswer() {
+        return new StringData("audio2.mp3");
+    }
+
+    @NonNull
+    @Override
+    public ExAudioWidget createWidget() {
+        return new ExAudioWidget(activity, new QuestionDetails(formEntryPrompt, "formAnalyticsID", readOnlyOverride),
+                new FakeQuestionMediaManager(), audioPlayer, new FakeWaitingForDataRegistry(), mediaUtils, externalAppIntentProvider, new ActivityAvailability(activity));
+    }
+
+    @Test
+    public void whenWidgetCreated_shouldLaunchButtonBeVisible() {
+        assertThat(getWidget().binding.launchExternalAppButton.getVisibility(), is(View.VISIBLE));
+    }
+
+    @Test
+    public void whenWidgetCreated_shouldLaunchButtonHaveProperName() {
+        assertThat(getWidget().binding.launchExternalAppButton.getText(), is("Launch"));
+    }
+
+    @Test
+    public void whenFontSizeNotChanged_defaultFontSizeShouldBeUsed() {
+        assertThat((int) getWidget().binding.launchExternalAppButton.getTextSize(), is(DEFAULT_FONT_SIZE - 1));
+    }
+
+    @Test
+    public void whenFontSizeChanged_CustomFontSizeShouldBeUsed() {
+        GeneralSharedPreferences.getInstance().save(KEY_FONT_SIZE, "30");
+
+        assertThat((int) getWidget().binding.launchExternalAppButton.getTextSize(), is(29));
+    }
+
+    @Test
+    public void whenThereIsNoAnswer_shouldAudioPlayerBeHidden() {
+        assertThat(getWidget().binding.audioPlayer.recordingDuration.getVisibility(), is(View.GONE));
+        assertThat(getWidget().binding.audioPlayer.waveform.getVisibility(), is(View.GONE));
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenThereIsAnswer_shouldAudioPlayerBeDisplayed() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.VISIBLE));
+    }
+
+    @Test
+    public void whenThereIsAnswer_shouldLaunchButtonBeHidden() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        assertThat(getWidget().binding.launchExternalAppButton.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenAnswerCleared_shouldAudioPlayerBeHidden() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExAudioWidget widget = getWidget();
+        widget.clearAnswer();
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenLaunchButtonClicked_externalAppShouldBeLaunchedByIntent() throws ExternalParamsException, XPathSyntaxException {
+        Intent intent = mock(Intent.class);
+        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
+        getWidget().binding.launchExternalAppButton.performClick();
+        assertThat(shadowOf(activity).getNextStartedActivity(), is(intent));
+    }
+
+    @Test
+    public void whenSetDataCalledWithNull_shouldExistedAnswerBeRemoved() {
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExAudioWidget widget = getWidget();
+        widget.setData(null);
+        assertThat(widget.getAnswer(), is(nullValue()));
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenUnsupportedFileTypeAttached_shouldNotThatFileBeAdded() throws IOException {
+        ExAudioWidget widget = getWidget();
+        File answer = File.createTempFile("doc", ".pdf");
+        when(mediaUtils.isAudioFile(answer)).thenReturn(false);
+        widget.setData(answer);
+        assertThat(widget.getAnswer(), is(nullValue()));
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.GONE));
+    }
+
+    @Test
+    public void whenUnsupportedFileTypeAttached_shouldTheFileBeRemoved() throws IOException {
+        ExAudioWidget widget = getWidget();
+        File answer = File.createTempFile("doc", ".pdf");
+        when(mediaUtils.isAudioFile(answer)).thenReturn(false);
+        widget.setData(answer);
+        verify(mediaUtils).deleteMediaFile(answer.getAbsolutePath());
+    }
+
+    @Test
+    public void whenUnsupportedFileTypeAttached_shouldToastBeDisplayed() throws IOException {
+        ExAudioWidget widget = getWidget();
+        File answer = File.createTempFile("doc", ".pdf");
+        when(mediaUtils.isAudioFile(answer)).thenReturn(false);
+        widget.setData(answer);
+        assertThat(ShadowToast.getTextOfLatestToast(), is("Application returned an invalid file type"));
+    }
+
+    @Test
+    public void usingReadOnlyOptionShouldMakeAllClickableElementsDisabled() {
+        when(formEntryPrompt.isReadOnly()).thenReturn(true);
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExAudioWidget widget = getWidget();
+        assertThat(widget.binding.launchExternalAppButton.getVisibility(), is(View.GONE));
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.VISIBLE));
+    }
+
+    @Test
+    public void whenReadOnlyOverrideOptionIsUsed_shouldAllClickableElementsBeDisabled() {
+        readOnlyOverride = true;
+        when(formEntryPrompt.getAnswerText()).thenReturn(getInitialAnswer().getDisplayText());
+
+        ExAudioWidget widget = getWidget();
+        assertThat(widget.binding.launchExternalAppButton.getVisibility(), is(View.GONE));
+        assertThat(getWidget().binding.audioPlayer.audioController.getVisibility(), is(View.VISIBLE));
+    }
+}
+

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExAudioWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExAudioWidgetTest.java
@@ -124,7 +124,7 @@ public class ExAudioWidgetTest extends FileWidgetTest<ExAudioWidget> {
     @Test
     public void whenLaunchButtonClicked_externalAppShouldBeLaunchedByIntent() throws ExternalParamsException, XPathSyntaxException {
         Intent intent = mock(Intent.class);
-        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
+        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any(), any())).thenReturn(intent);
         getWidget().binding.launchExternalAppButton.performClick();
         assertThat(shadowOf(activity).getNextStartedActivity(), is(intent));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExImageWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExImageWidgetTest.java
@@ -111,7 +111,7 @@ public class ExImageWidgetTest extends FileWidgetTest<ExImageWidget> {
     @Test
     public void whenLaunchButtonClicked_externalAppShouldBeLaunchedByIntent() throws ExternalParamsException, XPathSyntaxException {
         Intent intent = mock(Intent.class);
-        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
+        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any(), any())).thenReturn(intent);
         getWidget().binding.launchExternalAppButton.performClick();
         assertThat(shadowOf(activity).getNextStartedActivity(), is(intent));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/ExVideoWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/ExVideoWidgetTest.java
@@ -118,7 +118,7 @@ public class ExVideoWidgetTest extends FileWidgetTest<ExVideoWidget> {
     @Test
     public void whenClickingOnChooseButton_externalAppShouldBeLaunchedByIntent() throws ExternalParamsException, XPathSyntaxException {
         Intent intent = mock(Intent.class);
-        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any())).thenReturn(intent);
+        when(externalAppIntentProvider.getIntentToRunExternalApp(any(), any(), any(), any())).thenReturn(intent);
         getWidget().binding.captureVideoButton.performClick();
         assertThat(shadowOf(activity).getNextStartedActivity(), is(intent));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/FileWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/FileWidgetTest.java
@@ -31,6 +31,7 @@ public abstract class FileWidgetTest<W extends FileWidget> extends BinaryWidgetT
         File file = mock(File.class);
         when(file.exists()).thenReturn(true);
         when(file.getName()).thenReturn(answerData.getDisplayText());
+        when(file.getAbsolutePath()).thenReturn(answerData.getDisplayText());
         return file;
     }
 


### PR DESCRIPTION
Closes #4214

#### What has been done to verify that this works as intended?
I tested the new widget manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's a continuation of: https://github.com/getodk/collect/issues/4214

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Here I implemented a completly new ExAudioWidget. I didn't touch other widgets so we can focus on the new one and that would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
[exTestForm.xlsx](https://github.com/getodk/collect/files/5951659/exTestForm.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes https://github.com/getodk/docs/issues/1318

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)