### PR TITLE
Introduce in-mem SettingsProvider for tests

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -87,6 +87,7 @@ import org.odk.collect.android.preferences.keys.GeneralKeys;
 import org.odk.collect.android.preferences.keys.MetaKeys;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.preferences.source.SettingsStore;
+import org.odk.collect.android.preferences.source.SharedPreferencesSettingsProvider;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.projects.ProjectCreator;
 import org.odk.collect.android.projects.ProjectDetailsCreator;
@@ -228,7 +229,7 @@ public class AppDependencyModule {
     @Provides
     @Singleton
     public SettingsProvider providesSettingsProvider(Context context) {
-        return new SettingsProvider(context);
+        return new SharedPreferencesSettingsProvider(context);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -8,9 +8,9 @@ interface SettingsProvider {
 
     fun getGeneralSettings(projectId: String?): Settings
 
-    fun getGeneralSettings(): Settings
+    fun getGeneralSettings(): Settings = getGeneralSettings(null)
 
     fun getAdminSettings(projectId: String?): Settings
 
-    fun getAdminSettings(): Settings
+    fun getAdminSettings(): Settings = getAdminSettings(null)
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SettingsProvider.kt
@@ -1,53 +1,16 @@
 package org.odk.collect.android.preferences.source
 
-import android.content.Context
-import org.odk.collect.android.preferences.keys.AdminKeys
-import org.odk.collect.android.preferences.keys.GeneralKeys
-import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
 import org.odk.collect.shared.Settings
-import javax.inject.Singleton
 
-@Singleton
-class SettingsProvider(private val context: Context) {
+interface SettingsProvider {
 
-    private val settings = mutableMapOf<String, Settings>()
+    fun getMetaSettings(): Settings
 
-    fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
-        SharedPreferencesSettings(getSharedPrefs(META_SETTINGS_NAME))
-    }
+    fun getGeneralSettings(projectId: String?): Settings
 
-    @JvmOverloads
-    fun getGeneralSettings(projectId: String? = null): Settings {
-        val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
+    fun getGeneralSettings(): Settings
 
-        return settings.getOrPut(settingsId) {
-            SharedPreferencesSettings(getSharedPrefs(settingsId), GeneralKeys.getDefaults())
-        }
-    }
+    fun getAdminSettings(projectId: String?): Settings
 
-    @JvmOverloads
-    fun getAdminSettings(projectId: String? = null): Settings {
-        val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
-
-        return settings.getOrPut(settingsId) {
-            SharedPreferencesSettings(getSharedPrefs(settingsId), AdminKeys.getDefaults())
-        }
-    }
-
-    private fun getSharedPrefs(name: String) =
-        context.getSharedPreferences(name, Context.MODE_PRIVATE)
-
-    private fun getSettingsId(settingName: String, projectId: String?): String {
-        return if (projectId == null) {
-            settingName + (getMetaSettings().getString(CURRENT_PROJECT_ID))
-        } else {
-            settingName + projectId
-        }
-    }
-
-    companion object {
-        private const val META_SETTINGS_NAME = "meta"
-        private const val GENERAL_SETTINGS_NAME = "general_prefs"
-        private const val ADMIN_SETTINGS_NAME = "admin_prefs"
-    }
+    fun getAdminSettings(): Settings
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettingsProvider.kt
@@ -24,24 +24,8 @@ class SharedPreferencesSettingsProvider(private val context: Context) : Settings
         }
     }
 
-    override fun getGeneralSettings(): Settings {
-        val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, null)
-
-        return settings.getOrPut(settingsId) {
-            SharedPreferencesSettings(getSharedPrefs(settingsId), GeneralKeys.getDefaults())
-        }
-    }
-
     override fun getAdminSettings(projectId: String?): Settings {
         val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
-
-        return settings.getOrPut(settingsId) {
-            SharedPreferencesSettings(getSharedPrefs(settingsId), AdminKeys.getDefaults())
-        }
-    }
-
-    override fun getAdminSettings(): Settings {
-        val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, null)
 
         return settings.getOrPut(settingsId) {
             SharedPreferencesSettings(getSharedPrefs(settingsId), AdminKeys.getDefaults())

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettingsProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettingsProvider.kt
@@ -1,0 +1,67 @@
+package org.odk.collect.android.preferences.source
+
+import android.content.Context
+import org.odk.collect.android.preferences.keys.AdminKeys
+import org.odk.collect.android.preferences.keys.GeneralKeys
+import org.odk.collect.android.preferences.keys.MetaKeys
+import org.odk.collect.shared.Settings
+import javax.inject.Singleton
+
+@Singleton
+class SharedPreferencesSettingsProvider(private val context: Context) : SettingsProvider {
+
+    private val settings = mutableMapOf<String, Settings>()
+
+    override fun getMetaSettings() = settings.getOrPut(META_SETTINGS_NAME) {
+        SharedPreferencesSettings(getSharedPrefs(META_SETTINGS_NAME))
+    }
+
+    override fun getGeneralSettings(projectId: String?): Settings {
+        val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, projectId)
+
+        return settings.getOrPut(settingsId) {
+            SharedPreferencesSettings(getSharedPrefs(settingsId), GeneralKeys.getDefaults())
+        }
+    }
+
+    override fun getGeneralSettings(): Settings {
+        val settingsId = getSettingsId(GENERAL_SETTINGS_NAME, null)
+
+        return settings.getOrPut(settingsId) {
+            SharedPreferencesSettings(getSharedPrefs(settingsId), GeneralKeys.getDefaults())
+        }
+    }
+
+    override fun getAdminSettings(projectId: String?): Settings {
+        val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, projectId)
+
+        return settings.getOrPut(settingsId) {
+            SharedPreferencesSettings(getSharedPrefs(settingsId), AdminKeys.getDefaults())
+        }
+    }
+
+    override fun getAdminSettings(): Settings {
+        val settingsId = getSettingsId(ADMIN_SETTINGS_NAME, null)
+
+        return settings.getOrPut(settingsId) {
+            SharedPreferencesSettings(getSharedPrefs(settingsId), AdminKeys.getDefaults())
+        }
+    }
+
+    private fun getSharedPrefs(name: String) =
+        context.getSharedPreferences(name, Context.MODE_PRIVATE)
+
+    private fun getSettingsId(settingName: String, projectId: String?): String {
+        return if (projectId == null) {
+            settingName + (getMetaSettings().getString(MetaKeys.CURRENT_PROJECT_ID))
+        } else {
+            settingName + projectId
+        }
+    }
+
+    companion object {
+        private const val META_SETTINGS_NAME = "meta"
+        private const val GENERAL_SETTINGS_NAME = "general_prefs"
+        private const val ADMIN_SETTINGS_NAME = "admin_prefs"
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ExistingSettingsMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ExistingSettingsMigratorTest.kt
@@ -6,11 +6,9 @@ import org.hamcrest.Matchers.nullValue
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.android.support.InMemSettingsProvider
 import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
-import org.odk.collect.shared.Settings
-import org.odk.collect.testshared.InMemSettings
 
 class ExistingSettingsMigratorTest {
 
@@ -41,23 +39,4 @@ class ExistingSettingsMigratorTest {
         val existingSettingsMigrator = ExistingSettingsMigrator(mock(), mock(), mock())
         assertThat(existingSettingsMigrator.key(), `is`(nullValue()))
     }
-}
-
-private class InMemSettingsProvider : SettingsProvider {
-
-    private val metaSettings = InMemSettings()
-    private val settings = mutableMapOf<String?, InMemSettings>()
-
-    override fun getMetaSettings(): Settings {
-        return metaSettings
-    }
-
-    override fun getGeneralSettings(projectId: String?): Settings {
-        return settings.getOrPut(projectId) { InMemSettings() }
-    }
-
-    override fun getAdminSettings(projectId: String?): Settings {
-        return settings.getOrPut(projectId) { InMemSettings() }
-    }
-
 }

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ExistingSettingsMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ExistingSettingsMigratorTest.kt
@@ -4,12 +4,12 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.nullValue
 import org.junit.Test
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
+import org.odk.collect.shared.Settings
 import org.odk.collect.testshared.InMemSettings
 
 class ExistingSettingsMigratorTest {
@@ -20,25 +20,20 @@ class ExistingSettingsMigratorTest {
         val project1 = projectsRepository.save(Project.New("1", "1", "#ffffff"))
         val project2 = projectsRepository.save(Project.New("2", "2", "#ffffff"))
 
-        val project1GeneralSettings = InMemSettings()
-        val project1AdminSettings = InMemSettings()
-        val project2GeneralSettings = InMemSettings()
-        val project2AdminSettings = InMemSettings()
-
-        val settingsProvider = mock<SettingsProvider> {
-            on { getGeneralSettings(project1.uuid) } doReturn project1GeneralSettings
-            on { getAdminSettings(project1.uuid) } doReturn project1AdminSettings
-            on { getGeneralSettings(project2.uuid) } doReturn project2GeneralSettings
-            on { getAdminSettings(project2.uuid) } doReturn project2AdminSettings
-        }
-
+        val settingsProvider = InMemSettingsProvider()
         val settingsMigrator = mock<SettingsMigrator>()
         val existingSettingsMigrator =
             ExistingSettingsMigrator(projectsRepository, settingsProvider, settingsMigrator)
 
         existingSettingsMigrator.run()
-        verify(settingsMigrator).migrate(project1GeneralSettings, project1AdminSettings)
-        verify(settingsMigrator).migrate(project2GeneralSettings, project2AdminSettings)
+        verify(settingsMigrator).migrate(
+            settingsProvider.getGeneralSettings(project1.uuid),
+            settingsProvider.getAdminSettings(project1.uuid)
+        )
+        verify(settingsMigrator).migrate(
+            settingsProvider.getGeneralSettings(project2.uuid),
+            settingsProvider.getAdminSettings(project2.uuid)
+        )
     }
 
     @Test
@@ -46,4 +41,23 @@ class ExistingSettingsMigratorTest {
         val existingSettingsMigrator = ExistingSettingsMigrator(mock(), mock(), mock())
         assertThat(existingSettingsMigrator.key(), `is`(nullValue()))
     }
+}
+
+private class InMemSettingsProvider : SettingsProvider {
+
+    private val metaSettings = InMemSettings()
+    private val settings = mutableMapOf<String?, InMemSettings>()
+
+    override fun getMetaSettings(): Settings {
+        return metaSettings
+    }
+
+    override fun getGeneralSettings(projectId: String?): Settings {
+        return settings.getOrPut(projectId) { InMemSettings() }
+    }
+
+    override fun getAdminSettings(projectId: String?): Settings {
+        return settings.getOrPut(projectId) { InMemSettings() }
+    }
+
 }

--- a/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/SettingsImporterTest.kt
@@ -17,23 +17,19 @@ import org.mockito.kotlin.whenever
 import org.odk.collect.android.application.initialization.SettingsMigrator
 import org.odk.collect.android.application.initialization.migration.SharedPreferenceUtils
 import org.odk.collect.android.configure.qr.AppConfigurationKeys
-import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.android.support.InMemSettingsProvider
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.Settings
-import org.odk.collect.testshared.InMemSettings
 
 @RunWith(AndroidJUnit4::class)
 class SettingsImporterTest {
+
     private var currentProject = Project.Saved("1", "Project X", "X", "#cccccc")
 
-    private val generalSettings = InMemSettings()
-    private val adminSettings = InMemSettings()
-
-    private val settingsProvider = mock<SettingsProvider> {
-        on { getGeneralSettings(currentProject.uuid) } doReturn generalSettings
-        on { getAdminSettings(currentProject.uuid) } doReturn adminSettings
-    }
+    private val settingsProvider = InMemSettingsProvider()
+    private val generalSettings = settingsProvider.getGeneralSettings(currentProject.uuid)
+    private val adminSettings = settingsProvider.getAdminSettings(currentProject.uuid)
 
     private val projectsRepository = mock<ProjectsRepository> {}
     private var settingsValidator = mock<SettingsValidator> {

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormSourceProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormSourceProviderTest.kt
@@ -3,21 +3,17 @@ package org.odk.collect.android.formmanagement
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.Test
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.odk.collect.android.openrosa.OpenRosaFormSource
 import org.odk.collect.android.preferences.keys.GeneralKeys
-import org.odk.collect.android.preferences.source.SettingsProvider
-import org.odk.collect.testshared.InMemSettings
+import org.odk.collect.android.support.InMemSettingsProvider
 
 class FormSourceProviderTest {
 
     @Test
     fun `returned source uses project's server when passed`() {
-        val settings = InMemSettings()
-        val settingsProvider = mock<SettingsProvider> {
-            on { getGeneralSettings("projectId") } doReturn settings
-        }
+        val settingsProvider = InMemSettingsProvider()
+        val settings = settingsProvider.getGeneralSettings("projectId")
 
         val formSourceProvider = FormSourceProvider(settingsProvider, mock())
 

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/AppConfigurationGeneratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/AppConfigurationGeneratorTest.kt
@@ -13,20 +13,14 @@ import org.odk.collect.android.configure.qr.AppConfigurationGenerator
 import org.odk.collect.android.configure.qr.AppConfigurationKeys
 import org.odk.collect.android.preferences.keys.AdminKeys
 import org.odk.collect.android.preferences.keys.GeneralKeys
-import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.support.InMemSettingsProvider
 import org.odk.collect.projects.Project
-import org.odk.collect.testshared.InMemSettings
 
 @RunWith(AndroidJUnit4::class)
 class AppConfigurationGeneratorTest {
-    private val generalSettingsForProject1 = InMemSettings()
-    private val adminSettingsForProject1 = InMemSettings()
 
-    private val settingsProvider = mock<SettingsProvider> {
-        on { getGeneralSettings() } doReturn generalSettingsForProject1
-        on { getAdminSettings() } doReturn adminSettingsForProject1
-    }
+    private val settingsProvider = InMemSettingsProvider()
 
     private val currentProjectProvider: CurrentProjectProvider = mock {
         on { getCurrentProject() } doReturn Project.Saved("1", "Project X", "X", "#cccccc")

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/source/SharedPreferencesSettingsProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/source/SharedPreferencesSettingsProviderTest.kt
@@ -11,9 +11,9 @@ import org.junit.runner.RunWith
 import org.odk.collect.android.preferences.keys.MetaKeys.CURRENT_PROJECT_ID
 
 @RunWith(AndroidJUnit4::class)
-class SettingsProviderTest {
+class SharedPreferencesSettingsProviderTest {
 
-    private val settingsProvider = SettingsProvider(ApplicationProvider.getApplicationContext())
+    private val settingsProvider = SharedPreferencesSettingsProvider(ApplicationProvider.getApplicationContext())
 
     @Before
     fun setup() {

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectImporterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectImporterTest.kt
@@ -1,7 +1,5 @@
 package org.odk.collect.android.projects
 
-import android.app.Application
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.Matchers.`is`
@@ -9,7 +7,6 @@ import org.hamcrest.Matchers.contains
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
@@ -24,9 +21,7 @@ class ProjectImporterTest {
 
     private val rootDir = TempFiles.createTempDir()
 
-    private val context = ApplicationProvider.getApplicationContext<Application>()
     private val storagePathProvider = StoragePathProvider(mock(), rootDir.absolutePath)
-    private val settingsProvider = SettingsProvider(context)
 
     private val projectImporter = ProjectImporter(
         storagePathProvider,

--- a/collect_app/src/test/java/org/odk/collect/android/support/InMemSettingsProvider.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/support/InMemSettingsProvider.kt
@@ -1,0 +1,23 @@
+package org.odk.collect.android.support
+
+import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.shared.Settings
+import org.odk.collect.testshared.InMemSettings
+
+class InMemSettingsProvider : SettingsProvider {
+
+    private val metaSettings = InMemSettings()
+    private val settings = mutableMapOf<String?, InMemSettings>()
+
+    override fun getMetaSettings(): Settings {
+        return metaSettings
+    }
+
+    override fun getGeneralSettings(projectId: String?): Settings {
+        return settings.getOrPut("general:$projectId") { InMemSettings() }
+    }
+
+    override fun getAdminSettings(projectId: String?): Settings {
+        return settings.getOrPut("admin:$projectId") { InMemSettings() }
+    }
+}


### PR DESCRIPTION
This was something I felt would make some of our tests a bit cleaner, so wanted to add it in before we go any further.

#### What has been done to verify that this works as intended?

Ran tests.

#### Why is this the best possible solution? Were any other approaches considered?

Mockito worked fine, but it always feels a little grim stubbing concrete classes (rather than interfaces) and we were ending up with setup code we could avoid by just having a fake. I think this makes the tests we had that were using a stub `SettingsProvider` a bit easier to understand.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No risk to the app here really, as it's just a test change.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)