### PR TITLE
Update JavaRosa to 3.1.0 for odk:recordaudio

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -268,7 +268,7 @@ dependencies {
     implementation "com.rarepebble:colorpicker:3.0.1"
     implementation "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     implementation "net.sf.opencsv:opencsv:2.4"
-    implementation("org.getodk:javarosa:3.1.0-SNAPSHOT") {
+    implementation("org.getodk:javarosa:3.1.0") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
Upgrades to released version of JavaRosa. This is not identical to the snapshot because it contains https://github.com/getodk/javarosa/pull/615. That change should be virtually free of risk.

#### What has been done to verify that this works as intended?
Ran tests. We've also been using the snapshot for a few days in development.

#### Why is this the best possible solution? Were any other approaches considered?
Routine upgrade, no alternatives.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
When we introduced `odk:recordaudio`, we also made some changes to how events are handled. This affects the [`start-geopoint` feature](https://docs.getodk.org/form-question-types/#geolocation-at-survey-start) and [dynamic defaults](https://docs.getodk.org/form-logic/#dynamic-defaults). Both have good test coverage both in JavaRosa and Collect.

I think that this should go in without a targeted QA pass but that @getodk/testers should know about those risks for their regression pass. I'll look at what cases there are for both features and see about adding some extra checks. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)