### PR TITLE
Use color secondary as polyfill color for text fields

### DIFF
--- a/androidshared/src/main/res/values/material_theme_polyfill.xml
+++ b/androidshared/src/main/res/values/material_theme_polyfill.xml
@@ -9,9 +9,9 @@
 <resources>
 
     <style name="Theme.AndroidShared.MaterialComponents.Polyfill.TextInputLayout" parent="">
-        <item name="colorPrimary">?attr/colorOnSurface</item>
-        <item name="boxStrokeColor">?colorOnSurface</item>
-        <item name="hintTextColor">?colorOnSurface</item>
+        <item name="colorPrimary">?attr/colorSecondary</item>
+        <item name="boxStrokeColor">?attr/colorSecondary</item>
+        <item name="hintTextColor">?attr/colorSecondary</item>
     </style>
 
     <style name="Theme.AndroidShared.MaterialComponents.Polyfill.Button.TextButton" parent="">

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -8,38 +8,38 @@
 
     <ImageView
         android:id="@+id/logo"
-        android:src="@drawable/odk_logo"
         android:layout_width="60dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_standard"
         android:adjustViewBounds="true"
         android:contentDescription="@string/app_name"
-        android:layout_marginTop="@dimen/margin_standard"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:src="@drawable/odk_logo"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5" />
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/center"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintVertical_bias="0.5"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.5">
 
         <TextView
             android:id="@+id/tagline"
-            style="?textAppearanceHeadline4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:lines="2"
             android:text="@string/tagline"
-            app:layout_constraintTop_toTopOf="parent"
+            android:textAppearance="?textAppearanceHeadline4"
             app:layout_constraintBottom_toTopOf="@+id/configuration_buttons"
-            app:layout_constraintStart_toStartOf="@+id/configuration_buttons"/>
+            app:layout_constraintStart_toStartOf="@+id/configuration_buttons"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/configuration_buttons"
@@ -83,16 +83,16 @@
 
     <TextView
         android:id="@+id/app_name"
-        style="?textAppearanceBody1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_extra_small"
+        android:textAppearance="?textAppearanceBody1"
         android:textColor="@color/color_on_surface_medium_emphasis"
-        tools:text="ODK Collect v2022.3"
         app:layout_constraintBottom_toTopOf="@+id/configure_later"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="ODK Collect v2022.3" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/configure_later"
@@ -110,7 +110,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/dont_have_project"
-            android:textColor="?colorOnSurface"
+            android:textAppearance="?textAppearanceBody2"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
@@ -120,7 +120,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_small"
             android:text="@string/try_demo"
-            android:textColor="?colorSecondary"
+            android:textAppearance="@style/TextAppearance.Collect.Link"
             app:layout_constraintStart_toEndOf="@+id/dont_have_server"
             app:layout_constraintTop_toTopOf="@+id/dont_have_server" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -55,7 +55,7 @@
                 style="@style/Widget.Collect.Button.OutlinedButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:backgroundTint="@color/website_blue"
+                android:backgroundTint="?colorSecondary"
                 android:text="@string/configure_with_qr_code"
                 android:textAppearance="?attr/textAppearanceBody1"
                 android:textColor="@android:color/white"
@@ -120,7 +120,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_extra_small"
             android:text="@string/try_demo"
-            android:textColor="@color/website_blue"
+            android:textColor="?colorSecondary"
             app:layout_constraintStart_toEndOf="@+id/dont_have_server"
             app:layout_constraintTop_toTopOf="@+id/dont_have_server" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
@@ -148,7 +148,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin_extra_small"
                     android:text="@string/gdrive_configure"
-                    android:textColor="@color/website_blue"
+                    android:textColor="?colorSecondary"
                     app:layout_constraintStart_toEndOf="@+id/project_uses_gdrive"
                     app:layout_constraintTop_toTopOf="@+id/project_uses_gdrive" />
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
@@ -110,14 +110,14 @@
 
                 <TextView
                     android:id="@+id/tip_text"
-                    android:layout_height="wrap_content"
                     android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_small"
                     android:text="@string/project_config_tip"
                     android:textAppearance="?textAppearanceBody1"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@+id/tip_icon"
-                    android:layout_marginStart="@dimen/margin_small"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -138,7 +138,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/gdrive_project"
-                    android:textColor="?colorOnSurface"
+                    android:textAppearance="?textAppearanceBody1"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
 
@@ -148,7 +148,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin_extra_small"
                     android:text="@string/gdrive_configure"
-                    android:textColor="?colorSecondary"
+                    android:textAppearance="@style/TextAppearance.Collect.Link"
                     app:layout_constraintStart_toEndOf="@+id/project_uses_gdrive"
                     app:layout_constraintTop_toTopOf="@+id/project_uses_gdrive" />
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -20,8 +20,6 @@ the License.
     <color name="green_500">#4CAF50</color>
     <color name="deep_purple_500">#673AB7</color>
 
-    <color name="website_blue">#3e9fcc</color>
-
     <color name="highContrastHighlight">#ff8c00</color>
 
     <!-- Background colors in the GeoTrace status bar, under white text. -->

--- a/collect_app/src/main/res/values/light_theme.xml
+++ b/collect_app/src/main/res/values/light_theme.xml
@@ -10,7 +10,7 @@
     <style name="Theme.Collect.BaseLight" parent="Theme.AppCompat.Light.NoActionBar">
         <!--Material theme attributes-->
         <item name="colorPrimary">#E0E0E0</item>
-        <item name="colorSecondary">#2196F3</item>
+        <item name="colorSecondary">#3e9fcc</item>
         <item name="colorError">@color/red_500</item>
 
         <item name="colorPrimaryVariant">?colorPrimary</item>
@@ -47,7 +47,7 @@
         <item name="android:scrollbarSize">1.75mm</item>
         <item name="android:scrollbarAlwaysDrawVerticalTrack">true</item>
         <item name="android:fadeScrollbars">false</item>
-        <item name="colorAccent">@color/blue_500</item>
+        <item name="colorAccent">?colorSecondary</item>
         <item name="android:fontFamily">@string/font_family_regular</item>
         <item name="android:panelBackground">@android:color/white</item>
         <item name="alertDialogTheme">@style/Theme.Collect.Light.Dialog.Alert</item>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -36,4 +36,8 @@
         <item name="android:textAllCaps">false</item>
         <item name="android:letterSpacing">0.04</item>
     </style>
+
+    <style name="TextAppearance.Collect.Link" parent="TextAppearance.MaterialComponents.Body2">
+        <item name="android:textColor">?colorSecondary</item>
+    </style>
 </resources>


### PR DESCRIPTION
As the title says and it also:

* Switches our `colorSecondary` in the light theme to the newer "website blue" (and removes the color attribute)
* Introduces a `Link` text appearance

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)