### PR TITLE
Switch to existing helper for fill blank form test path

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -6,16 +6,13 @@ import android.app.Instrumentation;
 import android.content.Intent;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.database.forms.DatabaseFormColumns;
 
-import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
-import static androidx.test.espresso.matcher.CursorMatchers.withRowString;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isClickable;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -70,8 +67,7 @@ public class MainMenuPage extends Page<MainMenuPage> {
     }
 
     private void goToBlankForm(String formName) {
-        clickFillBlankForm();
-        onData(withRowString(DatabaseFormColumns.DISPLAY_NAME, formName)).perform(click());
+        clickFillBlankForm().clickOnForm(formName);
     }
 
     public EditSavedFormPage clickEditSavedForm() {


### PR DESCRIPTION
This switches our `startBlankForm` helper to using the helpers defined in `FillBlankForm` rather than its own custom code. We saw a test flake that looked like it could be solved by the `waitFor` in `FillBlankFormPage#assertFormExists` (which is now being used by `startBlankForm`).

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)