### PR TITLE
Fix crash when opening QR scanner

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -90,8 +90,7 @@ the specific language governing permissions and limitations under the License.
                 android:resource="@xml/provider_paths" />
         </provider>
 
-        <activity android:name=".activities.FirstLaunchActivity"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" />
+        <activity android:name=".activities.FirstLaunchActivity" />
         <activity android:name=".activities.MainMenuActivity" />
         <activity
             android:name=".activities.ScannerWithFlashlightActivity"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FirstLaunchActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FirstLaunchActivity.kt
@@ -28,6 +28,8 @@ class FirstLaunchActivity : CollectAbstractActivity() {
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setTheme(R.style.Theme_Collect_Light)
+
         binding = FirstLaunchLayoutBinding.inflate(layoutInflater)
         setContentView(binding.root)
         DaggerUtils.getComponent(this).inject(this)

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/CodeCaptureManagerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/CodeCaptureManagerFactory.kt
@@ -27,6 +27,7 @@ object CodeCaptureManagerFactory {
         return IntentIntegrator(activity)
             .setDesiredBarcodeFormats(supportedFormats)
             .setPrompt(prompt)
+            .setOrientationLocked(false) // Let UI control orientation lock
             .addExtra(Intents.Scan.SCAN_TYPE, Intents.Scan.MIXED_SCAN)
             .createScanIntent()
     }

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -32,7 +32,7 @@
 
         <TextView
             android:id="@+id/tagline"
-            style="@style/TextAppearance.Collect.Headline4"
+            style="?textAppearanceHeadline4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:lines="2"
@@ -83,7 +83,7 @@
 
     <TextView
         android:id="@+id/app_name"
-        style="@style/TextAppearance.Collect.Body1"
+        style="?textAppearanceBody1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_extra_small"

--- a/collect_app/src/main/res/values/dark_theme.xml
+++ b/collect_app/src/main/res/values/dark_theme.xml
@@ -25,12 +25,12 @@
         <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1</item>
         <item name="textAppearanceHeadline2">@style/TextAppearance.MaterialComponents.Headline2</item>
         <item name="textAppearanceHeadline3">@style/TextAppearance.MaterialComponents.Headline3</item>
-        <item name="textAppearanceHeadline4">@style/TextAppearance.MaterialComponents.Headline4</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.Collect.Headline4</item>
         <item name="textAppearanceHeadline5">@style/TextAppearance.Collect.Headline5</item>
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="textAppearanceSubtitle2">@style/TextAppearance.MaterialComponents.Subtitle2</item>
-        <item name="textAppearanceBody1">@style/TextAppearance.MaterialComponents.Body1</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.Collect.Body1</item>
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>
         <item name="textAppearanceButton">@style/TextAppearance.Collect.Button</item>

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -26,12 +26,12 @@
         <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1</item>
         <item name="textAppearanceHeadline2">@style/TextAppearance.MaterialComponents.Headline2</item>
         <item name="textAppearanceHeadline3">@style/TextAppearance.MaterialComponents.Headline3</item>
-        <item name="textAppearanceHeadline4">@style/TextAppearance.MaterialComponents.Headline4</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.Collect.Headline4</item>
         <item name="textAppearanceHeadline5">@style/TextAppearance.Collect.Headline5</item>
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="textAppearanceSubtitle2">@style/TextAppearance.MaterialComponents.Subtitle2</item>
-        <item name="textAppearanceBody1">@style/TextAppearance.MaterialComponents.Body1</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.Collect.Body1</item>
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>
         <item name="textAppearanceButton">@style/TextAppearance.Collect.Button</item>

--- a/collect_app/src/main/res/values/magenta_theme.xml
+++ b/collect_app/src/main/res/values/magenta_theme.xml
@@ -18,12 +18,12 @@
         <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1</item>
         <item name="textAppearanceHeadline2">@style/TextAppearance.MaterialComponents.Headline2</item>
         <item name="textAppearanceHeadline3">@style/TextAppearance.MaterialComponents.Headline3</item>
-        <item name="textAppearanceHeadline4">@style/TextAppearance.MaterialComponents.Headline4</item>
+        <item name="textAppearanceHeadline4">@style/TextAppearance.Collect.Headline4</item>
         <item name="textAppearanceHeadline5">@style/TextAppearance.Collect.Headline5</item>
         <item name="textAppearanceHeadline6">@style/TextAppearance.Collect.Headline6</item>
         <item name="textAppearanceSubtitle1">@style/TextAppearance.Collect.Subtitle1</item>
         <item name="textAppearanceSubtitle2">@style/TextAppearance.MaterialComponents.Subtitle2</item>
-        <item name="textAppearanceBody1">@style/TextAppearance.MaterialComponents.Body1</item>
+        <item name="textAppearanceBody1">@style/TextAppearance.Collect.Body1</item>
         <item name="textAppearanceBody2">@style/TextAppearance.Collect.Body2</item>
         <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>
         <item name="textAppearanceButton">@style/TextAppearance.Collect.Button</item>


### PR DESCRIPTION
Closes #4649

This PR fixes the crash but it will also allow barcode scanning screens to be rotated which we may not want.

#### What has been done to verify that this works as intended?

These changes feel pretty "configuration level" to me, so I only validated manually. If we feel like we want to add orientation locking back in then I think we should have tests for that, however.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I think we need to play with this to check we're OK with the behaviour change and if not we can look at adding orientation locks back in but in a more controlled way. Another option is just to let the bug on the launch screen (going to scan a QR code and then being locked in an orientation) continue to exist and look at fixing that later.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)