### PR TITLE
Fix background audio permissions flow

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.formentry;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -56,6 +57,11 @@ public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
                 try {
                     viewModel.grantAudioPermission();
                 } catch (IllegalStateException e) {
+                    Toast.makeText(
+                            activity,
+                            "Could not start recording. Please reopen form.",
+                            Toast.LENGTH_LONG
+                    ).show();
                     activity.finish();
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
@@ -44,18 +44,26 @@ public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
         return new MaterialAlertDialogBuilder(requireContext())
                 .setMessage(R.string.background_audio_permission_explanation)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
-                    permissionsProvider.requestRecordAudioPermission(activity, new PermissionListener() {
-                        @Override
-                        public void granted() {
-                            viewModel.grantAudioPermission();
-                        }
-
-                        @Override
-                        public void denied() {
-                            activity.finish();
-                        }
-                    });
+                    onOKClicked(activity);
                 })
                 .create();
+    }
+
+    private void onOKClicked(FragmentActivity activity) {
+        permissionsProvider.requestRecordAudioPermission(activity, new PermissionListener() {
+            @Override
+            public void granted() {
+                try {
+                    viewModel.grantAudioPermission();
+                } catch (IllegalStateException e) {
+                    activity.finish();
+                }
+            }
+
+            @Override
+            public void denied() {
+                activity.finish();
+            }
+        });
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
@@ -20,6 +20,8 @@ import org.odk.collect.android.permissions.PermissionsProvider;
 
 import javax.inject.Inject;
 
+import timber.log.Timber;
+
 public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
 
     @Inject
@@ -57,6 +59,8 @@ public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
                 try {
                     viewModel.grantAudioPermission();
                 } catch (IllegalStateException e) {
+                    Timber.e(e);
+
                     Toast.makeText(
                             activity,
                             "Could not start recording. Please reopen form.",

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioViewModel.java
@@ -117,6 +117,10 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
     }
 
     public void grantAudioPermission() {
+        if (tempTreeReferences.isEmpty()) {
+            throw new IllegalStateException("No TreeReferences to start recording with!");
+        }
+
         isPermissionRequired.setValue(false);
         startBackgroundRecording(tempQuality, new HashSet<>(tempTreeReferences));
         

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragmentTest.java
@@ -5,6 +5,7 @@ import android.widget.Button;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.testing.FragmentScenario;
 import androidx.lifecycle.ViewModel;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -26,6 +27,7 @@ import org.odk.collect.utilities.Clock;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -81,6 +83,24 @@ public class BackgroundAudioPermissionDialogFragmentTest {
 
             button.performClick();
             verify(backgroundAudioViewModel).grantAudioPermission();
+        });
+    }
+
+    @Test
+    public void clickingOk_andGrantingPermissions_whenGrantPermissionsThrowsIllegalStateException_finishesActivity() {
+        doThrow(IllegalStateException.class).when(backgroundAudioViewModel).grantAudioPermission();
+
+        FragmentScenario<BackgroundAudioPermissionDialogFragment> scenario = RobolectricHelpers.launchDialogFragment(BackgroundAudioPermissionDialogFragment.class);
+        scenario.onFragment(f -> {
+            FragmentActivity activity = f.getActivity(); // Need to grab this here as `getActivity()` will return null later
+
+            AlertDialog dialog = (AlertDialog) f.getDialog();
+            Button button = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
+
+            fakePermissionsProvider.setPermissionGranted(true);
+
+            button.performClick();
+            assertThat(activity.isFinishing(), is(true));
         });
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioViewModelTest.java
@@ -143,6 +143,11 @@ public class BackgroundAudioViewModelTest {
         assertThat(viewModel.isPermissionRequired().getValue(), is(false));
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void grantAudioPermission_whenThereWasNoPermissionCheck_throwsIllegalStateException() {
+        viewModel.grantAudioPermission();
+    }
+
     @Test
     public void setBackgroundRecordingEnabled_whenFalse_logsEventToAuditLog() {
         FormController formController = mock(FormController.class);


### PR DESCRIPTION
Closes  #4441

The user will now be returned to the main menu (with an error toast) if they end up in the scenario in the issue that would cause a crash. This will only happen in cases where the user starts a form with a savepoint (so it loads on the hierarchy page) with audio permissions denied and then grants audio permissions.

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

It's definitely not the best solution. There are definitely some things we could do to make this flow work without having to just bail out of the form. The two good ones (there are definitely some bad ones) that I've though of are:

1. Move the permission check and the state held about a recording while permission is being granted into the `audiorecorder` world. This would mean both internal and external recording could use the same mechanisms for handling the recording permissions. 
2. Use the `SavedStateHandle` in `BackgroundAudioViewModel` to store the state held about a recording while permission is being granted

I think **1** is the better solution here as it moves the state we need to hold onto while trying to start a recording into the lifecycle/realm of the recording rather than being subject to Android lifecycle. I'm becoming less and less interested in trying to deal with saved instance state as the whole thing is dealing with one big special case - rotation vs memory reclaim. 

Given implementing **1** just before release was probably a bad idea and that the crash feels like it's rare it made sense to me to flag the situation to the user and have them recover from it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue in question but I'd feel safer if we did some quick checks around background audio in general.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)