### PR TITLE
Convert StorageInitializerTest to robolectric

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/storage/StorageInitializerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/storage/StorageInitializerTest.java
@@ -1,20 +1,18 @@
-package org.odk.collect.android.instrumented.storage;
+package org.odk.collect.android.storage;
 
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.storage.StorageInitializer;
-import org.odk.collect.android.storage.StoragePathProvider;
+import org.robolectric.RobolectricTestRunner;
 
 import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(RobolectricTestRunner.class)
 public class StorageInitializerTest {
     private StoragePathProvider storagePathProvider;
     private StorageInitializer storageInitializer;


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
Just reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
StorageInitializerTest should be robolectric to avoid running emulators.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)