### PR TITLE
Catch nulls returned by getIndexFromXPath()

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -233,7 +233,6 @@ public class FormController {
                     int event = stepToNextEvent(true);
                     while (event != FormEntryController.EVENT_END_OF_FORM) {
                         String candidateXPath = getXPath(getFormIndex());
-                        // Log.i(t, "xpath: " + candidateXPath);
                         if (candidateXPath.equals(xpath)) {
                             returned = getFormIndex();
                             break;

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -213,6 +213,7 @@ public class FormController {
         return value;
     }
 
+    @Nullable
     public FormIndex getIndexFromXPath(String xpath) {
         switch (xpath) {
             case "beginningOfForm":

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -222,7 +222,7 @@ public class FormController {
                 return FormIndex.createEndOfFormIndex();
             case "unexpected":
                 Timber.e("Unexpected string from XPath");
-                throw new IllegalArgumentException("unexpected string from XPath");
+                return null;
             default:
                 FormIndex returned = null;
                 FormIndex saved = getFormIndex();

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -205,11 +205,15 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
             // we are resuming after having terminated -- set index to this
             // position...
             FormIndex idx = fc.getIndexFromXPath(xpath);
-            fc.jumpToIndex(idx);
+            if (idx != null) {
+                fc.jumpToIndex(idx);
+            }
         }
         if (waitingXPath != null) {
             FormIndex idx = fc.getIndexFromXPath(waitingXPath);
-            fc.setIndexWaitingForData(idx);
+            if (idx != null) {
+                fc.setIndexWaitingForData(idx);
+            }
         }
         data = new FECWrapper(fc, usedSavepoint);
         return data;


### PR DESCRIPTION
Closes #4407

#### What has been done to verify that this works as intended?
I tested the fix with harcoded nulls. 
I was also able to reproduce the crash but I'm not sure if it's the same way our users do.
Steps are:
1. In developer settings set Background process limit to `no background processes`
2. Open any form with two questions and navigate to the second one
3. Put the app into the background
4. Replace the form you opened with the same one but without that second question.
5. Open the app

#### Why is this the best possible solution? Were any other approaches considered?
We use that method in two places:
- to set the last visited form index so that after returning to the app we are moved to the same place
- to set the index of a widget that is waiting for data

in both cases doing nothing if the value is null is totally fine and safe.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just catch nulls and I don't think this requires testing.

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)