### PR TITLE
Prevents editing of form following failed submission

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/FormResubmissionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/FormResubmissionTest.java
@@ -1,0 +1,151 @@
+package org.odk.collect.android.feature.instancemanagement;
+
+import android.Manifest;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.RecordedIntentsRule;
+import org.odk.collect.android.dao.CursorLoaderFactory;
+import org.odk.collect.android.openrosa.HttpCredentialsInterface;
+import org.odk.collect.android.openrosa.HttpPostResult;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.StubOpenRosaServer;
+import org.odk.collect.android.support.TestDependencies;
+import org.odk.collect.android.support.TestRuleChain;
+import org.odk.collect.android.support.pages.MainMenuPage;
+import org.odk.collect.android.support.pages.SendFinalizedFormPage;
+
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+
+import timber.log.Timber;
+
+@RunWith(AndroidJUnit4.class)
+public class FormResubmissionTest {
+
+    public static final String _FORM_NAME = "One Question";
+    public static final String _FORM_XML = "one-question.xml";
+    public static final String _QUESTION = "what is your age";
+    public static final String _ANSWER = "123";
+
+    private boolean noHttpPostResult;
+    private boolean rejectResubmission;
+    private File submissionFile;
+
+    private final StubOpenRosaServer server = new StubOpenRosaServer() {
+        @NonNull
+        @Override
+        public HttpPostResult uploadSubmissionAndFiles(@NonNull File submissionFile,
+                                                       @NonNull List<File> fileList,
+                                                       @NonNull URI uri,
+                                                       @Nullable HttpCredentialsInterface credentials,
+                                                      long contentLength) throws Exception {
+            if(noHttpPostResult||rejectResubmission){
+                boolean doReject = handleFlag(submissionFile);
+                if(doReject){
+                    return new HttpPostResult("", 500, "Resubmission not permitted for " + submissionFile.getName());
+                }
+            }
+
+            return super.uploadSubmissionAndFiles(submissionFile,
+                    fileList,
+                    uri,
+                    credentials,
+                    contentLength);
+        }
+    };
+
+    private boolean handleFlag(@NotNull File submissionFile) throws InterruptedException {
+        if (noHttpPostResult) {
+            this.submissionFile = submissionFile;
+            int timeOutMs = 1000;
+            int timeOuts = 60*60;
+            Timber.i("sleeping for %s sec", timeOutMs * timeOuts / 1000);
+            for (int timeOut = 1; timeOut <= timeOuts; timeOut++) {
+                Thread.sleep(timeOutMs);
+                Timber.i("slept for %s ms", timeOut * timeOutMs);
+            }
+        } else{
+            return rejectResubmission
+                    && this.submissionFile.equals(submissionFile) ;
+        }
+        return false;
+    }
+
+    private final CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public RuleChain chain = TestRuleChain.chain(new TestDependencies(server))
+            .around(GrantPermissionRule.grant(Manifest.permission.GET_ACCOUNTS))
+            .around(new RecordedIntentsRule())
+            .around(rule);
+
+    private MainMenuPage createAndSubmitFormWithFailure() {
+        noHttpPostResult=true;
+        return rule.startAtMainMenu()
+                .setServer(server.getURL())
+                .copyForm(_FORM_XML)
+                .startBlankForm(_FORM_NAME)
+                .answerQuestion(_QUESTION, _ANSWER)
+                .swipeToEndScreen()
+                .clickSaveAndExit()
+                .clickSendFinalizedForm(1)
+                .clickOnForm(_FORM_NAME)
+                .clickSendSelected()
+//               clickOnText("CANCEL")
+                .pressBack(new MainMenuPage())
+                .clickViewSentForm(0)
+                .assertTextDoesNotExist(_FORM_NAME)
+                .pressBack(new MainMenuPage());
+    }
+
+    @Test
+    public void whenFailedFormCanBeEdited_ServerRejectsResubmission() {
+        CursorLoaderFactory.beforeUpdate = true;
+        rejectResubmission=true;
+        MainMenuPage mainMenuPage = createAndSubmitFormWithFailure();
+        noHttpPostResult=false;
+        mainMenuPage
+                .clickEditSavedForm(1)
+                .clickOnForm(_FORM_NAME)
+                .clickOnQuestion(_QUESTION)
+                .swipeToEndScreen()
+                .clickSaveAndExit()
+                .clickSendFinalizedForm(1)
+                .clickOnForm(_FORM_NAME)
+                .clickSendSelected()
+                .clickOK(new SendFinalizedFormPage())
+                .pressBack(new MainMenuPage())
+                .clickViewSentForm(0)
+                .assertTextDoesNotExist(_FORM_NAME);
+    }
+
+    @Test
+    public void whenFailedFormCannotBeEdited_ServerAcceptsResubmission() {
+        CursorLoaderFactory.beforeUpdate = false;
+        rejectResubmission=false;
+        MainMenuPage mainMenuPage = createAndSubmitFormWithFailure();
+        noHttpPostResult=false;
+        mainMenuPage
+                .clickEditSavedForm(1)
+                .assertTextDoesNotExist(_FORM_NAME)
+                .pressBack(new MainMenuPage())
+                .clickSendFinalizedForm(1)
+                .clickOnForm(_FORM_NAME)
+                .clickSendSelected()
+                .clickOK(new SendFinalizedFormPage())
+                .pressBack(new MainMenuPage())
+                .clickViewSentForm(1)
+                .assertText(_FORM_NAME);
+    }
+
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/FormResubmissionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/FormResubmissionTest.java
@@ -32,10 +32,10 @@ import timber.log.Timber;
 @RunWith(AndroidJUnit4.class)
 public class FormResubmissionTest {
 
-    public static final String _FORM_NAME = "One Question";
-    public static final String _FORM_XML = "one-question.xml";
-    public static final String _QUESTION = "what is your age";
-    public static final String _ANSWER = "123";
+    public static final String TEXT_FORM_NAME = "One Question";
+    public static final String TEXT_FORM_XML = "one-question.xml";
+    public static final String TEXT_QUESTION = "what is your age";
+    public static final String TEXT_ANSWER = "123";
 
     private boolean noHttpPostResult;
     private boolean rejectResubmission;
@@ -48,10 +48,10 @@ public class FormResubmissionTest {
                                                        @NonNull List<File> fileList,
                                                        @NonNull URI uri,
                                                        @Nullable HttpCredentialsInterface credentials,
-                                                      long contentLength) throws Exception {
-            if(noHttpPostResult||rejectResubmission){
+                                                       long contentLength) throws Exception {
+            if (noHttpPostResult || rejectResubmission) {
                 boolean doReject = handleFlag(submissionFile);
-                if(doReject){
+                if (doReject) {
                     return new HttpPostResult("", 500, "Resubmission not permitted for " + submissionFile.getName());
                 }
             }
@@ -68,15 +68,15 @@ public class FormResubmissionTest {
         if (noHttpPostResult) {
             this.submissionFile = submissionFile;
             int timeOutMs = 1000;
-            int timeOuts = 60*60;
+            int timeOuts = 60 * 60;
             Timber.i("sleeping for %s sec", timeOutMs * timeOuts / 1000);
             for (int timeOut = 1; timeOut <= timeOuts; timeOut++) {
                 Thread.sleep(timeOutMs);
                 Timber.i("slept for %s ms", timeOut * timeOutMs);
             }
-        } else{
+        } else {
             return rejectResubmission
-                    && this.submissionFile.equals(submissionFile) ;
+                    && this.submissionFile.equals(submissionFile);
         }
         return false;
     }
@@ -90,62 +90,62 @@ public class FormResubmissionTest {
             .around(rule);
 
     private MainMenuPage createAndSubmitFormWithFailure() {
-        noHttpPostResult=true;
+        noHttpPostResult = true;
         return rule.startAtMainMenu()
                 .setServer(server.getURL())
-                .copyForm(_FORM_XML)
-                .startBlankForm(_FORM_NAME)
-                .answerQuestion(_QUESTION, _ANSWER)
+                .copyForm(TEXT_FORM_XML)
+                .startBlankForm(TEXT_FORM_NAME)
+                .answerQuestion(TEXT_QUESTION, TEXT_ANSWER)
                 .swipeToEndScreen()
                 .clickSaveAndExit()
                 .clickSendFinalizedForm(1)
-                .clickOnForm(_FORM_NAME)
+                .clickOnForm(TEXT_FORM_NAME)
                 .clickSendSelected()
 //               clickOnText("CANCEL")
                 .pressBack(new MainMenuPage())
                 .clickViewSentForm(0)
-                .assertTextDoesNotExist(_FORM_NAME)
+                .assertTextDoesNotExist(TEXT_FORM_NAME)
                 .pressBack(new MainMenuPage());
     }
 
     @Test
     public void whenFailedFormCanBeEdited_ServerRejectsResubmission() {
         CursorLoaderFactory.beforeUpdate = true;
-        rejectResubmission=true;
+        rejectResubmission = true;
         MainMenuPage mainMenuPage = createAndSubmitFormWithFailure();
-        noHttpPostResult=false;
+        noHttpPostResult = false;
         mainMenuPage
                 .clickEditSavedForm(1)
-                .clickOnForm(_FORM_NAME)
-                .clickOnQuestion(_QUESTION)
+                .clickOnForm(TEXT_FORM_NAME)
+                .clickOnQuestion(TEXT_QUESTION)
                 .swipeToEndScreen()
                 .clickSaveAndExit()
                 .clickSendFinalizedForm(1)
-                .clickOnForm(_FORM_NAME)
+                .clickOnForm(TEXT_FORM_NAME)
                 .clickSendSelected()
                 .clickOK(new SendFinalizedFormPage())
                 .pressBack(new MainMenuPage())
                 .clickViewSentForm(0)
-                .assertTextDoesNotExist(_FORM_NAME);
+                .assertTextDoesNotExist(TEXT_FORM_NAME);
     }
 
     @Test
     public void whenFailedFormCannotBeEdited_ServerAcceptsResubmission() {
         CursorLoaderFactory.beforeUpdate = false;
-        rejectResubmission=false;
+        rejectResubmission = false;
         MainMenuPage mainMenuPage = createAndSubmitFormWithFailure();
-        noHttpPostResult=false;
+        noHttpPostResult = false;
         mainMenuPage
                 .clickEditSavedForm(1)
-                .assertTextDoesNotExist(_FORM_NAME)
+                .assertTextDoesNotExist(TEXT_FORM_NAME)
                 .pressBack(new MainMenuPage())
                 .clickSendFinalizedForm(1)
-                .clickOnForm(_FORM_NAME)
+                .clickOnForm(TEXT_FORM_NAME)
                 .clickSendSelected()
                 .clickOK(new SendFinalizedFormPage())
                 .pressBack(new MainMenuPage())
                 .clickViewSentForm(1)
-                .assertText(_FORM_NAME);
+                .assertText(TEXT_FORM_NAME);
     }
 
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
@@ -24,16 +24,24 @@ public class TestDependencies extends AppDependencyModule {
 
     private final CallbackCountingTaskExecutorRule countingTaskExecutorRule = new CallbackCountingTaskExecutorRule();
 
-    public final StubOpenRosaServer server = new StubOpenRosaServer();
     public final TestScheduler scheduler = new TestScheduler();
     public final FakeGoogleApi googleApi = new FakeGoogleApi();
     public final FakeGoogleAccountPicker googleAccountPicker = new FakeGoogleAccountPicker();
     public final StoragePathProvider storagePathProvider = new StoragePathProvider();
+    public final StubOpenRosaServer server;
 
     public final List<IdlingResource> idlingResources = asList(
             new SchedulerIdlingResource(scheduler),
             new CountingTaskExecutorIdlingResource(countingTaskExecutorRule)
     );
+
+    public TestDependencies(StubOpenRosaServer server) {
+        this.server = server;
+    }
+
+    public TestDependencies() {
+        this(new StubOpenRosaServer());
+    }
 
     @Override
     public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -26,6 +26,15 @@ import static org.hamcrest.core.AllOf.allOf;
 
 public class MainMenuPage extends Page<MainMenuPage> {
 
+    public ViewSentFormPage clickViewSentForm(int formCount) {
+        String text = formCount < 1
+                ? getTranslatedString(R.string.view_sent_forms_button)
+                .replace(" (%s)", "")
+                : getTranslatedString(R.string.view_sent_forms_button, formCount);
+        onView(withText(text)).perform(click());
+        return new ViewSentFormPage().assertOnPage();
+    }
+
     @Override
     public MainMenuPage assertOnPage() {
         onView(withText(containsString(getTranslatedString(R.string.app_name)))).check(matches(isDisplayed()));
@@ -186,11 +195,6 @@ public class MainMenuPage extends Page<MainMenuPage> {
     public OkDialog clickGetBlankFormWithError() {
         onView(withText(getTranslatedString(R.string.get_forms))).perform(scrollTo(), click());
         return new OkDialog().assertOnPage();
-    }
-
-    public ViewSentFormPage clickViewSentForm(int formCount) {
-        onView(withText(getTranslatedString(R.string.view_sent_forms_button, formCount))).perform(click());
-        return new ViewSentFormPage().assertOnPage();
     }
 
     public DeleteSavedFormPage clickDeleteSavedForm() {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -13,18 +13,12 @@ import org.odk.collect.forms.instances.Instance;
 
 public class CursorLoaderFactory {
 
-    public static boolean beforeUpdate;
-
     public CursorLoader createUnsentInstancesCursorLoader(String sortOrder) {
         String selection = DatabaseInstanceColumns.STATUS + " !=? " +
-                (beforeUpdate ? "" : ("and " + DatabaseInstanceColumns.STATUS + " !=? "));
-        String[] selectionArgs = beforeUpdate ?
-                new String[]{
-                        Instance.STATUS_SUBMITTED
-                }
-                : new String[]{
-                Instance.STATUS_SUBMITTED,
-                Instance.STATUS_SUBMISSION_FAILED
+                "and " + DatabaseInstanceColumns.STATUS + " !=? ";
+        String[] selectionArgs = new String[]{
+            Instance.STATUS_SUBMITTED,
+            Instance.STATUS_SUBMISSION_FAILED
         };
 
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -13,12 +13,37 @@ import org.odk.collect.forms.instances.Instance;
 
 public class CursorLoaderFactory {
 
+    public CursorLoader createSentInstancesCursorLoader(String sortOrder) {
+        String selection = DatabaseInstanceColumns.STATUS + " =? ";
+        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
+
+        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+    }
+
+    public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
+        CursorLoader cursorLoader;
+        if (charSequence.length() == 0) {
+            cursorLoader = createSentInstancesCursorLoader(sortOrder);
+        } else {
+            String selection =
+                    DatabaseInstanceColumns.STATUS + " =? and "
+                            + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
+            String[] selectionArgs = {
+                    Instance.STATUS_SUBMITTED,
+                    "%" + charSequence + "%"};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+        }
+
+        return cursorLoader;
+    }
+
     public CursorLoader createUnsentInstancesCursorLoader(String sortOrder) {
         String selection = DatabaseInstanceColumns.STATUS + " !=? " +
                 "and " + DatabaseInstanceColumns.STATUS + " !=? ";
         String[] selectionArgs = new String[]{
-            Instance.STATUS_SUBMITTED,
-            Instance.STATUS_SUBMISSION_FAILED
+                Instance.STATUS_SUBMITTED,
+                Instance.STATUS_SUBMISSION_FAILED
         };
 
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
@@ -40,31 +65,6 @@ public class CursorLoaderFactory {
         }
 
         return cursorLoader;
-    }
-
-    public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
-        CursorLoader cursorLoader;
-        if (charSequence.length() == 0) {
-            cursorLoader = createSentInstancesCursorLoader(sortOrder);
-        } else {
-            String selection =
-                    DatabaseInstanceColumns.STATUS + " =? and "
-                            + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
-            String[] selectionArgs = {
-                    Instance.STATUS_SUBMITTED,
-                    "%" + charSequence + "%"};
-
-            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-        }
-
-        return cursorLoader;
-    }
-
-    public CursorLoader createSentInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
     }
 
     public CursorLoader createSavedInstancesCursorLoader(String sortOrder) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -17,17 +17,35 @@ public class CursorLoaderFactory {
 
     public CursorLoader createUnsentInstancesCursorLoader(String sortOrder) {
         String selection = DatabaseInstanceColumns.STATUS + " !=? " +
-                (beforeUpdate ?"":("and " +DatabaseInstanceColumns.STATUS + " !=? "));
+                (beforeUpdate ? "" : ("and " + DatabaseInstanceColumns.STATUS + " !=? "));
         String[] selectionArgs = beforeUpdate ?
-            new String[]{
-                Instance.STATUS_SUBMITTED
-            }
-            :new String[]{
+                new String[]{
+                        Instance.STATUS_SUBMITTED
+                }
+                : new String[]{
                 Instance.STATUS_SUBMITTED,
                 Instance.STATUS_SUBMISSION_FAILED
-            };
+        };
 
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+    }
+
+    public CursorLoader createUnsentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
+        CursorLoader cursorLoader;
+        if (charSequence.length() == 0) {
+            cursorLoader = createUnsentInstancesCursorLoader(sortOrder);
+        } else {
+            String selection =
+                    DatabaseInstanceColumns.STATUS + " !=? and "
+                            + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
+            String[] selectionArgs = {
+                    Instance.STATUS_SUBMITTED,
+                    "%" + charSequence + "%"};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+        }
+
+        return cursorLoader;
     }
 
     public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -13,12 +13,37 @@ import org.odk.collect.forms.instances.Instance;
 
 public class CursorLoaderFactory {
 
+    public CursorLoader createSentInstancesCursorLoader(String sortOrder) {
+        String selection = DatabaseInstanceColumns.STATUS + " =? ";
+        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
+
+        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+    }
+
+    public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
+        CursorLoader cursorLoader;
+        if (charSequence.length() == 0) {
+            cursorLoader = createSentInstancesCursorLoader(sortOrder);
+        } else {
+            String selection =
+                    DatabaseInstanceColumns.STATUS + " =? and "
+                            + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
+            String[] selectionArgs = {
+                    Instance.STATUS_SUBMITTED,
+                    "%" + charSequence + "%"};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+        }
+
+        return cursorLoader;
+    }
+
     public CursorLoader createUnsentInstancesCursorLoader(String sortOrder) {
         String selection = DatabaseInstanceColumns.STATUS + " !=? " +
                 "and " + DatabaseInstanceColumns.STATUS + " !=? ";
-        String[] selectionArgs = new String[]{
-            Instance.STATUS_SUBMITTED,
-            Instance.STATUS_SUBMISSION_FAILED
+        String[] selectionArgs = {
+                Instance.STATUS_SUBMITTED,
+                Instance.STATUS_SUBMISSION_FAILED
         };
 
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
@@ -40,31 +65,6 @@ public class CursorLoaderFactory {
         }
 
         return cursorLoader;
-    }
-
-    public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
-        CursorLoader cursorLoader;
-        if (charSequence.length() == 0) {
-            cursorLoader = createSentInstancesCursorLoader(sortOrder);
-        } else {
-            String selection =
-                    DatabaseInstanceColumns.STATUS + " =? and "
-                            + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
-            String[] selectionArgs = {
-                    Instance.STATUS_SUBMITTED,
-                    "%" + charSequence + "%"};
-
-            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-        }
-
-        return cursorLoader;
-    }
-
-    public CursorLoader createSentInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
     }
 
     public CursorLoader createSavedInstancesCursorLoader(String sortOrder) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -73,24 +73,6 @@ public class CursorLoaderFactory {
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
     }
 
-    public CursorLoader createUnsentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
-        CursorLoader cursorLoader;
-        if (charSequence.length() == 0) {
-            cursorLoader = createUnsentInstancesCursorLoader(sortOrder);
-        } else {
-            String selection =
-                    DatabaseInstanceColumns.STATUS + " !=? and "
-                            + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
-            String[] selectionArgs = {
-                    Instance.STATUS_SUBMITTED,
-                    "%" + charSequence + "%"};
-
-            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-        }
-
-        return cursorLoader;
-    }
-
     public CursorLoader createSavedInstancesCursorLoader(String sortOrder) {
         String selection = DatabaseInstanceColumns.DELETED_DATE + " IS NULL ";
 

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -13,6 +13,23 @@ import org.odk.collect.forms.instances.Instance;
 
 public class CursorLoaderFactory {
 
+    public static boolean beforeUpdate;
+
+    public CursorLoader createUnsentInstancesCursorLoader(String sortOrder) {
+        String selection = DatabaseInstanceColumns.STATUS + " !=? " +
+                (beforeUpdate ?"":("and " +DatabaseInstanceColumns.STATUS + " !=? "));
+        String[] selectionArgs = beforeUpdate ?
+            new String[]{
+                Instance.STATUS_SUBMITTED
+            }
+            :new String[]{
+                Instance.STATUS_SUBMITTED,
+                Instance.STATUS_SUBMISSION_FAILED
+            };
+
+        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
+    }
+
     public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
@@ -33,13 +50,6 @@ public class CursorLoaderFactory {
 
     public CursorLoader createSentInstancesCursorLoader(String sortOrder) {
         String selection = DatabaseInstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-    }
-
-    public CursorLoader createUnsentInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + " !=? ";
         String[] selectionArgs = {Instance.STATUS_SUBMITTED};
 
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
@@ -170,7 +180,9 @@ public class CursorLoaderFactory {
         return cursorLoader;
     }
 
-    private CursorLoader getInstancesCursorLoader(String selection, String[] selectionArgs, String sortOrder) {
+    private CursorLoader getInstancesCursorLoader(String selection,
+                                                  String[] selectionArgs,
+                                                  String sortOrder) {
         return new CursorLoader(
                 Collect.getInstance(),
                 InstanceProviderAPI.CONTENT_URI,


### PR DESCRIPTION
Closes #4589

#### What has been done to verify that this works as intended?
Tested with new `FormResubmissionTest`.

#### Why is this the best possible solution? Were any other approaches considered?
See **Design Details** below.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Small change to behaviour from user perspective. 
No obvious regression risks. 

#### Do we need any specific form for testing your changes? If so, please attach one.
No form required. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
https://github.com/getodk/docs/issues/1367
****
## Design Details
Please excuse this rather elaborate account; writing it did help me refine the code significantly. 
### `CursorLoaderFactory`
Just one tiny mod seems to do the job: `createSavedInstancesCursorLoader()` adds `STATUS_SUBMISSION_FAILED` to the filter along with `STATUS_SUBMITTED`.
* For demo and WIP purposes the change is switched with class variable `beforeUpdate`.
	
### `FormResubmissionTest`
Closely derived from `SendFinalizedFormTest`, with two flags setting the following server behaviours:  
* `noHttpPostResult` causes a series of calls to `Thread.sleep()` - simulating a connection drop-out.
* `rejectResubmission` sets a limit of a single call for submissions passing the same file - simulating the response to resubmission after unintended editing.

The pair of `whenFailedForm…Resubmission()` methods simulate/test 'before' and 'after' behaviours. Both methods
* initialise the appropriate value of `CursorLoaderFactory.beforeUpdate`
* depend on `handleFlag` detailed below first to set `STATUS_SUBMISSION_FAILED` and then to reject or accept resubmission.
* need manual intervention as I haven't been able to work out how to simulate clicking on a CANCEL dialog. 
* call the slightly tweaked `MainMenuPage.clickViewSentForm()`
* share preliminary code defined in `createAndSubmitFormWithFailure()`

`handleFlag()` defines server responses to the states of the above-mentioned flags. 
* Called from the override of `uploadSubmissionAndFiles()` in the anonymous `StubOpenRosaServer` passed to the `TestDependencies` in the `RuleChain`.
This approach necessitated constructors for `TestDependencies` that set the final `StubOpenRosaServer` member.
****
#### Before submitting this PR, please make sure you have:
- [x ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)