### PR TITLE
Upgrades create "Default" project

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
@@ -55,6 +55,8 @@ class SplashScreenActivity : AppCompatActivity(), AddProjectDialog.AddProjectDia
     }
 
     private fun init() {
+        viewModel.importExistingProjectIfNeeded()
+
         when {
             viewModel.shouldFirstLaunchDialogBeDisplayed() -> DialogUtils.showIfNotShowing(FirstLaunchDialog::class.java, supportFragmentManager)
             viewModel.shouldDisplaySplashScreen -> startSplashScreen()

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
@@ -58,7 +58,7 @@ class SplashScreenActivity : AppCompatActivity(), AddProjectDialog.AddProjectDia
         viewModel.importExistingProjectIfNeeded()
 
         when {
-            viewModel.isFirstLaunch() -> DialogUtils.showIfNotShowing(FirstLaunchDialog::class.java, supportFragmentManager)
+            viewModel.isFirstLaunch -> DialogUtils.showIfNotShowing(FirstLaunchDialog::class.java, supportFragmentManager)
             viewModel.shouldDisplaySplashScreen -> startSplashScreen()
             else -> endSplashScreen()
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
@@ -58,7 +58,7 @@ class SplashScreenActivity : AppCompatActivity(), AddProjectDialog.AddProjectDia
         viewModel.importExistingProjectIfNeeded()
 
         when {
-            viewModel.shouldFirstLaunchDialogBeDisplayed() -> DialogUtils.showIfNotShowing(FirstLaunchDialog::class.java, supportFragmentManager)
+            viewModel.isFirstLaunch() -> DialogUtils.showIfNotShowing(FirstLaunchDialog::class.java, supportFragmentManager)
             viewModel.shouldDisplaySplashScreen -> startSplashScreen()
             else -> endSplashScreen()
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/SplashScreenActivity.kt
@@ -55,8 +55,6 @@ class SplashScreenActivity : AppCompatActivity(), AddProjectDialog.AddProjectDia
     }
 
     private fun init() {
-        viewModel.importExistingProjectIfNeeded()
-
         when {
             viewModel.isFirstLaunch -> DialogUtils.showIfNotShowing(FirstLaunchDialog::class.java, supportFragmentManager)
             viewModel.shouldDisplaySplashScreen -> startSplashScreen()

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
@@ -31,14 +31,14 @@ class SplashScreenViewModel(
     val doesLogoFileExist
         get() = splashScreenLogoFile.exists()
 
-    fun shouldFirstLaunchDialogBeDisplayed(): Boolean {
+    fun isFirstLaunch(): Boolean {
         val isFirstLaunch = !metaSettings.contains(MetaKeys.KEY_FIRST_LAUNCH)
         metaSettings.save(MetaKeys.KEY_FIRST_LAUNCH, false)
         return isFirstLaunch
     }
 
     fun importExistingProjectIfNeeded() {
-        if (!shouldFirstLaunchDialogBeDisplayed() && projectsRepository.getAll().isEmpty()) {
+        if (!isFirstLaunch() && projectsRepository.getAll().isEmpty()) {
             projectImporter.importExistingProject()
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
@@ -5,14 +5,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.keys.MetaKeys
+import org.odk.collect.android.projects.ProjectImporter
 import org.odk.collect.android.utilities.FileUtils
 import org.odk.collect.android.utilities.ScreenUtils
+import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.Settings
 import java.io.File
 
 class SplashScreenViewModel(
     private val generalSettings: Settings,
     private val metaSettings: Settings,
+    private val projectsRepository: ProjectsRepository,
+    private val projectImporter: ProjectImporter
 ) : ViewModel() {
 
     val shouldDisplaySplashScreen
@@ -33,9 +37,20 @@ class SplashScreenViewModel(
         return isFirstLaunch
     }
 
-    open class Factory constructor(private val generalSettings: Settings, private val metaSettings: Settings) : ViewModelProvider.Factory {
+    fun importExistingProjectIfNeeded() {
+        if (!shouldFirstLaunchDialogBeDisplayed() && projectsRepository.getAll().isEmpty()) {
+            projectImporter.importExistingProject()
+        }
+    }
+
+    open class Factory constructor(
+        private val generalSettings: Settings,
+        private val metaSettings: Settings,
+        private val projectsRepository: ProjectsRepository,
+        private val projectImporter: ProjectImporter
+    ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return SplashScreenViewModel(generalSettings, metaSettings) as T
+            return SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter) as T
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
@@ -4,8 +4,8 @@ import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.preferences.keys.GeneralKeys
-import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.android.projects.ProjectImporter
+import org.odk.collect.android.utilities.AppStateProvider
 import org.odk.collect.android.utilities.FileUtils
 import org.odk.collect.android.utilities.ScreenUtils
 import org.odk.collect.projects.ProjectsRepository
@@ -16,7 +16,8 @@ class SplashScreenViewModel(
     private val generalSettings: Settings,
     private val metaSettings: Settings,
     private val projectsRepository: ProjectsRepository,
-    private val projectImporter: ProjectImporter
+    private val projectImporter: ProjectImporter,
+    private val appStateProvider: AppStateProvider
 ) : ViewModel() {
 
     val shouldDisplaySplashScreen
@@ -31,14 +32,11 @@ class SplashScreenViewModel(
     val doesLogoFileExist
         get() = splashScreenLogoFile.exists()
 
-    fun isFirstLaunch(): Boolean {
-        val isFirstLaunch = !metaSettings.contains(MetaKeys.KEY_FIRST_LAUNCH)
-        metaSettings.save(MetaKeys.KEY_FIRST_LAUNCH, false)
-        return isFirstLaunch
-    }
+    val isFirstLaunch
+        get() = appStateProvider.isFreshInstall()
 
     fun importExistingProjectIfNeeded() {
-        if (!isFirstLaunch() && projectsRepository.getAll().isEmpty()) {
+        if (!isFirstLaunch && projectsRepository.getAll().isEmpty()) {
             projectImporter.importExistingProject()
         }
     }
@@ -47,10 +45,11 @@ class SplashScreenViewModel(
         private val generalSettings: Settings,
         private val metaSettings: Settings,
         private val projectsRepository: ProjectsRepository,
-        private val projectImporter: ProjectImporter
+        private val projectImporter: ProjectImporter,
+        private val appStateProvider: AppStateProvider
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter) as T
+            return SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter, appStateProvider) as T
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
@@ -4,18 +4,14 @@ import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.preferences.keys.GeneralKeys
-import org.odk.collect.android.projects.ProjectImporter
 import org.odk.collect.android.utilities.AppStateProvider
 import org.odk.collect.android.utilities.FileUtils
 import org.odk.collect.android.utilities.ScreenUtils
-import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.Settings
 import java.io.File
 
 class SplashScreenViewModel(
     private val generalSettings: Settings,
-    private val projectsRepository: ProjectsRepository,
-    private val projectImporter: ProjectImporter,
     private val appStateProvider: AppStateProvider
 ) : ViewModel() {
 
@@ -34,20 +30,12 @@ class SplashScreenViewModel(
     val isFirstLaunch
         get() = appStateProvider.isFreshInstall()
 
-    fun importExistingProjectIfNeeded() {
-        if (!isFirstLaunch && projectsRepository.getAll().isEmpty()) {
-            projectImporter.importExistingProject()
-        }
-    }
-
     open class Factory constructor(
         private val generalSettings: Settings,
-        private val projectsRepository: ProjectsRepository,
-        private val projectImporter: ProjectImporter,
         private val appStateProvider: AppStateProvider
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return SplashScreenViewModel(generalSettings, projectsRepository, projectImporter, appStateProvider) as T
+            return SplashScreenViewModel(generalSettings, appStateProvider) as T
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModel.kt
@@ -14,7 +14,6 @@ import java.io.File
 
 class SplashScreenViewModel(
     private val generalSettings: Settings,
-    private val metaSettings: Settings,
     private val projectsRepository: ProjectsRepository,
     private val projectImporter: ProjectImporter,
     private val appStateProvider: AppStateProvider
@@ -43,13 +42,12 @@ class SplashScreenViewModel(
 
     open class Factory constructor(
         private val generalSettings: Settings,
-        private val metaSettings: Settings,
         private val projectsRepository: ProjectsRepository,
         private val projectImporter: ProjectImporter,
         private val appStateProvider: AppStateProvider
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter, appStateProvider) as T
+            return SplashScreenViewModel(generalSettings, projectsRepository, projectImporter, appStateProvider) as T
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -21,6 +21,9 @@ import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.logic.actions.setgeopoint.CollectSetGeopointActionHandler;
 import org.odk.collect.android.preferences.FormUpdateMode;
 import org.odk.collect.android.preferences.keys.GeneralKeys;
+import org.odk.collect.android.projects.ProjectImporter;
+import org.odk.collect.android.utilities.AppStateProvider;
+import org.odk.collect.projects.ProjectsRepository;
 import org.odk.collect.shared.Settings;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.storage.StorageInitializer;
@@ -42,15 +45,23 @@ public class ApplicationInitializer {
     private final Settings generalSettings;
     private final Settings adminSettings;
     private final StorageInitializer storageInitializer;
+    private final ProjectsRepository projectsRepository;
+    private final AppStateProvider appStateProvider;
+    private final ProjectImporter projectImporter;
 
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     public ApplicationInitializer(Application context, UserAgentProvider userAgentProvider, SettingsPreferenceMigrator preferenceMigrator,
-                                  PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, SettingsProvider settingsProvider) {
+                                  PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, SettingsProvider settingsProvider,
+                                  ProjectsRepository projectsRepository, AppStateProvider appStateProvider, ProjectImporter projectImporter) {
         this.context = context;
         this.userAgentProvider = userAgentProvider;
         this.preferenceMigrator = preferenceMigrator;
         this.propertyManager = propertyManager;
         this.analytics = analytics;
         this.storageInitializer = storageInitializer;
+        this.projectsRepository = projectsRepository;
+        this.appStateProvider = appStateProvider;
+        this.projectImporter = projectImporter;
 
         generalSettings = settingsProvider.getGeneralSettings();
         adminSettings = settingsProvider.getAdminSettings();
@@ -61,6 +72,7 @@ public class ApplicationInitializer {
         initializePreferences();
         initializeFrameworks();
         initializeLocale();
+        importExistingProjectIfNeeded();
     }
 
     private void initializeStorage() {
@@ -136,6 +148,12 @@ public class ApplicationInitializer {
             MapboxUtils.initMapbox();
         } catch (Exception | Error ignore) {
             // ignored
+        }
+    }
+
+    private void importExistingProjectIfNeeded() {
+        if (!appStateProvider.isFreshInstall() && projectsRepository.getAll().isEmpty()) {
+            projectImporter.importExistingProject();
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -25,7 +25,6 @@ import org.odk.collect.android.projects.ProjectImporter;
 import org.odk.collect.android.utilities.AppStateProvider;
 import org.odk.collect.projects.ProjectsRepository;
 import org.odk.collect.shared.Settings;
-import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.utilities.UserAgentProvider;
 
@@ -51,20 +50,19 @@ public class ApplicationInitializer {
 
     @SuppressWarnings("PMD.ExcessiveParameterList")
     public ApplicationInitializer(Application context, UserAgentProvider userAgentProvider, SettingsPreferenceMigrator preferenceMigrator,
-                                  PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, SettingsProvider settingsProvider,
-                                  ProjectsRepository projectsRepository, AppStateProvider appStateProvider, ProjectImporter projectImporter) {
+                                  PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, Settings generalSettings,
+                                  Settings adminSettings, ProjectsRepository projectsRepository, AppStateProvider appStateProvider, ProjectImporter projectImporter) {
         this.context = context;
         this.userAgentProvider = userAgentProvider;
         this.preferenceMigrator = preferenceMigrator;
         this.propertyManager = propertyManager;
         this.analytics = analytics;
+        this.generalSettings = generalSettings;
+        this.adminSettings = adminSettings;
         this.storageInitializer = storageInitializer;
         this.projectsRepository = projectsRepository;
         this.appStateProvider = appStateProvider;
         this.projectImporter = projectImporter;
-
-        generalSettings = settingsProvider.getGeneralSettings();
-        adminSettings = settingsProvider.getAdminSettings();
     }
 
     public void initialize() {

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -97,6 +97,7 @@ import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.AdminPasswordProvider;
 import org.odk.collect.android.utilities.AndroidUserAgent;
+import org.odk.collect.android.utilities.AppStateProvider;
 import org.odk.collect.android.utilities.DeviceDetailsProvider;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.ExternalWebPageHelper;
@@ -554,12 +555,17 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider, ProjectsRepository projectsRepository, ProjectImporter projectImporter) {
-        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter);
+    public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider, ProjectsRepository projectsRepository, ProjectImporter projectImporter, AppStateProvider appStateProvider) {
+        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter, appStateProvider);
     }
 
     @Provides
     public ProjectImporter providesProjectImporter(ProjectsRepository projectsRepository, SettingsProvider settingsProvider) {
         return new ProjectImporter(projectsRepository, settingsProvider.getMetaSettings());
+    }
+
+    @Provides
+    public AppStateProvider providesAppStateProvider(Context context) {
+        return new AppStateProvider(context);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -316,8 +316,8 @@ public class AppDependencyModule {
                                                                  Analytics analytics, StorageInitializer storageInitializer, SettingsProvider settingsProvider,
                                                                  ProjectsRepository projectsRepository, AppStateProvider appStateProvider, ProjectImporter projectImporter) {
         return new ApplicationInitializer(application, userAgentProvider, preferenceMigrator,
-                propertyManager, analytics, storageInitializer, settingsProvider, projectsRepository,
-                appStateProvider, projectImporter);
+                propertyManager, analytics, storageInitializer, settingsProvider.getGeneralSettings(),
+                settingsProvider.getAdminSettings(), projectsRepository, appStateProvider, projectImporter);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -308,12 +308,16 @@ public class AppDependencyModule {
         return new CoroutineAndWorkManagerScheduler(workManager);
     }
 
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     @Singleton
     @Provides
     public ApplicationInitializer providesApplicationInitializer(Application application, UserAgentProvider userAgentProvider,
                                                                  SettingsPreferenceMigrator preferenceMigrator, PropertyManager propertyManager,
-                                                                 Analytics analytics, StorageInitializer storageInitializer, SettingsProvider settingsProvider) {
-        return new ApplicationInitializer(application, userAgentProvider, preferenceMigrator, propertyManager, analytics, storageInitializer, settingsProvider);
+                                                                 Analytics analytics, StorageInitializer storageInitializer, SettingsProvider settingsProvider,
+                                                                 ProjectsRepository projectsRepository, AppStateProvider appStateProvider, ProjectImporter projectImporter) {
+        return new ApplicationInitializer(application, userAgentProvider, preferenceMigrator,
+                propertyManager, analytics, storageInitializer, settingsProvider, projectsRepository,
+                appStateProvider, projectImporter);
     }
 
     @Provides
@@ -555,8 +559,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider, ProjectsRepository projectsRepository, ProjectImporter projectImporter, AppStateProvider appStateProvider) {
-        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), projectsRepository, projectImporter, appStateProvider);
+    public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider, AppStateProvider appStateProvider) {
+        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), appStateProvider);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -556,7 +556,7 @@ public class AppDependencyModule {
 
     @Provides
     public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider, ProjectsRepository projectsRepository, ProjectImporter projectImporter, AppStateProvider appStateProvider) {
-        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter, appStateProvider);
+        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), projectsRepository, projectImporter, appStateProvider);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -554,8 +554,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider) {
-        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings());
+    public SplashScreenViewModel.Factory providesSplashScreenViewModel(SettingsProvider settingsProvider, ProjectsRepository projectsRepository, ProjectImporter projectImporter) {
+        return new SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/keys/MetaKeys.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/keys/MetaKeys.java
@@ -9,7 +9,6 @@ public class MetaKeys {
     public static final String SERVER_LIST = "server_list";
     public static final String CURRENT_PROJECT_ID = "current_project_id";
     public static final String KEY_PROJECTS = "projects";
-    public static final String KEY_FIRST_LAUNCH = "first_launch";
 
     private MetaKeys() {
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -6,6 +6,8 @@ import org.odk.collect.android.preferences.keys.AdminKeys
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
 import org.odk.collect.shared.Settings
+import org.odk.collect.android.projects.ProjectImporter.Companion.DEMO_PROJECT_ID
+import org.odk.collect.projects.NOT_SPECIFIED_UUID
 
 class SettingsProvider(private val context: Context) {
     fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
@@ -13,7 +15,7 @@ class SettingsProvider(private val context: Context) {
     }
 
     @JvmOverloads
-    fun getGeneralSettings(projectId: String = ""): Settings {
+    fun getGeneralSettings(projectId: String = NOT_SPECIFIED_UUID): Settings {
         val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
 
         return settings.getOrPut(settingsId) {
@@ -26,7 +28,7 @@ class SettingsProvider(private val context: Context) {
     }
 
     @JvmOverloads
-    fun getAdminSettings(projectId: String = ""): Settings {
+    fun getAdminSettings(projectId: String = NOT_SPECIFIED_UUID): Settings {
         val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
 
         return settings.getOrPut(settingsId) {
@@ -34,8 +36,8 @@ class SettingsProvider(private val context: Context) {
         }
     }
 
-    private fun getSettingsId(settingName: String, projectId: String) = if (projectId.isBlank()) {
-        settingName + (getMetaSettings().getString(CURRENT_PROJECT_ID) ?: "")
+    private fun getSettingsId(settingName: String, projectId: String) = if (projectId == NOT_SPECIFIED_UUID) {
+        settingName + (getMetaSettings().getString(CURRENT_PROJECT_ID) ?: DEMO_PROJECT_ID)
     } else {
         settingName + projectId
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -5,9 +5,9 @@ import androidx.preference.PreferenceManager
 import org.odk.collect.android.preferences.keys.AdminKeys
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
-import org.odk.collect.shared.Settings
 import org.odk.collect.android.projects.ProjectImporter.Companion.DEMO_PROJECT_ID
 import org.odk.collect.projects.NOT_SPECIFIED_UUID
+import org.odk.collect.shared.Settings
 
 class SettingsProvider(private val context: Context) {
     fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
@@ -12,7 +12,7 @@ class ProjectImporter(
     fun importDemoProject() {
         val project = Project("Demo project", "D", "#3e9fcc", DEMO_PROJECT_ID)
         projectsRepository.add(project)
-        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, DEMO_PROJECT_ID)
+        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, "")
     }
 
     // Now it does the same like importDemoProject() but it should be changed later
@@ -23,6 +23,11 @@ class ProjectImporter(
     }
 
     companion object {
-        const val DEMO_PROJECT_ID = "DEMO"
+        /*
+        Should be empty to easily access existed settings (general and admin) that had be saved in versions
+        prior to the one that implemented "Projects" and treat them as those which belong to
+        the imported existed project.
+         */
+        const val DEMO_PROJECT_ID = ""
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
@@ -12,7 +12,7 @@ class ProjectImporter(
     fun importDemoProject() {
         val project = Project("Demo project", "D", "#3e9fcc", DEMO_PROJECT_ID)
         projectsRepository.add(project)
-        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, "")
+        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, DEMO_PROJECT_ID)
     }
 
     // Now it does the same like importDemoProject() but it should be changed later

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
@@ -15,8 +15,11 @@ class ProjectImporter(
         metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, DEMO_PROJECT_ID)
     }
 
+    // Now it does the same like importDemoProject() but it should be changed later
     fun importExistingProject() {
-        // TODO
+        val project = Project("Demo project", "D", "#3e9fcc", "1")
+        projectsRepository.add(project)
+        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, "1")
     }
 
     companion object {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectImporter.kt
@@ -17,9 +17,9 @@ class ProjectImporter(
 
     // Now it does the same like importDemoProject() but it should be changed later
     fun importExistingProject() {
-        val project = Project("Demo project", "D", "#3e9fcc", "1")
+        val project = Project("Demo project", "D", "#3e9fcc", DEMO_PROJECT_ID)
         projectsRepository.add(project)
-        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, "1")
+        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, DEMO_PROJECT_ID)
     }
 
     companion object {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AppStateProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AppStateProvider.kt
@@ -1,0 +1,17 @@
+package org.odk.collect.android.utilities
+
+import android.content.Context
+
+class AppStateProvider(private val context: Context) {
+    fun isFreshInstall(): Boolean {
+        return try {
+            val firstInstallTime = context.packageManager.getPackageInfo(context.packageName, 0).firstInstallTime
+            val lastUpdateTime = context.packageManager.getPackageInfo(context.packageName, 0).lastUpdateTime
+            firstInstallTime == lastUpdateTime
+        } catch (e: Exception) {
+            true
+        } catch (e: Error) {
+            true
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -28,7 +28,9 @@ import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel
 import org.odk.collect.android.fragments.dialogs.FirstLaunchDialog
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.android.projects.ProjectImporter
 import org.odk.collect.android.support.RobolectricHelpers
+import org.odk.collect.projects.ProjectsRepository
 
 @RunWith(AndroidJUnit4::class)
 class SplashScreenActivityTest {
@@ -43,8 +45,8 @@ class SplashScreenActivityTest {
         splashScreenViewModel = mock(SplashScreenViewModel::class.java)
 
         RobolectricHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
-            override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider): SplashScreenViewModel.Factory {
-                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings()) {
+            override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider, projectsRepository: ProjectsRepository, projectImporter: ProjectImporter): SplashScreenViewModel.Factory {
+                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return splashScreenViewModel as T
                     }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel
 import org.odk.collect.android.fragments.dialogs.FirstLaunchDialog
@@ -58,6 +59,12 @@ class SplashScreenActivityTest {
     @After
     fun teardown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `importExistingProjectIfNeeded() should be called`() {
+        ActivityScenario.launch(SplashScreenActivity::class.java)
+        verify(splashScreenViewModel).importExistingProjectIfNeeded()
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -21,6 +21,7 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.odk.collect.android.rules.MainCoroutineScopeRule
+import org.mockito.Mockito.spy
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel
 import org.odk.collect.android.fragments.dialogs.FirstLaunchDialog
@@ -29,11 +30,12 @@ import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.projects.ProjectImporter
 import org.odk.collect.android.support.RobolectricHelpers
 import org.odk.collect.projects.ProjectsRepository
+import org.odk.collect.android.utilities.AppStateProvider
 
 @RunWith(AndroidJUnit4::class)
 class SplashScreenActivityTest {
     @get:Rule
-    val coroutineScope =  MainCoroutineScopeRule()
+    val coroutineScope = MainCoroutineScopeRule()
 
     private lateinit var splashScreenViewModel: SplashScreenViewModel
 
@@ -42,8 +44,8 @@ class SplashScreenActivityTest {
         splashScreenViewModel = mock(SplashScreenViewModel::class.java)
 
         RobolectricHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
-            override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider, projectsRepository: ProjectsRepository, projectImporter: ProjectImporter): SplashScreenViewModel.Factory {
-                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter) {
+            override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider, projectsRepository: ProjectsRepository, projectImporter: ProjectImporter, appStateProvider: AppStateProvider): SplashScreenViewModel.Factory {
+                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter, appStateProvider) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return splashScreenViewModel as T
                     }
@@ -60,7 +62,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Fist Launch Screen should be displayed if the app is newly installed`() {
-        doReturn(true).`when`(splashScreenViewModel).isFirstLaunch()
+        doReturn(true).`when`(splashScreenViewModel).isFirstLaunch
 
         val scenario = ActivityScenario.launch(SplashScreenActivity::class.java)
         scenario.onActivity { activity: SplashScreenActivity ->
@@ -70,7 +72,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Fist Launch Screen should not be displayed if the app is not newly installed`() {
-        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist
 
@@ -82,7 +84,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Splash screen should be displayed with the default logo if it's enabled and no other logo is set`() {
-        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist
 
@@ -95,7 +97,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Splash screen should be displayed with custom logo if it's enabled and custom logo is set`() {
-        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(true).`when`(splashScreenViewModel).doesLogoFileExist
         doReturn(null).`when`(splashScreenViewModel).scaledSplashScreenLogoBitmap
@@ -111,7 +113,7 @@ class SplashScreenActivityTest {
     @ExperimentalCoroutinesApi
     @Test
     fun `The main menu should be displayed automatically after 2s if the Splash screen is enabled and the app is not newly installed`() = coroutineScope.runBlockingTest {
-        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist
 
@@ -129,7 +131,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The main menu should be displayed immediately if the splash screen is disabled and the app is not newly installed`() {
-        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch
         doReturn(false).`when`(splashScreenViewModel).shouldDisplaySplashScreen
 
         Intents.init()

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -8,22 +8,19 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
-import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.odk.collect.android.rules.MainCoroutineScopeRule
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel
 import org.odk.collect.android.fragments.dialogs.FirstLaunchDialog
@@ -35,14 +32,13 @@ import org.odk.collect.projects.ProjectsRepository
 
 @RunWith(AndroidJUnit4::class)
 class SplashScreenActivityTest {
-    private val testDispatcher = TestCoroutineDispatcher()
+    @get:Rule
+    val coroutineScope =  MainCoroutineScopeRule()
 
     private lateinit var splashScreenViewModel: SplashScreenViewModel
 
     @Before
     fun setup() {
-        Dispatchers.setMain(testDispatcher)
-
         splashScreenViewModel = mock(SplashScreenViewModel::class.java)
 
         RobolectricHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
@@ -54,11 +50,6 @@ class SplashScreenActivityTest {
                 }
             }
         })
-    }
-
-    @After
-    fun teardown() {
-        Dispatchers.resetMain()
     }
 
     @Test
@@ -119,7 +110,7 @@ class SplashScreenActivityTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun `The main menu should be displayed automatically after 2s if the Splash screen is enabled and the app is not newly installed`() = testDispatcher.runBlockingTest {
+    fun `The main menu should be displayed automatically after 2s if the Splash screen is enabled and the app is not newly installed`() = coroutineScope.runBlockingTest {
         doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -18,17 +18,14 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel
 import org.odk.collect.android.fragments.dialogs.FirstLaunchDialog
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.source.SettingsProvider
-import org.odk.collect.android.projects.ProjectImporter
 import org.odk.collect.android.rules.MainCoroutineScopeRule
 import org.odk.collect.android.support.RobolectricHelpers
 import org.odk.collect.android.utilities.AppStateProvider
-import org.odk.collect.projects.ProjectsRepository
 
 @RunWith(AndroidJUnit4::class)
 class SplashScreenActivityTest {
@@ -42,20 +39,14 @@ class SplashScreenActivityTest {
         splashScreenViewModel = mock(SplashScreenViewModel::class.java)
 
         RobolectricHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
-            override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider, projectsRepository: ProjectsRepository, projectImporter: ProjectImporter, appStateProvider: AppStateProvider): SplashScreenViewModel.Factory {
-                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), projectsRepository, projectImporter, appStateProvider) {
+            override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider, appStateProvider: AppStateProvider): SplashScreenViewModel.Factory {
+                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), appStateProvider) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return splashScreenViewModel as T
                     }
                 }
             }
         })
-    }
-
-    @Test
-    fun `importExistingProjectIfNeeded() should be called`() {
-        ActivityScenario.launch(SplashScreenActivity::class.java)
-        verify(splashScreenViewModel).importExistingProjectIfNeeded()
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -8,11 +8,10 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.Matchers.notNullValue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -20,17 +19,16 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.odk.collect.android.rules.MainCoroutineScopeRule
-import org.mockito.Mockito.spy
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel
 import org.odk.collect.android.fragments.dialogs.FirstLaunchDialog
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.projects.ProjectImporter
+import org.odk.collect.android.rules.MainCoroutineScopeRule
 import org.odk.collect.android.support.RobolectricHelpers
-import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.android.utilities.AppStateProvider
+import org.odk.collect.projects.ProjectsRepository
 
 @RunWith(AndroidJUnit4::class)
 class SplashScreenActivityTest {
@@ -45,7 +43,7 @@ class SplashScreenActivityTest {
 
         RobolectricHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
             override fun providesSplashScreenViewModel(settingsProvider: SettingsProvider, projectsRepository: ProjectsRepository, projectImporter: ProjectImporter, appStateProvider: AppStateProvider): SplashScreenViewModel.Factory {
-                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), settingsProvider.getMetaSettings(), projectsRepository, projectImporter, appStateProvider) {
+                return object : SplashScreenViewModel.Factory(settingsProvider.getGeneralSettings(), projectsRepository, projectImporter, appStateProvider) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return splashScreenViewModel as T
                     }
@@ -110,7 +108,6 @@ class SplashScreenActivityTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `The main menu should be displayed automatically after 2s if the Splash screen is enabled and the app is not newly installed`() = coroutineScope.runBlockingTest {
         doReturn(false).`when`(splashScreenViewModel).isFirstLaunch

--- a/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/SplashScreenActivityTest.kt
@@ -62,7 +62,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Fist Launch Screen should be displayed if the app is newly installed`() {
-        doReturn(true).`when`(splashScreenViewModel).shouldFirstLaunchDialogBeDisplayed()
+        doReturn(true).`when`(splashScreenViewModel).isFirstLaunch()
 
         val scenario = ActivityScenario.launch(SplashScreenActivity::class.java)
         scenario.onActivity { activity: SplashScreenActivity ->
@@ -72,7 +72,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Fist Launch Screen should not be displayed if the app is not newly installed`() {
-        doReturn(false).`when`(splashScreenViewModel).shouldFirstLaunchDialogBeDisplayed()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist
 
@@ -84,7 +84,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Splash screen should be displayed with the default logo if it's enabled and no other logo is set`() {
-        doReturn(false).`when`(splashScreenViewModel).shouldFirstLaunchDialogBeDisplayed()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist
 
@@ -97,7 +97,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The Splash screen should be displayed with custom logo if it's enabled and custom logo is set`() {
-        doReturn(false).`when`(splashScreenViewModel).shouldFirstLaunchDialogBeDisplayed()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(true).`when`(splashScreenViewModel).doesLogoFileExist
         doReturn(null).`when`(splashScreenViewModel).scaledSplashScreenLogoBitmap
@@ -113,7 +113,7 @@ class SplashScreenActivityTest {
     @ExperimentalCoroutinesApi
     @Test
     fun `The main menu should be displayed automatically after 2s if the Splash screen is enabled and the app is not newly installed`() = testDispatcher.runBlockingTest {
-        doReturn(false).`when`(splashScreenViewModel).shouldFirstLaunchDialogBeDisplayed()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
         doReturn(true).`when`(splashScreenViewModel).shouldDisplaySplashScreen
         doReturn(false).`when`(splashScreenViewModel).doesLogoFileExist
 
@@ -131,7 +131,7 @@ class SplashScreenActivityTest {
 
     @Test
     fun `The main menu should be displayed immediately if the splash screen is disabled and the app is not newly installed`() {
-        doReturn(false).`when`(splashScreenViewModel).shouldFirstLaunchDialogBeDisplayed()
+        doReturn(false).`when`(splashScreenViewModel).isFirstLaunch()
         doReturn(false).`when`(splashScreenViewModel).shouldDisplaySplashScreen
 
         Intents.init()

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
@@ -48,13 +48,13 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `shouldFirstLaunchDialogBeDisplayed() should return true if the app is newly installed`() {
-        assertThat(splashScreenViewModel.shouldFirstLaunchDialogBeDisplayed(), `is`(true))
+        assertThat(splashScreenViewModel.isFirstLaunch(), `is`(true))
         verify(metaSettings).save(MetaKeys.KEY_FIRST_LAUNCH, false)
     }
 
     @Test
     fun `shouldFirstLaunchDialogBeDisplayed() should return false if the app is not newly installed`() {
         `when`(metaSettings.contains(MetaKeys.KEY_FIRST_LAUNCH)).thenReturn(true)
-        assertThat(splashScreenViewModel.shouldFirstLaunchDialogBeDisplayed(), `is`(false))
+        assertThat(splashScreenViewModel.isFirstLaunch(), `is`(false))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
@@ -4,9 +4,10 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.android.preferences.source.SharedPreferencesSettings
@@ -22,8 +23,10 @@ class SplashScreenViewModelTest {
 
     @Before
     fun setup() {
-        generalSettings = Mockito.mock(SharedPreferencesSettings::class.java)
-        metaSettings = Mockito.mock(SharedPreferencesSettings::class.java)
+        generalSettings = mock(SharedPreferencesSettings::class.java)
+        metaSettings = mock(SharedPreferencesSettings::class.java)
+        projectsRepository = mock(ProjectsRepository::class.java)
+        projectImporter = mock(ProjectImporter::class.java)
         splashScreenViewModel = SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter)
     }
 
@@ -60,5 +63,21 @@ class SplashScreenViewModelTest {
     fun `shouldFirstLaunchDialogBeDisplayed() should return false if the app is not newly installed`() {
         `when`(metaSettings.contains(MetaKeys.KEY_FIRST_LAUNCH)).thenReturn(true)
         assertThat(splashScreenViewModel.isFirstLaunch(), `is`(false))
+    }
+
+    @Test
+    fun `Should existing project be imported when it's not first launch and projects repository is empty`() {
+        `when`(metaSettings.contains(MetaKeys.KEY_FIRST_LAUNCH)).thenReturn(true)
+        `when`(projectsRepository.getAll()).thenReturn(emptyList())
+        splashScreenViewModel.importExistingProjectIfNeeded()
+        verify(projectImporter).importExistingProject()
+    }
+
+    @Test
+    fun `Should not existing project be imported when it's first launch`() {
+        `when`(metaSettings.contains(MetaKeys.KEY_FIRST_LAUNCH)).thenReturn(false)
+        `when`(projectsRepository.getAll()).thenReturn(emptyList())
+        splashScreenViewModel.importExistingProjectIfNeeded()
+        verifyNoInteractions(projectImporter)
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
@@ -10,17 +10,21 @@ import org.mockito.Mockito.verify
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.android.preferences.source.SharedPreferencesSettings
+import org.odk.collect.android.projects.ProjectImporter
+import org.odk.collect.android.projects.ProjectsRepository
 
 class SplashScreenViewModelTest {
     private lateinit var generalSettings: SharedPreferencesSettings
     private lateinit var metaSettings: SharedPreferencesSettings
+    private lateinit var projectsRepository: ProjectsRepository
+    private lateinit var projectImporter: ProjectImporter
     private lateinit var splashScreenViewModel: SplashScreenViewModel
 
     @Before
     fun setup() {
         generalSettings = Mockito.mock(SharedPreferencesSettings::class.java)
         metaSettings = Mockito.mock(SharedPreferencesSettings::class.java)
-        splashScreenViewModel = SplashScreenViewModel(generalSettings, metaSettings)
+        splashScreenViewModel = SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter)
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
@@ -11,12 +11,11 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.source.SharedPreferencesSettings
 import org.odk.collect.android.projects.ProjectImporter
-import org.odk.collect.android.projects.ProjectsRepository
 import org.odk.collect.android.utilities.AppStateProvider
+import org.odk.collect.projects.ProjectsRepository
 
 class SplashScreenViewModelTest {
     private lateinit var generalSettings: SharedPreferencesSettings
-    private lateinit var metaSettings: SharedPreferencesSettings
     private lateinit var projectsRepository: ProjectsRepository
     private lateinit var projectImporter: ProjectImporter
     private lateinit var appStateProvider: AppStateProvider
@@ -25,11 +24,10 @@ class SplashScreenViewModelTest {
     @Before
     fun setup() {
         generalSettings = mock(SharedPreferencesSettings::class.java)
-        metaSettings = mock(SharedPreferencesSettings::class.java)
         projectsRepository = mock(ProjectsRepository::class.java)
         projectImporter = mock(ProjectImporter::class.java)
         appStateProvider = mock(AppStateProvider::class.java)
-        splashScreenViewModel = SplashScreenViewModel(generalSettings, metaSettings, projectsRepository, projectImporter, appStateProvider)
+        splashScreenViewModel = SplashScreenViewModel(generalSettings, projectsRepository, projectImporter, appStateProvider)
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/SplashScreenViewModelTest.kt
@@ -6,28 +6,20 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.preferences.source.SharedPreferencesSettings
-import org.odk.collect.android.projects.ProjectImporter
 import org.odk.collect.android.utilities.AppStateProvider
-import org.odk.collect.projects.ProjectsRepository
 
 class SplashScreenViewModelTest {
     private lateinit var generalSettings: SharedPreferencesSettings
-    private lateinit var projectsRepository: ProjectsRepository
-    private lateinit var projectImporter: ProjectImporter
     private lateinit var appStateProvider: AppStateProvider
     private lateinit var splashScreenViewModel: SplashScreenViewModel
 
     @Before
     fun setup() {
         generalSettings = mock(SharedPreferencesSettings::class.java)
-        projectsRepository = mock(ProjectsRepository::class.java)
-        projectImporter = mock(ProjectImporter::class.java)
         appStateProvider = mock(AppStateProvider::class.java)
-        splashScreenViewModel = SplashScreenViewModel(generalSettings, projectsRepository, projectImporter, appStateProvider)
+        splashScreenViewModel = SplashScreenViewModel(generalSettings, appStateProvider)
     }
 
     @Test
@@ -63,21 +55,5 @@ class SplashScreenViewModelTest {
     fun `isFirstLaunch should return false if the app is not newly installed`() {
         `when`(appStateProvider.isFreshInstall()).thenReturn(false)
         assertThat(splashScreenViewModel.isFirstLaunch, `is`(false))
-    }
-
-    @Test
-    fun `Should existing project be imported when it's not first launch and projects repository is empty`() {
-        `when`(appStateProvider.isFreshInstall()).thenReturn(false)
-        `when`(projectsRepository.getAll()).thenReturn(emptyList())
-        splashScreenViewModel.importExistingProjectIfNeeded()
-        verify(projectImporter).importExistingProject()
-    }
-
-    @Test
-    fun `Should not existing project be imported when it's first launch`() {
-        `when`(appStateProvider.isFreshInstall()).thenReturn(true)
-        `when`(projectsRepository.getAll()).thenReturn(emptyList())
-        splashScreenViewModel.importExistingProjectIfNeeded()
-        verifyNoInteractions(projectImporter)
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
@@ -1,0 +1,76 @@
+package org.odk.collect.android.application.initialization
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.gson.Gson
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.odk.collect.android.application.Collect
+import org.odk.collect.android.injection.DaggerUtils
+import org.odk.collect.android.injection.config.AppDependencyModule
+import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.android.projects.ProjectImporter
+import org.odk.collect.android.support.RobolectricHelpers
+import org.odk.collect.android.utilities.AppStateProvider
+import org.odk.collect.projects.ProjectsRepository
+import org.odk.collect.shared.UUIDGenerator
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ApplicationInitializerTest {
+    @Mock
+    lateinit var appStateProvider: AppStateProvider
+
+    @Mock
+    lateinit var projectsRepository: ProjectsRepository
+
+    @Mock
+    lateinit var projectImporter: ProjectImporter
+
+    lateinit var applicationInitializer: ApplicationInitializer
+
+    @Before
+    fun setup() {
+        appStateProvider = mock(AppStateProvider::class.java)
+        projectsRepository = mock(ProjectsRepository::class.java)
+        projectImporter = mock(ProjectImporter::class.java)
+
+        RobolectricHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
+            override fun providesAppStateProvider(context: Context): AppStateProvider {
+                return appStateProvider
+            }
+
+            override fun providesProjectsRepository(uuidGenerator: UUIDGenerator, gson: Gson, settingsProvider: SettingsProvider): ProjectsRepository {
+                return projectsRepository
+            }
+
+            override fun providesProjectImporter(projectsRepository: ProjectsRepository, settingsProvider: SettingsProvider): ProjectImporter {
+                return projectImporter
+            }
+        })
+
+        applicationInitializer = DaggerUtils.getComponent(ApplicationProvider.getApplicationContext<Collect>()).applicationInitializer()
+    }
+
+    @Test
+    fun `Should existing project be imported when it's not first launch and projects repository is empty`() {
+        `when`(appStateProvider.isFreshInstall()).thenReturn(false)
+        `when`(projectsRepository.getAll()).thenReturn(emptyList())
+        applicationInitializer.initialize()
+        verify(projectImporter).importExistingProject()
+    }
+
+    @Test
+    fun `Should not existing project be imported when it's first launch`() {
+        `when`(appStateProvider.isFreshInstall()).thenReturn(true)
+        `when`(projectsRepository.getAll()).thenReturn(emptyList())
+        applicationInitializer.initialize()
+        verifyNoInteractions(projectImporter)
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectImporterTest.kt
@@ -28,4 +28,11 @@ class ProjectImporterTest {
         verify(projectsRepository).add(Project("Demo project", "D", "#3e9fcc", DEMO_PROJECT_ID))
         verify(metaSettings).save(MetaKeys.CURRENT_PROJECT_ID, DEMO_PROJECT_ID)
     }
+
+    @Test
+    fun `Existed project should be imported when importExistingProject() called`() {
+        projectImporter.importExistingProject()
+        verify(projectsRepository).add(Project("Demo project", "D", "#3e9fcc", DEMO_PROJECT_ID))
+        verify(metaSettings).save(MetaKeys.CURRENT_PROJECT_ID, DEMO_PROJECT_ID)
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/rules/MainCoroutineScopeRule.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/rules/MainCoroutineScopeRule.kt
@@ -1,0 +1,26 @@
+package org.odk.collect.android.rules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class MainCoroutineScopeRule(private val dispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()) :
+    TestWatcher(),
+    TestCoroutineScope by TestCoroutineScope(dispatcher) {
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/projects/src/main/java/org/odk/collect/projects/InMemProjectsRepository.kt
+++ b/projects/src/main/java/org/odk/collect/projects/InMemProjectsRepository.kt
@@ -10,7 +10,7 @@ class InMemProjectsRepository(private val uuidGenerator: UUIDGenerator) : Projec
     override fun getAll() = projects
 
     override fun add(project: Project) {
-        if (project.uuid.isBlank()) {
+        if (project.uuid == NOT_SPECIFIED_UUID) {
             projects.add(project.copy(uuid = uuidGenerator.generateUUID()))
         } else {
             projects.add(project)

--- a/projects/src/main/java/org/odk/collect/projects/Project.kt
+++ b/projects/src/main/java/org/odk/collect/projects/Project.kt
@@ -1,8 +1,10 @@
 package org.odk.collect.projects
 
+const val NOT_SPECIFIED_UUID = "not_specified"
+
 data class Project(
     val name: String,
     val icon: String,
     val color: String,
-    val uuid: String = "",
+    val uuid: String = NOT_SPECIFIED_UUID,
 )

--- a/projects/src/main/java/org/odk/collect/projects/SharedPreferencesProjectsRepository.kt
+++ b/projects/src/main/java/org/odk/collect/projects/SharedPreferencesProjectsRepository.kt
@@ -26,7 +26,7 @@ class SharedPreferencesProjectsRepository(
     }
 
     override fun add(project: Project) {
-        val projects = if (project.uuid.isBlank()) {
+        val projects = if (project.uuid == NOT_SPECIFIED_UUID) {
             getAll().toMutableList().plus(project.copy(uuid = uuidGenerator.generateUUID()))
         } else {
             getAll().toMutableList().plus(project)

--- a/projects/src/test/java/org/odk/collect/projects/ProjectsRepositoryTest.kt
+++ b/projects/src/test/java/org/odk/collect/projects/ProjectsRepositoryTest.kt
@@ -6,6 +6,7 @@ import org.hamcrest.Matchers.isEmptyString
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
+import org.odk.collect.android.projects.ProjectImporter.Companion.DEMO_PROJECT_ID
 
 abstract class ProjectsRepositoryTest {
     private val projectX = Project("ProjectX", "X", "#FF0000")
@@ -53,8 +54,8 @@ abstract class ProjectsRepositoryTest {
 
     @Test
     fun `add() should not add uuid if specified`() {
-        projectsRepository.add(projectX.copy(uuid = "1"))
-        assertThat(projectsRepository.get("1"), `is`(projectX.copy(uuid = "1")))
+        projectsRepository.add(projectX.copy(uuid = DEMO_PROJECT_ID))
+        assertThat(projectsRepository.get(""), `is`(projectX.copy(uuid = DEMO_PROJECT_ID)))
     }
 
     @Test

--- a/projects/src/test/java/org/odk/collect/projects/ProjectsRepositoryTest.kt
+++ b/projects/src/test/java/org/odk/collect/projects/ProjectsRepositoryTest.kt
@@ -6,7 +6,6 @@ import org.hamcrest.Matchers.isEmptyString
 import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
-import org.odk.collect.android.projects.ProjectImporter.Companion.DEMO_PROJECT_ID
 
 abstract class ProjectsRepositoryTest {
     private val projectX = Project("ProjectX", "X", "#FF0000")
@@ -54,8 +53,8 @@ abstract class ProjectsRepositoryTest {
 
     @Test
     fun `add() should not add uuid if specified`() {
-        projectsRepository.add(projectX.copy(uuid = DEMO_PROJECT_ID))
-        assertThat(projectsRepository.get(""), `is`(projectX.copy(uuid = DEMO_PROJECT_ID)))
+        projectsRepository.add(projectX.copy(uuid = ""))
+        assertThat(projectsRepository.get(""), `is`(projectX.copy(uuid = "")))
     }
 
     @Test


### PR DESCRIPTION
Closes #4418

#### What has been done to verify that this works as intended?
I tested the change manually and ran tests.

#### Why is this the best possible solution? Were any other approaches considered?
Importing the existing project is pretty clear and obvious but I need to explain other changes I added here:
- [b14a7bb](https://github.com/getodk/collect/commit/b14a7bb2a34431bb3ba6ed552afb8bdb11516dab) it's just an improvement. I introduced a rule that we will be able to reuse in the future as recommended in https://developer.android.com/codelabs/kotlin-coroutines#5
- [16c2445](https://github.com/getodk/collect/commit/16c2445b98c1a3e4b4818b3e373798d3b1b45091) - I realized that I made a mistake my previous approach with sharedprefs to detect first launch was faulty because it retuned true for upgrades since the preference I used didn't exist in v1.30.
- [8eb2ef5](https://github.com/getodk/collect/commit/8eb2ef50668f9056d57d7ef7349e1e400b12141d) here I fixed managing preferences. I realized that the demo project should have empty string uuid so that we can by default use preferences that existed in v1.30. For example for admin preferences values were saved using `admin_prefs` key, with current implementation if we had two project: the default one and projectX (with uuid 1234) we can access those prefs just adding their uuid to `admin_prefs`:
  - for the demo project it would be `admin_prefs` + `"" `= just `admin_prefs` - existing admin prefs will be used
  - for the projectX it would be `admin_prefs` + `1234` = `admin_prefs1234`
   (see SettingsProvider class)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This will be tested later as a whole feature.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)