### PR TITLE
Don't configure ReferenceManager when doing form discovery parse

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMetadataParser.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMetadataParser.java
@@ -1,50 +1,23 @@
 package org.odk.collect.android.formmanagement;
 
-import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.core.reference.RootTranslator;
-import org.odk.collect.android.logic.FileReferenceFactory;
 import org.odk.collect.android.utilities.FileUtils;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.utilities.FileUtils.LAST_SAVED_FILENAME;
-import static org.odk.collect.android.utilities.FileUtils.STUB_XML;
-import static org.odk.collect.android.utilities.FileUtils.write;
-
 public class FormMetadataParser {
-
-    private final ReferenceManager referenceManager;
-
-    public FormMetadataParser(ReferenceManager referenceManager) {
-        this.referenceManager = referenceManager;
-    }
-
     public Map<String, String> parse(File file, File mediaDir) {
-        // Add a stub last-saved instance to the tmp media directory so it will be resolved
-        // when parsing a form definition with last-saved reference
-        File tmpLastSaved = new File(mediaDir, LAST_SAVED_FILENAME);
-        write(tmpLastSaved, STUB_XML.getBytes(StandardCharsets.UTF_8));
-        referenceManager.reset();
-        referenceManager.addReferenceFactory(new FileReferenceFactory(mediaDir.getAbsolutePath()));
-        referenceManager.addSessionRootTranslator(new RootTranslator("jr://file-csv/", "jr://file/"));
-
         HashMap<String, String> metadata;
         try {
             metadata = FileUtils.getMetadataFromFormDefinition(file);
         } catch (Exception e) {
-            referenceManager.reset();
-            tmpLastSaved.delete();
             Timber.e(e);
 
             throw e;
         }
-        referenceManager.reset();
-        tmpLastSaved.delete();
 
         return metadata;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsUpdater.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsUpdater.kt
@@ -1,7 +1,6 @@
 package org.odk.collect.android.formmanagement
 
 import android.content.Context
-import org.javarosa.core.reference.ReferenceManager
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.analytics.AnalyticsUtils
@@ -158,7 +157,7 @@ private fun formDownloader(
         projectSandbox.formsRepository,
         File(projectSandbox.cacheDir),
         projectSandbox.formsDir,
-        FormMetadataParser(ReferenceManager.instance()),
+        FormMetadataParser(),
         analytics
     )
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -186,7 +186,7 @@ public class AppDependencyModule {
 
     @Provides
     public FormDownloader providesFormDownloader(FormSourceProvider formSourceProvider, FormsRepositoryProvider formsRepositoryProvider, StoragePathProvider storagePathProvider, Analytics analytics) {
-        return new ServerFormDownloader(formSourceProvider.get(), formsRepositoryProvider.get(), new File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)), storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS), new FormMetadataParser(ReferenceManager.instance()), analytics);
+        return new ServerFormDownloader(formSourceProvider.get(), formsRepositoryProvider.get(), new File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)), storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS), new FormMetadataParser(), analytics);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
@@ -28,17 +28,13 @@ public class FormUtils {
      * directory with name matching the name of the directory represented by {@code formMediaDir}.
      * <p>
      * E.g. if /foo/bar/baz is passed in as {@code formMediaDir}, jr:// URIs will be resolved to
-     * /odk/root/forms/baz.
+     * projectRoot/forms/baz.
      */
     public static void setupReferenceManagerForForm(ReferenceManager referenceManager, File formMediaDir) {
-        // Clear mappings to the media dir for the previous form that was configured
-        referenceManager.clearSession();
+        referenceManager.reset();
 
-        // This should get moved to the Application Class
-        if (referenceManager.getFactories().length == 0) {
-            // Always build URIs against the ODK root, regardless of the absolute path of formMediaDir
-            referenceManager.addReferenceFactory(new FileReferenceFactory(new StoragePathProvider().getProjectRootDirPath()));
-        }
+        // Always build URIs against the project root, regardless of the absolute path of formMediaDir
+        referenceManager.addReferenceFactory(new FileReferenceFactory(new StoragePathProvider().getProjectRootDirPath()));
 
         addSessionRootTranslators(referenceManager,
                 buildSessionRootTranslators(formMediaDir.getName(), enumerateHostStrings()));
@@ -50,7 +46,7 @@ public class FormUtils {
 
     public static List<RootTranslator> buildSessionRootTranslators(String formMediaDir, String[] hostStrings) {
         List<RootTranslator> rootTranslators = new ArrayList<>();
-        // Set jr://... to point to /sdcard/odk/forms/formBasename-media/
+        // Set jr://... to point to <projectRoot>/forms/formBasename-media/
         final String translatedPrefix = String.format("jr://file/forms/" + formMediaDir + "/");
         for (String t : hostStrings) {
             rootTranslators.add(new RootTranslator(String.format("jr://%s/", t), translatedPrefix));

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
@@ -2,7 +2,6 @@ package org.odk.collect.android.utilities;
 
 import android.database.SQLException;
 
-import org.javarosa.core.reference.ReferenceManager;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formmanagement.DiskFormsSynchronizer;
@@ -21,8 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.FormUtils.setupReferenceManagerForForm;
 
 public class FormsDirDiskFormsSynchronizer implements DiskFormsSynchronizer {
 
@@ -209,10 +206,6 @@ public class FormsDirDiskFormsSynchronizer implements DiskFormsSynchronizer {
 
         HashMap<String, String> fields;
         try {
-            // If the form definition includes external secondary instances, they need to be resolved
-            final File formMediaDir = FileUtils.getFormMediaDir(formDefFile);
-            setupReferenceManagerForForm(ReferenceManager.instance(), formMediaDir);
-
             FileUtils.getOrCreateLastSavedSrc(formDefFile);
             fields = FileUtils.getMetadataFromFormDefinition(formDefFile);
         } catch (RuntimeException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
@@ -206,7 +206,6 @@ public class FormsDirDiskFormsSynchronizer implements DiskFormsSynchronizer {
 
         HashMap<String, String> fields;
         try {
-            FileUtils.getOrCreateLastSavedSrc(formDefFile);
             fields = FileUtils.getMetadataFromFormDefinition(formDefFile);
         } catch (RuntimeException e) {
             throw new IllegalArgumentException(formDefFile.getName() + " :: " + e.toString());

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMetadataParserTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMetadataParserTest.java
@@ -2,8 +2,6 @@ package org.odk.collect.android.formmanagement;
 
 import com.google.common.io.Files;
 
-import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.utilities.FileUtils;
@@ -13,18 +11,13 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
 
 public class FormMetadataParserTest {
 
     private File mediaDir;
-    private ReferenceManager referenceManager;
 
     @Before
     public void setup() {
-        referenceManager = ReferenceManager.instance();
-        referenceManager.reset();
-
         mediaDir = Files.createTempDir();
     }
 
@@ -73,46 +66,6 @@ public class FormMetadataParserTest {
         formMetadataParser.parse(formXml, mediaDir);
 
         assertThat(mediaDir.listFiles().length, is(0));
-    }
-
-    @Test
-    public void cleansUpReferenceManager() throws Exception {
-        File formXml = File.createTempFile("form", ".xml");
-        FileUtils.write(formXml, EXTERNAL_SECONDARY_INSTANCE.getBytes());
-
-        File externalInstance = new File(mediaDir, "external-data.xml");
-        FileUtils.write(externalInstance, EXTERNAL_INSTANCE.getBytes());
-
-        FormMetadataParser formMetadataParser = new FormMetadataParser();
-        formMetadataParser.parse(formXml, mediaDir);
-
-        try {
-            referenceManager.deriveReference("jr://file/external-data.xml");
-            fail("ReferenceManager still able to derive reference so hasn't been cleaned up!");
-        } catch (InvalidReferenceException ignored) {
-            // Pass
-        }
-    }
-
-    @Test
-    public void cleansUpReferenceManagerAfterFail() throws Exception {
-        File formXml = File.createTempFile("form", ".xml");
-
-        FormMetadataParser formMetadataParser = new FormMetadataParser();
-
-        try {
-            formMetadataParser.parse(formXml, mediaDir);
-            fail("Parse should have failed because file doesn't exist");
-        } catch (Exception e) {
-            // Expected
-        }
-
-        try {
-            referenceManager.deriveReference("jr://file/external-data.xml");
-            fail("ReferenceManager still able to derive reference so hasn't been cleaned up!");
-        } catch (InvalidReferenceException ignored) {
-            // Pass
-        }
     }
 
     private static final String EXTERNAL_SECONDARY_INSTANCE = "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\" >\n" +

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMetadataParserTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMetadataParserTest.java
@@ -4,7 +4,6 @@ import com.google.common.io.Files;
 
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.xform.parse.XFormParseException;
 import org.junit.Before;
 import org.junit.Test;
 import org.odk.collect.android.utilities.FileUtils;
@@ -37,7 +36,7 @@ public class FormMetadataParserTest {
         File externalInstance = new File(mediaDir, "external-data.xml");
         FileUtils.write(externalInstance, EXTERNAL_INSTANCE.getBytes());
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+        FormMetadataParser formMetadataParser = new FormMetadataParser();
         Map<String, String> metaData = formMetadataParser.parse(formXml, mediaDir);
         assertThat(metaData.get(FileUtils.FORMID), is("basic-external-xml-instance"));
     }
@@ -50,7 +49,7 @@ public class FormMetadataParserTest {
         File externalInstance = new File(mediaDir, "external-data.csv");
         FileUtils.write(externalInstance, CSV_EXTERNAL_INSTANCE.getBytes());
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+        FormMetadataParser formMetadataParser = new FormMetadataParser();
         Map<String, String> metaData = formMetadataParser.parse(formXml, mediaDir);
         assertThat(metaData.get(FileUtils.FORMID), is("basic-external-csv-instance"));
     }
@@ -60,35 +59,9 @@ public class FormMetadataParserTest {
         File formXml = File.createTempFile("form", ".xml");
         FileUtils.write(formXml, LAST_SAVED.getBytes());
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+        FormMetadataParser formMetadataParser = new FormMetadataParser();
         Map<String, String> metaData = formMetadataParser.parse(formXml, mediaDir);
         assertThat(metaData.get(FileUtils.FORMID), is("basic-last-saved"));
-    }
-
-    /**
-     * Edge case: a form could have an attachment with filename last-saved.xml. This will get
-     * replaced immediately on download and this test documents that behavior. We could let it go
-     * through but let's replace it immediately to help a user who tries this troubleshoot.
-     * Otherwise it would only be replaced when an instance is saved so a user could think everything
-     * is ok if they only try launching the form once.
-     *
-     * This is an unfortunate side effect of using the form media folder to store the contents that
-     * jr://instance/last-saved resolves to.
-     *
-     * Additionally, immediately replacing a secondary instance with name last-saved.xml avoid users
-     * exploiting this current implementation quirk as a feature to preload defaults for the first
-     * instance.
-     * */
-    @Test(expected = XFormParseException.class)
-    public void cannotParseFormWithExternalSecondaryInstanceNamedLastSaved() throws Exception {
-        File formXml = File.createTempFile("form", ".xml");
-        FileUtils.write(formXml, LAST_SAVED_EXTERNAL_SECONDARY_INSTANCE.getBytes());
-
-        File externalInstance = new File(mediaDir, "last-saved.xml");
-        FileUtils.write(externalInstance, EXTERNAL_INSTANCE.getBytes());
-
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
-        formMetadataParser.parse(formXml, mediaDir);
     }
 
     @Test
@@ -96,7 +69,7 @@ public class FormMetadataParserTest {
         File formXml = File.createTempFile("form", ".xml");
         FileUtils.write(formXml, LAST_SAVED.getBytes());
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+        FormMetadataParser formMetadataParser = new FormMetadataParser();
         formMetadataParser.parse(formXml, mediaDir);
 
         assertThat(mediaDir.listFiles().length, is(0));
@@ -110,7 +83,7 @@ public class FormMetadataParserTest {
         File externalInstance = new File(mediaDir, "external-data.xml");
         FileUtils.write(externalInstance, EXTERNAL_INSTANCE.getBytes());
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+        FormMetadataParser formMetadataParser = new FormMetadataParser();
         formMetadataParser.parse(formXml, mediaDir);
 
         try {
@@ -125,7 +98,7 @@ public class FormMetadataParserTest {
     public void cleansUpReferenceManagerAfterFail() throws Exception {
         File formXml = File.createTempFile("form", ".xml");
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(referenceManager);
+        FormMetadataParser formMetadataParser = new FormMetadataParser();
 
         try {
             formMetadataParser.parse(formXml, mediaDir);
@@ -228,30 +201,6 @@ public class FormMetadataParserTest {
             "        <input ref=\"/data/q1\">\n" +
             "            <label>Question</label>\n" +
             "        </input>\n" +
-            "    </h:body>\n" +
-            "</h:html>";
-
-    private static final String LAST_SAVED_EXTERNAL_SECONDARY_INSTANCE = "<h:html xmlns=\"http://www.w3.org/2002/xforms\" xmlns:h=\"http://www.w3.org/1999/xhtml\" >\n" +
-            "    <h:head>\n" +
-            "        <h:title>last-saved-attached</h:title>\n" +
-            "        <model>\n" +
-            "            <instance>\n" +
-            "                <data id=\"last-saved-attached\">\n" +
-            "                    <first/>\n" +
-            "                </data>\n" +
-            "            </instance>\n" +
-            "            <instance id=\"external-xml\" src=\"jr://file/last-saved.xml\" />\n" +
-            "            <bind nodeset=\"/data/first\" type=\"select1\"/>\n" +
-            "        </model>\n" +
-            "    </h:head>\n" +
-            "    <h:body>\n" +
-            "        <select1 ref=\"/data/first\">\n" +
-            "            <label>First</label>\n" +
-            "            <itemset nodeset=\"instance('external-xml')/root/item[first='']\">\n" +
-            "                <value ref=\"name\"/>\n" +
-            "                <label ref=\"label\"/>\n" +
-            "            </itemset>\n" +
-            "        </select1>\n" +
             "    </h:body>\n" +
             "</h:html>";
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -2,10 +2,8 @@ package org.odk.collect.android.formmanagement;
 
 import com.google.common.io.Files;
 
-import org.javarosa.core.reference.ReferenceManager;
 import org.junit.Test;
 import org.odk.collect.analytics.Analytics;
-import org.odk.collect.formstest.InMemFormsRepository;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormListItem;
 import org.odk.collect.forms.FormSource;
@@ -14,6 +12,7 @@ import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.forms.ManifestFile;
 import org.odk.collect.forms.MediaFile;
 import org.odk.collect.formstest.FormUtils;
+import org.odk.collect.formstest.InMemFormsRepository;
 import org.odk.collect.shared.strings.Md5;
 
 import java.io.ByteArrayInputStream;
@@ -66,7 +65,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         downloader.downloadForm(serverFormDetails, null, null);
 
         List<Form> allForms = formsRepository.getAll();
@@ -95,7 +94,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         downloader.downloadForm(serverFormDetails, null, null);
 
         String xformUpdate = createXFormBody("id", "updated");
@@ -136,7 +135,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         downloader.downloadForm(serverFormDetails, null, null);
 
         String xformUpdate = FormUtils.createXFormBody("id", "version", "A different title");
@@ -177,7 +176,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         try {
             downloader.downloadForm(serverFormDetails, null, null);
             fail("Expected exception because of missing form hash");
@@ -207,7 +206,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents2".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         downloader.downloadForm(serverFormDetails, null, null);
 
         List<Form> allForms = formsRepository.getAll();
@@ -253,7 +252,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents2".getBytes()));
 
-        FormMetadataParser formMetadataParser = new FormMetadataParser(ReferenceManager.instance()) {
+        FormMetadataParser formMetadataParser = new FormMetadataParser() {
             @Override
             public Map<String, String> parse(File file, File mediaDir) {
                 File[] mediaFiles = mediaDir.listFiles();
@@ -287,7 +286,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
         when(formSource.fetchMediaFile("http://file1")).thenThrow(new FormSourceException.FetchError());
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
 
         try {
             downloader.downloadForm(serverFormDetails, null, null);
@@ -321,7 +320,7 @@ public class ServerFormDownloaderTest {
         // Create file where media dir would go
         assertThat(new File(formsDir, "Form-media").createNewFile(), is(true));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
 
         try {
             downloader.downloadForm(serverFormDetails, null, null);
@@ -354,7 +353,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         RecordingProgressReporter progressReporter = new RecordingProgressReporter();
         downloader.downloadForm(serverFormDetails, progressReporter, null);
 
@@ -383,7 +382,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         downloader.downloadForm(serverFormDetails, null, null);
         assertThat(formsRepository.get(1L).isDeleted(), is(false));
     }
@@ -415,7 +414,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform2.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
         downloader.downloadForm(serverFormDetails, null, null);
         assertThat(formsRepository.get(1L).isDeleted(), is(true));
         assertThat(formsRepository.get(2L).isDeleted(), is(false));
@@ -446,7 +445,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform2.getBytes()));
 
         Analytics mockAnalytics = mock(Analytics.class);
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mockAnalytics);
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mockAnalytics);
         downloader.downloadForm(serverFormDetails, null, null);
 
         String formIdentifier = form.getDisplayName() + " " + form.getFormId();
@@ -479,7 +478,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
         Analytics mockAnalytics = mock(Analytics.class);
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mockAnalytics);
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mockAnalytics);
         downloader.downloadForm(serverFormDetails, null, null);
         verifyNoInteractions(mockAnalytics);
     }
@@ -507,7 +506,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl/draft.xml")).thenReturn(new ByteArrayInputStream(xform2.getBytes()));
 
         Analytics mockAnalytics = mock(Analytics.class);
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mockAnalytics);
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mockAnalytics);
         downloader.downloadForm(serverFormDetails, null, null);
 
         verifyNoInteractions(mockAnalytics);
@@ -530,7 +529,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
 
         // Initial download
         downloader.downloadForm(serverFormDetails, null, null);
@@ -575,7 +574,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
 
         // Initial download
         downloader.downloadForm(serverFormDetails, null, null);
@@ -624,7 +623,7 @@ public class ServerFormDownloaderTest {
                 null);
 
         CancelAfterFormDownloadFormSource formListApi = new CancelAfterFormDownloadFormSource(xform);
-        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
 
         try {
             downloader.downloadForm(serverFormDetails, null, formListApi);
@@ -653,7 +652,7 @@ public class ServerFormDownloaderTest {
                 )));
 
         CancelAfterMediaFileDownloadFormSource formListApi = new CancelAfterMediaFileDownloadFormSource(xform);
-        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(ReferenceManager.instance()), mock(Analytics.class));
+        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
 
         try {
             downloader.downloadForm(serverFormDetails, null, formListApi);


### PR DESCRIPTION
Closes #4634 

#### What has been done to verify that this works as intended?
The goal is to make it so `ReferenceManager` is only configured when a user loads a form for filling. I did a search through the codebase for `ReferenceManager.` and made sure all calls are access-only. I removed configuration from the disk sync task and metadata parsing (incidentally, there was some redundancy there so this is a good change overall).

Allowing form parses when a secondary instance is required without a configured `ReferenceManager` required JavaRosa changes. Those are at https://github.com/getodk/javarosa/pull/635 and include some new tests. The JR snapshot has now been updated to include those changes.

Manually tried the following cases:
- Download a form that requires a CSV external secondary instance [external-select-csv.xml.zip](https://github.com/getodk/collect/files/6712840/external-select-csv.xml.zip) without attaching the CSV. The download succeeds. Opening the form succeeds but there are no choices available.
-  Download a form that requires a CSV external secondary instance used in a select and attach a CSV with missing `label` and `name` columns. The download fails with `Failure`, as it does on master.
- Download a form that requires a CSV external secondary instance without attaching the CSV. Then attach a CSV with missing `label` and `name` columns and download the update. The update succeeds. Empty choices are displayed. Selecting a choice and moving to the next question shows an error.
- Download a form in one project, switch projects to a project with a form that has media, verify that the media is visible (e.g. All Widgets and Likert widget images)
- Download a form with a last-saved reference, then open it and verify last-saved is used
- Verify forms with media work on first and second open and with switches between projects
- adb push forms that have a last-saved call, that require an external CSV without pushing that CSV, verify they are correctly discovered. Verify adding the external CSV makes the choices appear.

#### Why is this the best possible solution? Were any other approaches considered?
It's relatively simple and improves Collect code quality.

I tried to add a helpful message when the file is missing (https://github.com/getodk/collect/pull/4643/commits/b953ef946eb1767d7ba4e60184a31a289c19e9f5) but I backed out of that because we can't currently tell the difference between a missing external secondary instance and a choice filter that doesn't return any items. Adding a message made a common case worse: having a cascade of selects in a field-list. In that case, you want all the lower-level questions to show no options until selections are made further up the chain.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This is pretty risky. Everything that touches media is affected. Everything that discovers forms is affected (automatic form downloads, disk sync, manual form download). The biggest risk is that media doesn't show up somewhere it should, especially when switching projects.

#### Do we need any specific form for testing your changes? If so, please attach one.
See cases above. Forms with last-saved an XML and CSV external secondary instances.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)