### PR TITLE
Show errors in recording overlay

### DIFF
--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -82,6 +82,7 @@ internal class AudioRecorderService : Service() {
         try {
             recorder.start(output)
             recordingRepository.start(sessionId)
+            throw Exception("whee")
             startUpdates()
         } catch (e: Exception) {
             notification.dismiss()

--- a/audiorecorder/src/main/res/drawable/ic_baseline_mic_off_24.xml
+++ b/audiorecorder/src/main/res/drawable/ic_baseline_mic_off_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,11h-1.7c0,0.74 -0.16,1.43 -0.43,2.05l1.23,1.23c0.56,-0.98 0.9,-2.09 0.9,-3.28zM14.98,11.17c0,-0.06 0.02,-0.11 0.02,-0.17L15,5c0,-1.66 -1.34,-3 -3,-3S9,3.34 9,5v0.18l5.98,5.99zM4.27,3L3,4.27l6.01,6.01L9.01,11c0,1.66 1.33,3 2.99,3 0.22,0 0.44,-0.03 0.65,-0.08l1.66,1.66c-0.71,0.33 -1.5,0.52 -2.31,0.52 -2.76,0 -5.3,-2.1 -5.3,-5.1L5,11c0,3.41 2.72,6.23 6,6.72L11,21h2v-3.28c0.91,-0.13 1.77,-0.45 2.54,-0.9L19.73,21 21,19.73 4.27,3z"/>
+</vector>

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2006,7 +2006,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         FormController formController = getFormController();
 
-        if (formController != null && !formEntryViewModel.isFormControllerSet()) {
+        if (formController != null && !formEntryViewModel.isFormControllerSet().getValue()) {
             Timber.e("FormController set in App but not ViewModel");
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
@@ -18,6 +18,7 @@ import org.odk.collect.android.databinding.AudioRecordingControllerFragmentBindi
 import org.odk.collect.android.formentry.BackgroundAudioViewModel;
 import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.utilities.TranslationHandler;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.strings.format.LengthFormatterKt;
 
@@ -70,7 +71,7 @@ public class AudioRecordingControllerFragment extends Fragment {
             } else if (session.getFile() == null) {
                 binding.getRoot().setVisibility(VISIBLE);
 
-                binding.timeCode.setText(LengthFormatterKt.formatLength(session.getDuration()));
+                binding.recordingStatusMessage.setText(LengthFormatterKt.formatLength(session.getDuration()));
                 binding.waveform.addAmplitude(session.getAmplitude());
 
                 if (session.getPaused()) {
@@ -105,5 +106,29 @@ public class AudioRecordingControllerFragment extends Fragment {
         });
 
         binding.stopRecording.setOnClickListener(v -> audioRecorder.stop());
+
+        formEntryViewModel.isFormControllerSet().observe(getViewLifecycleOwner(), (isSet) -> {
+            if (formEntryViewModel.hasBackgroundRecording() && !backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue()) {
+                configureViewForRequestedButDisabledBackgroundRecording();
+            }
+        });
+
+        backgroundAudioViewModel.isBackgroundRecordingEnabled().observe(getViewLifecycleOwner(), isEnabled -> {
+            if (formEntryViewModel.hasBackgroundRecording() && !isEnabled) {
+                configureViewForRequestedButDisabledBackgroundRecording();
+            }
+        });
+    }
+
+    private void configureViewForRequestedButDisabledBackgroundRecording() {
+        binding.getRoot().setVisibility(VISIBLE);
+
+        binding.recordingIcon.setImageDrawable(ContextCompat.getDrawable(getContext(), R.drawable.ic_baseline_mic_off_24));
+
+        binding.waveform.setVisibility(GONE);
+        binding.pauseRecording.setVisibility(GONE);
+        binding.stopRecording.setVisibility(GONE);
+
+        binding.recordingStatusMessage.setText(TranslationHandler.getString(getContext(), R.string.recording_disabled, "⋮"));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
@@ -107,20 +107,24 @@ public class AudioRecordingControllerFragment extends Fragment {
 
         binding.stopRecording.setOnClickListener(v -> audioRecorder.stop());
 
-        formEntryViewModel.isFormControllerSet().observe(getViewLifecycleOwner(), (isSet) -> {
-            if (formEntryViewModel.hasBackgroundRecording() && !backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue()) {
-                configureViewForRequestedButDisabledBackgroundRecording();
+        formEntryViewModel.isFormControllerSet().observe(getViewLifecycleOwner(), isSet -> {
+            if (formEntryViewModel.hasBackgroundRecording()) {
+                if (audioRecorder.getCurrentSession().getValue() != null && audioRecorder.getCurrentSession().getValue().getFailedToStart() != null) {
+                    configureViewForErrorState(TranslationHandler.getString(getContext(), R.string.start_recording_failed));
+                } else if (!backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue()) {
+                    configureViewForErrorState(TranslationHandler.getString(getContext(), R.string.recording_disabled, "⋮"));
+                }
             }
         });
 
         backgroundAudioViewModel.isBackgroundRecordingEnabled().observe(getViewLifecycleOwner(), isEnabled -> {
             if (formEntryViewModel.hasBackgroundRecording() && !isEnabled) {
-                configureViewForRequestedButDisabledBackgroundRecording();
+                configureViewForErrorState(TranslationHandler.getString(getContext(), R.string.recording_disabled, "⋮"));
             }
         });
     }
 
-    private void configureViewForRequestedButDisabledBackgroundRecording() {
+    private void configureViewForErrorState(String errorMessage) {
         binding.getRoot().setVisibility(VISIBLE);
 
         binding.recordingIcon.setImageDrawable(ContextCompat.getDrawable(getContext(), R.drawable.ic_baseline_mic_off_24));
@@ -129,6 +133,6 @@ public class AudioRecordingControllerFragment extends Fragment {
         binding.pauseRecording.setVisibility(GONE);
         binding.stopRecording.setVisibility(GONE);
 
-        binding.recordingStatusMessage.setText(TranslationHandler.getString(getContext(), R.string.recording_disabled, "⋮"));
+        binding.recordingStatusMessage.setText(errorMessage);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioViewModel.java
@@ -34,6 +34,7 @@ public class BackgroundAudioViewModel extends ViewModel {
     private final PermissionsChecker permissionsChecker;
 
     private final MutableLiveData<Boolean> isPermissionRequired = new MutableLiveData<>(false);
+    private final MutableLiveData<Boolean> isBackgroundRecordingEnabled;
 
     // These fields handle storing record action details while we're granting permissions
     private final HashSet<TreeReference> tempTreeReferences = new HashSet<>();
@@ -48,6 +49,8 @@ public class BackgroundAudioViewModel extends ViewModel {
         this.recordAudioActionRegistry.register((treeReference, quality) -> {
             new Handler(Looper.getMainLooper()).post(() -> handleRecordAction(treeReference, quality));
         });
+
+        isBackgroundRecordingEnabled = new MutableLiveData<>(preferencesProvider.getGeneralSharedPreferences().getBoolean(KEY_BACKGROUND_RECORDING, true));
     }
 
     @Override
@@ -59,8 +62,8 @@ public class BackgroundAudioViewModel extends ViewModel {
         return isPermissionRequired;
     }
 
-    public boolean isBackgroundRecordingEnabled() {
-        return preferencesProvider.getGeneralSharedPreferences().getBoolean(KEY_BACKGROUND_RECORDING, true);
+    public LiveData<Boolean> isBackgroundRecordingEnabled() {
+        return isBackgroundRecordingEnabled;
     }
 
     public void setBackgroundRecordingEnabled(boolean enabled) {
@@ -69,6 +72,7 @@ public class BackgroundAudioViewModel extends ViewModel {
         }
 
         preferencesProvider.getGeneralSharedPreferences().edit().putBoolean(KEY_BACKGROUND_RECORDING, enabled).apply();
+        isBackgroundRecordingEnabled.postValue(enabled);
     }
 
     public boolean isBackgroundRecording() {
@@ -84,7 +88,7 @@ public class BackgroundAudioViewModel extends ViewModel {
     }
 
     private void handleRecordAction(TreeReference treeReference, String quality) {
-        if (isBackgroundRecordingEnabled()) {
+        if (isBackgroundRecordingEnabled.getValue() != null && isBackgroundRecordingEnabled.getValue()) {
             if (permissionsChecker.isPermissionGranted(Manifest.permission.RECORD_AUDIO)) {
                 if (isBackgroundRecording()) {
                     RecordingSession session = audioRecorder.getCurrentSession().getValue();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -100,8 +100,7 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
 
         menu.findItem(R.id.menu_add_repeat).setVisible(formEntryViewModel.canAddRepeat());
         menu.findItem(R.id.menu_record_audio).setVisible(formEntryViewModel.hasBackgroundRecording());
-        menu.findItem(R.id.menu_record_audio).setChecked(backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue() != null
-                ? backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue() : false);
+        menu.findItem(R.id.menu_record_audio).setChecked(backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue() != null && backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -100,7 +100,8 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
 
         menu.findItem(R.id.menu_add_repeat).setVisible(formEntryViewModel.canAddRepeat());
         menu.findItem(R.id.menu_record_audio).setVisible(formEntryViewModel.hasBackgroundRecording());
-        menu.findItem(R.id.menu_record_audio).setChecked(backgroundAudioViewModel.isBackgroundRecordingEnabled());
+        menu.findItem(R.id.menu_record_audio).setChecked(backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue() != null
+                ? backgroundAudioViewModel.isBackgroundRecordingEnabled().getValue() : false);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -32,6 +32,8 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     @Nullable
     private FormController formController;
 
+    private final MutableLiveData<Boolean> isFormControllerSet = new MutableLiveData<>(false);
+
     @Nullable
     private FormIndex jumpBackIndex;
 
@@ -44,10 +46,11 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     @Override
     public void formLoaded(@NotNull FormController formController) {
         this.formController = formController;
+        isFormControllerSet.postValue(true);
     }
 
-    public boolean isFormControllerSet() {
-        return formController != null;
+    public LiveData<Boolean> isFormControllerSet() {
+        return isFormControllerSet;
     }
 
     @Nullable

--- a/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
+++ b/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
@@ -28,7 +28,7 @@
             app:tint="?colorOnPrimary" />
 
         <TextView
-            android:id="@+id/time_code"
+            android:id="@+id/recording_status_message"
             style="@style/TextAppearance.Collect.Subtitle1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
@@ -342,4 +342,24 @@ public class AudioRecordingControllerFragmentTest {
         });
     }
     //endregion
+
+    @Test
+    public void whenThereIsAnErrorStartingRecording_andBackgroundRecordingRequested_displaysError() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false); // FormController is not set
+        MutableLiveData<Boolean> formControllerSet = new MutableLiveData<>(false);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(formControllerSet);
+
+        audioRecorder.cleanUp(); // Reset recorder
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true); // FormController is set
+        formControllerSet.postValue(true);
+
+        audioRecorder.failOnStart();
+        audioRecorder.start("background", Output.AAC);
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.getRoot().getVisibility(), is(View.VISIBLE));
+            assertThat(fragment.binding.recordingStatusMessage.getText(), is("Could not start recording."));
+        });
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
@@ -5,6 +5,7 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.testing.FragmentScenario;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -13,7 +14,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.Analytics;
 import org.odk.collect.android.formentry.BackgroundAudioViewModel;
+import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.permissions.PermissionsChecker;
 import org.odk.collect.android.preferences.PreferencesProvider;
@@ -21,6 +24,7 @@ import org.odk.collect.android.support.RobolectricHelpers;
 import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.audiorecorder.testsupport.StubAudioRecorder;
+import org.odk.collect.utilities.Clock;
 import org.robolectric.annotation.Config;
 
 import java.io.File;
@@ -31,6 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.odk.collect.android.support.RobolectricHelpers.getFragmentByClass;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -39,6 +44,7 @@ public class AudioRecordingControllerFragmentTest {
 
     public StubAudioRecorder audioRecorder;
     private BackgroundAudioViewModel backgroundAudioViewModel;
+    private FormEntryViewModel formEntryViewModel;
 
     @Before
     public void setup() throws IOException {
@@ -46,7 +52,12 @@ public class AudioRecordingControllerFragmentTest {
         stubRecording.deleteOnExit();
 
         audioRecorder = new StubAudioRecorder(stubRecording.getAbsolutePath());
+
         backgroundAudioViewModel = mock(BackgroundAudioViewModel.class);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(true));
+
+        formEntryViewModel = mock(FormEntryViewModel.class);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(new MutableLiveData<>(true));
 
         RobolectricHelpers.overrideAppDependencyModule(new AppDependencyModule() {
 
@@ -62,6 +73,17 @@ public class AudioRecordingControllerFragmentTest {
             }
 
             @Override
+            public FormEntryViewModel.Factory providesFormEntryViewModelFactory(Clock clock, Analytics analytics) {
+                return new FormEntryViewModel.Factory(clock, analytics) {
+                    @NonNull
+                    @Override
+                    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+                        return (T) formEntryViewModel;
+                    }
+                };
+            }
+
+            @Override
             public AudioRecorder providesAudioRecorder(Application application) {
                 return audioRecorder;
             }
@@ -69,24 +91,25 @@ public class AudioRecordingControllerFragmentTest {
 
         // Needed to inflate views with theme attributes - needs to be a "real theme" because of DialogFragment
         ApplicationProvider.getApplicationContext().setTheme(R.style.Theme_Collect_Light);
-
-        // View only shows when recording in progress
-        audioRecorder.start("session", Output.AAC);
     }
 
     @Test
     public void updatesTimecode() {
+        audioRecorder.start("session", Output.AAC);
+
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
         scenario.onFragment(fragment -> {
-            assertThat(fragment.binding.timeCode.getText().toString(), equalTo("00:00"));
+            assertThat(fragment.binding.recordingStatusMessage.getText().toString(), equalTo("00:00"));
 
             audioRecorder.setDuration(40000);
-            assertThat(fragment.binding.timeCode.getText().toString(), equalTo("00:40"));
+            assertThat(fragment.binding.recordingStatusMessage.getText().toString(), equalTo("00:40"));
         });
     }
 
     @Test
     public void updatesWaveform() {
+        audioRecorder.start("session", Output.AAC);
+
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
         scenario.onFragment(fragment -> {
             assertThat(fragment.binding.waveform.getLatestAmplitude(), equalTo(0));
@@ -98,6 +121,8 @@ public class AudioRecordingControllerFragmentTest {
 
     @Test
     public void clickingPause_pausesRecording() {
+        audioRecorder.start("session", Output.AAC);
+
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
         scenario.onFragment(fragment -> {
             fragment.binding.pauseRecording.performClick();
@@ -107,6 +132,7 @@ public class AudioRecordingControllerFragmentTest {
 
     @Test
     public void whenRecordingPaused_clickingPause_resumesRecording() {
+        audioRecorder.start("session", Output.AAC);
         audioRecorder.pause();
 
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
@@ -118,6 +144,7 @@ public class AudioRecordingControllerFragmentTest {
 
     @Test
     public void whenRecordingPaused_pauseIconChangesToResume() {
+        audioRecorder.start("session", Output.AAC);
         audioRecorder.pause();
 
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
@@ -129,6 +156,7 @@ public class AudioRecordingControllerFragmentTest {
 
     @Test
     public void whenRecordingPaused_recordingStatusChangesToPaused() {
+        audioRecorder.start("session", Output.AAC);
         audioRecorder.pause();
 
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
@@ -139,6 +167,7 @@ public class AudioRecordingControllerFragmentTest {
 
     @Test
     public void whenRecordingResumed_pauseIconChangesToPause() {
+        audioRecorder.start("session", Output.AAC);
         audioRecorder.pause();
         audioRecorder.resume();
 
@@ -151,6 +180,7 @@ public class AudioRecordingControllerFragmentTest {
 
     @Test
     public void whenRecordingResumed_recordingStatusChangesToRecording() {
+        audioRecorder.start("session", Output.AAC);
         audioRecorder.pause();
         audioRecorder.resume();
 
@@ -163,6 +193,7 @@ public class AudioRecordingControllerFragmentTest {
     @Test
     @Config(sdk = 23)
     public void whenSDKOlderThan24_hidesPauseButton() {
+        audioRecorder.start("session", Output.AAC);
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
         scenario.onFragment(fragment -> {
             assertThat(fragment.binding.pauseRecording.getVisibility(), is(View.GONE));
@@ -172,6 +203,7 @@ public class AudioRecordingControllerFragmentTest {
     @Test
     @Config(sdk = 24)
     public void whenSDK24OrNewer_showsPauseButton() {
+        audioRecorder.start("session", Output.AAC);
         FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
         scenario.onFragment(fragment -> {
             assertThat(fragment.binding.pauseRecording.getVisibility(), is(View.VISIBLE));
@@ -191,4 +223,123 @@ public class AudioRecordingControllerFragmentTest {
             assertThat(dialog, notNullValue());
         });
     }
+
+    //region Options menu override for background recording
+    @Test
+    public void whenRecordAudioFalse_andBackgroundRecordingRequested_displaysError() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false); // FormController is not set
+        MutableLiveData<Boolean> formControllerSet = new MutableLiveData<>(false);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(formControllerSet);
+
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(false));
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true); // FormController is set
+        formControllerSet.postValue(true);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.getRoot().getVisibility(), is(View.VISIBLE));
+            assertThat(fragment.binding.recordingStatusMessage.getText(), is("Recording disabled. Enable in ⋮"));
+        });
+    }
+
+    @Test
+    public void whenRecordAudioFalse_andBackgroundRecordingRequested_displaysNoRecordingIcon() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false); // FormController is not set
+        MutableLiveData<Boolean> formControllerSet = new MutableLiveData<>(false);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(formControllerSet);
+
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(false));
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true); // FormController is set
+        formControllerSet.postValue(true);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.getRoot().getVisibility(), is(View.VISIBLE));
+            assertThat(shadowOf(fragment.binding.recordingIcon.getDrawable()).getCreatedFromResId(), is(R.drawable.ic_baseline_mic_off_24));
+        });
+    }
+
+    @Test
+    public void whenRecordAudioFalse_andBackgroundRecordingNotRequested_hidesAudioBar() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false); // FormController is not set
+        MutableLiveData<Boolean> formControllerSet = new MutableLiveData<>(false);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(formControllerSet);
+
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(false));
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        formControllerSet.postValue(true);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.getRoot().getVisibility(), is(View.GONE));
+        });
+    }
+
+    @Test
+    public void whenRecordAudioToggledToFalse_andBackgroundRecordingRequested_displaysError() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true);
+
+        MutableLiveData<Boolean> backgroundRecordingEnabled = new MutableLiveData<>(true);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(backgroundRecordingEnabled);
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        backgroundRecordingEnabled.postValue(false);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.recordingStatusMessage.getText(), is("Recording disabled. Enable in ⋮"));
+        });
+    }
+
+    @Test
+    public void whenRecordAudioTrue_andBackgroundRecordingRequested_displaysRecordingIcon() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false); // FormController is not set
+        MutableLiveData<Boolean> formControllerSet = new MutableLiveData<>(false);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(formControllerSet);
+
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(true));
+        audioRecorder.start("background", Output.AAC);
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true); // FormController is set
+        formControllerSet.postValue(true);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.getRoot().getVisibility(), is(View.VISIBLE));
+            assertThat(shadowOf(fragment.binding.recordingIcon.getDrawable()).getCreatedFromResId(), is(R.drawable.ic_baseline_mic_24));
+        });
+    }
+
+    @Test
+    public void whenRecordAudioTrue_andBackgroundRecordingNotRequested_hidesAudioBar() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(false); // FormController is not set
+        MutableLiveData<Boolean> formControllerSet = new MutableLiveData<>(false);
+        when(formEntryViewModel.isFormControllerSet()).thenReturn(formControllerSet);
+
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(true));
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        formControllerSet.postValue(true);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.getRoot().getVisibility(), is(View.GONE));
+        });
+    }
+
+    @Test
+    public void whenRecordAudioToggledToTrue_andBackgroundRecordingRequested_displaysError() {
+        when(formEntryViewModel.hasBackgroundRecording()).thenReturn(true);
+
+        MutableLiveData<Boolean> backgroundRecordingEnabled = new MutableLiveData<>(false);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(backgroundRecordingEnabled);
+
+        FragmentScenario<AudioRecordingControllerFragment> scenario = FragmentScenario.launch(AudioRecordingControllerFragment.class);
+        backgroundRecordingEnabled.postValue(true);
+
+        scenario.onFragment(fragment -> {
+            assertThat(fragment.binding.recordingStatusMessage.getText(), is("Recording disabled. Enable in ⋮"));
+        });
+    }
+    //endregion
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryMenuDelegateTest.java
@@ -2,6 +2,7 @@ package org.odk.collect.android.formentry;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.MutableLiveData;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Before;
@@ -63,6 +64,7 @@ public class FormEntryMenuDelegateTest {
 
         BackgroundLocationViewModel backgroundLocationViewModel = mock(BackgroundLocationViewModel.class);
         backgroundAudioViewModel = mock(BackgroundAudioViewModel.class);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(true));
 
         formEntryMenuDelegate = new FormEntryMenuDelegate(
                 activity,
@@ -123,7 +125,7 @@ public class FormEntryMenuDelegateTest {
 
     @Test
     public void onPrepare_whenBackgroundRecodingEnabled_checksRecordAudio() {
-        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(true);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(true));
 
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
@@ -134,7 +136,7 @@ public class FormEntryMenuDelegateTest {
 
     @Test
     public void onPrepare_whenNotRecordingInBackground_unchecksRecordAudio() {
-        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(false);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(false));
 
         RoboMenu menu = new RoboMenu();
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
@@ -310,7 +312,7 @@ public class FormEntryMenuDelegateTest {
         formEntryMenuDelegate.onCreateOptionsMenu(Robolectric.setupActivity(FragmentActivity.class).getMenuInflater(), menu);
         formEntryMenuDelegate.onPrepareOptionsMenu(menu);
 
-        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(false);
+        when(backgroundAudioViewModel.isBackgroundRecordingEnabled()).thenReturn(new MutableLiveData<>(false));
 
         formEntryMenuDelegate.onOptionsItemSelected(new RoboMenuItem(R.id.menu_record_audio));
         verify(backgroundAudioViewModel).setBackgroundRecordingEnabled(true);

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -289,6 +289,9 @@
     <!-- Text warning that user after they're reenabled background audio recording that it won't start again until they re-open the form -->
     <string name="background_audio_recording_enabled_explanation">Recording will not begin immediately. You must re-open the form to record.</string>
 
+    <!-- Text displayed in the audio bar when background audio recording is explicitly disabled from the options menu. Should be as short as possible. The inserted string is ⋮ which indicates the options menu. -->
+    <string name="recording_disabled">Recording disabled. Enable in %s</string>
+
     <!-- Title for dialog asking the user if they want to delete a file -->
     <string name="delete_answer_file_question">Delete file?</string>
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -194,7 +194,7 @@
     <!-- Text displayed when user tries to start recording while the mic is already in use -->
     <string name="mic_in_use">Microphone is already in use.</string>
 
-    <!-- Error message displayed when copying media from a temporary directory fails -->
+    <!-- Error message displayed when copying media from a temporary directory fails. The inserted string is a directory name on the Android device. -->
     <string name="answer_file_copy_failed_message">Media could not be attached to form but is available at %1$s</string>
 
     <string name="saving_audio_recording_failed">Saving audio recording failed</string>


### PR DESCRIPTION
Closes #4383

I wasn't able to finish this and am handing off to @seadowg. I believe the "Recording disabled" message fully works as intended. However, to show a message when recording failed, some additional state needs to be saved. I thought we could query the current session but that gets cleaned up after the message is shown, even in the background case.

The intended behavior for the "Record audio" toggle is that the "Recording disabled" message should always be shown when the toggle was off at some point in a form filling session. That is, even if it gets toggled back on, because the recording doesn't resume, the message should show. There's one edge case exception:
1. launch form with "Record audio" enabled
1. toggle "Record audio" off
1. toggle "Record audio" back on
1. rotate screen

In that case, the "recording disabled" message isn't visible anymore even though recording is still disabled for this form filling session. I think this is ok -- it's not very likely to happen and the resulting state is not so bad.

#### What has been done to verify that this works as intended?
Added and ran automated tests. Tried manually with forms on QA server. 

For the message on failure to start recording in the background case, I changed the code to explicitly throw an exception in `AudioRecorderService.startRecording`. I don't know of another way to trigger the error.

#### Why is this the best possible solution? Were any other approaches considered?
There are two distinct cases for the "Record audio" toggle: when recording is already off at form launch and when recording gets toggled off during a form filling session. These are different because when `AudioRecordingControllerFragment` is first built, the form isn't loaded yet and so we have no way of knowing whether it requests background recording. I tried to combine them but couldn't come up with a way. With the failure to start case, I think the separated structure makes sense.

Right now the "recording disabled" message is shown if the form requests recording without regard of whether a recording action has actually been triggered. That's generally right for now because recording is typically triggered by any entry into a form. However, it's not strictly correct because it would be possible to manually edit form XML and trigger background recording on `odk-instance-first-load`. I think that it's unlikely enough that it doesn't matter and we can handle different triggering events or multiple recordings if/when we support multiple recordings.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Regression risks are centered around the recording overlay and what's displayed on it when.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms with and without background and foreground recording.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)