### PR TITLE
Cancel auto update job when deleting project

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/AboutPageTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/AboutPageTest.java
@@ -2,8 +2,8 @@ package org.odk.collect.android.regression;
 
 import android.Manifest;
 
-import androidx.test.rule.GrantPermissionRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,8 +11,8 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.AboutPage;
-import org.odk.collect.android.support.pages.MainMenuPage;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -27,14 +27,14 @@ public class AboutPageTest {
     public CollectTestRule rule = new CollectTestRule();
 
     @Rule
-    public RuleChain ruleChain = RuleChain
-            .outerRule(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
+    public RuleChain ruleChain = TestRuleChain.chain()
+            .around(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
             .around(rule);
 
     @Test
     public void when_rotateScreenOnAboutPage_should_notCrash() {
         //TestCase1
-        new MainMenuPage()
+        rule.startAtMainMenu()
                 .openProjectSettings()
                 .clickAbout()
                 .rotateToLandscape(new AboutPage())
@@ -45,7 +45,7 @@ public class AboutPageTest {
     @Test
     public void when_openAboutPage_should_iconsBeVisible() {
         //TestCase2
-        new MainMenuPage()
+        rule.startAtMainMenu()
                 .openProjectSettings()
                 .clickAbout()
                 .assertOnPage();
@@ -114,7 +114,7 @@ public class AboutPageTest {
     @Test
     public void when_OpenSourcesLibrariesLicenses_should_openSourceLicensesTitleBeDisplayed() {
         //TestCase3
-        new MainMenuPage()
+        rule.startAtMainMenu()
                 .openProjectSettings()
                 .clickAbout()
                 .clickOnOpenSourceLibrariesLicenses();

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/FormUpdateManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/FormUpdateManager.java
@@ -3,4 +3,6 @@ package org.odk.collect.android.backgroundwork;
 public interface FormUpdateManager {
 
     void scheduleUpdates();
+
+    void cancelUpdates();
 }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SchedulerFormUpdateAndSubmitManager.java
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/SchedulerFormUpdateAndSubmitManager.java
@@ -66,6 +66,11 @@ public class SchedulerFormUpdateAndSubmitManager implements FormUpdateManager, F
     }
 
     @Override
+    public void cancelUpdates() {
+        scheduler.cancelDeferred(getAutoUpdateTag());
+    }
+
+    @Override
     public void scheduleSubmit() {
         scheduler.networkDeferred(AUTO_SEND_TAG, new AutoSendTaskSpec());
     }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
@@ -1,0 +1,26 @@
+package org.odk.collect.android.projects
+
+import org.odk.collect.android.backgroundwork.FormUpdateManager
+import org.odk.collect.projects.Project.Saved
+import org.odk.collect.projects.ProjectsRepository
+
+class ProjectDeleter(
+    private val projectsRepository: ProjectsRepository,
+    private val currentProjectProvider: CurrentProjectProvider,
+    private val formUpdateManager: FormUpdateManager
+) {
+    fun deleteCurrentProject(): Saved? {
+        formUpdateManager.cancelUpdates()
+
+        val currentProject = currentProjectProvider.getCurrentProject()
+        projectsRepository.delete(currentProject.uuid)
+
+        return if (projectsRepository.getAll().isNotEmpty()) {
+            val newProject = projectsRepository.getAll()[0]
+            currentProjectProvider.setCurrentProject(newProject.uuid)
+            newProject
+        } else {
+            null
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AppStateProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AppStateProvider.kt
@@ -5,18 +5,17 @@ import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.shared.Settings
 
 class AppStateProvider(private val packageInfo: PackageInfo, private val metaSettings: Settings) {
+
     fun isFreshInstall(): Boolean {
-        return alwaysFresh.let {
-            if (it) {
-                true
-            } else {
-                !isUpdatedVersion() && !metaSettings.contains(MetaKeys.FIRST_LAUNCH)
-            }
-        }
+        return !isUpdatedVersion() && !metaSettings.contains(MetaKeys.FIRST_LAUNCH)
     }
 
     private fun isUpdatedVersion(): Boolean {
-        return packageInfo.firstInstallTime != packageInfo.lastUpdateTime
+        return if (alwaysFresh) {
+            false
+        } else {
+            packageInfo.firstInstallTime != packageInfo.lastUpdateTime
+        }
     }
 
     companion object {

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/SchedulerFormUpdateAndSubmitManagerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/SchedulerFormUpdateAndSubmitManagerTest.kt
@@ -56,4 +56,13 @@ class SchedulerFormUpdateAndSubmitManagerTest {
             eq(mapOf(AutoUpdateTaskSpec.DATA_PROJECT_ID to projectId))
         )
     }
+
+    @Test
+    fun `cancelUpdates cancels auto update for current project`() {
+        val manager =
+            SchedulerFormUpdateAndSubmitManager(scheduler, settingsProvider, application)
+
+        manager.cancelUpdates()
+        verify(scheduler).cancelDeferred("serverPollingJob:$projectId")
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectDeleterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectDeleterTest.kt
@@ -1,0 +1,24 @@
+package org.odk.collect.android.projects
+
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.odk.collect.android.backgroundwork.FormUpdateManager
+import org.odk.collect.projects.Project
+
+class ProjectDeleterTest {
+
+    @Test
+    fun deletingProject_cancelsScheduledFormUpdates() {
+        val currentProjectProvider = mock<CurrentProjectProvider> {
+            on { getCurrentProject() } doReturn Project.Saved("id", "name", "i", "#ffffff")
+        }
+
+        val formUpdateManager = mock<FormUpdateManager>()
+        val deleter = ProjectDeleter(mock(), currentProjectProvider, formUpdateManager)
+
+        deleter.deleteCurrentProject()
+        verify(formUpdateManager).cancelUpdates()
+    }
+}


### PR DESCRIPTION
Work towards #4430
~~Blocked by #4588~~ 

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

Nothing to discuss here really. Cancellation lives next to scheduling and I had to pull out a small use case for project deletion to let me write a unit test to drive the cancellation call out.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Like most of these PRs we'll skip QA on this and come back to it later.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)