### PR TITLE
Fix discard changes dialog appearing on pressing back button in Geopoly Activity when original answer is same for GeoShape and GeoTrace widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -282,7 +282,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
     }
 
     @Override public void onBackPressed() {
-        if (map != null && !formatPoints(map.getPolyPoints(featureId)).equals(originalAnswerString)) {
+        if (map != null && !parsePoints(originalAnswerString).equals(map.getPolyPoints(featureId))) {
             showBackDialog();
         } else {
             finish();
@@ -341,11 +341,13 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
         StringBuilder result = new StringBuilder();
         for (MapPoint point : points) {
             // TODO(ping): Remove excess precision when we're ready for the output to change.
-            result.append(String.format(Locale.US, "%s %s %s %s;",
+            result.append(String.format(Locale.US, "%s %s %s %s; ",
                     Double.toString(point.lat), Double.toString(point.lon),
                     Double.toString(point.alt), Float.toString((float) point.sd)));
         }
-        return result.toString().trim();
+
+        String answer = result.toString().trim();
+        return answer.isEmpty() ? answer : answer.substring(0, answer.length() - 1);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -34,6 +34,7 @@ import org.odk.collect.android.geo.SettingsDialogFragment;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.MapsPreferences;
 import org.odk.collect.android.utilities.DialogUtils;
+import org.odk.collect.android.utilities.StringUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
 import java.util.ArrayList;
@@ -346,8 +347,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
                     Double.toString(point.alt), Float.toString((float) point.sd)));
         }
 
-        String answer = result.toString().trim();
-        return answer.isEmpty() ? answer : answer.substring(0, answer.length() - 1);
+        return StringUtils.removeEnd(result.toString().trim(), ";");
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -342,7 +342,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
         StringBuilder result = new StringBuilder();
         for (MapPoint point : points) {
             // TODO(ping): Remove excess precision when we're ready for the output to change.
-            result.append(String.format(Locale.US, "%s %s %s %s; ",
+            result.append(String.format(Locale.US, "%s %s %s %s;",
                     Double.toString(point.lat), Double.toString(point.lon),
                     Double.toString(point.alt), Float.toString((float) point.sd)));
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -34,12 +34,11 @@ import org.odk.collect.android.geo.SettingsDialogFragment;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.MapsPreferences;
 import org.odk.collect.android.utilities.DialogUtils;
-import org.odk.collect.android.utilities.StringUtils;
+import org.odk.collect.android.utilities.GeoUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -278,7 +277,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
     private void finishWithResult() {
         List<MapPoint> points = map.getPolyPoints(featureId);
         setResult(RESULT_OK, new Intent().putExtra(
-            FormEntryActivity.ANSWER_KEY, formatPoints(points)));
+            FormEntryActivity.ANSWER_KEY, GeoUtils.formatPointsResultString(points, outputMode.equals(OutputMode.GEOSHAPE))));
         finish();
     }
 
@@ -324,30 +323,6 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
             }
         }
         return points;
-    }
-
-    /**
-     * Serializes a list of vertices into a string, in the format
-     * appropriate for storing as the result of this form question.
-     */
-    private String formatPoints(List<MapPoint> points) {
-        if (outputMode == OutputMode.GEOSHAPE) {
-            // Polygons are stored with a last point that duplicates the
-            // first point.  Add this extra point if it's not already present.
-            int count = points.size();
-            if (count > 1 && !points.get(0).equals(points.get(count - 1))) {
-                points.add(points.get(0));
-            }
-        }
-        StringBuilder result = new StringBuilder();
-        for (MapPoint point : points) {
-            // TODO(ping): Remove excess precision when we're ready for the output to change.
-            result.append(String.format(Locale.US, "%s %s %s %s;",
-                    Double.toString(point.lat), Double.toString(point.lon),
-                    Double.toString(point.alt), Float.toString((float) point.sd)));
-        }
-
-        return StringUtils.removeEnd(result.toString().trim(), ";");
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/GeoUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/GeoUtils.java
@@ -3,9 +3,12 @@ package org.odk.collect.android.utilities;
 import android.location.Location;
 import android.os.Bundle;
 
+import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.storage.StoragePathProvider;
 
 import java.io.File;
+import java.util.List;
+import java.util.Locale;
 
 import static org.odk.collect.android.geo.MapFragment.KEY_REFERENCE_LAYER;
 
@@ -13,6 +16,30 @@ public class GeoUtils {
 
     private GeoUtils() {
 
+    }
+
+    /**
+     * Serializes a list of vertices into a string, in the format
+     * appropriate for storing as the result of the form question.
+     */
+    public static String formatPointsResultString(List<MapPoint> points, boolean isShape) {
+        if (isShape) {
+            // Polygons are stored with a last point that duplicates the
+            // first point.  Add this extra point if it's not already present.
+            int count = points.size();
+            if (count > 1 && !points.get(0).equals(points.get(count - 1))) {
+                points.add(points.get(0));
+            }
+        }
+        StringBuilder result = new StringBuilder();
+        for (MapPoint point : points) {
+            // TODO(ping): Remove excess precision when we're ready for the output to change.
+            result.append(String.format(Locale.US, "%s %s %s %s;",
+                    Double.toString(point.lat), Double.toString(point.lon),
+                    Double.toString(point.alt), Float.toString((float) point.sd)));
+        }
+
+        return StringUtils.removeEnd(result.toString().trim(), ";");
     }
 
     public static String formatLocationResultString(Location location) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/StringUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/StringUtils.java
@@ -178,5 +178,17 @@ public class StringUtils {
         }
         return text;
     }
+
+    public static String removeEnd(String str, String remove) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+
+        if (str.endsWith(remove)) {
+            return str.substring(0, str.length() - remove.length());
+        }
+
+        return str;
+    }
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointMapWidget.java
@@ -58,7 +58,7 @@ public class GeoPointMapWidget extends QuestionWidget implements WidgetDataRecei
         binding.simpleButton.setOnClickListener(v -> geoDataRequester.requestGeoPoint(context, prompt, answerText, waitingForDataRegistry));
 
         answerText = prompt.getAnswerText();
-        binding.geoAnswerText.setText(GeoWidgetUtils.getAnswerToDisplay(getContext(), answerText));
+        binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
 
         boolean dataAvailable = answerText != null && !answerText.isEmpty();
         if (getFormEntryPrompt().isReadOnly()) {
@@ -109,7 +109,7 @@ public class GeoPointMapWidget extends QuestionWidget implements WidgetDataRecei
     @Override
     public void setData(Object answer) {
         answerText = answer.toString();
-        binding.geoAnswerText.setText(GeoWidgetUtils.getAnswerToDisplay(getContext(), answerText));
+        binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
         binding.simpleButton.setText(answerText == null || answerText.isEmpty() ? R.string.get_point : R.string.view_change_location);
         widgetValueChanged();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -63,7 +63,7 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
         answerText = prompt.getAnswerText();
 
         if (answerText != null && !answerText.isEmpty()) {
-            binding.geoAnswerText.setText(GeoWidgetUtils.getAnswerToDisplay(getContext(), answerText));
+            binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
             binding.simpleButton.setText(R.string.change_location);
         } else {
             binding.simpleButton.setText(R.string.get_point);
@@ -103,7 +103,7 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
     @Override
     public void setData(Object answer) {
         answerText = answer.toString();
-        binding.geoAnswerText.setText(GeoWidgetUtils.getAnswerToDisplay(getContext(), answerText));
+        binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
         binding.simpleButton.setText(answerText == null || answerText.isEmpty() ? R.string.get_point : R.string.change_location);
         widgetValueChanged();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoShapeWidget.java
@@ -28,6 +28,7 @@ import org.odk.collect.android.databinding.GeoWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.GeoDataRequester;
+import org.odk.collect.android.widgets.utilities.GeoWidgetUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 @SuppressLint("ViewConstructor")
@@ -54,7 +55,7 @@ public class GeoShapeWidget extends QuestionWidget implements WidgetDataReceiver
         binding.simpleButton.setOnClickListener(v ->
                 geoDataRequester.requestGeoShape(context, prompt, getAnswerText(), waitingForDataRegistry));
 
-        String stringAnswer = prompt.getAnswerText();
+        String stringAnswer = GeoWidgetUtils.getGeoPolyAnswerToDisplay(prompt.getAnswerText());
         binding.geoAnswerText.setText(stringAnswer);
 
         boolean dataAvailable = stringAnswer != null && !stringAnswer.isEmpty();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoTraceWidget.java
@@ -30,6 +30,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.geo.MapConfigurator;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.GeoDataRequester;
+import org.odk.collect.android.widgets.utilities.GeoWidgetUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 /**
@@ -67,7 +68,7 @@ public class GeoTraceWidget extends QuestionWidget implements WidgetDataReceiver
             }
         });
 
-        String stringAnswer = prompt.getAnswerText();
+        String stringAnswer = GeoWidgetUtils.getGeoPolyAnswerToDisplay(prompt.getAnswerText());
         binding.geoAnswerText.setText(stringAnswer);
 
         boolean dataAvailable = stringAnswer != null && !stringAnswer.isEmpty();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
@@ -38,7 +38,7 @@ public class GeoWidgetUtils {
 
     public static String getGeoPolyAnswerToDisplay(String answer) {
         if (answer != null && !answer.isEmpty()) {
-            answer = StringUtils.removeEnd(answer.replaceAll("\\s", ""), ";");
+            answer = StringUtils.removeEnd(answer.replaceAll(";\\s", ";"), ";");
         }
         return answer;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
@@ -5,6 +5,7 @@ import android.location.Location;
 
 import org.javarosa.core.model.QuestionDef;
 import org.odk.collect.android.R;
+import org.odk.collect.android.utilities.StringUtils;
 
 import java.text.DecimalFormat;
 
@@ -17,7 +18,7 @@ public class GeoWidgetUtils {
 
     }
 
-    public static String getAnswerToDisplay(Context context, String answer) {
+    public static String getGeoPointAnswerToDisplay(Context context, String answer) {
         try {
             if (answer != null && !answer.isEmpty()) {
                 String[] parts = answer.split(" ");
@@ -33,6 +34,13 @@ public class GeoWidgetUtils {
             return "";
         }
         return "";
+    }
+
+    public static String getGeoPolyAnswerToDisplay(String answer) {
+        if (answer != null && !answer.isEmpty()) {
+            answer = StringUtils.removeEnd(answer.replaceAll("\\s", ""), ";");
+        }
+        return answer;
     }
 
     public static double[] getLocationParamsFromStringAnswer(String answer) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/GeoUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/GeoUtilsTest.java
@@ -5,11 +5,16 @@ import android.os.Bundle;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.location.LocationTestUtils;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.robolectric.RobolectricTestRunner;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static android.location.LocationManager.GPS_PROVIDER;
 import static junit.framework.TestCase.assertNotNull;
@@ -24,6 +29,36 @@ import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class GeoUtilsTest {
+    private final List<MapPoint> points = new ArrayList<>(Arrays.asList(
+            new MapPoint(11, 12, 13, 14),
+            new MapPoint(21, 22, 23, 24),
+            new MapPoint(31, 32, 33, 34)
+    ));
+
+    @Test
+    public void whenPointsAreNull_formatPoints_returnsEmptyString() {
+        assertEquals(GeoUtils.formatPointsResultString(Collections.emptyList(), true), "");
+        assertEquals(GeoUtils.formatPointsResultString(Collections.emptyList(), false), "");
+    }
+
+    @Test
+    public void geotraces_areSeparatedBySemicolon_withoutTrialingSemicolon() {
+        assertEquals(GeoUtils.formatPointsResultString(points, false),
+                "11.0 12.0 13.0 14.0;21.0 22.0 23.0 24.0;31.0 32.0 33.0 34.0");
+    }
+
+    @Test
+    public void geoshapes_areSeparatedBySemicolon_withoutTrialingSemicolon_andHaveMatchingFirstAndLastPoints() {
+        assertEquals(GeoUtils.formatPointsResultString(points, true),
+                "11.0 12.0 13.0 14.0;21.0 22.0 23.0 24.0;31.0 32.0 33.0 34.0;11.0 12.0 13.0 14.0");
+    }
+
+    @Test
+    public void test_formatLocationResultString() {
+        Location location = LocationTestUtils.createLocation("GPS", 1, 2, 3, 4);
+        assertEquals(GeoUtils.formatLocationResultString(location), "1.0 2.0 3.0 4.0");
+    }
+
     @Test
     public void capitalizesGps() {
         String input = "gps";

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointMapWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointMapWidgetTest.java
@@ -55,7 +55,7 @@ public class GeoPointMapWidgetTest {
     @Test
     public void whenPromptHasAnswer_answerTextViewShowsCorrectAnswer() {
         GeoPointMapWidget widget = createWidget(promptWithAnswer(answer));
-        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
+        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getGeoPointAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class GeoPointMapWidgetTest {
     public void setData_updatesWidgetDisplayedAnswer() {
         GeoPointMapWidget widget = createWidget(promptWithAnswer(null));
         widget.setData(answer.getDisplayText());
-        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
+        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getGeoPointAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
@@ -59,7 +59,7 @@ public class GeoPointWidgetTest {
     @Test
     public void answerTextViewShouldShowCorrectAnswer() {
         GeoPointWidget widget = createWidget(promptWithAnswer(answer));
-        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
+        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getGeoPointAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
     }
 
     @Test
@@ -116,7 +116,7 @@ public class GeoPointWidgetTest {
     public void setData_updatesWidgetDisplayedAnswer() {
         GeoPointWidget widget = createWidget(promptWithAnswer(null));
         widget.setData(answer.getDisplayText());
-        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
+        assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getGeoPointAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/GeoWidgetHelpers.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/GeoWidgetHelpers.java
@@ -47,7 +47,7 @@ public class GeoWidgetHelpers {
         boolean first = true;
         for (double[] doubles : getRandomDoubleArrayList()) {
             if (!first) {
-                b.append("; ");
+                b.append(';');
             }
             first = false;
             b.append(stringFromDoubles(doubles));

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtilsTest.java
@@ -20,19 +20,19 @@ public class GeoWidgetUtilsTest {
 
     @Test
     public void getAnswerToDisplay_whenAnswerIsNull_returnsEmptyString() {
-        assertEquals(GeoWidgetUtils.getAnswerToDisplay(context, null), "");
+        assertEquals(GeoWidgetUtils.getGeoPointAnswerToDisplay(context, null), "");
     }
 
     @Test
     public void getAnswerToDisplay_whenAnswerIsNotConvertible_returnsEmptyString() {
-        assertEquals(GeoWidgetUtils.getAnswerToDisplay(context, "blah"), "");
+        assertEquals(GeoWidgetUtils.getGeoPointAnswerToDisplay(context, "blah"), "");
     }
 
     @Test
     public void getAnswerToDisplay_whenAnswerIsNotNullAndConvertible_returnsAnswer() {
         String stringAnswer = answer.getDisplayText();
         String[] parts = stringAnswer.split(" ");
-        assertEquals(GeoWidgetUtils.getAnswerToDisplay(context, stringAnswer), context.getString(
+        assertEquals(GeoWidgetUtils.getGeoPointAnswerToDisplay(context, stringAnswer), context.getString(
                 R.string.gps_result,
                 GeoWidgetUtils.convertCoordinatesIntoDegreeFormat(context, Double.parseDouble(parts[0]), "lat"),
                 GeoWidgetUtils.convertCoordinatesIntoDegreeFormat(context, Double.parseDouble(parts[1]), "lon"),


### PR DESCRIPTION
Closes #4267 and Closes #4451 and closes #4179

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?
I tested it on Android 9, as well as on emulator running on Android 10

#### Why is this the best possible solution? Were any other approaches considered?

- I updated `formatPoint` method to remove last semi colon from the answer string and add spaces after points while concatenating.
- I used `parsePoints` to check if the points are actually modified or not, while pressing back button in `GeoPolyActivity`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I just modified `formatPoint` method in `GeoPolyActivity`, and I have checked all possible cases for read only and non read only widgets.

#### Do we need any specific form for testing your changes? If so, please attach one.
form attached on the issue #4267 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)