### PR TITLE
Group settings buttons with current project and add margins between project list projects

### DIFF
--- a/androidshared/src/main/res/values/dimens.xml
+++ b/androidshared/src/main/res/values/dimens.xml
@@ -8,4 +8,5 @@
     <dimen name="margin_large">24dp</dimen>
     <dimen name="margin_extra_large">32dp</dimen>
 
+    <dimen name="project_list_icon_size">30dp</dimen>
 </resources>

--- a/androidshared/src/main/res/values/dimens.xml
+++ b/androidshared/src/main/res/values/dimens.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <!-- "Standard" set of margin sizes for Android (pre and post Material) -->
     <dimen name="margin_extra_small">4dp</dimen>
     <dimen name="margin_small">8dp</dimen>
     <dimen name="margin_standard">16dp</dimen>
     <dimen name="margin_large">24dp</dimen>
     <dimen name="margin_extra_large">32dp</dimen>
-
-    <dimen name="project_list_icon_size">30dp</dimen>
 </resources>

--- a/collect_app/src/main/res/drawable/project_icon_background.xml
+++ b/collect_app/src/main/res/drawable/project_icon_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <solid android:color="@android:color/black"/>
-    <size android:width="@dimen/project_list_icon_size" android:height="@dimen/project_list_icon_size"/>
+    <size android:width="30dp" android:height="30dp"/>
 </shape>

--- a/collect_app/src/main/res/drawable/project_icon_background.xml
+++ b/collect_app/src/main/res/drawable/project_icon_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <solid android:color="@android:color/black"/>
-    <size android:width="30dp" android:height="30dp"/>
+    <size android:width="@dimen/project_list_icon_size" android:height="@dimen/project_list_icon_size"/>
 </shape>

--- a/collect_app/src/main/res/layout/project_list_item.xml
+++ b/collect_app/src/main/res/layout/project_list_item.xml
@@ -27,7 +27,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small"
-            android:textAppearance="@style/TextAppearance.Collect.Subtitle1"
+            android:textAppearance="?textAppearanceSubtitle1"
             tools:text="A project"/>
 
         <TextView

--- a/collect_app/src/main/res/layout/project_list_item.xml
+++ b/collect_app/src/main/res/layout/project_list_item.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_marginTop="@dimen/margin_small"
     xmlns:tools="http://schemas.android.com/tools">
 
     <org.odk.collect.android.projects.ProjectIconView

--- a/collect_app/src/main/res/layout/project_list_item.xml
+++ b/collect_app/src/main/res/layout/project_list_item.xml
@@ -2,14 +2,16 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <org.odk.collect.android.projects.ProjectIconView
         android:id="@+id/project_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="A"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -24,13 +26,15 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small"
-            android:textAppearance="@style/TextAppearance.Collect.Subtitle1" />
+            android:textAppearance="@style/TextAppearance.Collect.Subtitle1"
+            tools:text="A project"/>
 
         <TextView
             android:id="@+id/project_subtext"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small"
-            android:textAppearance="@style/TextAppearance.Collect.Body2.MediumEmphasis" />
+            android:textAppearance="@style/TextAppearance.Collect.Body2.MediumEmphasis"
+            tools:text="my.cool.project.com"/>
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -100,6 +100,7 @@
         android:id="@+id/bottom_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
+        android:layout_marginTop="@dimen/margin_small"
         android:alpha="0.2"
         android:background="?colorOnSurface"
         app:layout_constraintStart_toEndOf="parent"

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -53,8 +53,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
+        android:layout_marginStart="@dimen/project_list_icon_size"
         android:text="@string/general_preferences"
-        app:layout_constraintStart_toStartOf="@+id/guideline_start"
+        app:layout_constraintStart_toStartOf="@+id/current_project"
         app:layout_constraintTop_toBottomOf="@+id/current_project" />
 
     <com.google.android.material.button.MaterialButton
@@ -62,6 +63,7 @@
         style="@style/Widget.Collect.Button.OutlinedButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/project_list_icon_size"
         android:text="@string/admin_preferences"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
         app:layout_constraintTop_toBottomOf="@+id/general_settings_button" />
@@ -81,9 +83,9 @@
         android:id="@+id/project_list_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintHeight_max="100dp"
         android:layout_marginBottom="@dimen/margin_small"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_max="100dp"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
         app:layout_constraintTop_toBottomOf="@+id/top_divider">
 

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -53,7 +53,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_small"
-        android:layout_marginStart="@dimen/project_list_icon_size"
+        android:layout_marginStart="38dp"
         android:text="@string/general_preferences"
         app:layout_constraintStart_toStartOf="@+id/current_project"
         app:layout_constraintTop_toBottomOf="@+id/current_project" />
@@ -63,7 +63,7 @@
         style="@style/Widget.Collect.Button.OutlinedButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/project_list_icon_size"
+        android:layout_marginStart="38dp"
         android:text="@string/admin_preferences"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
         app:layout_constraintTop_toBottomOf="@+id/general_settings_button" />


### PR DESCRIPTION
We've gotten feedback that it's not clear what "general settings" and "admin settings" connects to. This PR attempts to address that.

#### What has been done to verify that this works as intended?
Manual verification.

#### Why is this the best possible solution? Were any other approaches considered?
The alignment of the settings button isn't perfect because it's missing margin. The goal for now is just to see whether the general approach is acceptable and we can do a final cleanup pass after beta.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
These are just layout changes so risk is very low. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)