### PR TITLE
Always enable analytics in beta

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -22,6 +22,7 @@ import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.logic.actions.setgeopoint.CollectSetGeopointActionHandler;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.utilities.LaunchState;
+import org.odk.collect.android.version.VersionInformation;
 import org.odk.collect.utilities.UserAgentProvider;
 
 import java.util.Locale;
@@ -37,11 +38,12 @@ public class ApplicationInitializer {
     private final StorageInitializer storageInitializer;
     private final LaunchState launchState;
     private final AppUpgrader appUpgrader;
+    private final VersionInformation versionInformation;
 
     public ApplicationInitializer(Application context, UserAgentProvider userAgentProvider,
                                   PropertyManager propertyManager, Analytics analytics,
                                   StorageInitializer storageInitializer, LaunchState launchState,
-                                  AppUpgrader appUpgrader) {
+                                  AppUpgrader appUpgrader, VersionInformation versionInformation) {
         this.context = context;
         this.userAgentProvider = userAgentProvider;
         this.propertyManager = propertyManager;
@@ -49,6 +51,7 @@ public class ApplicationInitializer {
         this.storageInitializer = storageInitializer;
         this.launchState = launchState;
         this.appUpgrader = appUpgrader;
+        this.versionInformation = versionInformation;
     }
 
     public void initialize() {
@@ -80,10 +83,7 @@ public class ApplicationInitializer {
     }
 
     private void initializeAnalytics() {
-        analytics.setAnalyticsCollectionEnabled(false);
-
-//        FormUpdateMode formUpdateMode = getFormUpdateMode(context, generalSettings);
-//        analytics.setUserProperty("FormUpdateMode", formUpdateMode.getValue(context));
+        analytics.setAnalyticsCollectionEnabled(versionInformation.getBetaNumber() != null);
     }
 
     private void initializeLocale() {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -83,7 +83,7 @@ public class ApplicationInitializer {
     }
 
     private void initializeAnalytics() {
-        analytics.setAnalyticsCollectionEnabled(versionInformation.getBetaNumber() != null);
+        analytics.setAnalyticsCollectionEnabled(versionInformation.isBeta());
     }
 
     private void initializeLocale() {

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -43,8 +43,8 @@ import org.odk.collect.android.configure.SettingsImporter;
 import org.odk.collect.android.configure.SettingsValidator;
 import org.odk.collect.android.configure.SharedPreferencesServerRepository;
 import org.odk.collect.android.configure.StructureAndTypeSettingsValidator;
-import org.odk.collect.android.configure.qr.CachingQRCodeGenerator;
 import org.odk.collect.android.configure.qr.AppConfigurationGenerator;
+import org.odk.collect.android.configure.qr.CachingQRCodeGenerator;
 import org.odk.collect.android.configure.qr.QRCodeDecoder;
 import org.odk.collect.android.configure.qr.QRCodeGenerator;
 import org.odk.collect.android.configure.qr.QRCodeUtils;
@@ -586,7 +586,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ApplicationInitializer providesApplicationInitializer(Application context, UserAgentProvider userAgentProvider, PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, LaunchState launchState, AppUpgrader appUpgrader) {
-        return new ApplicationInitializer(context, userAgentProvider, propertyManager, analytics, storageInitializer, launchState, appUpgrader);
+    public ApplicationInitializer providesApplicationInitializer(Application context, UserAgentProvider userAgentProvider, PropertyManager propertyManager, Analytics analytics, StorageInitializer storageInitializer, LaunchState launchState, AppUpgrader appUpgrader, VersionInformation versionInformation) {
+        return new ApplicationInitializer(context, userAgentProvider, propertyManager, analytics, storageInitializer, launchState, appUpgrader, versionInformation);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/IdentityPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/IdentityPreferencesFragment.java
@@ -71,7 +71,7 @@ public class IdentityPreferencesFragment extends BaseGeneralPreferencesFragment 
         final CheckBoxPreference analyticsPreference = (CheckBoxPreference) findPreference(KEY_ANALYTICS);
 
         if (analyticsPreference != null) {
-            if (versionInformation.getBetaNumber() != null) {
+            if (versionInformation.isBeta()) {
                 displayDisabled(analyticsPreference, true);
                 analyticsPreference.setSummary(analyticsPreference.getSummary() + " Usage data collection cannot be disabled in beta versions of Collect.");
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/IdentityPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/IdentityPreferencesFragment.java
@@ -21,19 +21,24 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.preference.CheckBoxPreference;
 
-import org.odk.collect.android.R;
 import org.odk.collect.analytics.Analytics;
+import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.utilities.MultiClickGuard;
+import org.odk.collect.android.version.VersionInformation;
 
 import javax.inject.Inject;
 
 import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_ANALYTICS;
+import static org.odk.collect.android.preferences.utilities.PreferencesUtils.displayDisabled;
 
 public class IdentityPreferencesFragment extends BaseGeneralPreferencesFragment {
 
     @Inject
     Analytics analytics;
+
+    @Inject
+    VersionInformation versionInformation;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -66,10 +71,15 @@ public class IdentityPreferencesFragment extends BaseGeneralPreferencesFragment 
         final CheckBoxPreference analyticsPreference = (CheckBoxPreference) findPreference(KEY_ANALYTICS);
 
         if (analyticsPreference != null) {
-            analyticsPreference.setOnPreferenceClickListener(preference -> {
-                analytics.setAnalyticsCollectionEnabled(analyticsPreference.isChecked());
-                return true;
-            });
+            if (versionInformation.getBetaNumber() != null) {
+                displayDisabled(analyticsPreference, true);
+                analyticsPreference.setSummary(analyticsPreference.getSummary() + " Usage data collection cannot be disabled in beta versions of Collect.");
+            } else {
+                analyticsPreference.setOnPreferenceClickListener(preference -> {
+                    analytics.setAnalyticsCollectionEnabled(analyticsPreference.isChecked());
+                    return true;
+                });
+            }
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/version/VersionInformation.java
+++ b/collect_app/src/main/java/org/odk/collect/android/version/VersionInformation.java
@@ -65,7 +65,7 @@ public class VersionInformation {
         return getVersionDescriptionComponents().length == 1;
     }
 
-    private boolean isBeta() {
+    public boolean isBeta() {
         return versionDescriptionProvider.getVersionDescription().contains("beta");
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
@@ -30,6 +30,7 @@ class ApplicationInitializerTest {
             mock(),
             launchState,
             appUpgrader,
+            mock()
         )
 
         applicationInitializer.initialize()
@@ -52,6 +53,7 @@ class ApplicationInitializerTest {
             mock(),
             launchState,
             appUpgrader,
+            mock()
         )
 
         applicationInitializer.initialize()
@@ -70,6 +72,7 @@ class ApplicationInitializerTest {
             mock(),
             launchState,
             mock(),
+            mock()
         )
 
         applicationInitializer.initialize()

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
@@ -29,7 +29,7 @@ class ApplicationInitializerTest {
             mock(),
             mock(),
             launchState,
-            appUpgrader
+            appUpgrader,
         )
 
         applicationInitializer.initialize()
@@ -51,7 +51,7 @@ class ApplicationInitializerTest {
             mock(),
             mock(),
             launchState,
-            appUpgrader
+            appUpgrader,
         )
 
         applicationInitializer.initialize()
@@ -69,7 +69,7 @@ class ApplicationInitializerTest {
             mock(),
             mock(),
             launchState,
-            mock()
+            mock(),
         )
 
         applicationInitializer.initialize()

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -798,7 +798,7 @@
 
     <string name="analytics_preferences">Usage data</string>
     <string name="analytics">Collect anonymous usage data</string>
-    <string name="analytics_summary">Anonymous usage data helps the ODK team prioritize fixes and features</string>
+    <string name="analytics_summary">Anonymous usage data helps the ODK team prioritize fixes and features.</string>
 
     <string name="form_metadata_title">Form Metadata</string>
     <string name="form_metadata">Form metadata</string>


### PR DESCRIPTION
We're going to make analytics enable and disable based on the current project (#4605) but until then we'll just force it on at an app level for beta releases. I've made it so analytics and crash reporting is enabled on app start for beta releases. Also, the setting will be disabled for the user, and I've added a note to the setting summary, so it's (hopefully) clear what's happening.

#### What has been done to verify that this works as intended?

Verified manually.  

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. We already had a lot of the machinery in place for checking if the app is a beta or not so I just used that.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good for someone else to sanity check this by making a beta build and checking they see analytics in the real time dashboard. I just hardcoded the app to be a beta to check the settings all looked correct.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)