### PR TITLE
Prevent recording service from being recreated

### DIFF
--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderService.kt
@@ -73,7 +73,7 @@ internal class AudioRecorderService : Service() {
             }
         }
 
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     private fun startRecording(sessionId: Serializable, output: Output) {


### PR DESCRIPTION
Well this is a weird one. While investigating #4433 I found that if the app is restarted by Android the "Recording..." notification pops up. This is because we were returning `START_STICKY` from `onStartCommand` in `AudioRecorderService` when we really needed to be returning `START_NOT_STICKY`. Docs on these flags are [here](https://developer.android.com/reference/android/app/Service#START_NOT_STICKY) and it would be good for another developer to sanity check that the flag I've chosen seems to make sense.

Just to be clear, to reproduce the problem I found (and that this PR fixes) you can do:

1. Start a form with background recording
2. Find "Collect" in system settings
3. Revoke the microphone permission

#### What has been done to verify that this works as intended?

Verified manually. We could test that the service is sticky/not stick from the return of `onStartCommand` but it wouldn't verify any actual behaviour.

#### Why is this the best possible solution? Were any other approaches considered?

I'd initially thought that this service should be sticky because of the examples given in the docs. However, it doesn't seem like we'd ever want the service to be restarted by Android as we'll restart it if we need it for either internal or background recording.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think it'd be good to check internal recording and background before merging this if we've already covered it in the regression pass. If we haven't, I think just running through those features as part of the regression pass is good so we can just go ahead and merge this.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)