### PR TITLE
Show project name in app bar

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -92,6 +92,7 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
         currentProjectViewModel = new ViewModelProvider(this, currentProjectViewModelFactory).get(CurrentProjectViewModel.class);
         currentProjectViewModel.getCurrentProject().observe(this, project -> {
             invalidateOptionsMenu();
+            setTitle(project.getName());
         });
 
         initToolbar();
@@ -265,7 +266,6 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
 
     private void initToolbar() {
         Toolbar toolbar = findViewById(R.id.toolbar);
-        setTitle(String.format("%s %s", getString(R.string.app_name), mainMenuViewModel.getVersion()));
         setSupportActionBar(toolbar);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -182,6 +182,9 @@ public class MainMenuActivity extends CollectAbstractActivity implements AdminPa
             }
         });
 
+        TextView appName = findViewById(R.id.app_name);
+        appName.setText(String.format("%s %s", getString(R.string.app_name), mainMenuViewModel.getVersion()));
+
         TextView versionSHAView = findViewById(R.id.version_sha);
         String versionSHA = mainMenuViewModel.getVersionCommitDescription();
         if (versionSHA != null) {

--- a/collect_app/src/main/res/layout/app_bar_layout.xml
+++ b/collect_app/src/main/res/layout/app_bar_layout.xml
@@ -13,7 +13,6 @@
             style="@style/Widget.MaterialComponents.Toolbar.Primary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:navigationIcon="@drawable/notes"
             tools:title="Title" />
 
     </com.google.android.material.appbar.AppBarLayout>

--- a/collect_app/src/main/res/layout/form_entry.xml
+++ b/collect_app/src/main/res/layout/form_entry.xml
@@ -27,8 +27,7 @@ the License.
             style="@style/Widget.MaterialComponents.Toolbar.Primary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:elevation="0dp"
-            app:navigationIcon="@drawable/notes" />
+            android:elevation="0dp" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/audio_recording_controller"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -91,17 +91,17 @@
 
                 <TextView
                     android:id="@+id/app_name"
-                    style="@style/TextAppearance.Collect.Body1"
+                    android:textAppearance="?textAppearanceBody1"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
                     android:layout_marginTop="@dimen/margin_standard"
-                    android:textColor="@color/dark_gray"
+                    android:textColor="@color/color_on_surface_medium_emphasis"
                     tools:text="ODK Collect v2022.3" />
 
                 <TextView
                     android:id="@+id/version_sha"
-                    style="@style/TextAppearance.Collect.Caption"
+                    android:textAppearance="?textAppearanceCaption"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"

--- a/collect_app/src/main/res/layout/main_menu.xml
+++ b/collect_app/src/main/res/layout/main_menu.xml
@@ -90,12 +90,21 @@
                     tools:text="@string/manage_files" />
 
                 <TextView
+                    android:id="@+id/app_name"
+                    style="@style/TextAppearance.Collect.Body1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="@dimen/margin_standard"
+                    android:textColor="@color/dark_gray"
+                    tools:text="ODK Collect v2022.3" />
+
+                <TextView
                     android:id="@+id/version_sha"
                     style="@style/TextAppearance.Collect.Caption"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:layout_marginTop="@dimen/margin_standard"
                     tools:text="commit sha" />
             </LinearLayout>
         </LinearLayout>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -22,8 +22,6 @@ the License.
 
     <color name="highContrastHighlight">#ff8c00</color>
 
-    <color name="dark_gray">#999999</color>
-
     <!-- Background colors in the GeoTrace status bar, under white text. -->
     <color name="locationStatusSearching">#333333</color>
     <color name="locationStatusAcceptable">#337733</color>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -22,6 +22,8 @@ the License.
 
     <color name="highContrastHighlight">#ff8c00</color>
 
+    <color name="dark_gray">#999999</color>
+
     <!-- Background colors in the GeoTrace status bar, under white text. -->
     <color name="locationStatusSearching">#333333</color>
     <color name="locationStatusAcceptable">#337733</color>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -32,7 +32,4 @@
         <item name="android:textAllCaps">false</item>
         <item name="android:letterSpacing">0.04</item>
     </style>
-
-    <style name="TextAppearance.Collect.Caption" parent="TextAppearance.MaterialComponents.Caption">
-    </style>
 </resources>

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.kt
@@ -80,6 +80,14 @@ class MainMenuActivityTest {
     }
 
     @Test
+    fun `Activity title is current project name`() {
+        val scenario = ActivityScenario.launch(MainMenuActivity::class.java)
+        scenario.onActivity {
+            assertThat(it.title, `is`("Project"))
+        }
+    }
+
+    @Test
     fun `Project icon for current project should be displayed`() {
         val scenario = ActivityScenario.launch(MainMenuActivity::class.java)
         scenario.onActivity { activity: MainMenuActivity ->


### PR DESCRIPTION
Closes #4584

#### What has been done to verify that this works as intended?
Manually tried it.

#### Why is this the best possible solution? Were any other approaches considered?
I could be convinced to make the app name and version black. I used a dark gray to match the first launch screen version introduced at https://github.com/getodk/collect/pull/4601. Otherwise, I matched the spirit of the mockups and the items we indicated in the issue with as minimal of changes as possible for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I don't think there are any code-related risks. There is a risk that the behavior change will be confusing or disorienting to users. This is why we want it to be in the beta so we can get feedback as soon as possible.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1365

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)