### PR TITLE
Increase sensitivity of overlay waveform

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
@@ -92,7 +92,7 @@ public class AudioRecordingControllerFragment extends Fragment {
             binding.getRoot().setVisibility(VISIBLE);
 
             binding.timeCode.setText(LengthFormatterKt.formatLength(session.getDuration()));
-            binding.waveform.addAmplitude(session.getAmplitude());
+            binding.waveform.addAmplitude(6 * session.getAmplitude());
 
             if (session.getPaused()) {
                 binding.pauseRecording.setIcon(ContextCompat.getDrawable(requireContext(), R.drawable.ic_baseline_mic_24));

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingControllerFragment.java
@@ -92,7 +92,7 @@ public class AudioRecordingControllerFragment extends Fragment {
             binding.getRoot().setVisibility(VISIBLE);
 
             binding.timeCode.setText(LengthFormatterKt.formatLength(session.getDuration()));
-            binding.waveform.addAmplitude(6 * session.getAmplitude());
+            binding.waveform.addAmplitude(session.getAmplitude());
 
             if (session.getPaused()) {
                 binding.pauseRecording.setIcon(ContextCompat.getDrawable(requireContext(), R.drawable.ic_baseline_mic_24));

--- a/collect_app/src/main/java/org/odk/collect/android/audio/Waveform.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/Waveform.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.audio;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.widget.FrameLayout;
@@ -10,6 +11,7 @@ import androidx.annotation.Nullable;
 import com.visualizer.amplitude.AudioRecordView;
 
 import org.jetbrains.annotations.NotNull;
+import org.odk.collect.android.R;
 import org.odk.collect.android.databinding.WaveformLayoutBinding;
 
 import java.util.Random;
@@ -22,24 +24,30 @@ public class Waveform extends FrameLayout {
 
     private AudioRecordView audioRecordView;
     private Integer lastAmplitude;
+    private boolean mini;
 
     public Waveform(@NotNull Context context) {
         super(context);
-        init(context);
+        init(context, null);
     }
 
     public Waveform(@NotNull Context context, @NotNull AttributeSet attrs) {
         super(context, attrs);
-        init(context);
+        init(context, attrs);
     }
 
     public Waveform(@NotNull Context context, @NotNull AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        init(context);
+        init(context, attrs);
     }
 
-    private void init(Context context) {
+    private void init(Context context, @Nullable AttributeSet attrs) {
         audioRecordView = WaveformLayoutBinding.inflate(LayoutInflater.from(context), this, true).getRoot();
+
+        if (attrs != null) {
+            TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.Waveform, 0, 0);
+            mini = styledAttributes.getBoolean(R.styleable.Waveform_mini, false);
+        }
     }
 
     @Override
@@ -49,12 +57,17 @@ public class Waveform extends FrameLayout {
     }
 
     public void addAmplitude(int amplitude) {
+        lastAmplitude = amplitude;
+
         if (SIMULATED) {
             amplitude = new Random().nextInt(22760);
         }
 
-        lastAmplitude = amplitude;
-        audioRecordView.update(amplitude);
+        if (mini) {
+            audioRecordView.update(amplitude * 6);
+        } else {
+            audioRecordView.update(amplitude);
+        }
     }
 
     @Nullable

--- a/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
+++ b/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -40,7 +41,8 @@
             android:id="@+id/waveform"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:layout_marginStart="@dimen/margin_small" />
+            android:layout_marginStart="@dimen/margin_small"
+            custom:mini="true" />
     </LinearLayout>
 
     <LinearLayout

--- a/collect_app/src/main/res/values/attrs.xml
+++ b/collect_app/src/main/res/values/attrs.xml
@@ -5,4 +5,8 @@
         <attr name="dividerColor" format="color" />
         <attr name="dividerCompat" format="reference" />
     </declare-styleable>
+
+    <declare-styleable name="Waveform">
+        <attr name="mini" format="boolean" />
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
We're considering a slight cosmetic change to how the waveform appears on the recording overlay. This is a minor, low-risk change that might end up coming in after regression testing is done. The problem we have right now is that by representing the full volume range in the waveform, the difference in volume as someone speaks is barely visible.

Folks who have experimented with a range of devices report that device microphones can reliably represent at most 90-100dB (https://stackoverflow.com/a/14870458/137744). That's a pretty big range (dB is a log scale) but it's bounded. Typical human speech is between 50 and 65 dB and shouting is around 80dB.

The raw max amplitude values are a linear scale with the highest sound pressure the mic can represent being 32767, the max value of a 16-bit unsigned int (https://stackoverflow.com/a/10954785/137744).

The library we're using takes those values and scales them down for display. To make the waveform more sensitive, I propose simply scaling up the source amplitude. This means we'll clip the upper range and not be able to differentiate between loud and extremely loud values. These are outside of human voice range so not relevant to us.

Ideally the waveform would show movement from a quiet speaking voice to a loudly projected voice when most devices are held at arm's reach. I think it's better to exaggerate the movement at the low end to provide feedback that something is happening. Even if a lot of speech is clipped off the top, we still need to breathe and pause so there'll be some visual feedback that something is going on.

I've landed on a multiplier of 6 after experimenting with some devices. It's not perfect but I do think it's a big improvement.