### PR TITLE
Remove unneeded close action from tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -271,20 +271,16 @@ public class FieldListUpdateTest {
                 .assertTextDoesNotExist("A1", "B1", "C1", "A1A") // No choices should be shown for levels 2 and 3 when no selection is made for level 1
                 .openSelectMinimalDialog(0)
                 .clickOnText("C") // Selecting C for level 1 should only reveal options for C at level 2
-                .closeSelectMinimalDialog()
                 .assertTextDoesNotExist("A1", "B1")
                 .openSelectMinimalDialog(1)
                 .clickOnText("C1")
-                .closeSelectMinimalDialog()
                 .assertTextDoesNotExist("A1A")
                 .clickOnText("C")
                 .clickOnText("A") // Selecting A for level 1 should reveal options for A at level 2
-                .closeSelectMinimalDialog()
                 .openSelectMinimalDialog(1)
                 .assertText("A1")
                 .assertTextDoesNotExist("A1A", "B1", "C1")
                 .clickOnText("A1") // Selecting A1 for level 2 should reveal options for A1 at level 3
-                .closeSelectMinimalDialog()
                 .openSelectMinimalDialog(2)
                 .assertText("A1A")
                 .assertTextDoesNotExist("B1A", "B1", "C1");
@@ -387,7 +383,6 @@ public class FieldListUpdateTest {
                 .openSelectMinimalDialog()
                 .assertText("Mango", "Oranges", "Strawberries")
                 .clickOnText("Strawberries")
-                .closeSelectMinimalDialog()
                 .assertText("Target15")
                 .assertSelectMinimalDialogAnswer("Strawberries");
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -78,7 +78,7 @@ public class FillBlankFormTest {
     @Test
     public void searchBar_ShouldSearchForm() {
         //TestCase12
-        new MainMenuPage()
+        rule.startAtMainMenu()
                 .clickFillBlankForm()
                 .clickMenuFilter()
                 .searchInBar("Aaa")
@@ -416,7 +416,7 @@ public class FillBlankFormTest {
     @Test
     public void question_ShouldBeVisibleOnTheTopOfHierarchy() {
         //TestCase23
-        new MainMenuPage()
+        rule.startAtMainMenu()
                 .copyForm("manyQ.xml")
                 .startBlankForm("manyQ")
                 .swipeToNextQuestion("t2")
@@ -430,21 +430,18 @@ public class FillBlankFormTest {
     @Test
     public void bigForm_ShouldBeFilledSuccessfully() {
         //TestCase18
-        new MainMenuPage()
+        rule.startAtMainMenu()
                 .copyForm("nigeria-wards.xml")
                 .startBlankForm("Nigeria Wards")
                 .assertQuestion("State")
                 .openSelectMinimalDialog()
                 .clickOnText("Adamawa")
-                .closeSelectMinimalDialog()
                 .swipeToNextQuestion("LGA", true)
                 .openSelectMinimalDialog()
                 .clickOnText("Ganye")
-                .closeSelectMinimalDialog()
                 .swipeToNextQuestion("Ward", true)
                 .openSelectMinimalDialog()
                 .clickOnText("Jaggu")
-                .closeSelectMinimalDialog()
                 .swipeToNextQuestion("Comments")
                 .swipeToEndScreen()
                 .clickSaveAndExit();


### PR DESCRIPTION
This just removes an action from tests that wasn't needed and was exploding because the view it referred to was deleted.