### PR TITLE
Use correct signature for openOrCreateDatabase to prevent crashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/AltDatabasePathContext.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/AltDatabasePathContext.kt
@@ -19,7 +19,7 @@ class AltDatabasePathContext(private val path: String, context: Context) : Conte
     override fun openOrCreateDatabase(
         name: String,
         mode: Int,
-        factory: SQLiteDatabase.CursorFactory,
+        factory: SQLiteDatabase.CursorFactory?,
         errorHandler: DatabaseErrorHandler?
     ): SQLiteDatabase {
         return openOrCreateDatabase(name, mode, factory)
@@ -28,7 +28,7 @@ class AltDatabasePathContext(private val path: String, context: Context) : Conte
     override fun openOrCreateDatabase(
         name: String,
         mode: Int,
-        factory: SQLiteDatabase.CursorFactory
+        factory: SQLiteDatabase.CursorFactory?
     ): SQLiteDatabase {
         return SQLiteDatabase.openOrCreateDatabase(getDatabasePath(name), null)
     }

--- a/download-robolectric-deps.sh
+++ b/download-robolectric-deps.sh
@@ -1,3 +1,5 @@
+set -e
+
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all/6.0.1_r3-robolectric-r1/android-all-6.0.1_r3-robolectric-r1.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all/7.0.0_r1-robolectric-r1/android-all-7.0.0_r1-robolectric-r1.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all/9-robolectric-4913185-2/android-all-9-robolectric-4913185-2.jar -P robolectric-deps


### PR DESCRIPTION
This fixes an issue where some older versions of Android pass an optional value as `null` to a method we'd overriden but made the parameter non-null.

#### What has been done to verify that this works as intended?

@grzesiek2010 can you verify this fixes the issue on your device?

#### Why is this the best possible solution? Were any other approaches considered?

Annoyingly there isn't really a way to ensure this doesn't come up again. I'll file a bug with the Android team around `ContextWrapper` not having correct annotations on `openOrCreateDatabase` (which would prevent Kotlin conversion going wrong here).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just fixes the issue. No need for QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)