### PR TITLE
Fully remove Firebase Performance to fix release builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.4'
         classpath 'org.jacoco:org.jacoco.core:0.8.6'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
-        classpath 'com.google.firebase:perf-plugin:1.3.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.4.1"
     }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.firebase.crashlytics'
-apply plugin: 'com.google.firebase.firebase-perf'
 apply from: '../config/quality.gradle'
 apply from: '../config/jacoco.gradle'
 
@@ -151,9 +150,6 @@ android {
             resValue("bool", "CRASHLYTICS_ENABLED", "false")
             resValue("string", "GOOGLE_MAPS_API_KEY", googleMapsApiKey)
             buildConfigField 'String', "MAPBOX_ACCESS_TOKEN", '"' + mapboxToken + '"'
-            FirebasePerformance {
-                instrumentationEnabled false
-            }
         }
     }
 
@@ -247,7 +243,6 @@ dependencies {
     implementation "com.google.android.gms:play-services-maps:17.0.0"
     implementation "com.google.android.gms:play-services-location:17.1.0"
 
-    implementation 'com.google.firebase:firebase-perf:19.0.11'
     implementation 'com.google.firebase:firebase-analytics:18.0.0'
     implementation 'com.google.firebase:firebase-crashlytics:17.3.0'
 

--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -9,7 +9,6 @@
 -keep class org.javarosa.**
 -keep class org.odk.collect.android.logic.actions.**
 -keep class android.support.v7.widget.** { *; }
--keep class com.google.android.gms.internal.firebase-perf.** { *; }
 -keepclassmembers class * {
   @com.google.api.client.util.Key <fields>;
 }

--- a/docs/WindowsDevSetup.md
+++ b/docs/WindowsDevSetup.md
@@ -4,20 +4,10 @@
 Most ODK devs are using OS X or Linux. Occasionally problems surface for Windows users due to code changes or tool changes. Such problems commonly include file path separators and file permissions differences from Linux/OSX. However in general it is possible to develop ODK using Android Studio on Windows.
 
 ## Known Issues
-* Do not upgrade to Android Studio 3.6. See: [Issue 3507](https://github.com/getodk/collect/issues/3507)
-* Firebase Perf plugin exposes bug in Android Studio 3.5: <https://stackoverflow.com/a/59015733>
+None currently
 
 ## Current Workarounds
-* Firebase Perf: disable with the following modifications
-
- __build.gradle__:  comment out the line that looks like:
-
-        classpath 'com.google.firebase:perf-plugin:1.3.1'
-
- __collect_app/build.gradle__: comment out the two firebase-perf lines that look like:
-
-        apply plugin: 'com.google.firebase.firebase-perf'
-        implementation 'com.google.firebase:firebase-perf:19.0.2' 
+None currently
     
 ## Configuring Android Studio for Windows
 * Change line endings to Unix. Settings > Editor > Code Style > General (tab) > Line Separator :: Unix and Mac OS (\n)


### PR DESCRIPTION
Closes #3739

Release builds were failing on the `transformClassesWithFirebasePerformancePluginForXXX` step. Removing the Firebase Performance dependency fixes this.

#### What has been done to verify that this works as intended?
Made a self-signed release build, verified that it runs.

#### Why is this the best possible solution? Were any other approaches considered?
We no longer enable Firebase Performance anyway so removing the dependency makes sense. This has positive side effects like speeding up the build.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)