### PR TITLE
Remove support for form list responses without form hashes and without OpenRosa headers

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
@@ -15,7 +15,6 @@ import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.ResetStateRule;
 import org.odk.collect.android.support.StubOpenRosaServer;
-import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.utilities.UserAgentProvider;
 
 @RunWith(AndroidJUnit4.class)
@@ -42,7 +41,9 @@ public class BadServerTest {
             .around(rule);
 
     @Test
-    public void whenHashNotIncludedInFormList_canGetBlankForm_fillItIn_andSubmit() {
+    // The hash from the form list wasn't used for a long time so some server implementations omitted it even though
+    // it's required by the spec. Now we explicitly show an error.
+    public void whenHashNotIncludedInFormList_showError() {
         server.removeHashInFormList();
         server.addForm("One Question", "one-question", "1", "one-question.xml");
 
@@ -50,16 +51,6 @@ public class BadServerTest {
                 .setServer(server.getURL())
                 .clickGetBlankForm()
                 .clickGetSelected()
-                .assertText("One Question (Version:: 1 ID: one-question) - Success")
-                .clickOK(new MainMenuPage())
-
-                .startBlankForm("One Question")
-                .swipeToEndScreen()
-                .clickSaveAndExit()
-
-                .clickSendFinalizedForm(1)
-                .clickOnForm("One Question")
-                .clickSendSelected()
-                .assertText("One Question - Success");
+                .assertText("One Question (Version:: 1 ID: one-question) - Missing form hash. ODK-compatible servers must include form hashes in their form lists. Please talk to the person who asked you to collect data.");
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -140,7 +140,6 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         noHashInFormList = true;
     }
 
-
     public String getURL() {
         return "https://" + HOST;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -104,11 +104,6 @@ public class AnalyticsEvents {
     public static final String CUSTOM_ENDPOINT_SUB = "CustomEndpointSub";
 
     /**
-     * Track usage of legacy Aggregate < 1 form list API code paths.
-     */
-    public static final String LEGACY_FORM_LIST = "LegacyFormList";
-
-    /**
      * Tracks how often the audio player seek bar is used.
      */
     public static final String AUDIO_PLAYER_SEEK = "AudioPlayerSeek";

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormsRepository.java
@@ -87,7 +87,7 @@ public class DatabaseFormsRepository implements FormsRepository {
     @Override
     public Form getOneByMd5Hash(@NotNull String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException("null hash");
+            throw new IllegalArgumentException("Missing form hash. ODK-compatible servers must include form hashes in their form lists. Please talk to the person who asked you to collect data.");
         }
 
         String selection = DatabaseFormColumns.MD5_HASH + "=?";

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDownloadException.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormDownloadException.java
@@ -1,4 +1,11 @@
 package org.odk.collect.android.formmanagement;
 
 public class FormDownloadException extends Exception {
+    public FormDownloadException() {
+        super();
+    }
+
+    public FormDownloadException(String message) {
+        super(message);
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormSourceExceptionMapper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormSourceExceptionMapper.java
@@ -9,6 +9,7 @@ import static org.odk.collect.forms.FormSourceException.ParseError;
 import static org.odk.collect.forms.FormSourceException.SecurityError;
 import static org.odk.collect.forms.FormSourceException.ServerError;
 import static org.odk.collect.forms.FormSourceException.Unreachable;
+import static org.odk.collect.forms.FormSourceException.ServerNotOpenRosaError;
 import static org.odk.collect.android.utilities.TranslationHandler.getString;
 
 public class FormSourceExceptionMapper {
@@ -28,6 +29,8 @@ public class FormSourceExceptionMapper {
             return getString(context, R.string.server_error, ((ServerError) exception).getServerUrl(), ((ServerError) exception).getStatusCode()) + " " + getString(context, R.string.report_to_project_lead);
         } else if (exception instanceof ParseError) {
             return getString(context, R.string.invalid_response, ((ParseError) exception).getServerUrl()) + " " + getString(context, R.string.report_to_project_lead);
+        } else if (exception instanceof ServerNotOpenRosaError) {
+            return "This server does not correctly implement the OpenRosa formList API." + " " + getString(context, R.string.report_to_project_lead);
         } else {
             return getString(context, R.string.report_to_project_lead);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormSourceProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormSourceProvider.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.formmanagement
 
-import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.openrosa.OpenRosaFormSource
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface
 import org.odk.collect.android.openrosa.OpenRosaResponseParserImpl
@@ -11,8 +10,7 @@ import org.odk.collect.forms.FormSource
 
 class FormSourceProvider(
     private val settingsProvider: SettingsProvider,
-    private val openRosaHttpInterface: OpenRosaHttpInterface,
-    private val analytics: Analytics
+    private val openRosaHttpInterface: OpenRosaHttpInterface
 ) {
 
     @JvmOverloads
@@ -27,7 +25,6 @@ class FormSourceProvider(
             formListPath,
             openRosaHttpInterface,
             WebCredentialsUtils(generalSettings),
-            analytics,
             OpenRosaResponseParserImpl()
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -56,14 +56,10 @@ public class ServerFormDownloader implements FormDownloader {
     @Override
     public void downloadForm(ServerFormDetails form, @Nullable ProgressReporter progressReporter, @Nullable Supplier<Boolean> isCancelled) throws FormDownloadException, InterruptedException {
         Form formOnDevice;
-        if (form.getHash() != null) {
+        try {
             formOnDevice = formsRepository.getOneByMd5Hash(getMd5HashWithoutPrefix(form.getHash()));
-        } else {
-            /*
-             This allows us to support non open rosa servers and open rosa servers that don't
-             return hashes. Can be removed when we drop support for these.
-             */
-            formOnDevice = formsRepository.getLatestByFormIdAndVersion(form.getFormId(), form.getFormVersion());
+        } catch (IllegalArgumentException e) {
+            throw new FormDownloadException(e.getMessage());
         }
 
         if (formOnDevice != null) {

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -563,8 +563,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public FormSourceProvider providesFormSourceProvider(SettingsProvider settingsProvider, OpenRosaHttpInterface openRosaHttpInterface, Analytics analytics) {
-        return new FormSourceProvider(settingsProvider, openRosaHttpInterface, analytics);
+    public FormSourceProvider providesFormSourceProvider(SettingsProvider settingsProvider, OpenRosaHttpInterface openRosaHttpInterface) {
+        return new FormSourceProvider(settingsProvider, openRosaHttpInterface);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
@@ -1,7 +1,6 @@
 package org.odk.collect.android.openrosa;
 
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.utilities.DocumentFetchResult;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.forms.FormListItem;
@@ -9,9 +8,7 @@ import org.odk.collect.forms.FormSource;
 import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.forms.ManifestFile;
 import org.odk.collect.forms.MediaFile;
-import org.odk.collect.shared.strings.Md5;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.UnknownHostException;
@@ -22,7 +19,6 @@ import javax.net.ssl.SSLException;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
-import static org.odk.collect.android.analytics.AnalyticsEvents.LEGACY_FORM_LIST;
 
 public class OpenRosaFormSource implements FormSource {
 
@@ -33,16 +29,12 @@ public class OpenRosaFormSource implements FormSource {
     private String serverURL;
     private final String formListPath;
 
-    private final Analytics analytics;
-
-    public OpenRosaFormSource(String serverURL, String formListPath, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils, Analytics analytics, OpenRosaResponseParser openRosaResponseParser) {
+    public OpenRosaFormSource(String serverURL, String formListPath, OpenRosaHttpInterface openRosaHttpInterface, WebCredentialsUtils webCredentialsUtils, OpenRosaResponseParser openRosaResponseParser) {
         this.openRosaResponseParser = openRosaResponseParser;
         this.webCredentialsUtils = webCredentialsUtils;
         this.openRosaXMLFetcher = new OpenRosaXmlFetcher(openRosaHttpInterface, this.webCredentialsUtils);
         this.serverURL = serverURL;
         this.formListPath = formListPath;
-
-        this.analytics = analytics;
     }
 
     @Override
@@ -68,8 +60,6 @@ public class OpenRosaFormSource implements FormSource {
                 throw new FormSourceException.ParseError(serverURL);
             }
         } else {
-            String serverHash = Md5.getMd5Hash(new ByteArrayInputStream(serverURL.getBytes()));
-            analytics.logServerEvent(LEGACY_FORM_LIST, serverHash);
             throw new FormSourceException.ServerNotOpenRosaError();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -22,6 +22,7 @@ import org.odk.collect.android.formmanagement.FormDownloadException;
 import org.odk.collect.android.formmanagement.FormDownloader;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.listeners.DownloadFormsTaskListener;
+import org.odk.collect.android.utilities.TranslationHandler;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -70,7 +71,7 @@ public class DownloadFormsTask extends
 
                 results.put(serverFormDetails, Collect.getInstance().getString(R.string.success));
             } catch (FormDownloadException e) {
-                results.put(serverFormDetails, Collect.getInstance().getString(R.string.failure));
+                results.put(serverFormDetails, e.getMessage() != null ? e.getMessage() : TranslationHandler.getString(Collect.getInstance(), R.string.failure));
             } catch (InterruptedException e) {
                 return emptyMap();
             }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormSourceExceptionMapperTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormSourceExceptionMapperTest.java
@@ -55,4 +55,10 @@ public class FormSourceExceptionMapperTest {
         String expectedString = context.getString(R.string.invalid_response, "http://unknown.com") + " " + context.getString(R.string.report_to_project_lead);
         assertThat(mapper.getMessage(new FormSourceException.ParseError("http://unknown.com")), is(expectedString));
     }
+
+    @Test
+    public void serverNotOpenRosaError_returnsNotOpenRosaMessage() {
+        String expectedString = "This server does not correctly implement the OpenRosa formList API. " + context.getString(R.string.report_to_project_lead);
+        assertThat(mapper.getMessage(new FormSourceException.ServerNotOpenRosaError()), is(expectedString));
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormSourceProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormSourceProviderTest.kt
@@ -19,7 +19,7 @@ class FormSourceProviderTest {
             on { getGeneralSettings("projectId") } doReturn settings
         }
 
-        val formSourceProvider = FormSourceProvider(settingsProvider, mock(), mock())
+        val formSourceProvider = FormSourceProvider(settingsProvider, mock())
 
         settings.save(GeneralKeys.KEY_SERVER_URL, "http://example.com")
         settings.save(GeneralKeys.KEY_FORMLIST_URL, "/a-path")

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -162,6 +162,31 @@ public class ServerFormDownloaderTest {
     }
 
     @Test
+    public void whenFormListMissingHash_throwsError() throws Exception {
+        String xform = createXFormBody("id", "version");
+        ServerFormDetails serverFormDetails = new ServerFormDetails(
+                "Form",
+                "http://downloadUrl",
+                "id",
+                "version",
+                null,
+                true,
+                false,
+                null);
+
+        FormSource formSource = mock(FormSource.class);
+        when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
+
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        try {
+            downloader.downloadForm(serverFormDetails, null, null);
+            fail("Expected exception because of missing form hash");
+        } catch (FormDownloadException e) {
+            // pass
+        }
+    }
+
+    @Test
     public void whenFormHasMediaFiles_downloadsAndSavesFormAndMediaFiles() throws Exception {
         String xform = createXFormBody("id", "version");
         ServerFormDetails serverFormDetails = new ServerFormDetails(

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
@@ -140,6 +140,26 @@ public class OpenRosaFormSourceTest {
     }
 
     @Test
+    public void fetchFormList_whenResponseHasNoOpenRosaHeader_throwsServerNotOpenRosaError() throws Exception {
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+
+        when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(
+                new ByteArrayInputStream(RESPONSE.getBytes()),
+                new HashMap<String, String>() {{
+                    // No OpenRosa header
+                }},
+                "", 200
+        ));
+
+        try {
+            formListApi.fetchFormList();
+            fail("Expected exception because server is not OpenRosa server.");
+        } catch (FormSourceException.ServerNotOpenRosaError e) {
+            // pass
+        }
+    }
+
+    @Test
     public void fetchManifest_whenThereIsAnUnknownHostException_throwsUnreachableFormApiException() throws Exception {
         OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
 

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/api/OpenRosaFormSourceTest.java
@@ -1,14 +1,13 @@
 package org.odk.collect.android.openrosa.api;
 
 import org.junit.Test;
-import org.odk.collect.analytics.Analytics;
-import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.android.openrosa.HttpGetResult;
 import org.odk.collect.android.openrosa.OpenRosaConstants;
 import org.odk.collect.android.openrosa.OpenRosaFormSource;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.openrosa.OpenRosaResponseParser;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
+import org.odk.collect.forms.FormSourceException;
 
 import java.io.ByteArrayInputStream;
 import java.net.SocketTimeoutException;
@@ -29,15 +28,13 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("PMD.DoubleBraceInitialization")
 public class OpenRosaFormSourceTest {
-
-    private final Analytics analytics = mock(Analytics.class);
     private final OpenRosaHttpInterface httpInterface = mock(OpenRosaHttpInterface.class);
     private final WebCredentialsUtils webCredentialsUtils = mock(WebCredentialsUtils.class);
     private final OpenRosaResponseParser responseParser = mock(OpenRosaResponseParser.class);
 
     @Test
     public void fetchFormList_removesTrailingSlashesFromUrl() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(
                 new ByteArrayInputStream(RESPONSE.getBytes()),
@@ -53,7 +50,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenThereIsAnUnknownHostException_throwsUnreachableFormApiException() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(UnknownHostException.class);
@@ -66,7 +63,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenThereIsAnSSLException_throwsSecurityErrorFormApiException() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(SSLException.class);
@@ -79,7 +76,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenThereIsATimeout_throwsFetchError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(SocketTimeoutException.class);
@@ -92,7 +89,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenThereIsA404_throwsUnreachableApiException() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 404));
@@ -105,7 +102,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenThereIsAServerError_throwsServerError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 500));
@@ -119,7 +116,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenOpenRosaResponse_whenParserFails_throwsParseError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(
@@ -141,13 +138,11 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchFormList_whenResponseHasNoOpenRosaHeader_throwsServerNotOpenRosaError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com///", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(
                 new ByteArrayInputStream(RESPONSE.getBytes()),
-                new HashMap<String, String>() {{
-                    // No OpenRosa header
-                }},
+                new HashMap<String, String>(), // No OpenRosa header
                 "", 200
         ));
 
@@ -161,7 +156,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchManifest_whenThereIsAnUnknownHostException_throwsUnreachableFormApiException() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenThrow(UnknownHostException.class);
@@ -174,7 +169,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchManifest_whenThereIsAServerError_throwsServerError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 503));
@@ -188,7 +183,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchManifest_whenOpenRosaResponse_whenParserFails_throwsParseError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(
@@ -210,7 +205,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchManifest_whenNotOpenRosaResponse_throwsParseError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(
@@ -229,7 +224,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchForm_whenThereIsAServerError_throwsServerError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 500));
@@ -243,7 +238,7 @@ public class OpenRosaFormSourceTest {
 
     @Test
     public void fetchMediaFile_whenThereIsAServerError_throwsServerError() throws Exception {
-        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, analytics, responseParser);
+        OpenRosaFormSource formListApi = new OpenRosaFormSource("http://blah.com", "/formList", httpInterface, webCredentialsUtils, responseParser);
 
         try {
             when(httpInterface.executeGetRequest(any(), any(), any())).thenReturn(new HttpGetResult(null, new HashMap<>(), "hash", 500));

--- a/forms/src/main/java/org/odk/collect/forms/FormSourceException.java
+++ b/forms/src/main/java/org/odk/collect/forms/FormSourceException.java
@@ -66,4 +66,9 @@ public class FormSourceException extends Exception {
             return serverUrl;
         }
     }
+
+    // Aggregate 0.9 and prior used a custom API before the OpenRosa standard was in place. Aggregate continued
+    // to provide this response to HTTP requests so some custom servers tried to implement it.
+    public static class ServerNotOpenRosaError extends FormSourceException {
+    }
 }


### PR DESCRIPTION
Closes #4450 
As announced [on the forum](https://forum.getodk.org/t/breaking-changes-coming-to-collect-v2021-2/33169).

This would be good to get in any beta we do to give folks a chance to see the change in action.

Usage of the legacy API has gone up over the past few months ([analytics](https://console.firebase.google.com/u/0/project/api-project-322300403941/analytics/app/android:org.odk.collect.android/events/~2Freport~2FLegacyFormList%3Ft%3D1623196424583&fpn%3D322300403941&swu%3D1&sgu%3D1&sus%3Dupgraded&params%3D_u..pageSize%253D25%2526_r..eventId%253DLegacyFormList%2526_u.dateOption%253Dlast90Days&cs%3Dapp.m.events.detail&r%3Ddefault&g%3D1)). That means this change will be more disruptive than we'd hoped but it's still a very small fraction of users. I see this increase in usage as a sign that we need to make the deprecation sooner than later or else folks will keep on developing against the legacy API.

#### What has been done to verify that this works as intended?
Added and ran tests. Manually verified the happy path against the demo server.

#### Why is this the best possible solution? Were any other approaches considered?
- I initially wasn't going to keep the smoke test for the missing hash case but I decided to do so because it's the only place we can test that the message is correctly shown in the manual form download case.
- It's really important to show a specific message in the missing hash case. I decided to do this by exposing a message from `FormDownloadException` if one exists. It's not the cleanest thing but this is an area we know we need to come back to sooner than later because we just show the unhelpful "Failure" for every other failure case. What I did seems like a reasonable interim solution. I only exposed it for the manual download case because I imagine folks with custom servers that don't follow ODK development don't use update features.
- I decided to remove analytics for the legacy API. We're committed to removing support for it and I don't think tracking attempts to use it would affect our behavior.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think this is relatively low-risk overall. The biggest source of risk I can think of is if I didn't think of something related to background form update cases. For example, I was initially thinking of passing on the `IllegalArgumentException` from `getByMd5Hash` for the missing hash case but that would have required handling that exception type for all three paths to downloading forms (and I think `FormDownloadException` is more appropriate after all.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. I don't think this should go through QA since it needs a badly-behaved server to verify. The non-error cases will be verified as we continue development and will be looked at in the regression pass.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)