### PR TITLE
Change default server to use Central for background recording support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ We try to make sure that all issues in the issue tracker are as close to fully s
     **Note:** You can see the emulator setup used on CI in  `.circleci/config.yml`.
 
 ## Testing a form without a server
-When you first run Collect, it is set to download forms from [https://opendatakit.appspot.com/](https://opendatakit.appspot.com/), the demo server. You can sometimes verify your changes with those forms but it can also be helpful to put a specific test form on your device. Here are some options for that:
+When you first run Collect, it is set to download forms from [https://demo.getodk.org/](https://demo.getodk.org/), the demo server. You can sometimes verify your changes with those forms but it can also be helpful to put a specific test form on your device. Here are some options for that:
 
-1. The `All Widgets` form from the default Aggregate server is [here](https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0). You can also try [example forms](https://github.com/XLSForm/example-forms) and [test forms](https://github.com/XLSForm/test-forms) or [make your own](https://xlsform.org).
+1. The `All Widgets` form from the default server is [here](https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0). You can also try [example forms](https://github.com/XLSForm/example-forms) and [test forms](https://github.com/XLSForm/test-forms) or [make your own](https://xlsform.org).
 
 1. Convert the XLSForm (xlsx) to XForm (xml). Use the [ODK website](http://getodk.org/xlsform/) or [XLSForm Offline](https://gumroad.com/l/xlsform-offline) or [pyxform](https://github.com/XLSForm/pyxform).
 

--- a/collect_app/src/main/res/values/untranslated.xml
+++ b/collect_app/src/main/res/values/untranslated.xml
@@ -10,7 +10,7 @@ the specific language governing permissions and limitations under the License. -
     <string name="app_name" translatable="false">ODK Collect</string>
     <string name="protocol_odk_default" translatable="false">odk_default</string>
     <string name="protocol_google_sheets" translatable="false">google_sheets</string>
-    <string name="default_server_url" translatable="false">https://opendatakit.appspot.com</string>
+    <string name="default_server_url" translatable="false">https://demo.getodk.org</string>
     <string name="default_odk_formlist" translatable="false">/formList</string>
     <string name="default_odk_submission" translatable="false">/submission</string>
     <string name="app_url" translatable="false">http://getodk.org</string>


### PR DESCRIPTION
The https://opendatakit.appspot.com default server runs Aggregate which we don't expect to update to support background recording. It doesn't "just work" because Aggregate uses JavaRosa to parse forms and so would need an update to get support for the `recordaudio` action.

#### What has been done to verify that this works as intended?
Ran the project, verified that the default server has changed and that I can get blank forms and send finalized forms to the new one.

#### Why is this the best possible solution? Were any other approaches considered?
The URL `https://demo.getodk.org` better represents the project since we don't use the name Open Data Kit anymore. It's set up so that any request without valid OpenRosa headers redirects to https://getodk.org which provides users information about the project. demo.getodk.org just proxies requests to a real Central server which means we can easily change where demo forms are served from as needed.

We could also consider some kind of migration for users who are updating and already have the appspot server set. I don't think it's important enough to be worth it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This only affects new downloads of Collect or users who want to try out demo forms. There should be no regression risk. At the moment, different versions of Collect will have different demo servers which is not ideal. We'll try to get https://opendatakit.appspot.com to also proxy requests to the same server (though not yet clear how to do that on AppEngine).

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No. I checked to see if https://opendatakit.appspot.com was anywhere in the docs and it's not.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)