### PR TITLE
Don't strip out org.mp4parser.boxes

### DIFF
--- a/collect_app/proguard-rules.txt
+++ b/collect_app/proguard-rules.txt
@@ -9,6 +9,7 @@
 -keep class org.javarosa.**
 -keep class org.odk.collect.android.logic.actions.**
 -keep class android.support.v7.widget.** { *; }
+-keep class org.mp4parser.boxes.** { *; }
 -keepclassmembers class * {
   @com.google.api.client.util.Key <fields>;
 }


### PR DESCRIPTION
Fixes stitching together audio in release builds by updating proguard rules.