### PR TITLE
Create one style for dialogs

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingErrorDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingErrorDialogFragment.java
@@ -7,9 +7,8 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -37,7 +36,7 @@ public class AudioRecordingErrorDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        MaterialAlertDialogBuilder dialogBuilder = new MaterialAlertDialogBuilder(requireContext())
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(requireContext())
                 .setPositiveButton(R.string.ok, null);
 
         if (exception != null && exception.getValue() instanceof MicInUseException) {

--- a/collect_app/src/main/java/org/odk/collect/android/audio/BackgroundAudioHelpDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/BackgroundAudioHelpDialogFragment.java
@@ -7,9 +7,8 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -20,7 +19,7 @@ public class BackgroundAudioHelpDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         LayoutInflater inflater = LayoutInflater.from(requireContext());
         View view = inflater.inflate(R.layout.background_audio_help_fragment_layout, null);
-        return new MaterialAlertDialogBuilder(requireContext())
+        return new AlertDialog.Builder(requireContext())
                 .setView(view)
                 .setPositiveButton(R.string.ok, null)
                 .create();

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/ShowQRCodeFragment.java
@@ -12,7 +12,6 @@
 
 package org.odk.collect.android.configure.qr;
 
-import android.app.AlertDialog;
 import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -24,6 +23,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.AppCompatCheckedTextView;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
@@ -7,11 +7,10 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -44,7 +43,7 @@ public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
         setCancelable(false);
 
         final FragmentActivity activity = requireActivity();
-        return new MaterialAlertDialogBuilder(requireContext())
+        return new AlertDialog.Builder(requireContext())
                 .setMessage(R.string.background_audio_permission_explanation)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     onOKClicked(activity);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -6,9 +6,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
@@ -148,14 +147,14 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
             boolean enabled = !item.isChecked();
 
             if (!enabled) {
-                new MaterialAlertDialogBuilder(activity)
+                new AlertDialog.Builder(activity)
                         .setMessage(R.string.stop_recording_confirmation)
                         .setPositiveButton(R.string.disable_recording, (dialog, which) -> backgroundAudioViewModel.setBackgroundRecordingEnabled(false))
                         .setNegativeButton(R.string.cancel, null)
                         .create()
                         .show();
             } else {
-                new MaterialAlertDialogBuilder(activity)
+                new AlertDialog.Builder(activity)
                         .setMessage(R.string.background_audio_recording_enabled_explanation)
                         .setCancelable(false)
                         .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RecordingWarningDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RecordingWarningDialogFragment.java
@@ -5,9 +5,8 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -16,7 +15,7 @@ public class RecordingWarningDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        return new MaterialAlertDialogBuilder(requireActivity())
+        return new AlertDialog.Builder(requireActivity())
                 .setTitle(R.string.recording)
                 .setMessage(R.string.recording_warning)
                 .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/SaveAnswerFileErrorDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/SaveAnswerFileErrorDialogFragment.java
@@ -7,10 +7,9 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -35,7 +34,7 @@ public class SaveAnswerFileErrorDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        return new MaterialAlertDialogBuilder(requireContext())
+        return new AlertDialog.Builder(requireContext())
                 .setTitle(R.string.error_occured)
                 .setMessage(getString(R.string.answer_file_copy_failed_message, formSaveViewModel.getAnswerFileError().getValue()))
                 .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomTimePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomTimePickerDialog.java
@@ -4,13 +4,10 @@ import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.format.DateFormat;
 import android.util.AttributeSet;
-import android.view.Window;
 import android.widget.TimePicker;
 
 import androidx.annotation.NonNull;
@@ -64,10 +61,6 @@ public class CustomTimePickerDialog extends DialogFragment {
         fixSpinner(requireContext(), dialog, viewModel.getLocalDateTime().getHourOfDay(),
                 viewModel.getLocalDateTime().getMinuteOfHour(), DateFormat.is24HourFormat(requireContext()));
 
-        Window window = dialog.getWindow();
-        if (window != null) {
-            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-        }
         return dialog;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FixedDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FixedDatePickerDialog.java
@@ -5,13 +5,10 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.Window;
 import android.widget.DatePicker;
 
 import androidx.annotation.NonNull;
@@ -65,16 +62,11 @@ public class FixedDatePickerDialog extends DialogFragment {
         DatePickerDialog dialog = new DatePickerDialog(requireActivity(), viewModel.getDialogTheme(), viewModel.getDateSetListener(),
                 viewModel.getLocalDateTime().getYear(), viewModel.getLocalDateTime().getMonthOfYear() - 1, viewModel.getLocalDateTime().getDayOfMonth());
 
-        if (themeUtils.isHoloDialogTheme(viewModel.getDialogTheme())) {
+        if (themeUtils.isSpinnerDatePickerDialogTheme(viewModel.getDialogTheme())) {
             dialog.setTitle(requireContext().getString(R.string.select_date));
             fixSpinner(requireContext(), dialog, viewModel.getLocalDateTime().getYear(), viewModel.getLocalDateTime().getMonthOfYear() - 1,
                     viewModel.getLocalDateTime().getDayOfMonth());
             hidePickersIfNeeded(dialog, viewModel.getLocalDateTime());
-
-            Window window = dialog.getWindow();
-            if (window != null) {
-                window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-            }
 
             //noinspection deprecation
             dialog.getDatePicker().setCalendarViewShown(false);

--- a/collect_app/src/main/java/org/odk/collect/android/permissions/PermissionsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/permissions/PermissionsProvider.java
@@ -223,7 +223,7 @@ public class PermissionsProvider {
     }
 
     protected void showAdditionalExplanation(Activity activity, int title, int message, int drawable, @NonNull PermissionListener action) {
-        AlertDialog alertDialog = new AlertDialog.Builder(activity, R.style.Theme_Collect_Dialog_PermissionAlert)
+        AlertDialog alertDialog = new AlertDialog.Builder(activity)
                 .setTitle(title)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> action.denied())

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/AdminPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/AdminPreferencesFragment.java
@@ -23,11 +23,10 @@ import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.preference.EditTextPreference;
 import androidx.preference.Preference;
-
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.ActivityUtils;
@@ -134,7 +133,7 @@ public class AdminPreferencesFragment extends BaseAdminPreferencesFragment
                     startActivity(pref);
                     break;
                 case DELETE_PROJECT_KEY:
-                    new MaterialAlertDialogBuilder(requireActivity())
+                    new AlertDialog.Builder(requireActivity())
                             .setTitle(R.string.delete_project_confirm_message)
                             .setNegativeButton(R.string.delete_project_no, (dialog, which) -> { })
                             .setPositiveButton(R.string.delete_project_yes, (dialog, which) -> deleteProject())

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -1,15 +1,13 @@
 package org.odk.collect.android.projects
 
+import android.app.Dialog
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
-import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.R
@@ -53,17 +51,10 @@ class ProjectSettingsDialog : DialogFragment() {
         currentProjectViewModel = ViewModelProvider(requireActivity(), currentProjectViewModelFactory)[CurrentProjectViewModel::class.java]
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        binding = ProjectSettingsDialogLayoutBinding.inflate(inflater)
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        binding = ProjectSettingsDialogLayoutBinding.inflate(LayoutInflater.from(context))
         setupCurrentProjectView()
-        inflateListOfInActiveProjects(view.context)
+        inflateListOfInActiveProjects(requireContext())
 
         binding.closeIcon.setOnClickListener {
             dismiss()
@@ -95,6 +86,10 @@ class ProjectSettingsDialog : DialogFragment() {
             startActivity(Intent(requireContext(), AboutActivity::class.java))
             dismiss()
         }
+
+        return AlertDialog.Builder(requireActivity())
+            .setView(binding.root)
+            .create()
     }
 
     private fun inflateListOfInActiveProjects(context: Context) {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -40,7 +40,7 @@ class ProjectSettingsDialog : DialogFragment() {
     @Inject
     lateinit var currentProjectViewModelFactory: CurrentProjectViewModel.Factory
 
-    private lateinit var binding: ProjectSettingsDialogLayoutBinding
+    lateinit var binding: ProjectSettingsDialogLayoutBinding
 
     private lateinit var currentProjectViewModel: CurrentProjectViewModel
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -99,10 +99,10 @@ public final class ThemeUtils {
     }
 
     @StyleRes
-    public int getMaterialDialogTheme() {
+    public int getCalendarDatePickerDialogTheme() {
         return isDarkTheme()
-                ? R.style.Theme_Collect_Dark_Dialog
-                : R.style.Theme_Collect_Light_Dialog;
+                ? R.style.Theme_Collect_Dark_Calendar_DatePicker_Dialog
+                : R.style.Theme_Collect_Light_Calendar_DatePicker_Dialog;
     }
 
     @StyleRes

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -112,6 +112,13 @@ public final class ThemeUtils {
                 R.style.Theme_Collect_Light_Spinner_DatePicker_Dialog;
     }
 
+    @StyleRes
+    public int getSpinnerTimePickerDialogTheme() {
+        return isDarkTheme() ?
+                R.style.Theme_Collect_Dark_Spinner_TimePicker_Dialog :
+                R.style.Theme_Collect_Light_Spinner_TimePicker_Dialog;
+    }
+
     private int getAttributeValue(@AttrRes int resId) {
         TypedValue outValue = new TypedValue();
         context.getTheme().resolveAttribute(resId, outValue, true);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ThemeUtils.java
@@ -93,9 +93,9 @@ public final class ThemeUtils {
         return isDarkTheme() ? android.R.drawable.divider_horizontal_dark : android.R.drawable.divider_horizontal_bright;
     }
 
-    public boolean isHoloDialogTheme(int theme) {
-        return theme == android.R.style.Theme_Holo_Light_Dialog ||
-                theme == android.R.style.Theme_Holo_Dialog;
+    public boolean isSpinnerDatePickerDialogTheme(int theme) {
+        return theme == R.style.Theme_Collect_Dark_Spinner_DatePicker_Dialog ||
+                theme == R.style.Theme_Collect_Light_Spinner_DatePicker_Dialog;
     }
 
     @StyleRes
@@ -106,10 +106,10 @@ public final class ThemeUtils {
     }
 
     @StyleRes
-    public int getHoloDialogTheme() {
+    public int getSpinnerDatePickerDialogTheme() {
         return isDarkTheme() ?
-                android.R.style.Theme_Holo_Dialog :
-                android.R.style.Theme_Holo_Light_Dialog;
+                R.style.Theme_Collect_Dark_Spinner_DatePicker_Dialog :
+                R.style.Theme_Collect_Light_Spinner_DatePicker_Dialog;
     }
 
     private int getAttributeValue(@AttrRes int resId) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -21,7 +21,7 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import androidx.appcompat.app.AlertDialog;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -218,7 +218,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
 
                 @Override
                 public void onRemoveClicked() {
-                    new MaterialAlertDialogBuilder(getContext())
+                    new AlertDialog.Builder(getContext())
                             .setTitle(R.string.delete_answer_file_question)
                             .setMessage(R.string.answer_file_delete_warning)
                             .setPositiveButton(R.string.delete_answer_file, (dialog, which) -> clearAnswer())

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -8,7 +8,7 @@ import android.media.MediaMetadataRetriever;
 import android.util.TypedValue;
 import android.view.View;
 
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import androidx.appcompat.app.AlertDialog;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -178,7 +178,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
 
                 @Override
                 public void onRemoveClicked() {
-                    new MaterialAlertDialogBuilder(getContext())
+                    new AlertDialog.Builder(getContext())
                             .setTitle(R.string.delete_answer_file_question)
                             .setMessage(R.string.answer_file_delete_warning)
                             .setPositiveButton(R.string.delete_answer_file, (dialog, which) -> clearAnswer())

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtils.java
@@ -193,7 +193,7 @@ public class DateTimeWidgetUtils {
         ThemeUtils themeUtils = new ThemeUtils(context);
 
         Bundle bundle = new Bundle();
-        bundle.putInt(DIALOG_THEME, themeUtils.getHoloDialogTheme());
+        bundle.putInt(DIALOG_THEME, themeUtils.getSpinnerDatePickerDialogTheme());
         bundle.putSerializable(TIME, dateTime);
 
         DialogUtils.showIfNotShowing(CustomTimePickerDialog.class, bundle, ((FragmentActivity) context).getSupportFragmentManager());
@@ -235,7 +235,7 @@ public class DateTimeWidgetUtils {
             theme = themeUtils.getCalendarDatePickerDialogTheme();
         }
         if (!datePickerDetails.isCalendarMode() || isBrokenSamsungDevice()) {
-            theme = themeUtils.getHoloDialogTheme();
+            theme = themeUtils.getSpinnerDatePickerDialogTheme();
         }
 
         return theme;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtils.java
@@ -232,7 +232,7 @@ public class DateTimeWidgetUtils {
     private static int getDatePickerTheme(ThemeUtils themeUtils, DatePickerDetails datePickerDetails) {
         int theme = 0;
         if (!isBrokenSamsungDevice()) {
-            theme = themeUtils.getMaterialDialogTheme();
+            theme = themeUtils.getCalendarDatePickerDialogTheme();
         }
         if (!datePickerDetails.isCalendarMode() || isBrokenSamsungDevice()) {
             theme = themeUtils.getHoloDialogTheme();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtils.java
@@ -193,7 +193,7 @@ public class DateTimeWidgetUtils {
         ThemeUtils themeUtils = new ThemeUtils(context);
 
         Bundle bundle = new Bundle();
-        bundle.putInt(DIALOG_THEME, themeUtils.getSpinnerDatePickerDialogTheme());
+        bundle.putInt(DIALOG_THEME, themeUtils.getSpinnerTimePickerDialogTheme());
         bundle.putSerializable(TIME, dateTime);
 
         DialogUtils.showIfNotShowing(CustomTimePickerDialog.class, bundle, ((FragmentActivity) context).getSupportFragmentManager());

--- a/collect_app/src/main/res/drawable/project_settings_dialog_background.xml
+++ b/collect_app/src/main/res/drawable/project_settings_dialog_background.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="?colorSurface"/>
-    <corners android:radius="10dp" />
-</shape>

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -2,8 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@drawable/project_settings_dialog_background">
+    android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline_start"
@@ -42,7 +41,7 @@
 
     <org.odk.collect.android.projects.ProjectListItemView
         android:id="@+id/current_project"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_standard"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -48,6 +48,7 @@
         <item name="android:fadeScrollbars">false</item>
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
+        <item name="alertDialogTheme">@style/Theme.Collect.Dark.Dialog</item>
         <item name="searchViewStyle">@style/Widget.Collect.SearchView.Dark</item>
         <item name="iconColor">#ffffff</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
@@ -66,7 +67,10 @@
         <item name="searchHintIcon">@null</item>
     </style>
 
-    <style name="Theme.Collect.Dark.Dialog" parent="android:Theme.Material.Dialog">
-        <item name="android:colorAccent">?attr/colorSecondary</item>
+    <style name="Theme.Collect.Dark.Dialog" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="colorAccent">?attr/colorSecondary</item>
+        <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+        <item name="dialogCornerRadius">8dp</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -49,6 +49,7 @@
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
         <item name="alertDialogTheme">@style/Theme.Collect.Dark.Dialog.Alert</item>
+        <item name="android:alertDialogTheme">@style/Theme.Collect.Dark.Dialog.Alert</item>
         <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
         <item name="iconColor">#ffffff</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -49,7 +49,7 @@
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
         <item name="alertDialogTheme">@style/Theme.Collect.Dark.Dialog</item>
-        <item name="searchViewStyle">@style/Widget.Collect.SearchView.Dark</item>
+        <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
         <item name="iconColor">#ffffff</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <!--
@@ -61,10 +61,6 @@
             https://developer.android.com/reference/android/widget/ImageView.html#attr_android:tint
         -->
         <item name="android:tintMode" tools:targetApi="21">src_in</item>
-    </style>
-
-    <style name="Widget.Collect.SearchView.Dark" parent="Widget.AppCompat.SearchView">
-        <item name="searchHintIcon">@null</item>
     </style>
 
     <style name="Theme.Collect.Dark.Dialog" parent="Theme.AppCompat.Dialog.Alert">

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -79,4 +79,12 @@
     <style name="Theme.Collect.Dark.Spinner.DatePicker.Dialog" parent="Theme.Collect.Dark.Dialog.Alert">
         <item name="android:datePickerStyle">@style/Theme.Collect.Spinner.DatePicker</item>
     </style>
+
+    <style name="Theme.Collect.Dark.Spinner.TimePicker.Dialog" parent="Theme.Collect.Dark.Dialog.Alert">
+        <item name="android:timePickerStyle">@style/Theme.Collect.Dark.Spinner.TimePicker</item>
+    </style>
+
+    <style name="Theme.Collect.Dark.Spinner.TimePicker" parent="android:Widget.Material.TimePicker">
+        <item name="android:timePickerMode">spinner</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -77,7 +77,7 @@
     </style>
 
     <style name="Theme.Collect.Dark.Spinner.DatePicker.Dialog" parent="Theme.Collect.Dark.Dialog.Alert">
-        <item name="android:datePickerStyle">@style/Theme.Collect.Spinner.DatePicker</item>
+        <item name="android:datePickerStyle">@android:style/Widget.DatePicker</item>
     </style>
 
     <style name="Theme.Collect.Dark.Spinner.TimePicker.Dialog" parent="Theme.Collect.Dark.Dialog.Alert">

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -48,7 +48,7 @@
         <item name="android:fadeScrollbars">false</item>
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
-        <item name="alertDialogTheme">@style/Theme.Collect.Dark.Dialog</item>
+        <item name="alertDialogTheme">@style/Theme.Collect.Dark.Dialog.Alert</item>
         <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
         <item name="iconColor">#ffffff</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
@@ -63,10 +63,16 @@
         <item name="android:tintMode" tools:targetApi="21">src_in</item>
     </style>
 
-    <style name="Theme.Collect.Dark.Dialog" parent="Theme.AppCompat.Dialog.Alert">
+    <style name="Theme.Collect.Dark.Dialog.Alert" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorAccent">?attr/colorSecondary</item>
         <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+        <item name="dialogCornerRadius">8dp</item>
+    </style>
+
+    <style name="Theme.Collect.Dark.Calendar.DatePicker.Dialog" parent="Theme.AppCompat.Dialog">
+        <item name="colorAccent">?attr/colorSecondary</item>
+        <item name="android:background">?attr/colorPrimary</item>
         <item name="dialogCornerRadius">8dp</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -75,4 +75,8 @@
         <item name="android:background">?attr/colorPrimary</item>
         <item name="dialogCornerRadius">8dp</item>
     </style>
+
+    <style name="Theme.Collect.Dark.Spinner.DatePicker.Dialog" parent="Theme.Collect.Dark.Dialog.Alert">
+        <item name="android:datePickerStyle">@style/Theme.Collect.Spinner.DatePicker</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -65,6 +65,7 @@
 
     <style name="Theme.Collect.Dark.Dialog.Alert" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorAccent">?attr/colorSecondary</item>
+        <item name="android:background">?attr/colorSurface</item>
         <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
         <item name="dialogCornerRadius">8dp</item>
@@ -72,7 +73,7 @@
 
     <style name="Theme.Collect.Dark.Calendar.DatePicker.Dialog" parent="Theme.AppCompat.Dialog">
         <item name="colorAccent">?attr/colorSecondary</item>
-        <item name="android:background">?attr/colorPrimary</item>
+        <item name="android:background">?attr/colorSurface</item>
         <item name="dialogCornerRadius">8dp</item>
     </style>
 

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -51,7 +51,7 @@
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
         <item name="alertDialogTheme">@style/Theme.Collect.BaseLight.Dialog.Alert</item>
-        <item name="searchViewStyle">@style/Widget.Collect.SearchView.Light</item>
+        <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
         <item name="iconColor">#000000</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:tintMode" tools:targetApi="21">src_in</item>
@@ -62,10 +62,6 @@
         <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
         <item name="dialogCornerRadius">8dp</item>
-    </style>
-
-    <style name="Widget.Collect.SearchView.Light" parent="Widget.AppCompat.Light.SearchView">
-        <item name="searchHintIcon">@null</item>
     </style>
 
     <style name="Theme.Collect.Light.Dialog" parent="android:Theme.Material.Light.Dialog">

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -68,4 +68,8 @@
         <item name="colorAccent">?attr/colorSecondary</item>
         <item name="dialogCornerRadius">8dp</item>
     </style>
+
+    <style name="Theme.Collect.Light.Spinner.DatePicker.Dialog" parent="Theme.Collect.Light.Dialog.Alert">
+        <item name="android:datePickerStyle">@style/Theme.Collect.Spinner.DatePicker</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -72,4 +72,12 @@
     <style name="Theme.Collect.Light.Spinner.DatePicker.Dialog" parent="Theme.Collect.Light.Dialog.Alert">
         <item name="android:datePickerStyle">@style/Theme.Collect.Spinner.DatePicker</item>
     </style>
+
+    <style name="Theme.Collect.Light.Spinner.TimePicker.Dialog" parent="Theme.Collect.Light.Dialog.Alert">
+        <item name="android:timePickerStyle">@style/Theme.Collect.Light.Spinner.TimePicker</item>
+    </style>
+
+    <style name="Theme.Collect.Light.Spinner.TimePicker" parent="android:Widget.Material.Light.TimePicker">
+        <item name="android:timePickerMode">spinner</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -51,6 +51,7 @@
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
         <item name="alertDialogTheme">@style/Theme.Collect.Light.Dialog.Alert</item>
+        <item name="android:alertDialogTheme">@style/Theme.Collect.Light.Dialog.Alert</item>
         <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
         <item name="iconColor">#000000</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -59,6 +59,9 @@
 
     <style name="Theme.Collect.BaseLight.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">?attr/colorSecondary</item>
+        <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+        <item name="dialogCornerRadius">8dp</item>
     </style>
 
     <style name="Widget.Collect.SearchView.Light" parent="Widget.AppCompat.Light.SearchView">

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -50,21 +50,22 @@
         <item name="colorAccent">@color/blue_500</item>
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
-        <item name="alertDialogTheme">@style/Theme.Collect.BaseLight.Dialog.Alert</item>
+        <item name="alertDialogTheme">@style/Theme.Collect.Light.Dialog.Alert</item>
         <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
         <item name="iconColor">#000000</item>
         <item name="android:textDirection" tools:targetApi="17">locale</item>
         <item name="android:tintMode" tools:targetApi="21">src_in</item>
     </style>
 
-    <style name="Theme.Collect.BaseLight.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="Theme.Collect.Light.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">?attr/colorSecondary</item>
         <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
         <item name="dialogCornerRadius">8dp</item>
     </style>
 
-    <style name="Theme.Collect.Light.Dialog" parent="android:Theme.Material.Light.Dialog">
-        <item name="android:colorAccent">?attr/colorSecondary</item>
+    <style name="Theme.Collect.Light.Calendar.DatePicker.Dialog" parent="Theme.AppCompat.Light.Dialog">
+        <item name="colorAccent">?attr/colorSecondary</item>
+        <item name="dialogCornerRadius">8dp</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -70,7 +70,7 @@
     </style>
 
     <style name="Theme.Collect.Light.Spinner.DatePicker.Dialog" parent="Theme.Collect.Light.Dialog.Alert">
-        <item name="android:datePickerStyle">@style/Theme.Collect.Spinner.DatePicker</item>
+        <item name="android:datePickerStyle">@android:style/Widget.DatePicker</item>
     </style>
 
     <style name="Theme.Collect.Light.Spinner.TimePicker.Dialog" parent="Theme.Collect.Light.Dialog.Alert">

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -49,7 +49,7 @@
         <!-- Used as divider in many places. Not sure why. -->
         <item name="dividerCompat">@android:drawable/divider_horizontal_bright</item>
 
-        <item name="alertDialogTheme">@style/Theme.Collect.Magenta.Dialog</item>
+        <item name="alertDialogTheme">@style/Theme.Collect.Magenta.Dialog.Alert</item>
 
         <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
 
@@ -60,7 +60,7 @@
         <item name="android:textDirection">locale</item>
     </style>
 
-    <style name="Theme.Collect.Magenta.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
+    <style name="Theme.Collect.Magenta.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">?attr/colorSecondary</item>
         <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -49,8 +49,6 @@
         <!-- Used as divider in many places. Not sure why. -->
         <item name="dividerCompat">@android:drawable/divider_horizontal_bright</item>
 
-        <item name="alertDialogTheme">@style/Theme.Collect.Magenta.Dialog.Alert</item>
-
         <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
 
         <!-- Always show scrollbars for a11y reasons -->
@@ -58,12 +56,5 @@
 
         <!-- Use locale for text direction in views -->
         <item name="android:textDirection">locale</item>
-    </style>
-
-    <style name="Theme.Collect.Magenta.Dialog.Alert" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorAccent">?attr/colorSecondary</item>
-        <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
-        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
-        <item name="dialogCornerRadius">8dp</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -51,17 +51,13 @@
 
         <item name="alertDialogTheme">@style/Theme.Collect.Magenta.Dialog</item>
 
-        <item name="searchViewStyle">@style/Widget.Collect.SearchView.Magenta.Theme</item>
+        <item name="searchViewStyle">@style/Widget.Collect.SearchView</item>
 
         <!-- Always show scrollbars for a11y reasons -->
         <item name="android:fadeScrollbars">false</item>
 
         <!-- Use locale for text direction in views -->
         <item name="android:textDirection">locale</item>
-    </style>
-
-    <style name="Widget.Collect.SearchView.Magenta.Theme" parent="Widget.AppCompat.SearchView">
-        <item name="searchHintIcon">@null</item>
     </style>
 
     <style name="Theme.Collect.Magenta.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -49,6 +49,8 @@
         <!-- Used as divider in many places. Not sure why. -->
         <item name="dividerCompat">@android:drawable/divider_horizontal_bright</item>
 
+        <item name="alertDialogTheme">@style/Theme.Collect.Magenta.Dialog</item>
+
         <item name="searchViewStyle">@style/Widget.Collect.SearchView.Magenta.Theme</item>
 
         <!-- Always show scrollbars for a11y reasons -->
@@ -62,4 +64,10 @@
         <item name="searchHintIcon">@null</item>
     </style>
 
+    <style name="Theme.Collect.Magenta.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="colorAccent">?attr/colorSecondary</item>
+        <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+        <item name="dialogCornerRadius">8dp</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/permission_dialog_theme.xml
+++ b/collect_app/src/main/res/values/permission_dialog_theme.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <style name="Theme.Collect.Dialog.PermissionAlert" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="android:textColor">@android:color/black</item>
-    </style>
-</resources>

--- a/collect_app/src/main/res/values/styles.xml
+++ b/collect_app/src/main/res/values/styles.xml
@@ -59,4 +59,8 @@
     <style name="Widget.Collect.SearchView" parent="Widget.AppCompat.SearchView">
         <item name="searchHintIcon">@null</item>
     </style>
+
+    <style name="Theme.Collect.Spinner.DatePicker" parent="android:Widget.DatePicker">
+        <item name="android:datePickerMode">spinner</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/styles.xml
+++ b/collect_app/src/main/res/values/styles.xml
@@ -55,4 +55,8 @@
     <style name="PositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <item name="android:textColor">?attr/colorSecondary</item>
     </style>
+
+    <style name="Widget.Collect.SearchView" parent="Widget.AppCompat.SearchView">
+        <item name="searchHintIcon">@null</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/styles.xml
+++ b/collect_app/src/main/res/values/styles.xml
@@ -47,4 +47,12 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50dp</item>
     </style>
+
+    <style name="NegativeButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">?attr/colorSecondary</item>
+    </style>
+
+    <style name="PositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+        <item name="android:textColor">?attr/colorSecondary</item>
+    </style>
 </resources>

--- a/collect_app/src/main/res/values/styles.xml
+++ b/collect_app/src/main/res/values/styles.xml
@@ -59,8 +59,4 @@
     <style name="Widget.Collect.SearchView" parent="Widget.AppCompat.SearchView">
         <item name="searchHintIcon">@null</item>
     </style>
-
-    <style name="Theme.Collect.Spinner.DatePicker" parent="android:Widget.DatePicker">
-        <item name="android:datePickerMode">spinner</item>
-    </style>
 </resources>

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
@@ -1,17 +1,16 @@
 package org.odk.collect.android.projects
 
+import androidx.core.view.children
 import androidx.lifecycle.ViewModel
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.pressBack
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -55,11 +54,12 @@ class ProjectSettingsDialogTest {
 
     @Test
     fun `The dialog should be dismissed after clicking on the 'X' button`() {
-        val scenario = RobolectricHelpers.launchDialogFragmentInContainer(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
+        val scenario = RobolectricHelpers.launchDialogFragment(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
         scenario.onFragment {
-            assertThat(it.isVisible, `is`(true))
-            onView(withId(R.id.close_icon)).perform(click())
-            assertThat(it.isVisible, `is`(false))
+            assertThat(it.dialog!!.isShowing, `is`(true))
+            it.binding.closeIcon.performClick()
+            RobolectricHelpers.runLooper()
+            assertThat(it.dialog, `is`(nullValue()))
         }
     }
 
@@ -67,20 +67,22 @@ class ProjectSettingsDialogTest {
     fun `The dialog should be dismissed after clicking on a device back button`() {
         val scenario = RobolectricHelpers.launchDialogFragment(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
         scenario.onFragment {
-            assertThat(it.isVisible, `is`(true))
+            assertThat(it.dialog!!.isShowing, `is`(true))
             onView(isRoot()).perform(pressBack())
-            assertThat(it.isVisible, `is`(false))
+            RobolectricHelpers.runLooper()
+            assertThat(it.dialog, `is`(nullValue()))
         }
     }
 
     @Test
     fun `General settings should be started after clicking on the 'General Settings' button`() {
-        val scenario = RobolectricHelpers.launchDialogFragmentInContainer(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
+        val scenario = RobolectricHelpers.launchDialogFragment(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
         scenario.onFragment {
             Intents.init()
-            assertThat(it.isVisible, `is`(true))
-            onView(withText(R.string.general_preferences)).perform(click())
-            assertThat(it.isVisible, `is`(false))
+            assertThat(it.dialog!!.isShowing, `is`(true))
+            it.binding.generalSettingsButton.performClick()
+            RobolectricHelpers.runLooper()
+            assertThat(it.dialog, `is`(nullValue()))
             assertThat(Intents.getIntents()[0], hasComponent(GeneralPreferencesActivity::class.java.name))
             Intents.release()
         }
@@ -88,12 +90,13 @@ class ProjectSettingsDialogTest {
 
     @Test
     fun `Admin settings should be started after clicking on the 'Admin Settings' button`() {
-        val scenario = RobolectricHelpers.launchDialogFragmentInContainer(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
+        val scenario = RobolectricHelpers.launchDialogFragment(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
         scenario.onFragment {
             Intents.init()
-            assertThat(it.isVisible, `is`(true))
-            onView(withText(R.string.admin_preferences)).perform(click())
-            assertThat(it.isVisible, `is`(false))
+            assertThat(it.dialog!!.isShowing, `is`(true))
+            it.binding.adminSettingsButton.performClick()
+            RobolectricHelpers.runLooper()
+            assertThat(it.dialog, `is`(nullValue()))
             assertThat(Intents.getIntents()[0], hasComponent(AdminPreferencesActivity::class.java.name))
             Intents.release()
         }
@@ -101,12 +104,13 @@ class ProjectSettingsDialogTest {
 
     @Test
     fun `About section should be started after clicking on the 'About' button`() {
-        val scenario = RobolectricHelpers.launchDialogFragmentInContainer(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
+        val scenario = RobolectricHelpers.launchDialogFragment(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
         scenario.onFragment {
             Intents.init()
-            assertThat(it.isVisible, `is`(true))
-            onView(withText(R.string.about_preferences)).perform(click())
-            assertThat(it.isVisible, `is`(false))
+            assertThat(it.dialog!!.isShowing, `is`(true))
+            it.binding.aboutButton.performClick()
+            RobolectricHelpers.runLooper()
+            assertThat(it.dialog, `is`(nullValue()))
             assertThat(Intents.getIntents()[0], hasComponent(AboutActivity::class.java.name))
             Intents.release()
         }
@@ -118,9 +122,9 @@ class ProjectSettingsDialogTest {
         appDependencyComponent.projectsRepository().save(Project("Project Y", "Y", "#ffffff", "2"))
         appDependencyComponent.currentProjectProvider().setCurrentProject("1")
 
-        val scenario = RobolectricHelpers.launchDialogFragmentInContainer(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
+        val scenario = RobolectricHelpers.launchDialogFragment(ProjectSettingsDialog::class.java, R.style.Theme_Collect_Light)
         scenario.onFragment {
-            onView(withText("Project Y")).perform(click())
+            it.binding.projectList.children.iterator().asSequence().first().performClick()
             verify(currentProjectViewModel).setCurrentProject(Project("Project Y", "Y", "#ffffff", "2"))
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
@@ -77,8 +77,8 @@ public class ThemeUtilsTest {
         assertEquals(themeUtils.getAppTheme(), R.style.Theme_Collect_Light);
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Light);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Light);
-        assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Light_Dialog);
-        assertEquals(themeUtils.getSpinnerDatePickerDialogTheme(), android.R.style.Theme_Holo_Light_Dialog);
+        assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Light_Calendar_DatePicker_Dialog);
+        assertEquals(themeUtils.getSpinnerDatePickerDialogTheme(), R.style.Theme_Collect_Light_Spinner_DatePicker_Dialog);
     }
 
     @Test
@@ -87,8 +87,8 @@ public class ThemeUtilsTest {
         assertEquals(themeUtils.getAppTheme(), R.style.Theme_Collect_Dark);
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Dark);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Dark);
-        assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Dark_Dialog);
-        assertEquals(themeUtils.getSpinnerDatePickerDialogTheme(), android.R.style.Theme_Holo_Dialog);
+        assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Dark_Calendar_DatePicker_Dialog);
+        assertEquals(themeUtils.getSpinnerDatePickerDialogTheme(), R.style.Theme_Collect_Dark_Spinner_DatePicker_Dialog);
     }
 
     private void assertCurrentTheme(Resources.Theme expectedTheme, Resources.Theme actualTheme, boolean assertTrue) {

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
@@ -77,7 +77,7 @@ public class ThemeUtilsTest {
         assertEquals(themeUtils.getAppTheme(), R.style.Theme_Collect_Light);
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Light);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Light);
-        assertEquals(themeUtils.getMaterialDialogTheme(), R.style.Theme_Collect_Light_Dialog);
+        assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Light_Dialog);
         assertEquals(themeUtils.getHoloDialogTheme(), android.R.style.Theme_Holo_Light_Dialog);
     }
 
@@ -87,7 +87,7 @@ public class ThemeUtilsTest {
         assertEquals(themeUtils.getAppTheme(), R.style.Theme_Collect_Dark);
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Dark);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Dark);
-        assertEquals(themeUtils.getMaterialDialogTheme(), R.style.Theme_Collect_Dark_Dialog);
+        assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Dark_Dialog);
         assertEquals(themeUtils.getHoloDialogTheme(), android.R.style.Theme_Holo_Dialog);
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/ThemeUtilsTest.java
@@ -78,7 +78,7 @@ public class ThemeUtilsTest {
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Light);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Light);
         assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Light_Dialog);
-        assertEquals(themeUtils.getHoloDialogTheme(), android.R.style.Theme_Holo_Light_Dialog);
+        assertEquals(themeUtils.getSpinnerDatePickerDialogTheme(), android.R.style.Theme_Holo_Light_Dialog);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class ThemeUtilsTest {
         assertEquals(themeUtils.getSettingsTheme(), R.style.Theme_Collect_Settings_Dark);
         assertEquals(themeUtils.getBottomDialogTheme(), R.style.Theme_Collect_MaterialDialogSheet_Dark);
         assertEquals(themeUtils.getCalendarDatePickerDialogTheme(), R.style.Theme_Collect_Dark_Dialog);
-        assertEquals(themeUtils.getHoloDialogTheme(), android.R.style.Theme_Holo_Dialog);
+        assertEquals(themeUtils.getSpinnerDatePickerDialogTheme(), android.R.style.Theme_Holo_Dialog);
     }
 
     private void assertCurrentTheme(Resources.Theme expectedTheme, Resources.Theme actualTheme, boolean assertTrue) {


### PR DESCRIPTION
Closes #4482 

#### What has been done to verify that this works as intended?
I tested the app manually checking different dialogs.

#### Why is this the best possible solution? Were any other approaches considered?
I decided to get rid of MaterialAlertDialogs and use AlertDialogs from androidX because that second type of dialogs is used under the hood in preferences, so if we want to make our dialogs look the same across the app we can't use other dialog types in the rest of our codebase https://github.com/getodk/collect/commit/adfeee8d5f565755bb6d9c0bbe05a3c885d7242f.

Then I fixed my custom project settings dialog by using an alert dialog there as well: https://github.com/getodk/collect/commit/235c6c9607afa15ba14380f086fad08ec9328030 and thanks to that I don't need [the custom background view](https://github.com/getodk/collect/commit/235c6c9607afa15ba14380f086fad08ec9328030#diff-e91520b6e127ceb35d5fec81d1a442956d2f97e4344b44b558ecc17e73b108d8L1) anymore. Fortunately, it was the only dialog fragment that didn't use alert dialog so every other dialog fragment should also have rounded corners.

Some screenshots:

| Before  | After | Before  | After |
| ------------- | ------------- | ------------- | ------------- |
| ![Screenshot_1621254376](https://user-images.githubusercontent.com/3276264/118489802-89df9d00-b71d-11eb-9391-be56769580e8.png)  | ![Screenshot_1621254309](https://user-images.githubusercontent.com/3276264/118489796-89470680-b71d-11eb-9f49-a5f10b38ac98.png)  | ![Screenshot_1621254366](https://user-images.githubusercontent.com/3276264/118489899-a380e480-b71d-11eb-89ae-192fe54c13fc.png) | ![Screenshot_1621254290](https://user-images.githubusercontent.com/3276264/118489894-a2e84e00-b71d-11eb-837f-b58e4431c3ed.png) |
| ![Screenshot_1621254401](https://user-images.githubusercontent.com/3276264/118490021-cad7b180-b71d-11eb-95cc-7eed2c4ec6c9.png) | ![Screenshot_1621254447](https://user-images.githubusercontent.com/3276264/118490024-cb704800-b71d-11eb-8308-2145bcb7697c.png) | ![Screenshot_1621254384](https://user-images.githubusercontent.com/3276264/118489721-73394600-b71d-11eb-9cb2-e84da9c5c41f.png)  | ![Screenshot_1621254319](https://user-images.githubusercontent.com/3276264/118489713-72081900-b71d-11eb-92db-55b5b375b350.png)  |
| ![Screenshot_1621344836](https://user-images.githubusercontent.com/3276264/118660661-aef01080-b7ee-11eb-9f2b-295e3e1b85c3.png) | ![Screenshot_1621344696](https://user-images.githubusercontent.com/3276264/118660652-abf52000-b7ee-11eb-8485-c3009a3ccacb.png) | ![Screenshot_1621344829](https://user-images.githubusercontent.com/3276264/118660466-836d2600-b7ee-11eb-8e89-534f8f49e9f0.png) | ![Screenshot_1621344683](https://user-images.githubusercontent.com/3276264/118660463-82d48f80-b7ee-11eb-8779-74f7147adc2a.png)

Let me know if you think that we need the corners even more rounded.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should add rounded corners to our dialogs and make them look similar no matter if it's 
- a dialog in preferences 
- an alert dialog we use to confirm some actions 
- custom dialog fragments

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)