### PR TITLE
Log analytics on return from OpenMapKit app

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -177,6 +177,7 @@ import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 import static android.view.animation.AnimationUtils.loadAnimation;
 import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+import static org.odk.collect.android.analytics.AnalyticsEvents.OPEN_MAP_KIT_RESPONSE;
 import static org.odk.collect.android.analytics.AnalyticsEvents.SAVE_INCOMPLETE;
 import static org.odk.collect.android.formentry.FormIndexAnimationHandler.Direction.BACKWARDS;
 import static org.odk.collect.android.formentry.FormIndexAnimationHandler.Direction.FORWARDS;
@@ -785,6 +786,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         switch (requestCode) {
             case RequestCodes.OSM_CAPTURE:
+                analytics.logFormEvent(OPEN_MAP_KIT_RESPONSE, Collect.getCurrentFormIdentifierHash());
                 setWidgetData(intent.getStringExtra("OSM_FILE_NAME"));
                 break;
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -161,4 +161,9 @@ public class AnalyticsEvents {
      * from disk and then encrypted
      */
     public static final String IMPORT_AND_ENCRYPT_INSTANCE = "ImportAndEncryptInstance";
+
+    /**
+     * Tracks responses from OpenMapKit to the OSMWidget
+     */
+    public static final String OPEN_MAP_KIT_RESPONSE = "OpenMapKitResponse";
 }


### PR DESCRIPTION
Closes #4466

#### What has been done to verify that this works as intended?
Nothing. 😬

#### Why is this the best possible solution? Were any other approaches considered?
The other (likely more) logical place to put this would be `OSMWidget.setData`. However, this is not mission-critical and might not stay in for very long so I'd prefer to just get it in there without adding new dependencies to the widget or worrying about testing. I think that's reasonable but if you don't, let me know.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
No risk to users. Worst thing that can happen is that the analytics we want don't actually get logged.

#### Do we need any specific form for testing your changes? If so, please attach one.
No. I don't think we should verify this at all beyond making sure the code makes sense.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)