### PR TITLE
Update JavaRosa to get secondary instance performance improvements

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -270,7 +270,7 @@ dependencies {
     implementation "com.rarepebble:colorpicker:3.0.1"
     implementation "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     implementation "net.sf.opencsv:opencsv:2.4"
-    implementation("org.getodk:javarosa:3.1.0") {
+    implementation("org.getodk:javarosa:3.2.0-SNAPSHOT") {
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
Closes #4363

This should halve the time it takes to generate and display a filtered choice list. It should also make navigation to questions with choice lists instant if the values involved in the filter expressions haven't changed. For example, in a form with a district question and then a settlement question filtered based on district, if the district doesn't change, it should be instant to go to the settlement question, to view the settlement question in the hierarchy view, etc. Note that when loading a saved form, all of the choice lists will need to be filtered so displaying that initial hierarchy screen will take time.

#### What has been done to verify that this works as intended?
- JavaRosa tests added and reviewed by @dcbriccetti.
- Verified [external 52k split form](https://drive.google.com/drive/u/0/folders/1QwX7E-u19jzXvzwkOpj2Y4X-xb9ihd1f) with Samsung Galaxy Tab A. Prior to PR navigating to Settlement question after changing District question took ~11s. Now it takes ~5s.
- Verified that navigation is instant when filter values don't change.
- Verified that saving a form with large secondary instances is instant
- Verified that a form instance with large secondary instances can be opened for editing

#### Why is this the best possible solution? Were any other approaches considered?
See https://github.com/getodk/javarosa/pull/626 and https://github.com/getodk/javarosa/pull/619.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
There's risk around anything having to do with selects with choice filters. In particular, there's risk around the filtering happening correctly and updating when needed and there's risk around translated choices.

#### Do we need any specific form for testing your changes? If so, please attach one.
This is a tricky one to verify because the main risk is around different kinds of form definitions. I've checked:
- [external 52k split](https://drive.google.com/drive/u/0/folders/1QwX7E-u19jzXvzwkOpj2Y4X-xb9ihd1f) (external selects, 52k choices, no translations)
- [Nigeria wards internal](https://docs.google.com/spreadsheets/d/1B9vUMXvXNoLoV3SWEBTxxyhyJ-vxLbZ6EI2hbpl4nYw/edit#gid=0) (internal selects, 12k choices, no translations)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)