### PR TITLE
Migrate settings on upgrade

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/CollectSettingsMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/CollectSettingsMigrator.java
@@ -31,11 +31,11 @@ import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_USGS_MAP_
 /**
  * Migrates old preference keys and values to new ones.
  */
-public class CollectSettingsPreferenceMigrator implements SettingsPreferenceMigrator {
+public class CollectSettingsMigrator implements SettingsMigrator {
 
     private final Settings metaPrefs;
 
-    public CollectSettingsPreferenceMigrator(Settings metaPrefs) {
+    public CollectSettingsMigrator(Settings metaPrefs) {
         this.metaPrefs = metaPrefs;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingSettingsMigrator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingSettingsMigrator.kt
@@ -1,0 +1,25 @@
+package org.odk.collect.android.application.initialization
+
+import org.odk.collect.android.application.initialization.upgrade.Upgrade
+import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.projects.ProjectsRepository
+
+class ExistingSettingsMigrator(
+    private val projectsRepository: ProjectsRepository,
+    private val settingsProvider: SettingsProvider,
+    private val settingsMigrator: SettingsMigrator
+) : Upgrade {
+
+    override fun key(): String? {
+        return null
+    }
+
+    override fun run() {
+        projectsRepository.getAll().forEach {
+            settingsMigrator.migrate(
+                settingsProvider.getGeneralSettings(it.uuid),
+                settingsProvider.getAdminSettings(it.uuid)
+            )
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/SettingsMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/SettingsMigrator.java
@@ -2,7 +2,7 @@ package org.odk.collect.android.application.initialization;
 
 import org.odk.collect.shared.Settings;
 
-public interface SettingsPreferenceMigrator {
+public interface SettingsMigrator {
 
     void migrate(Settings generalSettings, Settings adminSettings);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/configure/SettingsImporter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/SettingsImporter.kt
@@ -2,7 +2,7 @@ package org.odk.collect.android.configure
 
 import org.json.JSONException
 import org.json.JSONObject
-import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator
+import org.odk.collect.android.application.initialization.SettingsMigrator
 import org.odk.collect.android.configure.qr.AppConfigurationKeys
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.projects.Project
@@ -11,7 +11,7 @@ import org.odk.collect.shared.Settings
 
 class SettingsImporter(
     private val settingsProvider: SettingsProvider,
-    private val preferenceMigrator: SettingsPreferenceMigrator,
+    private val settngsMigrator: SettingsMigrator,
     private val settingsValidator: SettingsValidator,
     private val generalDefaults: Map<String, Any>,
     private val adminDefaults: Map<String, Any>,
@@ -46,7 +46,7 @@ class SettingsImporter(
             // Ignored
         }
 
-        preferenceMigrator.migrate(generalSettings, adminSettings)
+        settngsMigrator.migrate(generalSettings, adminSettings)
 
         clearUnknownKeys(generalSettings, generalDefaults)
         clearUnknownKeys(adminSettings, adminDefaults)

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -29,10 +29,10 @@ import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
 import org.odk.collect.android.activities.viewmodels.SplashScreenViewModel;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.initialization.ApplicationInitializer;
-import org.odk.collect.android.application.initialization.CollectSettingsPreferenceMigrator;
+import org.odk.collect.android.application.initialization.CollectSettingsMigrator;
 import org.odk.collect.android.application.initialization.ExistingProjectMigrator;
 import org.odk.collect.android.application.initialization.FormUpdatesUpgrade;
-import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator;
+import org.odk.collect.android.application.initialization.SettingsMigrator;
 import org.odk.collect.android.application.initialization.upgrade.AppUpgrader;
 import org.odk.collect.android.backgroundwork.FormUpdateAndInstanceSubmitScheduler;
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler;
@@ -314,8 +314,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SettingsPreferenceMigrator providesPreferenceMigrator(SettingsProvider settingsProvider) {
-        return new CollectSettingsPreferenceMigrator(settingsProvider.getMetaSettings());
+    public SettingsMigrator providesPreferenceMigrator(SettingsProvider settingsProvider) {
+        return new CollectSettingsMigrator(settingsProvider.getMetaSettings());
     }
 
     @Provides
@@ -335,7 +335,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SettingsImporter providesCollectSettingsImporter(SettingsProvider settingsProvider, SettingsPreferenceMigrator preferenceMigrator, SettingsValidator settingsValidator, SettingsChangeHandler settingsChangeHandler, ProjectsRepository projectsRepository) {
+    public SettingsImporter providesCollectSettingsImporter(SettingsProvider settingsProvider, SettingsMigrator preferenceMigrator, SettingsValidator settingsValidator, SettingsChangeHandler settingsChangeHandler, ProjectsRepository projectsRepository) {
         return new SettingsImporter(
                 settingsProvider,
                 preferenceMigrator,

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -31,6 +31,7 @@ import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.initialization.ApplicationInitializer;
 import org.odk.collect.android.application.initialization.CollectSettingsMigrator;
 import org.odk.collect.android.application.initialization.ExistingProjectMigrator;
+import org.odk.collect.android.application.initialization.ExistingSettingsMigrator;
 import org.odk.collect.android.application.initialization.FormUpdatesUpgrade;
 import org.odk.collect.android.application.initialization.SettingsMigrator;
 import org.odk.collect.android.application.initialization.upgrade.AppUpgrader;
@@ -578,9 +579,15 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public AppUpgrader providesAppUpgrader(SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, FormUpdatesUpgrade formUpdatesUpgrade) {
+    public ExistingSettingsMigrator providesExistingSettingsMigrator(ProjectsRepository projectsRepository, SettingsProvider settingsProvider, SettingsMigrator settingsMigrator) {
+        return new ExistingSettingsMigrator(projectsRepository, settingsProvider, settingsMigrator);
+    }
+
+    @Provides
+    public AppUpgrader providesAppUpgrader(SettingsProvider settingsProvider, ExistingProjectMigrator existingProjectMigrator, FormUpdatesUpgrade formUpdatesUpgrade, ExistingSettingsMigrator existingSettingsMigrator) {
         return new AppUpgrader(settingsProvider.getMetaSettings(), asList(
                 existingProjectMigrator,
+                existingSettingsMigrator,
                 formUpdatesUpgrade
         ));
     }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/CollectSettingsMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/CollectSettingsMigratorTest.java
@@ -19,7 +19,7 @@ import static org.odk.collect.android.application.initialization.migration.Share
 import static org.odk.collect.android.application.initialization.migration.SharedPreferenceUtils.initPrefs;
 
 @RunWith(AndroidJUnit4.class)
-public class CollectSettingsPreferenceMigratorTest {
+public class CollectSettingsMigratorTest {
 
     private final Settings generalSettings = TestSettingsProvider.getGeneralSettings();
     private final Settings adminSettings = TestSettingsProvider.getAdminSettings();
@@ -266,6 +266,6 @@ public class CollectSettingsPreferenceMigratorTest {
     }
 
     private void runMigrations() {
-        new CollectSettingsPreferenceMigrator(metaSettings).migrate(generalSettings, adminSettings);
+        new CollectSettingsMigrator(metaSettings).migrate(generalSettings, adminSettings);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ExistingSettingsMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ExistingSettingsMigratorTest.kt
@@ -1,0 +1,49 @@
+package org.odk.collect.android.application.initialization
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.projects.InMemProjectsRepository
+import org.odk.collect.projects.Project
+import org.odk.collect.testshared.InMemSettings
+
+class ExistingSettingsMigratorTest {
+
+    @Test
+    fun `migrates general and admin settings for each project`() {
+        val projectsRepository = InMemProjectsRepository()
+        val project1 = projectsRepository.save(Project.New("1", "1", "#ffffff"))
+        val project2 = projectsRepository.save(Project.New("2", "2", "#ffffff"))
+
+        val project1GeneralSettings = InMemSettings()
+        val project1AdminSettings = InMemSettings()
+        val project2GeneralSettings = InMemSettings()
+        val project2AdminSettings = InMemSettings()
+
+        val settingsProvider = mock<SettingsProvider> {
+            on { getGeneralSettings(project1.uuid) } doReturn project1GeneralSettings
+            on { getAdminSettings(project1.uuid) } doReturn project1AdminSettings
+            on { getGeneralSettings(project2.uuid) } doReturn project2GeneralSettings
+            on { getAdminSettings(project2.uuid) } doReturn project2AdminSettings
+        }
+
+        val settingsMigrator = mock<SettingsMigrator>()
+        val existingSettingsMigrator =
+            ExistingSettingsMigrator(projectsRepository, settingsProvider, settingsMigrator)
+
+        existingSettingsMigrator.run()
+        verify(settingsMigrator).migrate(project1GeneralSettings, project1AdminSettings)
+        verify(settingsMigrator).migrate(project2GeneralSettings, project2AdminSettings)
+    }
+
+    @Test
+    fun `has null key`() {
+        val existingSettingsMigrator = ExistingSettingsMigrator(mock(), mock(), mock())
+        assertThat(existingSettingsMigrator.key(), `is`(nullValue()))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.odk.collect.android.application.initialization.SettingsPreferenceMigrator
+import org.odk.collect.android.application.initialization.SettingsMigrator
 import org.odk.collect.android.application.initialization.migration.SharedPreferenceUtils
 import org.odk.collect.android.configure.qr.AppConfigurationKeys
 import org.odk.collect.android.preferences.source.SettingsProvider
@@ -121,7 +121,7 @@ class SettingsImporterTest {
     @Test // Migrations might add/rename/move keys
     fun migratesPreferences_beforeLoadingDefaults() {
         val migrator =
-            SettingsPreferenceMigrator { _: Settings?, _: Settings? ->
+            SettingsMigrator { _: Settings?, _: Settings? ->
                 if (generalSettings.contains("key1")) {
                     throw RuntimeException("defaults already loaded!")
                 }
@@ -146,7 +146,7 @@ class SettingsImporterTest {
                 JSONObject().put("unknown_key", "value")
             )
         val migrator =
-            SettingsPreferenceMigrator { _: Settings?, _: Settings? ->
+            SettingsMigrator { _: Settings?, _: Settings? ->
                 if (!generalSettings.contains("unknown_key")) {
                     throw RuntimeException("unknowns already cleared!")
                 }


### PR DESCRIPTION
Closes #4604 

#### What has been done to verify that this works as intended?

New tests and verified manually (went back to a version that would actually apply a settings migration)

#### Why is this the best possible solution? Were any other approaches considered?

This just adds another `Upgrade` to handle the settings migration like we've doing for existing project and work manager upgrades.

I did notice as part of this that we weirdly migrate meta settings when we migrate any other settings, which now makes even less sense (due to multiple settings because of projects). Probably something to tidy up later, but no need to address right now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We'll start looking at QA for all this soon but no need for a pass before merging.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)