### PR TITLE
Make parameter that can be passed null nullable

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CodeCaptureManagerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CodeCaptureManagerFactory.kt
@@ -14,7 +14,7 @@ object CodeCaptureManagerFactory {
         activity: Activity,
         barcodeView: DecoratedBarcodeView,
         savedInstanceState: Bundle?,
-        supportedFormats: Collection<String>,
+        supportedFormats: Collection<String>?,
         prompt: String = ""
     ): CaptureManager {
         val captureManager = CaptureManager(activity, barcodeView)
@@ -23,7 +23,7 @@ object CodeCaptureManagerFactory {
         return captureManager
     }
 
-    private fun getIntent(activity: Activity, supportedFormats: Collection<String>, prompt: String = ""): Intent {
+    private fun getIntent(activity: Activity, supportedFormats: Collection<String>?, prompt: String = ""): Intent {
         return IntentIntegrator(activity)
             .setDesiredBarcodeFormats(supportedFormats)
             .setPrompt(prompt)


### PR DESCRIPTION
This should fix [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/9ab0c7fc721315dd96a006b126ac630d?time=last-seven-days&versions=v2021.2-beta.0%20(4182)&sessionEventKey=60D0FF27031200013EFDF79C83C900D1_1554802030431161723) (requires auth).

This crash could be reproduced by trying to scan using the bar code widget.

#### What has been done to verify that this works as intended?

Checked manually.

#### Why is this the best possible solution? Were any other approaches considered?

This is just a type error that would be hard to catch with tests. We could build a full UI test for the barcode widget, but I don't think that's a priority right now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue! This can be verified pretty easily by using the barcode widget.

#### Do we need any specific form for testing your changes? If so, please attach one.

The widget is available in the "All widgets" form.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)