### PR TITLE
Make sure form update jobs are rescheduled on upgrade

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -26,8 +26,6 @@ import org.odk.collect.utilities.UserAgentProvider;
 
 import java.util.Locale;
 
-import javax.inject.Inject;
-
 import timber.log.Timber;
 
 public class ApplicationInitializer {
@@ -40,7 +38,6 @@ public class ApplicationInitializer {
     private final LaunchState launchState;
     private final AppUpgrader appUpgrader;
 
-    @Inject
     public ApplicationInitializer(Application context, UserAgentProvider userAgentProvider,
                                   PropertyManager propertyManager, Analytics analytics,
                                   StorageInitializer storageInitializer, LaunchState launchState,

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/FormUpdatesUpgrade.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/FormUpdatesUpgrade.kt
@@ -5,7 +5,7 @@ import org.odk.collect.android.backgroundwork.FormUpdateScheduler
 import org.odk.collect.async.Scheduler
 import org.odk.collect.projects.ProjectsRepository
 
-class SchedulerUpgrade(
+class FormUpdatesUpgrade(
     private val scheduler: Scheduler,
     private val projectsRepository: ProjectsRepository,
     private val formUpdateScheduler: FormUpdateScheduler

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SchedulerUpgrade.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SchedulerUpgrade.kt
@@ -1,0 +1,25 @@
+package org.odk.collect.android.application.initialization
+
+import org.odk.collect.android.application.initialization.upgrade.Upgrade
+import org.odk.collect.android.backgroundwork.FormUpdateScheduler
+import org.odk.collect.async.Scheduler
+import org.odk.collect.projects.ProjectsRepository
+
+class SchedulerUpgrade(
+    private val scheduler: Scheduler,
+    private val projectsRepository: ProjectsRepository,
+    private val formUpdateScheduler: FormUpdateScheduler
+) : Upgrade {
+
+    override fun key(): String? {
+        return null
+    }
+
+    override fun run() {
+        scheduler.cancelAllDeferred()
+
+        projectsRepository.getAll().forEach {
+            formUpdateScheduler.scheduleUpdates(it.uuid)
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -30,6 +30,7 @@ import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.initialization.CollectSettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.ExistingProjectMigrator;
+import org.odk.collect.android.application.initialization.SchedulerUpgrade;
 import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.upgrade.AppUpgrader;
 import org.odk.collect.android.backgroundwork.FormUpdateAndInstanceSubmitScheduler;
@@ -134,6 +135,7 @@ import dagger.Provides;
 import okhttp3.OkHttpClient;
 
 import static androidx.core.content.FileProvider.getUriForFile;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.odk.collect.android.preferences.keys.MetaKeys.KEY_INSTALL_ID;
 
@@ -570,9 +572,12 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public AppUpgrader providesAppUpgrader(SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator) {
-        return new AppUpgrader(settingsProvider.getMetaSettings(), singletonList(
-                existingProjectMigrator
+    public AppUpgrader providesAppUpgrader(SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, Scheduler scheduler, FormUpdateScheduler formUpdateScheduler, ProjectsRepository projectsRepository) {
+        SchedulerUpgrade schedulerUpgrade = new SchedulerUpgrade(scheduler, projectsRepository, formUpdateScheduler);
+
+        return new AppUpgrader(settingsProvider.getMetaSettings(), asList(
+                existingProjectMigrator,
+                schedulerUpgrade
         ));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -28,6 +28,7 @@ import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel;
 import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
+import org.odk.collect.android.application.initialization.ApplicationInitializer;
 import org.odk.collect.android.application.initialization.CollectSettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.ExistingProjectMigrator;
 import org.odk.collect.android.application.initialization.FormUpdatesUpgrade;
@@ -582,5 +583,10 @@ public class AppDependencyModule {
                 existingProjectMigrator,
                 formUpdatesUpgrade
         ));
+    }
+
+    @Provides
+    public ApplicationInitializer providesApplicationInitializer(Application context, UserAgentProvider userAgentProvider, PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, LaunchState launchState, AppUpgrader appUpgrader) {
+        return new ApplicationInitializer(context, userAgentProvider, propertyManager, analytics, storageInitializer, launchState, appUpgrader);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -30,7 +30,7 @@ import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.initialization.CollectSettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.ExistingProjectMigrator;
-import org.odk.collect.android.application.initialization.SchedulerUpgrade;
+import org.odk.collect.android.application.initialization.FormUpdatesUpgrade;
 import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator;
 import org.odk.collect.android.application.initialization.upgrade.AppUpgrader;
 import org.odk.collect.android.backgroundwork.FormUpdateAndInstanceSubmitScheduler;
@@ -572,12 +572,15 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public AppUpgrader providesAppUpgrader(SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, Scheduler scheduler, FormUpdateScheduler formUpdateScheduler, ProjectsRepository projectsRepository) {
-        SchedulerUpgrade schedulerUpgrade = new SchedulerUpgrade(scheduler, projectsRepository, formUpdateScheduler);
+    public FormUpdatesUpgrade providesFormUpdatesUpgrader(Scheduler scheduler, ProjectsRepository projectsRepository, FormUpdateScheduler formUpdateScheduler) {
+        return new FormUpdatesUpgrade(scheduler, projectsRepository, formUpdateScheduler);
+    }
 
+    @Provides
+    public AppUpgrader providesAppUpgrader(SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, FormUpdatesUpgrade formUpdatesUpgrade) {
         return new AppUpgrader(settingsProvider.getMetaSettings(), asList(
                 existingProjectMigrator,
-                schedulerUpgrade
+                formUpdatesUpgrade
         ));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/application/RobolectricApplication.java
+++ b/collect_app/src/test/java/org/odk/collect/android/application/RobolectricApplication.java
@@ -18,8 +18,6 @@ public class RobolectricApplication extends Collect {
 
     @Override
     public void onCreate() {
-        super.onCreate();
-
         // Prevents OKHttp from exploding on initialization https://github.com/robolectric/robolectric/issues/5115
         System.setProperty("javax.net.ssl.trustStore", "NONE");
 
@@ -29,6 +27,8 @@ public class RobolectricApplication extends Collect {
         } catch (IllegalStateException e) {
             // initialize() explodes if it's already been called
         }
+
+        super.onCreate();
 
         // We don't want to deal with permission checks in Robolectric
         ShadowApplication shadowApplication = shadowOf(this);

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/FormUpdatesUpgradeTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/FormUpdatesUpgradeTest.kt
@@ -1,0 +1,35 @@
+package org.odk.collect.android.application.initialization
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.odk.collect.android.backgroundwork.FormUpdateScheduler
+import org.odk.collect.async.Scheduler
+import org.odk.collect.projects.InMemProjectsRepository
+import org.odk.collect.projects.Project
+
+class FormUpdatesUpgradeTest {
+
+    @Test
+    fun `cancels all existing background jobs`() {
+        val scheduler = mock<Scheduler>()
+        val formUpdatesUpgrade = FormUpdatesUpgrade(scheduler, InMemProjectsRepository(), mock())
+
+        formUpdatesUpgrade.run()
+        verify(scheduler).cancelAllDeferred()
+    }
+
+    @Test
+    fun `schedules updates for all projects`() {
+        val projectsRepository = InMemProjectsRepository()
+        val project1 = projectsRepository.save(Project.New("1", "1", "#ffffff"))
+        val project2 = projectsRepository.save(Project.New("2", "2", "#ffffff"))
+
+        val formUpdateScheduler = mock<FormUpdateScheduler>()
+        val formUpdatesUpgrade = FormUpdatesUpgrade(mock(), projectsRepository, formUpdateScheduler)
+
+        formUpdatesUpgrade.run()
+        verify(formUpdateScheduler).scheduleUpdates(project1.uuid)
+        verify(formUpdateScheduler).scheduleUpdates(project2.uuid)
+    }
+}

--- a/projects/src/main/java/org/odk/collect/projects/InMemProjectsRepository.kt
+++ b/projects/src/main/java/org/odk/collect/projects/InMemProjectsRepository.kt
@@ -2,7 +2,7 @@ package org.odk.collect.projects
 
 import org.odk.collect.shared.strings.UUIDGenerator
 
-class InMemProjectsRepository(private val uuidGenerator: UUIDGenerator) : ProjectsRepository {
+class InMemProjectsRepository(private val uuidGenerator: UUIDGenerator = UUIDGenerator()) : ProjectsRepository {
     val projects = mutableListOf<Project.Saved>()
 
     override fun get(uuid: String) = projects.find { it.uuid == uuid }


### PR DESCRIPTION
Closes #4430
~~Blocked by #4602~~

This makes sure that, when the app is upgraded, existing background jobs are cancelled and then form updates are rescheduled.

#### What has been done to verify that this works as intended?

New tests and verified manually for match exactly (configured for 1.30.1 and then updated to current dev version).

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to chat about here, as the structure of how upgrade work was defined and discussed in an earlier PR. I've left a couple of comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We'll skip QA on this for the moment and test background jobs as a whole later.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)