### PR TITLE
Use larger machine to speed up Circle CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,14 @@ references:
     docker:
       - image: circleci/android:api-30
     resource_class: xlarge
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:+UseContainerSupport -XX:MaxRAMPercentage=90.0" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
 
 jobs:
   compile:
     <<: *android_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
-
       - run:
           name: Generate combined build.gradle file for cache key
           command: cat build.gradle */build.gradle > deps.txt
@@ -42,8 +41,6 @@ jobs:
 
   check_quality:
     <<: *android_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -59,8 +56,6 @@ jobs:
 
   test_modules:
     <<: *android_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -107,8 +102,6 @@ jobs:
 
   test_app:
     <<: *android_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -138,8 +131,6 @@ jobs:
 
   build_instrumented:
     <<: *android_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -152,8 +143,6 @@ jobs:
 
   test_instrumented:
     <<: *android_config
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ references:
       - image: circleci/android:api-30
     resource_class: xlarge
     environment:
+      ROBOLECTRIC_HEAP_SIZE: '14336m'
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:+UseContainerSupport -XX:MaxRAMPercentage=90.0" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,13 @@ references:
     working_directory: ~/work
     docker:
       - image: circleci/android:api-30
+    resource_class: xlarge
 
 jobs:
   compile:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - checkout
 
@@ -24,7 +25,7 @@ jobs:
           key: deps-{{ checksum "deps.txt" }}
       - run:
           name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
@@ -32,7 +33,7 @@ jobs:
 
       - run:
           name: Compile code
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 assembleDebug
 
       - persist_to_workspace:
           root: ~/work
@@ -42,7 +43,7 @@ jobs:
   check_quality:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -51,7 +52,7 @@ jobs:
 
       - run:
           name: Run code quality checks
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 checkCode
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 checkCode
       - store_artifacts:
           path: collect_app/build/reports
           destination: reports
@@ -59,7 +60,7 @@ jobs:
   test_modules:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -70,28 +71,28 @@ jobs:
 
       - run:
           name: Run shared unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 shared:test
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 shared:test
       - run:
           name: Run formtest unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 formstest:test
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 formstest:test
       - run:
           name: Run async unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 async:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 async:testDebug
       - run:
           name: Run strings unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 strings:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 strings:testDebug
       - run:
           name: Run material unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 material:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 material:testDebug
       - run:
           name: Run audioclips unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 audioclips:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 audioclips:testDebug
       - run:
           name: Run audiorecorder unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 audiorecorder:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 audiorecorder:testDebug
       - run:
           name: Run projects unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 projects:test
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 projects:test
 
       - save_cache:
           paths:
@@ -107,7 +108,7 @@ jobs:
   test_app:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -118,11 +119,11 @@ jobs:
 
       - run:
           name: Compile app unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:compileDebugUnitTestSources
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:compileDebugUnitTestSources
 
       - run:
           name: Run app unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:testDebug
 
       - save_cache:
           paths:
@@ -138,7 +139,7 @@ jobs:
   build_instrumented:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -147,12 +148,12 @@ jobs:
 
       - run:
           name: Assemble connected test build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 assembleDebugAndroidTest
 
   test_instrumented:
     <<: *android_config
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m" -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx12g" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
     steps:
       - attach_workspace:
           at: ~/work
@@ -161,7 +162,7 @@ jobs:
 
       - run:
           name: Assemble test build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug assembleDebugAndroidTest
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 assembleDebug assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ references:
     resource_class: xlarge
     environment:
       ROBOLECTRIC_HEAP_SIZE: '14336m'
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-XX:+UseContainerSupport -XX:MaxRAMPercentage=90.0" -Dorg.gradle.parallel="true" -Dkotlin.compiler.execution.strategy=in-process'
 
 jobs:
   compile:
@@ -20,12 +19,15 @@ jobs:
       - checkout
       - run:
           name: Generate combined build.gradle file for cache key
-          command: cat build.gradle */build.gradle > deps.txt
+          command: cat build.gradle */build.gradle .circleci/gradle.properties > deps.txt
       - restore_cache:
           key: deps-{{ checksum "deps.txt" }}
       - run:
           name: Download dependencies
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 androidDependencies
+      - run:
+          name: Copy gradle config
+          command: cp .circleci/gradle.properties ~/.gradle/gradle.properties
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ references:
     docker:
       - image: circleci/android:api-30
     resource_class: xlarge
-    environment:
-      ROBOLECTRIC_HEAP_SIZE: '14336m'
 
 jobs:
   compile:

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx14336M -Dkotlin.daemon.jvm.options\="-Xmx14336M"
+robolectricHeapSize=14336m
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx14336M -Dkotlin.daemon.jvm.options\="-Xmx14336M"
+org.gradle.parallel=true
+kotlin.compiler.execution.strategy=in-process

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -193,9 +193,6 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
-            all {
-                maxHeapSize = "1024m"
-            }
         }
     }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -194,7 +194,7 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
             all {
-                maxHeapSize = "${System.env.ROBOLECTRIC_HEAP_SIZE != null ? System.env.ROBOLECTRIC_HEAP_SIZE : "2048m"}"
+                maxHeapSize = robolectricHeapSize
             }
         }
     }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -193,6 +193,9 @@ android {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
+            all {
+                maxHeapSize = "14336m"
+            }
         }
     }
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -194,7 +194,7 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
             all {
-                maxHeapSize = "14336m"
+                maxHeapSize = "${System.env.ROBOLECTRIC_HEAP_SIZE != null ? System.env.ROBOLECTRIC_HEAP_SIZE : "2048m"}"
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M"
+robolectricHeapSize=1024m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
 #You can override this in ~/.gradle/gradle.properties
-org.gradle.jvmargs=-Xmx1024m
-
 android.useAndroidX=true
 android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 #You can override this in ~/.gradle/gradle.properties
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M"


### PR DESCRIPTION
These changes (especially @seadowg's) reduce the build from 19m to about 10m. We can get more improvement if we run tests by package name (or by timing) so that the slowest part of the build (testDebug) can be run in parallel.

The change to gradle.properties might result in faster or slower local tests depending what the defaults everyone has on their machine, but I don't think that should be a blocker to merging.
