### PR TITLE
Add project config tip and placeholder dialog for GDrive configuration

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
 import androidx.core.widget.doOnTextChanged
 import org.odk.collect.android.R
@@ -13,6 +14,7 @@ import org.odk.collect.android.activities.MainMenuActivity
 import org.odk.collect.android.configure.qr.AppConfigurationGenerator
 import org.odk.collect.android.databinding.ManualProjectCreatorDialogLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
+import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.SoftKeyboardController
 import org.odk.collect.android.utilities.ToastUtils
 import org.odk.collect.material.MaterialFullScreenDialogFragment
@@ -60,6 +62,10 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
         binding.addButton.setOnClickListener {
             handleAddingNewProject()
         }
+
+        binding.gdrive.setOnClickListener {
+            showGdrivePlaceholderDialog()
+        }
     }
 
     override fun onCloseClicked() {
@@ -88,5 +94,14 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
         projectCreator.createNewProject(settingsJson)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
         ToastUtils.showLongToast(getString(org.odk.collect.projects.R.string.new_project_created))
+    }
+
+    private fun showGdrivePlaceholderDialog() {
+        val dialog = AlertDialog.Builder(requireContext())
+            .setTitle("Google Drive configuration coming soon")
+            .setMessage("Google Drive configuration is not fully implemented in this beta!")
+            .setPositiveButton(getString(R.string.ok)) { _, _ -> }
+            .create()
+        DialogUtils.showDialog(dialog, activity)
     }
 }

--- a/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/colorSurface">
@@ -79,7 +80,8 @@
                 android:layout_margin="@dimen/margin_standard"
                 android:hint="@string/password"
                 android:theme="@style/Theme.AndroidShared.MaterialComponents.Polyfill.TextInputLayout"
-                app:layout_constraintTop_toBottomOf="@+id/username">
+                app:layout_constraintTop_toBottomOf="@+id/username"
+                tools:layout_editor_absoluteX="16dp">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/password_input_text"
@@ -89,6 +91,67 @@
                     android:singleLine="true" />
 
             </com.google.android.material.textfield.TextInputLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/config_tip"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_standard"
+                app:layout_constraintBottom_toTopOf="@+id/gdrive"
+                app:layout_constraintTop_toBottomOf="@+id/password">
+
+                <ImageView
+                    android:id="@+id/tip_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_outline_info_24"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tip_text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="0dp"
+                    android:text="@string/project_config_tip"
+                    android:textAppearance="?textAppearanceBody1"
+                    app:layout_constraintStart_toEndOf="@+id/tip_icon"
+                    android:layout_marginStart="@dimen/margin_small"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/gdrive"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_standard"
+                android:layout_marginBottom="@dimen/margin_standard"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/password">
+
+                <TextView
+                    android:id="@+id/project_uses_gdrive"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/gdrive_project"
+                    android:textColor="?colorOnSurface"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+                <TextView
+                    android:id="@+id/configure_gdrive"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_extra_small"
+                    android:text="@string/gdrive_configure"
+                    android:textColor="@color/website_blue"
+                    app:layout_constraintStart_toEndOf="@+id/project_uses_gdrive"
+                    app:layout_constraintTop_toTopOf="@+id/project_uses_gdrive" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1012,6 +1012,11 @@
     <string name="configure_with_qr_code">Configure with QR code</string>
     <!-- Text for the button that allows for manually entering project details. Should be short -->
     <string name="configure_manually">Manually enter project details</string>
+    <string name="project_config_tip">After you add your project, you can configure it in General and Admin Settings</string>
+    <!-- Immediately followed by "Configure" which is a link to configure a Google Drive project -->
+    <string name="gdrive_project">My project uses Google Drive.</string>
+    <!-- Preceded by "My project uses Google Drive." Tapping opens a dialog to configure a Google Drive Project -->
+    <string name="gdrive_configure">Configure</string>
     <!-- Immediately followed by "Try Collect" which is a link to create a demo project -->
     <string name="dont_have_project">Don\'t have a project yet?</string>
     <!-- Preceded by "Don't have a project yet?" question -->


### PR DESCRIPTION
I think this is important to have as part of the first beta so as many users as possible have a chance to react to it. In particular, we should know if users have trouble finding the option.

#### What has been done to verify that this works as intended?
Tried it.

#### Why is this the best possible solution? Were any other approaches considered?
I went down the path of actually wiring the necessary pieces together to do a GDrive configuration but I backed out of it because we'll also need to configure project name, etc for that case. The "lean dialog" lets us make sure users can find GDrive config if they want it and then we can work on actually making it work for the next beta.

I made the font size for the tip bigger than in the original mockup because I found it hard to read. In a polishing pass we'll want to consider whether we like that, whether the Gdrive/Try Collect text should be bigger as well, etc.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Worst case is probably that my dialog launching introduces some kind of crash on the manual config screen. This is pretty localized so minimal risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)