### PR TITLE
Use current project for shortcuts UI

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.java
@@ -2,22 +2,15 @@ package org.odk.collect.android.feature.external;
 
 import android.content.Intent;
 
-import androidx.test.core.app.ActivityScenario;
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.activities.AndroidShortcutsActivity;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.FormEntryPage;
-
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(AndroidJUnit4.class)
 public class AndroidShortcutsTest {
@@ -34,21 +27,11 @@ public class AndroidShortcutsTest {
                 .copyForm("one-question.xml")
                 .clickFillBlankForm(); // Load form
 
-        pickAndLaunchShortcutForForm("One Question")
+        Intent shortcutIntent = rule.launchShortcuts()
+                .selectForm("One Question");
+
+        rule.launch(shortcutIntent, new FormEntryPage("One Question"))
                 .assertQuestion("what is your age");
     }
 
-    private FormEntryPage pickAndLaunchShortcutForForm(String formName) {
-        ActivityScenario<AndroidShortcutsActivity> scenario = ActivityScenario.launch(AndroidShortcutsActivity.class);
-        onView(withText(formName)).perform(click());
-        Intent resultData = scenario.getResult().getResultData();
-        Intent shortcutIntent = resultData.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT);
-
-         /*
-        This can't use ActivityScenario.launch because of: https://github.com/android/android-test/issues/496
-         */
-        shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        ApplicationProvider.getApplicationContext().startActivity(shortcutIntent);
-        return new FormEntryPage(formName);
-    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.support.pages.MainMenuPage;
 
 @RunWith(AndroidJUnit4.class)
 public class AndroidShortcutsTest {
@@ -20,6 +21,21 @@ public class AndroidShortcutsTest {
     @Rule
     public RuleChain testRuleChain = TestRuleChain.chain()
             .around(rule);
+
+    @Test
+    public void showsFormsForCurrentProject() {
+        rule.startAtMainMenu()
+                .copyForm("one-question.xml")
+                .clickFillBlankForm() // Load form
+                .pressBack(new MainMenuPage())
+                .addAndSwitchToProject("https://example.com")
+                .copyForm("two-question.xml")
+                .clickFillBlankForm(); // Load form
+
+        rule.launchShortcuts()
+                .assertText("Two Question")
+                .assertTextDoesNotExist("One Question");
+    }
 
     @Test
     public void canFillOutFormFromShortcut() {
@@ -34,4 +50,21 @@ public class AndroidShortcutsTest {
                 .assertQuestion("what is your age");
     }
 
+    @Test
+    public void whenDifferentProjectSelected_canStillFillOutFormFromShortcut() {
+        rule.startAtMainMenu()
+                .copyForm("one-question.xml")
+                .clickFillBlankForm() // Load form
+                .pressBack(new MainMenuPage());
+
+        Intent shortcutIntent = rule.launchShortcuts()
+                .selectForm("One Question");
+
+        rule.restart()
+                .startAtMainMenu()
+                .addAndSwitchToProject("https://example.com");
+
+        rule.launch(shortcutIntent, new FormEntryPage("One Question"))
+                .assertQuestion("what is your age");
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RankingWidgetWithCSVTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RankingWidgetWithCSVTest.java
@@ -15,13 +15,14 @@ public class RankingWidgetWithCSVTest {
 
     private static final String TEST_FORM = "ranking_widget.xml";
 
+    public FormActivityTestRule activityTestRule = AdbFormLoadingUtils.getFormActivityTestRuleFor(TEST_FORM);
+
     @Rule
     public RuleChain copyFormChain = RuleChain
             .outerRule(new ResetStateRule())
-            .around(new CopyFormRule(TEST_FORM, Collections.singletonList("fruits.csv")));
+            .around(new CopyFormRule(TEST_FORM, Collections.singletonList("fruits.csv"), true))
+            .around(activityTestRule);
 
-    @Rule
-    public FormActivityTestRule activityTestRule = AdbFormLoadingUtils.getFormActivityTestRuleFor(TEST_FORM);
 
     @Test
     public void rankingWidget_shouldDisplayItemsFromSearchFunc() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
@@ -51,7 +51,7 @@ public class AllWidgetsFormTest {
                     return activityAvailability;
                 }
             }))
-            .around(new CopyFormRule("all-widgets.xml"))
+            .around(new CopyFormRule("all-widgets.xml", true))
             .around(activityTestRule);
 
     @BeforeClass

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/AdbFormLoadingUtils.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/AdbFormLoadingUtils.java
@@ -16,9 +16,12 @@
 
 package org.odk.collect.android.support;
 
+import android.app.Application;
+
 import androidx.test.core.app.ApplicationProvider;
 
 import org.jetbrains.annotations.NotNull;
+import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormsDirDiskFormsSynchronizer;
@@ -106,19 +109,18 @@ public class AdbFormLoadingUtils {
      * @return the forms dir path that the user would expect (from docs)
      */
     private static String getFormsDirPath() {
-        return firstProjectPath() + "/forms/";
+        return currentProjectPath() + "/forms/";
     }
 
     /**
      * @return the instances dir path that the user would expect (from docs)
      */
     private static String getInstancesDirPath() {
-        return firstProjectPath() + "/instances/";
+        return currentProjectPath() + "/instances/";
     }
 
     @NotNull
-    private static String firstProjectPath() {
-        String projectsDirPath = ApplicationProvider.getApplicationContext().getExternalFilesDir(null) + "/projects/";
-        return projectsDirPath + "/" + new File(projectsDirPath).list()[0];
+    private static String currentProjectPath() {
+        return DaggerUtils.getComponent(ApplicationProvider.<Application>getApplicationContext()).storagePathProvider().getProjectRootDirPath();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
@@ -37,7 +37,7 @@ public class CollectTestRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                ActivityScenario.launch(SplashScreenActivity.class);
+                restart();
 
                 if (!CopyFormRule.projectCreated && skipLaunchScreen) {
                     onView(withText(R.string.try_demo)).perform(click());
@@ -46,6 +46,11 @@ public class CollectTestRule implements TestRule {
                 base.evaluate();
             }
         };
+    }
+
+    public CollectTestRule restart() {
+        ActivityScenario.launch(SplashScreenActivity.class);
+        return this;
     }
 
     public MainMenuPage startAtMainMenu() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
@@ -1,14 +1,20 @@
 package org.odk.collect.android.support;
 
+import android.content.Intent;
+
 import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.odk.collect.android.R;
+import org.odk.collect.android.activities.AndroidShortcutsActivity;
 import org.odk.collect.android.activities.SplashScreenActivity;
 import org.odk.collect.android.support.pages.FirstLaunchPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
+import org.odk.collect.android.support.pages.Page;
+import org.odk.collect.android.support.pages.ShortcutsPage;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -48,5 +54,19 @@ public class CollectTestRule implements TestRule {
 
     public FirstLaunchPage startAtFirstLaunch() {
         return new FirstLaunchPage().assertOnPage();
+    }
+
+    public ShortcutsPage launchShortcuts() {
+        ActivityScenario<AndroidShortcutsActivity> scenario = ActivityScenario.launch(AndroidShortcutsActivity.class);
+        return new ShortcutsPage(scenario).assertOnPage();
+    }
+
+    public <T extends Page<T>> T launch(Intent intent, T destination) {
+        /*
+        This can't use ActivityScenario.launch because of: https://github.com/android/android-test/issues/496
+         */
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        ApplicationProvider.getApplicationContext().startActivity(intent);
+        return destination.assertOnPage();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FormActivityTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FormActivityTestRule.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.support;
 
+import android.app.Application;
 import android.content.Intent;
 
 import androidx.test.core.app.ActivityScenario;
@@ -9,10 +10,10 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.odk.collect.android.activities.FormEntryActivity;
-import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.provider.FormsProviderAPI;
 import org.odk.collect.android.storage.StorageSubdirectory;
-
-import static org.odk.collect.android.activities.FormEntryActivity.EXTRA_TESTING_PATH;
+import org.odk.collect.forms.Form;
 
 public class FormActivityTestRule implements TestRule {
 
@@ -34,9 +35,14 @@ public class FormActivityTestRule implements TestRule {
     }
 
     private Intent getActivityIntent() {
-        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), FormEntryActivity.class);
-        intent.putExtra(EXTRA_TESTING_PATH, new StoragePathProvider().getOdkDirPath(StorageSubdirectory.FORMS) + "/" + formFilename);
+        Application application = ApplicationProvider.getApplicationContext();
 
+        String formPath = DaggerUtils.getComponent(application).storagePathProvider().getOdkDirPath(StorageSubdirectory.FORMS) + "/" + formFilename;
+        Form form = DaggerUtils.getComponent(application).formsRepositoryProvider().get().getOneByPath(formPath);
+        String projectId = DaggerUtils.getComponent(application).currentProjectProvider().getCurrentProject().getUuid();
+
+        Intent intent = new Intent(application, FormEntryActivity.class);
+        intent.setData(FormsProviderAPI.getUri(projectId, form.getDbId()));
         return intent;
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -176,6 +176,14 @@ public class MainMenuPage extends Page<MainMenuPage> {
                 .pressBack(new MainMenuPage());
     }
 
+    public MainMenuPage addAndSwitchToProject(String serverUrl) {
+        return openProjectSettings()
+                .clickAddProject()
+                .switchToManualMode()
+                .inputUrl(serverUrl)
+                .addProject();
+    }
+
     public ServerAuthDialog clickGetBlankFormWithAuthenticationError() {
         onView(withText(getTranslatedString(R.string.get_forms))).perform(scrollTo(), click());
         return new ServerAuthDialog().assertOnPage();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.support.pages
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -55,7 +56,7 @@ internal class ProjectSettingsDialogPage() : Page<ProjectSettingsDialogPage>() {
     }
 
     fun selectProject(projectName: String): MainMenuPage {
-        clickOnText(projectName)
+        onView(allOf(hasDescendant(withText(projectName)), withContentDescription(getTranslatedString(R.string.switch_to_project, projectName)))).perform(click())
         return MainMenuPage().assertOnPage()
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ShortcutsPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ShortcutsPage.java
@@ -1,0 +1,29 @@
+package org.odk.collect.android.support.pages;
+
+import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.activities.AndroidShortcutsActivity;
+
+public class ShortcutsPage extends Page<ShortcutsPage> {
+
+    private final ActivityScenario<AndroidShortcutsActivity> scenario;
+
+    public ShortcutsPage(ActivityScenario<AndroidShortcutsActivity> scenario) {
+        this.scenario = scenario;
+    }
+
+    @Override
+    public ShortcutsPage assertOnPage() {
+        assertText(R.string.select_odk_shortcut);
+        return this;
+    }
+
+    public Intent selectForm(String formName) {
+        clickOnText(formName);
+        Intent resultData = scenario.getResult().getResultData();
+        return resultData.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT);
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcutsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcutsActivity.java
@@ -23,10 +23,14 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.jetbrains.annotations.NotNull;
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.formmanagement.BlankFormsListViewModel;
 import org.odk.collect.android.formmanagement.BlankFormsListViewModel.BlankForm;
 import org.odk.collect.android.injection.DaggerUtils;
+import org.odk.collect.android.preferences.source.SettingsProvider;
 
 import java.util.List;
 
@@ -43,13 +47,19 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
     @Inject
     BlankFormsListViewModel.Factory blankFormsListViewModelFactory;
 
+    @Inject
+    Analytics analytics;
+
+    @Inject
+    SettingsProvider settingsProvider;
+
     @Override
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         DaggerUtils.getComponent(this).inject(this);
         BlankFormsListViewModel blankFormsListViewModel = new ViewModelProvider(this, blankFormsListViewModelFactory).get(BlankFormsListViewModel.class);
         List<BlankForm> forms = blankFormsListViewModel.getForms();
-        
+
         showFormListDialog(forms);
     }
 
@@ -57,6 +67,9 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
         new AlertDialog.Builder(this)
                 .setTitle(R.string.select_odk_shortcut)
                 .setItems(forms.stream().map(BlankForm::getName).toArray(String[]::new), (dialog, item) -> {
+                    String serverHash = AnalyticsUtils.getServerHash(settingsProvider.getGeneralSettings());
+                    analytics.logServerEvent(AnalyticsEvents.CREATE_SHORTCUT, serverHash);
+
                     Intent intent = getShortcutIntent(forms, item);
                     setResult(RESULT_OK, intent);
                     finish();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcutsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcutsActivity.java
@@ -21,12 +21,13 @@ import android.os.Parcelable;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProvider;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.formmanagement.BlankFormsListViewModel;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.provider.FormsProviderAPI;
-import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.forms.Form;
 
 import java.util.ArrayList;
@@ -43,18 +44,21 @@ import javax.inject.Inject;
 public class AndroidShortcutsActivity extends AppCompatActivity {
 
     @Inject
-    FormsRepositoryProvider formsRepositoryProvider;
+    CurrentProjectProvider currentProjectProvider;
 
     @Inject
-    CurrentProjectProvider currentProjectProvider;
+    BlankFormsListViewModel.Factory blankFormsListViewModelFactory;
 
     private Uri[] commands;
     private String[] names;
+    private BlankFormsListViewModel blankFormsListViewModel;
 
     @Override
     public void onCreate(Bundle bundle) {
         super.onCreate(bundle);
         DaggerUtils.getComponent(this).inject(this);
+        blankFormsListViewModel = new ViewModelProvider(this, blankFormsListViewModelFactory).get(BlankFormsListViewModel.class);
+
         buildMenuList();
     }
 
@@ -65,10 +69,7 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
         ArrayList<String> names = new ArrayList<>();
         ArrayList<Uri> commands = new ArrayList<>();
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setTitle(R.string.select_odk_shortcut);
-
-        List<Form> forms = formsRepositoryProvider.get().getAll();
+        List<Form> forms = blankFormsListViewModel.getForms();
         for (Form form : forms) {
             String formName = form.getDisplayName();
             names.add(formName);
@@ -78,6 +79,9 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
 
         this.names = names.toArray(new String[0]);
         this.commands = commands.toArray(new Uri[0]);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle(R.string.select_odk_shortcut);
 
         builder.setItems(this.names, (dialog, item) -> returnShortcut(this.names[item], this.commands[item]));
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -243,7 +243,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     // Tracks whether we are autosaving
     public static final String KEY_AUTO_SAVED = "autosaved";
 
-    public static final String EXTRA_TESTING_PATH = "testingPath";
     public static final String KEY_READ_PHONE_STATE_PERMISSION_REQUEST_NEEDED = "readPhoneStatePermissionRequestNeeded";
 
     private boolean autoSaved;
@@ -598,10 +597,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             uriMimeType = getContentResolver().getType(uri);
         }
 
-        if (uriMimeType == null && intent.hasExtra(EXTRA_TESTING_PATH)) {
-            formPath = intent.getStringExtra(EXTRA_TESTING_PATH);
-
-        } else if (uriMimeType != null && uriMimeType.equals(InstanceProviderAPI.CONTENT_ITEM_TYPE)) {
+        if (uriMimeType != null && uriMimeType.equals(InstanceProviderAPI.CONTENT_ITEM_TYPE)) {
             Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
 
             if (instance == null) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -633,10 +633,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
 
             formPath = candidateForms.get(0).getFormFilePath();
-        } else if (uriMimeType != null
-                && uriMimeType.equals(FormsProviderAPI.CONTENT_ITEM_TYPE)) {
-
-            Form form = formsRepository.get(ContentUriHelper.getIdFromUri(uri));
+        } else if (uriMimeType != null && uriMimeType.equals(FormsProviderAPI.CONTENT_ITEM_TYPE)) {
+            String projectId = uri.getQueryParameter("projectId");
+            Form form = formsRepositoryProvider.get(projectId).get(ContentUriHelper.getIdFromUri(uri));
             if (form != null) {
                 formPath = form.getFormFilePath();
             }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -169,6 +169,11 @@ public class AnalyticsEvents {
     public static final String OPEN_MAP_KIT_RESPONSE = "OpenMapKitResponse";
 
     /**
+     * Tracks how often users create shortcuts to forms
+     */
+    public static final String CREATE_SHORTCUT = "CreateShortcut";
+
+    /**
      * Tracks how often instances that have been deleted on disk are opened for editing/viewing
      */
     public static final String OPEN_DELETED_INSTANCE = "OpenDeletedInstance";

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
@@ -2,8 +2,13 @@ package org.odk.collect.android.analytics;
 
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.forms.FormSourceException;
+import org.odk.collect.shared.Settings;
+import org.odk.collect.shared.strings.Md5;
+
+import java.io.ByteArrayInputStream;
 
 import static java.lang.String.format;
+import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_SERVER_URL;
 import static org.odk.collect.forms.FormSourceException.AuthRequired;
 import static org.odk.collect.forms.FormSourceException.FetchError;
 import static org.odk.collect.forms.FormSourceException.ParseError;
@@ -15,6 +20,11 @@ public class AnalyticsUtils {
 
     private AnalyticsUtils() {
 
+    }
+
+    public static String getServerHash(Settings generalSettings) {
+        String currentServerUrl = generalSettings.getString(KEY_SERVER_URL);
+        return Md5.getMd5Hash(new ByteArrayInputStream(currentServerUrl.getBytes()));
     }
 
     public static void logMatchExactlyCompleted(Analytics analytics, FormSourceException exception) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.java
@@ -6,16 +6,12 @@ import org.odk.collect.android.backgroundwork.FormUpdateScheduler;
 import org.odk.collect.android.configure.SettingsChangeHandler;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.source.SettingsProvider;
-import org.odk.collect.shared.Settings;
-import org.odk.collect.shared.strings.Md5;
 
-import java.io.ByteArrayInputStream;
-
+import static org.odk.collect.android.analytics.AnalyticsUtils.getServerHash;
 import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_EXTERNAL_APP_RECORDING;
 import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_FORM_UPDATE_MODE;
 import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_PERIODIC_FORM_UPDATES_CHECK;
 import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_PROTOCOL;
-import static org.odk.collect.android.preferences.keys.GeneralKeys.KEY_SERVER_URL;
 
 public class CollectSettingsChangeHandler implements SettingsChangeHandler {
 
@@ -40,10 +36,7 @@ public class CollectSettingsChangeHandler implements SettingsChangeHandler {
         }
 
         if (changedKey.equals(KEY_EXTERNAL_APP_RECORDING) && !((Boolean) newValue)) {
-            Settings generalSettings = settingsProvider.getGeneralSettings(projectId);
-            String currentServerUrl = generalSettings.getString(KEY_SERVER_URL);
-            String serverHash = Md5.getMd5Hash(new ByteArrayInputStream(currentServerUrl.getBytes()));
-
+            String serverHash = getServerHash(settingsProvider.getGeneralSettings(projectId));
             analytics.logServerEvent(AnalyticsEvents.INTERNAL_RECORDING_OPT_IN, serverHash);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -18,12 +18,15 @@ import org.odk.collect.android.preferences.FormUpdateMode;
 import org.odk.collect.android.preferences.keys.GeneralKeys;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.CurrentProjectProvider;
+import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.async.Scheduler;
+import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormSourceException;
-import org.odk.collect.shared.strings.Md5;
 import org.odk.collect.shared.Settings;
+import org.odk.collect.shared.strings.Md5;
 
 import java.io.ByteArrayInputStream;
+import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -39,8 +42,9 @@ public class BlankFormsListViewModel extends ViewModel {
     private final Analytics analytics;
     private final FormsUpdater formsUpdater;
     private final CurrentProjectProvider currentProjectProvider;
+    private final FormsRepositoryProvider formsRepositoryProvider;
 
-    public BlankFormsListViewModel(Application application, Scheduler scheduler, SyncStatusAppState syncRepository, SettingsProvider settingsProvider, Analytics analytics, FormsUpdater formsUpdater, CurrentProjectProvider currentProjectProvider) {
+    public BlankFormsListViewModel(Application application, Scheduler scheduler, SyncStatusAppState syncRepository, SettingsProvider settingsProvider, Analytics analytics, FormsUpdater formsUpdater, CurrentProjectProvider currentProjectProvider, FormsRepositoryProvider formsRepositoryProvider) {
         this.application = application;
         this.scheduler = scheduler;
         this.syncRepository = syncRepository;
@@ -48,6 +52,11 @@ public class BlankFormsListViewModel extends ViewModel {
         this.analytics = analytics;
         this.formsUpdater = formsUpdater;
         this.currentProjectProvider = currentProjectProvider;
+        this.formsRepositoryProvider = formsRepositoryProvider;
+    }
+
+    public List<Form> getForms() {
+        return formsRepositoryProvider.get().getAll();
     }
 
     public boolean isMatchExactlyEnabled() {
@@ -101,9 +110,10 @@ public class BlankFormsListViewModel extends ViewModel {
         private final Analytics analytics;
         private final FormsUpdater formsUpdater;
         private final CurrentProjectProvider currentProjectProvider;
+        private final FormsRepositoryProvider formsRepositoryProvider;
 
         @Inject
-        public Factory(Application application, Scheduler scheduler, SyncStatusAppState syncRepository, SettingsProvider settingsProvider, Analytics analytics, FormsUpdater formsUpdater, CurrentProjectProvider currentProjectProvider) {
+        public Factory(Application application, Scheduler scheduler, SyncStatusAppState syncRepository, SettingsProvider settingsProvider, Analytics analytics, FormsUpdater formsUpdater, CurrentProjectProvider currentProjectProvider, FormsRepositoryProvider formsRepositoryProvider) {
             this.application = application;
             this.scheduler = scheduler;
             this.syncRepository = syncRepository;
@@ -111,12 +121,13 @@ public class BlankFormsListViewModel extends ViewModel {
             this.analytics = analytics;
             this.formsUpdater = formsUpdater;
             this.currentProjectProvider = currentProjectProvider;
+            this.formsRepositoryProvider = formsRepositoryProvider;
         }
 
         @NonNull
         @Override
         public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-            return (T) new BlankFormsListViewModel(application, scheduler, syncRepository, settingsProvider, analytics, formsUpdater, currentProjectProvider);
+            return (T) new BlankFormsListViewModel(application, scheduler, syncRepository, settingsProvider, analytics, formsUpdater, currentProjectProvider, formsRepositoryProvider);
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/BlankFormsListViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/BlankFormsListViewModelTest.java
@@ -57,7 +57,7 @@ public class BlankFormsListViewModelTest {
         MutableLiveData<Boolean> liveData = new MutableLiveData<>(true);
         when(syncRepository.isSyncing("testProject")).thenReturn(liveData);
 
-        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), mock(Scheduler.class), syncRepository, settingsProvider, analytics, mock(FormsUpdater.class), currentProjectProvider);
+        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), mock(Scheduler.class), syncRepository, settingsProvider, analytics, mock(FormsUpdater.class), currentProjectProvider, null);
         assertThat(viewModel.isSyncing().getValue(), is(true));
 
         liveData.setValue(false);
@@ -69,7 +69,7 @@ public class BlankFormsListViewModelTest {
         MutableLiveData<FormSourceException> liveData = new MutableLiveData<>(new FormSourceException.FetchError());
         when(syncRepository.getSyncError("testProject")).thenReturn(liveData);
 
-        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), mock(Scheduler.class), syncRepository, settingsProvider, analytics, mock(FormsUpdater.class), currentProjectProvider);
+        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), mock(Scheduler.class), syncRepository, settingsProvider, analytics, mock(FormsUpdater.class), currentProjectProvider, null);
         LiveData<Boolean> outOfSync = liveDataTester.activate(viewModel.isOutOfSync());
 
         assertThat(outOfSync.getValue(), is(true));
@@ -83,7 +83,7 @@ public class BlankFormsListViewModelTest {
         FakeScheduler fakeScheduler = new FakeScheduler();
         FormsUpdater formsUpdater = mock(FormsUpdater.class);
 
-        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), fakeScheduler, syncRepository, settingsProvider, analytics, formsUpdater, currentProjectProvider);
+        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), fakeScheduler, syncRepository, settingsProvider, analytics, formsUpdater, currentProjectProvider, null);
 
         doReturn(true).when(formsUpdater).matchFormsWithServer("testProject");
         LiveData<Boolean> result = viewModel.syncWithServer();
@@ -97,7 +97,7 @@ public class BlankFormsListViewModelTest {
         FakeScheduler fakeScheduler = new FakeScheduler();
         FormsUpdater formsUpdater = mock(FormsUpdater.class);
 
-        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), fakeScheduler, syncRepository, settingsProvider, analytics, formsUpdater, currentProjectProvider);
+        BlankFormsListViewModel viewModel = new BlankFormsListViewModel(mock(Application.class), fakeScheduler, syncRepository, settingsProvider, analytics, formsUpdater, currentProjectProvider, null);
 
         doReturn(false).when(formsUpdater).matchFormsWithServer("testProject");
         LiveData<Boolean> result = viewModel.syncWithServer();


### PR DESCRIPTION
Closes #4640 
~~Blocked by #4462~~

I initially thought I'd have to do more work to get this working properly, as the shortcuts weren't respecting the "Hide old versions" setting. Looking at the old implementation ([here](https://github.com/getodk/collect/blob/d539ef61b151ed66307cb40351dd40802c5afe36/collect_app/src/main/java/org/odk/collect/android/activities/AndroidShortcuts.java#L69)) in 1.30.1 however, it looks like we always returned all forms rather than just the newest versions. Noticing that, I also realized that shortcuts will not work with form updates, which seems like a problem for their use with things like Match Exactly. I didn't try to fix either of these problems here, but it's probably something to keep in mind for the future.

EDIT: It looks like the above points are also discussed in [this issue](https://github.com/getodk/collect/issues/4247).

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

I chose to use the `BlankFormsListViewModel` here, as I can imagine we'll eventually end up using it for the "Fill Blank Form" (or whatever might replace it) and "Delete Blank Form" pages in future. I think we'll be able to use and expand on the new `getForms` and `BlankForm` class there as well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This can go in without QA I think as it'll be covered in a regression pass.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)