### PR TITLE
Upgrade Google Services to get correct json config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
-        // Do not upgrade until https://github.com/google/play-services-plugins/issues/163 is addressed
-        classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.google.gms:google-services:4.3.5'
         classpath 'org.jacoco:org.jacoco.core:0.8.6'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
Same issue as https://github.com/getodk/collect/pull/4273; we upgraded Google Services again and hit the same bug.

#### What has been done to verify that this works as intended?
Looked at [the release notes](https://firebase.google.com/support/release-notes/android#google-services_plugin_v4-3-5). Added a corrupt `google-services.json` file for the selfSignedRelease flavor. Confirmed that with v4.3.4 it was ignored and that with v4.3.5 the build fails.

The most important functionality that uses Google Services is location acquisition. I did a quick check to make sure it's still possible to get location indoors. This means we're getting the Fused location provider which comes from Google Services.

#### Why is this the best possible solution? Were any other approaches considered?
I considered downgrading but the changelog makes it look like the .5 point release was really about fixing this issue. I'd rather keep downgrading as an absolute last resort in general.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Risk is around anything that uses Play Services. I think it's low because the changelog for the .4 and .5 releases don't indicate many changes. I've verified the most important functionality which is around location.

I'm marking as `needs testing` just in case QA sees another reason for concern. I will include it in the next beta.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)