### PR TITLE
Stop caching settings statically to prevent state leaks in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           command: ls -R collect_app/src/test/java/ | grep Test.kt >> collect_app_test_files.txt
       - run:
           name: Convert test file list to test class list
-          command: cat collect_app_test_files.txt | sed 's@/@.@g' | sed "s/\.java//" | sed "s/\.kt//" > collect_app_test_classes.txt
+          command: cat collect_app_test_files.txt | sed "s/\.java//" | sed "s/\.kt//" > collect_app_test_classes.txt
 
       - run:
           name: Generate list of tests for this fork

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
 
   test_app:
     <<: *android_config
-    parallelism: 25
+    parallelism: 50
     steps:
       - attach_workspace:
           at: ~/work
@@ -110,8 +110,22 @@ jobs:
           key: deps-robolectric-{{ checksum "deps.txt" }}
 
       - run:
+          name: Generate list of test Java tests
+          command: ls -R collect_app/src/test/java/ | grep Test.java >> collect_app_test_files.txt
+      - run:
+          name: Generate list of test Kotlin tests
+          command: ls -R collect_app/src/test/java/ | grep Test.kt >> collect_app_test_files.txt
+      - run:
+          name: Convert test file list to test class list
+          command: cat collect_app_test_files.txt | sed 's@/@.@g' | sed "s/\.java//" | sed "s/\.kt//" > collect_app_test_classes.txt
+
+      - run:
+          name: Generate list of tests for this fork
+          command: cat collect_app_test_classes.txt | circleci tests split > fork_test_classes.txt
+      - run:
           name: Run app unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:testDebug $(ls collect_app/src/test/java/org/odk/collect/android/ | circleci tests split | awk '{for (i=1; i<=NF; i++) printf "--tests org.odk.collect.android.%s* ",$i}')
+          command: |
+            ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:testDebug $(cat fork_test_classes.txt | awk '{for (i=1; i<=NF; i++) printf "--tests %s ",$i}')
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
 
   test_app:
     <<: *android_config
+    parallelism: 10
     steps:
       - attach_workspace:
           at: ~/work
@@ -109,12 +110,8 @@ jobs:
           key: deps-robolectric-{{ checksum "deps.txt" }}
 
       - run:
-          name: Compile app unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:compileDebugUnitTestSources
-
-      - run:
           name: Run app unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:testDebug
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=8 collect_app:testDebug $(ls collect_app/src/test/java/org/odk/collect/android/ | circleci tests split | awk '{for (i=1; i<=NF; i++) printf "--tests org.odk.collect.android.%s* ",$i}')
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
 
   test_app:
     <<: *android_config
-    parallelism: 10
+    parallelism: 25
     steps:
       - attach_workspace:
           at: ~/work

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/forms/FormNavigationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/forms/FormNavigationTest.java
@@ -46,7 +46,7 @@ import static junit.framework.Assert.assertEquals;
  * need to navigate to an index of the first question of all we want to display on one page.
  */
 @RunWith(Parameterized.class)
-public class FormNavigationTestCase {
+public class FormNavigationTest {
 
     @Parameters(name = "{0}")
     public static Iterable<Object[]> data() {
@@ -81,7 +81,7 @@ public class FormNavigationTestCase {
     private final String formName;
     private final String[] expectedIndices;
 
-    public FormNavigationTestCase(String formName, String[] expectedIndices) {
+    public FormNavigationTest(String formName, String[] expectedIndices) {
         this.formName = formName;
         this.expectedIndices = expectedIndices;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -68,11 +68,9 @@ import org.odk.collect.android.preferences.screens.IdentityPreferencesFragment;
 import org.odk.collect.android.preferences.screens.ServerPreferencesFragment;
 import org.odk.collect.android.preferences.screens.UserInterfacePreferencesFragment;
 import org.odk.collect.android.preferences.source.SettingsProvider;
-import org.odk.collect.projects.AddProjectDialog;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.projects.ProjectImporter;
 import org.odk.collect.android.projects.ProjectSettingsDialog;
-import org.odk.collect.projects.ProjectsRepository;
 import org.odk.collect.android.provider.FormsProvider;
 import org.odk.collect.android.provider.InstanceProvider;
 import org.odk.collect.android.storage.StorageInitializer;
@@ -83,6 +81,8 @@ import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.odk.collect.android.widgets.ExStringWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
+import org.odk.collect.projects.AddProjectDialog;
+import org.odk.collect.projects.ProjectsRepository;
 
 import javax.inject.Singleton;
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -10,30 +10,24 @@ import org.odk.collect.projects.NOT_SPECIFIED_UUID
 import org.odk.collect.shared.Settings
 
 class SettingsProvider(private val context: Context) {
-    fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
-        SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE))
-    }
+
+    fun getMetaSettings() = SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE))
 
     @JvmOverloads
     fun getGeneralSettings(projectId: String = NOT_SPECIFIED_UUID): Settings {
         val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
 
-        return settings.getOrPut(settingsId) {
-            if (settingsId == GENERAL_SETTINGS_NAME) {
-                SharedPreferencesSettings(PreferenceManager.getDefaultSharedPreferences(context), GeneralKeys.DEFAULTS)
-            } else {
-                SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
-            }
+        return if (settingsId == GENERAL_SETTINGS_NAME) {
+            SharedPreferencesSettings(PreferenceManager.getDefaultSharedPreferences(context), GeneralKeys.DEFAULTS)
+        } else {
+            SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
         }
     }
 
     @JvmOverloads
     fun getAdminSettings(projectId: String = NOT_SPECIFIED_UUID): Settings {
         val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
-
-        return settings.getOrPut(settingsId) {
-            SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), AdminKeys.getDefaults())
-        }
+        return SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), AdminKeys.getDefaults())
     }
 
     private fun getSettingsId(settingName: String, projectId: String) = if (projectId == NOT_SPECIFIED_UUID) {
@@ -43,8 +37,6 @@ class SettingsProvider(private val context: Context) {
     }
 
     companion object {
-        private val settings = mutableMapOf<String, Settings>()
-
         private const val META_SETTINGS_NAME = "meta"
         private const val GENERAL_SETTINGS_NAME = "general_prefs"
         private const val ADMIN_SETTINGS_NAME = "admin_prefs"

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -8,7 +8,9 @@ import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
 import org.odk.collect.android.projects.ProjectImporter.Companion.DEMO_PROJECT_ID
 import org.odk.collect.projects.NOT_SPECIFIED_UUID
 import org.odk.collect.shared.Settings
+import javax.inject.Singleton
 
+@Singleton
 class SettingsProvider(private val context: Context) {
 
     private val settings = mutableMapOf<String, Settings>()

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -11,23 +11,32 @@ import org.odk.collect.shared.Settings
 
 class SettingsProvider(private val context: Context) {
 
-    fun getMetaSettings() = SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE))
+    private val settings = mutableMapOf<String, Settings>()
+
+    fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
+        SharedPreferencesSettings(context.getSharedPreferences(META_SETTINGS_NAME, Context.MODE_PRIVATE))
+    }
 
     @JvmOverloads
     fun getGeneralSettings(projectId: String = NOT_SPECIFIED_UUID): Settings {
         val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
 
-        return if (settingsId == GENERAL_SETTINGS_NAME) {
-            SharedPreferencesSettings(PreferenceManager.getDefaultSharedPreferences(context), GeneralKeys.DEFAULTS)
-        } else {
-            SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
+        return settings.getOrPut(settingsId) {
+            if (settingsId == GENERAL_SETTINGS_NAME) {
+                SharedPreferencesSettings(PreferenceManager.getDefaultSharedPreferences(context), GeneralKeys.DEFAULTS)
+            } else {
+                SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), GeneralKeys.DEFAULTS)
+            }
         }
     }
 
     @JvmOverloads
     fun getAdminSettings(projectId: String = NOT_SPECIFIED_UUID): Settings {
         val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
-        return SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), AdminKeys.getDefaults())
+
+        return settings.getOrPut(settingsId) {
+            SharedPreferencesSettings(context.getSharedPreferences(settingsId, Context.MODE_PRIVATE), AdminKeys.getDefaults())
+        }
     }
 
     private fun getSettingsId(settingName: String, projectId: String) = if (projectId == NOT_SPECIFIED_UUID) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettings.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettings.kt
@@ -5,7 +5,8 @@ import org.odk.collect.shared.Settings
 import java.util.Collections
 
 class SharedPreferencesSettings(private val sharedPreferences: SharedPreferences, private val settingKeysToDefaults: Map<String, Any> = emptyMap()) : Settings {
-    private lateinit var sharedPreferencesListener: SharedPreferences.OnSharedPreferenceChangeListener
+
+    private var sharedPreferencesListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
 
     override fun setDefaultForAllSettingsWithoutValues() {
         for ((key, value) in settingKeysToDefaults) {

--- a/collect_app/src/test/java/org/odk/collect/android/application/RobolectricApplication.java
+++ b/collect_app/src/test/java/org/odk/collect/android/application/RobolectricApplication.java
@@ -3,13 +3,10 @@ package org.odk.collect.android.application;
 import androidx.work.Configuration;
 import androidx.work.WorkManager;
 
-import org.odk.collect.android.database.forms.FormsDatabaseProvider;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowApplication;
-
-import javax.inject.Inject;
 
 import static org.robolectric.Shadows.shadowOf;
 
@@ -18,9 +15,6 @@ import static org.robolectric.Shadows.shadowOf;
  */
 
 public class RobolectricApplication extends Collect {
-
-    @Inject
-    FormsDatabaseProvider formsDatabaseProvider;
 
     @Override
     public void onCreate() {

--- a/collect_app/src/test/java/org/odk/collect/android/support/ShadowPlayServicesUtil.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/ShadowPlayServicesUtil.java
@@ -1,4 +1,4 @@
-package org.odk.collect.android;
+package org.odk.collect.android.support;
 
 import android.content.Context;
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/CustomSQLiteQueryBuilderTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public class CustomSQLiteQueryBuilderTestCase {
+public class CustomSQLiteQueryBuilderTest {
 
     private final String[] columns = {"_id", "col1", "col2", "col3"};
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
@@ -18,6 +18,8 @@ import org.robolectric.RuntimeEnvironment;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotSame;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_APP_THEME;
 
 /**
@@ -29,7 +31,7 @@ public class ThemeUtilsTest {
     private final int[] attrs;
     private ThemeUtils themeUtils;
     private MainMenuActivity mainMenuActivity;
-    private final Settings generalSettings = TestSettingsProvider.getGeneralSettings();
+    private Settings generalSettings;
 
     public ThemeUtilsTest() {
         attrs = new int[]{
@@ -46,6 +48,7 @@ public class ThemeUtilsTest {
 
         mainMenuActivity = Robolectric.setupActivity(MainMenuActivity.class);
         themeUtils = new ThemeUtils(mainMenuActivity);
+        generalSettings = TestSettingsProvider.getGeneralSettings();
     }
 
     @Test
@@ -117,6 +120,7 @@ public class ThemeUtilsTest {
 
     private void applyDarkTheme() {
         generalSettings.save(KEY_APP_THEME, mainMenuActivity.getString(R.string.app_theme_dark));
+        assertThat(generalSettings.getString(KEY_APP_THEME), is(mainMenuActivity.getString(R.string.app_theme_dark)));
     }
 
     private void applyLightTheme() {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
@@ -24,14 +24,14 @@ import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_APP_THEME
  * Unit tests for checking the behaviour of updating themes from User Interface settings
  */
 @RunWith(RobolectricTestRunner.class)
-public class ThemeUtilsTests {
+public class ThemeUtilsTest {
 
     private final int[] attrs;
     private ThemeUtils themeUtils;
     private MainMenuActivity mainMenuActivity;
     private final Settings generalSettings = TestSettingsProvider.getGeneralSettings();
 
-    public ThemeUtilsTests() {
+    public ThemeUtilsTest() {
         attrs = new int[]{
                 android.R.attr.alertDialogTheme,
                 android.R.attr.searchViewStyle,


### PR DESCRIPTION
Follow ups to this:

- [x] Identify stalling test(s)
- [x] Find missing tests (it looks like we're 10 short)
- [x] Move bash into a script so it's not littered in Circle CI config

#### What has been done to verify that this works as intended?

Ran tests.

#### Why is this the best possible solution? Were any other approaches considered?

Just moves caching of `SharedPreferencesSettings` away from the `companion` so it doesn't create any static state leaks between tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be safe to merge without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)