### PR TITLE
Make background audio confirmation dialog buttons more specific

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -145,12 +145,14 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
             if (!enabled) {
                 new MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.stop_recording_confirmation)
-                        .setPositiveButton(R.string.ok, (dialog, which) -> backgroundAudioViewModel.setBackgroundRecordingEnabled(false))
+                        .setPositiveButton(R.string.disable_recording, (dialog, which) -> backgroundAudioViewModel.setBackgroundRecordingEnabled(false))
+                        .setNegativeButton(R.string.cancel, null)
                         .create()
                         .show();
             } else {
                 new MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.background_audio_recording_enabled_explanation)
+                        .setCancelable(false)
                         .setPositiveButton(R.string.ok, null)
                         .create()
                         .show();

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -284,6 +284,9 @@
     <!-- Text asking the user to confirm whether they want to stop recording or not (which deletes the recording file) -->
     <string name="stop_recording_confirmation">This form requests background audio recording. Disabling it will stop recording and discard existing audio. Are you sure you want to proceed?</string>
 
+    <!-- Button text for the dialog confirming whether the user wants to disable background recording -->
+    <string name="disable_recording">Disable recording</string>
+
     <!-- Text warning that user after they're reenabled background audio recording that it won't start again until they re-open the form -->
     <string name="background_audio_recording_enabled_explanation">Recording will not begin immediately. You must re-open the form to record.</string>
 


### PR DESCRIPTION
Closes #4393

While I was reviewing this behavior, I also made the following changes:
- Change confirmation button text from "OK" to "Disable Recording". It didn't feel very clear that "OK" would actually make the change since "OK" is often used as an acknowledgement that the text was understood.
- We really want users who are re-enabling background recording to read the notice about the recording not resuming for this session. For that reason, I made the dialog not cancelable.

#### What has been done to verify that this works as intended?
Manual checks.

#### Why is this the best possible solution? Were any other approaches considered?
These are subjective user experience changes. I am prioritizing them because I think this whole override is pretty confusing and we want to be as precise as we can.

There's more we can do here. The dialog text when disabling recording, re-enabling it and then disabling it again is pretty confusing since recording is already disabled at that point. But that seems less likely to happen so I think it's ok for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No regression risk as this is just changing strings. Hopefully this makes the override slightly easier to understand and makes it less likely that a user will accidentally disable recording.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)