### PR TITLE
Add fallback for servers that don't return hash in form list

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
@@ -1,0 +1,65 @@
+package org.odk.collect.android.feature.smoke;
+
+import android.Manifest;
+import android.webkit.MimeTypeMap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.injection.config.AppDependencyModule;
+import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.StubOpenRosaServer;
+import org.odk.collect.android.support.pages.MainMenuPage;
+import org.odk.collect.utilities.UserAgentProvider;
+
+@RunWith(AndroidJUnit4.class)
+public class BadServerTest {
+
+    public final StubOpenRosaServer server = new StubOpenRosaServer();
+
+    public CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_PHONE_STATE,
+                    Manifest.permission.GET_ACCOUNTS
+            ))
+            .around(new ResetStateRule(new AppDependencyModule() {
+                @Override
+                public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider) {
+                    return server;
+                }
+            }))
+            .around(rule);
+
+    @Test
+    public void whenHashNotIncludedInFormList_canGetBlankForm_fillItIn_andSubmit() {
+        server.removeHashInFormList();
+        server.addForm("One Question", "one-question", "1", "one-question.xml");
+
+        rule.mainMenu()
+                .setServer(server.getURL())
+                .clickGetBlankForm()
+                .clickGetSelected()
+                .assertText("One Question (Version:: 1 ID: one-question) - Success")
+                .clickOK(new MainMenuPage(rule))
+
+                .startBlankForm("One Question")
+                .swipeToEndScreen()
+                .clickSaveAndExit()
+
+                .clickSendFinalizedForm(1)
+                .clickOnForm("One Question")
+                .clickSendSelected()
+                .assertText("One Question - Success");
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -42,6 +42,7 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
     private String password;
     private boolean alwaysReturnError;
     private boolean fetchingFormsError;
+    private boolean noHashInFormList;
 
     @NonNull
     @Override
@@ -135,6 +136,11 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         fetchingFormsError = true;
     }
 
+    public void removeHashInFormList() {
+        noHashInFormList = true;
+    }
+
+
     public String getURL() {
         return "https://" + HOST;
     }
@@ -169,15 +175,18 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         for (int i = 0; i < forms.size(); i++) {
             FormManifestEntry form = forms.get(i);
 
-            String hash = getMd5Hash(getFormXML(String.valueOf(i)));
-
-            stringBuilder
+            StringBuilder xform = stringBuilder
                     .append("<xform>\n")
                     .append("<formID>" + form.getID() + "</formID>\n")
                     .append("<name>" + form.getFormLabel() + "</name>\n")
-                    .append("<version>" + form.getVersion() + "</version>\n")
-                    .append("<hash>md5:" + hash + "</hash>\n")
-                    .append("<downloadUrl>" + getURL() + "/form?formId=" + i + "</downloadUrl>\n")
+                    .append("<version>" + form.getVersion() + "</version>\n");
+
+            if (!noHashInFormList) {
+                String hash = getMd5Hash(getFormXML(String.valueOf(i)));
+                xform.append("<hash>md5:" + hash + "</hash>\n");
+            }
+
+            xform.append("<downloadUrl>" + getURL() + "/form?formId=" + i + "</downloadUrl>\n")
                     .append("</xform>\n");
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.dao.FormsDao;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.forms.Form;
@@ -64,7 +65,11 @@ public class DatabaseFormsRepository implements FormsRepository {
 
     @Nullable
     @Override
-    public Form getOneByMd5Hash(String hash) {
+    public Form getOneByMd5Hash(@NotNull String hash) {
+        if (hash == null) {
+            throw new IllegalArgumentException("Null hash");
+        }
+
         FormsDao formsDao = new FormsDao();
 
         try (Cursor cursor = formsDao.getFormsCursorForMd5Hash(hash)) {

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseFormsRepository.java
@@ -67,7 +67,7 @@ public class DatabaseFormsRepository implements FormsRepository {
     @Override
     public Form getOneByMd5Hash(@NotNull String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException("Null hash");
+            throw new IllegalArgumentException("null hash");
         }
 
         FormsDao formsDao = new FormsDao();

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -55,7 +55,17 @@ public class ServerFormDownloader implements FormDownloader {
 
     @Override
     public void downloadForm(ServerFormDetails form, @Nullable ProgressReporter progressReporter, @Nullable Supplier<Boolean> isCancelled) throws FormDownloadException, InterruptedException {
-        Form formOnDevice = formsRepository.getOneByMd5Hash(getMd5HashWithoutPrefix(form.getHash()));
+        Form formOnDevice;
+        if (form.getHash() != null) {
+            formOnDevice = formsRepository.getOneByMd5Hash(getMd5HashWithoutPrefix(form.getHash()));
+        } else {
+            /*
+             This allows us to support non open rosa servers and open rosa servers that don't
+             return hashes. Can be removed when we drop support for these.
+             */
+            formOnDevice = formsRepository.getLatestByFormIdAndVersion(form.getFormId(), form.getFormVersion());
+        }
+
         if (formOnDevice != null) {
             if (formOnDevice.isDeleted()) {
                 formsRepository.restore(formOnDevice.getId());

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -1,7 +1,10 @@
 package org.odk.collect.android.forms;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface FormsRepository {
@@ -15,7 +18,7 @@ public interface FormsRepository {
     Form getOneByPath(String path);
 
     @Nullable
-    Form getOneByMd5Hash(String hash);
+    Form getOneByMd5Hash(@NotNull String hash);
 
     List<Form> getAll();
 
@@ -31,7 +34,7 @@ public interface FormsRepository {
 
     void softDelete(Long id);
 
-    void deleteByMd5Hash(String md5Hash);
+    void deleteByMd5Hash(@NotNull String md5Hash);
 
     void restore(Long id);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/forms/FormsRepository.java
@@ -4,7 +4,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface FormsRepository {

--- a/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/forms/FormsRepositoryTest.java
@@ -200,4 +200,9 @@ public abstract class FormsRepositoryTest {
         formsRepository.delete(1L);
         assertThat(formsDir.listFiles(), emptyArray());
     }
+
+    @Test(expected = Exception.class)
+    public void getOneByMd5Hash_whenHashIsNull_explodes() {
+        buildSubject().getOneByMd5Hash(null);
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -56,7 +56,7 @@ public class InMemFormsRepository implements FormsRepository {
     @Override
     public Form getOneByMd5Hash(@NotNull String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException("Null hash");
+            throw new IllegalArgumentException("null hash");
         }
 
         return forms.stream().filter(f -> f.getMD5Hash().equals(hash)).findFirst().orElse(null);

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemFormsRepository.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.support;
 
+import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.forms.Form;
 import org.odk.collect.android.forms.FormsRepository;
 import org.odk.collect.android.utilities.FileUtils;
@@ -53,7 +54,11 @@ public class InMemFormsRepository implements FormsRepository {
 
     @Nullable
     @Override
-    public Form getOneByMd5Hash(String hash) {
+    public Form getOneByMd5Hash(@NotNull String hash) {
+        if (hash == null) {
+            throw new IllegalArgumentException("Null hash");
+        }
+
         return forms.stream().filter(f -> f.getMD5Hash().equals(hash)).findFirst().orElse(null);
     }
 


### PR DESCRIPTION
Closes #4444

This just adds a fallback (based on the previous implementation) for `null` hashes.

#### What has been done to verify that this works as intended?

New test.

#### Why is this the best possible solution? Were any other approaches considered?

We considered failing earlier and to show the user an error about the open rosa spec but decided that that will be a change for 1.31.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the problem. This does make changes to form download code, so it would be good to do a pass on download forms from different servers.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)