### PR TITLE
Update spreadsheet locale to en_GB to avoid problems with date formats

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
@@ -116,6 +116,7 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
             TreeElement instanceElement = getInstanceElement(formFilePath, instanceFile);
             setUpSpreadsheet(spreadsheetUrl);
+            sheetsHelper.updateSpreadsheetLocaleForNewSpreadsheet(spreadsheet.getSpreadsheetId(), spreadsheet.getSheets().get(0).getProperties().getTitle());
             if (hasRepeatableGroups(instanceElement)) {
                 createSheetsIfNeeded(instanceElement);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/sheets/SheetsHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/sheets/SheetsHelper.java
@@ -26,10 +26,14 @@ import com.google.api.services.sheets.v4.model.UpdateSheetPropertiesRequest;
 import com.google.api.services.sheets.v4.model.UpdateSpreadsheetPropertiesRequest;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
+import org.odk.collect.android.utilities.StringUtils;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import timber.log.Timber;
 
 public class SheetsHelper {
 
@@ -79,6 +83,33 @@ public class SheetsHelper {
 
         // send the API request
         sheetsAPI.batchUpdate(spreadsheetId, requests);
+    }
+
+    public void updateSpreadsheetLocaleForNewSpreadsheet(String spreadsheetId, String mainSheetTitle) {
+       try {
+           if (!isNewSpreadsheet(spreadsheetId, mainSheetTitle)) {
+               return;
+           }
+
+           SpreadsheetProperties sheetProperties = new SpreadsheetProperties()
+                   .setLocale("en_GB");
+
+           List<Request> requests = new ArrayList<>();
+           requests.add(
+                   new Request().setUpdateSpreadsheetProperties(
+                           new UpdateSpreadsheetPropertiesRequest()
+                                   .setProperties(sheetProperties)
+                                   .setFields("locale")));
+
+           sheetsAPI.batchUpdate(spreadsheetId, requests);
+        } catch (IOException e) {
+            Timber.w(e);
+        }
+    }
+
+    private boolean isNewSpreadsheet(String spreadsheetId, String mainSheetTitle) throws IOException {
+        List<List<Object>> sheetCells = getSheetCells(spreadsheetId, StringUtils.ellipsizeBeginning(mainSheetTitle));
+        return sheetCells == null || sheetCells.isEmpty();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/sheets/SheetsHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/sheets/SheetsHelper.java
@@ -85,6 +85,7 @@ public class SheetsHelper {
         sheetsAPI.batchUpdate(spreadsheetId, requests);
     }
 
+    // Force a locale that correctly interprets dates sent by Collect, unlike en_US
     public void updateSpreadsheetLocaleForNewSpreadsheet(String spreadsheetId, String mainSheetTitle) {
        try {
            if (!isNewSpreadsheet(spreadsheetId, mainSheetTitle)) {

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/sheets/SheetsHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/sheets/SheetsHelper.java
@@ -107,7 +107,7 @@ public class SheetsHelper {
         }
     }
 
-    private boolean isNewSpreadsheet(String spreadsheetId, String mainSheetTitle) throws IOException {
+    public boolean isNewSpreadsheet(String spreadsheetId, String mainSheetTitle) throws IOException {
         List<List<Object>> sheetCells = getSheetCells(spreadsheetId, StringUtils.ellipsizeBeginning(mainSheetTitle));
         return sheetCells == null || sheetCells.isEmpty();
     }


### PR DESCRIPTION
Closes #4415

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
I analyzed the possible solutions and:
- it's not possible to specify single cell formats during uploading with the current implementation because we send a collection of plain strings.
- one of the other options would be to refactor our current implementation to use [AppendCellsRequest](https://developers.google.com/resources/api-libraries/documentation/sheets/v4/java/latest/com/google/api/services/sheets/v4/model/AppendCellsRequest.html) which allows uploading a collection of [CellData](https://developers.google.com/resources/api-libraries/documentation/sheets/v4/java/latest/com/google/api/services/sheets/v4/model/CellData.html) where we could specify formats of such cells. The problem is that we would not only need to refactor the code as I mentioned but also represent dates as numbers. It would require more work and would be much riskier!
- so I decided that the easiest possible solutions should be the best one here. We can set locale to United Kingdom when the sheet is initialized and that will solve the issue. If A user needs a different locale (and they do that consciously) it's possible to change it in settings after sending the first form and it won't be changed by ODK Collect then. Please notice that in most cases users probably do not need a different locale than en_GB, the problem stems from the fact that spreadsheets are generated for them with different locales based on their locations and they do not even notice it like in case of the user who reported the issue on the forum.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change here is small and safe. The only difference compared to the master branch is that before sending data to an empty sheet the spreadsheet will be updated and its locale should be changed to `United Kingdom`. It should take place only once, so if we send the next forms it shouldn't happen again.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with date questions.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes, I think it would be good to add a note about locales somewhere.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)