### PR TITLE
SettingsProvider should use current project if none is specified

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/keys/MetaKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/keys/MetaKeys.java
@@ -1,8 +1,5 @@
 package org.odk.collect.android.preferences.keys;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class MetaKeys {
 
     public static final String KEY_INSTALL_ID = "metadata_installid";
@@ -11,14 +8,6 @@ public class MetaKeys {
     public static final String LAST_UPDATED_NOTIFICATION = "last_updated_notification";
     public static final String SERVER_LIST = "server_list";
     public static final String CURRENT_PROJECT_ID = "current_project_id";
-
-    public static final String DEFAULT_PROJECT_ID = "default";
-
-    public static Map<String, Object> getDefaults() {
-        Map<String, Object> defaults = new HashMap<>();
-        defaults.put(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID);
-        return defaults;
-    }
 
     private MetaKeys() {
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/keys/MetaKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/keys/MetaKeys.java
@@ -1,5 +1,8 @@
 package org.odk.collect.android.preferences.keys;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class MetaKeys {
 
     public static final String KEY_INSTALL_ID = "metadata_installid";
@@ -7,6 +10,15 @@ public class MetaKeys {
     public static final String KEY_GOOGLE_BUG_154855417_FIXED = "google_bug_154855417_fixed";
     public static final String LAST_UPDATED_NOTIFICATION = "last_updated_notification";
     public static final String SERVER_LIST = "server_list";
+    public static final String CURRENT_PROJECT_ID = "current_project_id";
+
+    public static final String DEFAULT_PROJECT_ID = "default";
+
+    public static Map<String, Object> getDefaults() {
+        Map<String, Object> defaults = new HashMap<>();
+        defaults.put(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID);
+        return defaults;
+    }
 
     private MetaKeys() {
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -4,13 +4,11 @@ import android.content.Context
 import androidx.preference.PreferenceManager
 import org.odk.collect.android.preferences.keys.AdminKeys
 import org.odk.collect.android.preferences.keys.GeneralKeys
-import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
-import org.odk.collect.android.preferences.keys.MetaKeys.DEFAULT_PROJECT_ID
 
 class SettingsProvider(private val context: Context) {
     fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
-        SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE), MetaKeys.getDefaults())
+        SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE))
     }
 
     @JvmOverloads
@@ -18,7 +16,7 @@ class SettingsProvider(private val context: Context) {
         val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
 
         return settings.getOrPut(settingsId) {
-            if (settingsId == GENERAL_SETTINGS_NAME + DEFAULT_PROJECT_ID) {
+            if (settingsId == GENERAL_SETTINGS_NAME) {
                 SharedPreferencesSettings(PreferenceManager.getDefaultSharedPreferences(context), GeneralKeys.DEFAULTS)
             } else {
                 SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
@@ -36,7 +34,7 @@ class SettingsProvider(private val context: Context) {
     }
 
     private fun getSettingsId(settingName: String, projectId: String) = if (projectId.isBlank()) {
-        settingName + getMetaSettings().getString(CURRENT_PROJECT_ID)
+        settingName + (getMetaSettings().getString(CURRENT_PROJECT_ID) ?: "")
     } else {
         settingName + projectId
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -4,34 +4,41 @@ import android.content.Context
 import androidx.preference.PreferenceManager
 import org.odk.collect.android.preferences.keys.AdminKeys
 import org.odk.collect.android.preferences.keys.GeneralKeys
+import org.odk.collect.android.preferences.keys.MetaKeys
+import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
+import org.odk.collect.android.preferences.keys.MetaKeys.DEFAULT_PROJECT_ID
 
 class SettingsProvider(private val context: Context) {
-    fun getMetaSettings(): Settings {
-        return settings.getOrPut(META_SETTINGS_NAME) {
-            SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE))
-        }
+    fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
+        SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE), MetaKeys.getDefaults())
     }
 
     @JvmOverloads
     fun getGeneralSettings(projectId: String = ""): Settings {
-        val preferenceId = GENERAL_SETTINGS_NAME + projectId
+        val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
 
-        return settings.getOrPut(preferenceId) {
-            if (projectId.isBlank()) {
+        return settings.getOrPut(settingsId) {
+            if (settingsId == GENERAL_SETTINGS_NAME + DEFAULT_PROJECT_ID) {
                 SharedPreferencesSettings(PreferenceManager.getDefaultSharedPreferences(context), GeneralKeys.DEFAULTS)
             } else {
-                SharedPreferencesSettings(context.getSharedPreferences(preferenceId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
+                SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
             }
         }
     }
 
     @JvmOverloads
     fun getAdminSettings(projectId: String = ""): Settings {
-        val preferenceId = ADMIN_SETTINGS_NAME + projectId
+        val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
 
-        return settings.getOrPut(preferenceId) {
-            SharedPreferencesSettings(context.getSharedPreferences(preferenceId, Context.MODE_PRIVATE), AdminKeys.getDefaults())
+        return settings.getOrPut(settingsId) {
+            SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), AdminKeys.getDefaults())
         }
+    }
+
+    private fun getSettingsId(settingName: String, projectId: String) = if (projectId.isBlank()) {
+        settingName + getMetaSettings().getString(CURRENT_PROJECT_ID)
+    } else {
+        settingName + projectId
     }
 
     companion object {

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/source/SettingsProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/source/SettingsProviderTest.kt
@@ -9,7 +9,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
-import org.odk.collect.android.preferences.keys.MetaKeys.DEFAULT_PROJECT_ID
 
 @RunWith(AndroidJUnit4::class)
 class SettingsProviderTest {
@@ -17,7 +16,7 @@ class SettingsProviderTest {
 
     @Before
     fun setup() {
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID)
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, null)
     }
 
     @Test
@@ -52,7 +51,7 @@ class SettingsProviderTest {
         val generalSettings2 = settingsProvider.getGeneralSettings()
         assertThat(generalSettings, `is`(not(generalSettings2)))
 
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID)
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, null)
 
         val generalSettings3 = settingsProvider.getGeneralSettings()
         assertThat(generalSettings, `is`(generalSettings3))
@@ -72,7 +71,7 @@ class SettingsProviderTest {
         val adminSettings2 = settingsProvider.getAdminSettings()
         assertThat(adminSettings, `is`(not(adminSettings2)))
 
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID)
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, null)
 
         val adminSettings3 = settingsProvider.getAdminSettings()
         assertThat(adminSettings, `is`(adminSettings3))

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/source/SettingsProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/source/SettingsProviderTest.kt
@@ -1,0 +1,85 @@
+package org.odk.collect.android.preferences.source
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
+import org.odk.collect.android.preferences.keys.MetaKeys.DEFAULT_PROJECT_ID
+
+@RunWith(AndroidJUnit4::class)
+class SettingsProviderTest {
+    private val settingsProvider = SettingsProvider(ApplicationProvider.getApplicationContext())
+
+    @Before
+    fun setup() {
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID)
+    }
+
+    @Test
+    fun `getMetaSettings() should always return the same object no matter what CURRENT_PROJECT_ID is`() {
+        val metaSettings = settingsProvider.getMetaSettings()
+        assertThat(metaSettings, `is`(settingsProvider.getMetaSettings()))
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+        assertThat(metaSettings, `is`(settingsProvider.getMetaSettings()))
+    }
+
+    @Test
+    fun `getGeneralSettings() should always return the same object for given projectId`() {
+        assertThat(settingsProvider.getGeneralSettings(), `is`(settingsProvider.getGeneralSettings()))
+        assertThat(settingsProvider.getGeneralSettings("1234"), `is`(settingsProvider.getGeneralSettings("1234")))
+        assertThat(settingsProvider.getGeneralSettings("1234"), `is`(not(settingsProvider.getGeneralSettings())))
+    }
+
+    @Test
+    fun `getAdminSettings() should always return the same object for given projectId`() {
+        assertThat(settingsProvider.getAdminSettings(), `is`(settingsProvider.getAdminSettings()))
+        assertThat(settingsProvider.getAdminSettings("1234"), `is`(settingsProvider.getAdminSettings("1234")))
+        assertThat(settingsProvider.getAdminSettings("1234"), `is`(not(settingsProvider.getAdminSettings())))
+    }
+
+    @Test
+    fun `Proper general settings should be used depending on CURRENT_PROJECT_ID`() {
+        val generalSettings = settingsProvider.getGeneralSettings()
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+
+        val generalSettings2 = settingsProvider.getGeneralSettings()
+        assertThat(generalSettings, `is`(not(generalSettings2)))
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID)
+
+        val generalSettings3 = settingsProvider.getGeneralSettings()
+        assertThat(generalSettings, `is`(generalSettings3))
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+
+        val generalSettings4 = settingsProvider.getGeneralSettings()
+        assertThat(generalSettings2, `is`(generalSettings4))
+    }
+
+    @Test
+    fun `Proper admin settings should be used depending on CURRENT_PROJECT_ID`() {
+        val adminSettings = settingsProvider.getAdminSettings()
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+
+        val adminSettings2 = settingsProvider.getAdminSettings()
+        assertThat(adminSettings, `is`(not(adminSettings2)))
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, DEFAULT_PROJECT_ID)
+
+        val adminSettings3 = settingsProvider.getAdminSettings()
+        assertThat(adminSettings, `is`(adminSettings3))
+
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+
+        val adminSettings4 = settingsProvider.getAdminSettings()
+        assertThat(adminSettings2, `is`(adminSettings4))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/source/SettingsProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/source/SettingsProviderTest.kt
@@ -20,7 +20,7 @@ class SettingsProviderTest {
     }
 
     @Test
-    fun `getMetaSettings() should always return the same object no matter what CURRENT_PROJECT_ID is`() {
+    fun `The same mata settings should always be returned no matter what current project is`() {
         val metaSettings = settingsProvider.getMetaSettings()
         assertThat(metaSettings, `is`(settingsProvider.getMetaSettings()))
 
@@ -29,56 +29,54 @@ class SettingsProviderTest {
     }
 
     @Test
-    fun `getGeneralSettings() should always return the same object for given projectId`() {
+    fun `The same general settings should always be returned for current project`() {
         assertThat(settingsProvider.getGeneralSettings(), `is`(settingsProvider.getGeneralSettings()))
+    }
+
+    @Test
+    fun `The same general settings should always be returned for given projectId`() {
         assertThat(settingsProvider.getGeneralSettings("1234"), `is`(settingsProvider.getGeneralSettings("1234")))
+    }
+
+    @Test
+    fun `The same general settings should be returned for given projectId and current project if the those are the same`() {
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+        assertThat(settingsProvider.getGeneralSettings("1234"), `is`(settingsProvider.getGeneralSettings()))
+    }
+
+    @Test
+    fun `Different general settings should be returned for different projectIds`() {
+        assertThat(settingsProvider.getGeneralSettings("1234"), `is`(not(settingsProvider.getGeneralSettings("4321"))))
+    }
+
+    @Test
+    fun `Different general settings should be returned for given projectId and current project if those are not the same`() {
         assertThat(settingsProvider.getGeneralSettings("1234"), `is`(not(settingsProvider.getGeneralSettings())))
     }
 
     @Test
-    fun `getAdminSettings() should always return the same object for given projectId`() {
+    fun `The same admin settings should always be returned for current project`() {
         assertThat(settingsProvider.getAdminSettings(), `is`(settingsProvider.getAdminSettings()))
+    }
+
+    @Test
+    fun `The same admin settings should always be returned for given projectId`() {
         assertThat(settingsProvider.getAdminSettings("1234"), `is`(settingsProvider.getAdminSettings("1234")))
+    }
+
+    @Test
+    fun `The same admin settings should be returned for given projectId and current project if those are the same`() {
+        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
+        assertThat(settingsProvider.getAdminSettings("1234"), `is`(settingsProvider.getAdminSettings()))
+    }
+
+    @Test
+    fun `Different admin settings should be returned for different projectIds`() {
+        assertThat(settingsProvider.getAdminSettings("1234"), `is`(not(settingsProvider.getAdminSettings("4321"))))
+    }
+
+    @Test
+    fun `Different admin settings should be returned for given projectId and current project if those are not the same`() {
         assertThat(settingsProvider.getAdminSettings("1234"), `is`(not(settingsProvider.getAdminSettings())))
-    }
-
-    @Test
-    fun `Proper general settings should be used depending on CURRENT_PROJECT_ID`() {
-        val generalSettings = settingsProvider.getGeneralSettings()
-
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
-
-        val generalSettings2 = settingsProvider.getGeneralSettings()
-        assertThat(generalSettings, `is`(not(generalSettings2)))
-
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, null)
-
-        val generalSettings3 = settingsProvider.getGeneralSettings()
-        assertThat(generalSettings, `is`(generalSettings3))
-
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
-
-        val generalSettings4 = settingsProvider.getGeneralSettings()
-        assertThat(generalSettings2, `is`(generalSettings4))
-    }
-
-    @Test
-    fun `Proper admin settings should be used depending on CURRENT_PROJECT_ID`() {
-        val adminSettings = settingsProvider.getAdminSettings()
-
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
-
-        val adminSettings2 = settingsProvider.getAdminSettings()
-        assertThat(adminSettings, `is`(not(adminSettings2)))
-
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, null)
-
-        val adminSettings3 = settingsProvider.getAdminSettings()
-        assertThat(adminSettings, `is`(adminSettings3))
-
-        settingsProvider.getMetaSettings().save(CURRENT_PROJECT_ID, "1234")
-
-        val adminSettings4 = settingsProvider.getAdminSettings()
-        assertThat(adminSettings2, `is`(adminSettings4))
     }
 }


### PR DESCRIPTION
Closes #4467

#### What has been done to verify that this works as intended?
I ran tests, reviewed implemented changes and tested the app manually.

#### Why is this the best possible solution? Were any other approaches considered?
I decided not to implement project repository now and use meta settings to track which project is active. Thanks to that I don't need to pass any additional object to `SettingsProvider` since meta setting are already there.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We won't test it now.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)