### PR TITLE
Make sure quotes are always escaped in audit CSVs

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEvent.java
@@ -21,8 +21,6 @@ import androidx.annotation.NonNull;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.form.api.FormEntryController;
 
-import static org.odk.collect.android.utilities.CSVUtils.getEscapedValueForCsv;
-
 public class AuditEvent {
 
     public enum AuditEventType {
@@ -210,14 +208,6 @@ public class AuditEvent {
             this.oldValue = "";
             this.newValue = "";
             return false;
-        }
-
-        if (oldValue.contains(",") || oldValue.contains("\n")) {
-            oldValue = getEscapedValueForCsv(oldValue);
-        }
-
-        if (this.newValue.contains(",") || this.newValue.contains("\n")) {
-            this.newValue = getEscapedValueForCsv(this.newValue);
         }
 
         return true;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventCSVLine.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventCSVLine.java
@@ -39,22 +39,16 @@ public class AuditEventCSVLine {
         }
 
         if (isTrackingChangesEnabled) {
-            string += String.format(",%s,%s", oldValue, newValue);
+            string += String.format(",%s,%s", getEscapedValueForCsv(oldValue), getEscapedValueForCsv(newValue));
         }
 
         if (user != null) {
-            if (user.contains(",") || user.contains("\n")) {
-                string += String.format(",%s", getEscapedValueForCsv(user));
-            } else {
-                string += String.format(",%s", user);
-            }
+            string += String.format(",%s", getEscapedValueForCsv(user));
         }
 
         if (isTrackingChangesReasonEnabled) {
-            if (changeReason != null && (changeReason.contains(",") || changeReason.contains("\n"))) {
+            if (changeReason != null) {
                 string += String.format(",%s", getEscapedValueForCsv(changeReason));
-            } else if (changeReason != null) {
-                string += String.format(",%s", changeReason);
             } else {
                 string += ",";
             }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CSVUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CSVUtils.java
@@ -2,41 +2,43 @@ package org.odk.collect.android.utilities;
 
 import org.jetbrains.annotations.Contract;
 
+/**
+ * Escape strings according to https://tools.ietf.org/html/rfc4180
+ */
 public class CSVUtils {
 
     private CSVUtils() {
 
     }
 
-    /**
-     * Escapes quotes and then wraps in quotes for output to CSV.
-     */
-    @Contract("null -> null")
+    @Contract(value = "null -> null; !null -> !null", pure = true)
     public static String getEscapedValueForCsv(String value) {
         if (value == null) {
             return null;
         }
 
-        if (value.contains("\"")) {
-            value = escapeDoubleQuote(value);
-        }
-
-        return quoteString(value);
+        return quoteStringIfNeeded(escapeDoubleQuote(value));
     }
 
-    @Contract("null -> null; !null -> !null")
-    public static String escapeDoubleQuote(String value) {
+    @Contract(value = "null -> null; !null -> !null", pure = true)
+    private static String escapeDoubleQuote(String value) {
         if (value == null) {
             return null;
         }
+
         return value.replaceAll("\"", "\"\"");
     }
 
     @Contract(value = "null -> null; !null -> !null", pure = true)
-    public static String quoteString(String value) {
+    private static String quoteStringIfNeeded(String value) {
         if (value == null) {
             return null;
         }
-        return "\"" + value + "\"";
+
+        if (value.contains(",") || value.contains("\n") || value.contains("\"")) {
+            return "\"" + value + "\"";
+        } else {
+            return value;
+        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventCSVLineTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/audit/AuditEventCSVLineTest.java
@@ -4,6 +4,8 @@ import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.instance.TreeReference;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -38,6 +40,35 @@ public class AuditEventCSVLineTest {
 
     private static final long START_TIME = 1545392727685L;
     private static final long END_TIME = 1545392728527L;
+
+    //region CSV spec (https://tools.ietf.org/html/rfc4180)
+    @Test
+    public void commas_shouldBeSurroundedByQuotes() {
+        AuditEvent auditEvent = new AuditEvent(1L, QUESTION, getTestFormIndex(), "a, b", "c, d", "e, f");
+        auditEvent.recordValueChange("g, h");
+        auditEvent.setEnd(2L);
+        String csvLine = toCSVLine(auditEvent, false, true, true);
+        assertThat(csvLine, is("question,/data/text1,1,2,\"a, b\",\"g, h\",\"c, d\",\"e, f\""));
+    }
+
+    @Test
+    public void newlines_shouldBeSurroundedByQuotes() {
+        AuditEvent auditEvent = new AuditEvent(1L, QUESTION, getTestFormIndex(), "a\nb", "c\nd", "e\nf");
+        auditEvent.recordValueChange("g\nh");
+        auditEvent.setEnd(2L);
+        String csvLine = toCSVLine(auditEvent, false, true, true);
+        assertThat(csvLine, is("question,/data/text1,1,2,\"a\nb\",\"g\nh\",\"c\nd\",\"e\nf\""));
+    }
+
+    @Test
+    public void quotes_shouldBeEscaped_andSurroundedByQuotes() {
+        AuditEvent auditEvent = new AuditEvent(1L, QUESTION, getTestFormIndex(), "a\"b", "c\"d", "e\"f");
+        auditEvent.recordValueChange("g\"h");
+        auditEvent.setEnd(2L);
+        String csvLine = toCSVLine(auditEvent, false, true, true);
+        assertThat(csvLine, is("question,/data/text1,1,2,\"a\"\"b\",\"g\"\"h\",\"c\"\"d\",\"e\"\"f\""));
+    }
+    //endregion
 
     @Test
     public void toString_() {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/CSVUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/CSVUtilsTest.java
@@ -1,30 +1,35 @@
 package org.odk.collect.android.utilities;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.odk.collect.android.utilities.CSVUtils.getEscapedValueForCsv;
 
 public class CSVUtilsTest {
     @Test
-    public void testEscapeDoubleQuote() {
-        Assert.assertNull(CSVUtils.escapeDoubleQuote(null));
-        Assert.assertEquals("", CSVUtils.escapeDoubleQuote(""));
-        Assert.assertEquals("no quotes", CSVUtils.escapeDoubleQuote("no quotes"));
-        Assert.assertEquals("string with \"\"quotes\"\"", CSVUtils.escapeDoubleQuote("string with \"quotes\""));
+    public void null_shouldBePassedThrough() {
+        assertThat(getEscapedValueForCsv(null), is(nullValue()));
     }
 
     @Test
-    public void testQuoteString() {
-        Assert.assertNull(CSVUtils.quoteString(null));
-        Assert.assertEquals("\"\"", CSVUtils.quoteString(""));
-        Assert.assertEquals("\"string\"", CSVUtils.quoteString("string"));
-        Assert.assertEquals("\"string with \"quotes\"\"", CSVUtils.quoteString("string with \"quotes\""));
+    public void stringsWithoutQuotesCommasOrNewlines_shouldBePassedThrough() {
+        assertThat(getEscapedValueForCsv("a b c d e"), is("a b c d e"));
     }
 
     @Test
-    public void testGetEscapedValueForCsv() {
-        Assert.assertNull(CSVUtils.getEscapedValueForCsv(null));
-        Assert.assertEquals("\"\"", CSVUtils.getEscapedValueForCsv(""));
-        Assert.assertEquals("\"string\"", CSVUtils.getEscapedValueForCsv("string"));
-        Assert.assertEquals("\"string with \"\"quotes\"\"\"", CSVUtils.getEscapedValueForCsv("string with \"quotes\""));
+    public void quotes_shouldBeEscaped_andSurroundedByQuotes() {
+        assertThat(getEscapedValueForCsv("a\"b\""), is("\"a\"\"b\"\"\""));
+    }
+
+    @Test
+    public void commas_shouldBeSurroundedByQuotes() {
+        assertThat(getEscapedValueForCsv("a,b"), is("\"a,b\""));
+    }
+
+    @Test
+    public void newlines_shouldBeSurroundedByQuotes() {
+        assertThat(getEscapedValueForCsv("a\nb"), is("\"a\nb\""));
     }
 }


### PR DESCRIPTION
Also add more targeted tests and simplify code flow.

Closes #4473

#### What has been done to verify that this works as intended?
Wrote and ran tests.

I also verified that Central can now correctly export audits with quotes using [this form](https://test.central.getodk.org/#/projects/149/forms/audit-log/submissions) (auth required).

#### Why is this the best possible solution? Were any other approaches considered?
It should now correctly follow https://tools.ietf.org/html/rfc4180 and this is supported through targeted tests.

I also made some changes to centralize the CSV escaping behavior in `CsvUtils` and the calls in `AuditEventCsvLine`. I think this makes the flow easier to follow and less error-prone because there's less redundancy. I vaguely remember expressing some issues with the prior structure and I can't remember why we kept it. I can't see a reason now but maybe @grzesiek2010 will think of one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intended change is just to correctly escape quotes in audit CSVs. Risk is centralized around the audit and specifically the old value, new value, user and change reason columns. There's a risk I didn't identify every column that needs to be escaped so a sanity check on that would be good (there's no way to test for that).

#### Do we need any specific form for testing your changes? If so, please attach one.
https://docs.google.com/spreadsheets/d/12bYCMPCou7Xd4zVF6aQ0rupZQrAr28EH00lz3vJq6To/edit#gid=0

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)