### PR TITLE
Show warning when opening deleted instance

### DIFF
--- a/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
@@ -7,10 +7,11 @@ interface Analytics {
     @Deprecated("")
     fun logEvent(category: String, action: String, label: String)
 
+    fun logEvent(event: String)
     fun logFormEvent(event: String, formIdHash: String)
+    fun logServerEvent(event: String, serverHash: String)
     fun logFatal(throwable: Throwable)
     fun logNonFatal(message: String)
-    fun logServerEvent(event: String, serverHash: String)
     fun setAnalyticsCollectionEnabled(isAnalyticsEnabled: Boolean)
     fun setUserProperty(name: String, value: String)
 }

--- a/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
@@ -25,6 +25,10 @@ class BlockableFirebaseAnalytics(application: Application) : Analytics {
         firebaseAnalytics.logEvent(category, bundle)
     }
 
+    override fun logEvent(event: String) {
+        firebaseAnalytics.logEvent(event, null)
+    }
+
     override fun logFormEvent(event: String, formIdHash: String) {
         val bundle = Bundle()
         bundle.putString("form", formIdHash)

--- a/analytics/src/main/java/org/odk/collect/analytics/NoopAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/NoopAnalytics.kt
@@ -3,6 +3,8 @@ package org.odk.collect.analytics
 class NoopAnalytics : Analytics {
     override fun logEvent(category: String, action: String) {}
     override fun logEvent(category: String, action: String, label: String) {}
+
+    override fun logEvent(event: String) {}
     override fun logFormEvent(event: String, formIdHash: String) {}
     override fun logFatal(throwable: Throwable) {}
     override fun logNonFatal(message: String) {}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/InstancesAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/InstancesAdbTest.kt
@@ -6,6 +6,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.odk.collect.android.R
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestDependencies
@@ -34,7 +35,7 @@ class InstancesAdbTest {
     }
 
     @Test
-    fun deletingInstanceOnDisk_andThenOpeningInstance_doesNotCrash() {
+    fun deletingInstanceOnDisk_andThenOpeningInstance_showsWarning_andRemovesInstance() {
         val mainMenuPage = rule.startAtMainMenu()
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
@@ -47,6 +48,9 @@ class InstancesAdbTest {
 
         mainMenuPage
             .clickEditSavedForm(1)
-            .clickOnText("One Question")
+            .clickOnFormWithDialog("One Question")
+            .assertText(R.string.instance_deleted_message)
+            .clickOK(MainMenuPage())
+            .assertNumberOfEditableForms(0)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -64,6 +64,7 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDateTime;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AMRAppender;
 import org.odk.collect.android.audio.AudioControllerView;
@@ -610,6 +611,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
             instancePath = instance.getInstanceFilePath();
             if (!new File(instancePath).exists()) {
+                analytics.logEvent(AnalyticsEvents.OPEN_DELETED_INSTANCE);
                 new InstanceDeleter(new InstancesRepositoryProvider(Collect.getInstance()).get(), formsRepository).delete(instance.getDbId());
                 createErrorDialog(getString(R.string.instance_deleted_message), true);
                 return;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -107,6 +107,7 @@ import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
 import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment;
 import org.odk.collect.android.fragments.dialogs.RankingWidgetDialog;
 import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
+import org.odk.collect.android.instancemanagement.InstanceDeleter;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.FormController.FailedConstraint;
 import org.odk.collect.android.javarosawrapper.FormDesignException;
@@ -608,6 +609,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
 
             instancePath = instance.getInstanceFilePath();
+            if (!new File(instancePath).exists()) {
+                new InstanceDeleter(new InstancesRepositoryProvider(Collect.getInstance()).get(), formsRepository).delete(instance.getDbId());
+                createErrorDialog(getString(R.string.instance_deleted_message), true);
+                return;
+            }
+
             List<Form> candidateForms = formsRepository.getAllByFormIdAndVersion(instance.getFormId(), instance.getFormVersion());
 
             if (candidateForms.isEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -167,4 +167,9 @@ public class AnalyticsEvents {
      * Tracks responses from OpenMapKit to the OSMWidget
      */
     public static final String OPEN_MAP_KIT_RESPONSE = "OpenMapKitResponse";
+
+    /**
+     * Tracks how often instances that have been deleted on disk are opened for editing/viewing
+     */
+    public static final String OPEN_DELETED_INSTANCE = "OpenDeletedInstance";
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -200,6 +200,9 @@
     <!-- Text displayed in the audio bar when background audio recording is explicitly disabled from the options menu. Should be as short as possible. The inserted string is ⋮ which indicates the options menu. -->
     <string name="recording_disabled">Recording disabled. Enable in %s</string>
 
+    <!-- Error displayed when opened filled form has been deleted on disk -->
+    <string name="instance_deleted_message">Filled form has been deleted!</string>
+
     <!--
     ##############################################
     # FORM FEATURES


### PR DESCRIPTION
Closes #4647

#### What has been done to verify that this works as intended?

Updated test for new behaviour.

#### Why is this the best possible solution? Were any other approaches considered?

I chose to just detect the problem as part of the `FormEntryActivity`'s load code, rather than doing anything up front on the form list. This part of `FormEntryActivity` badly needs some refactoring but this and #4657 touch it, so I didn't want to look at even light touch improvements, unfortunately. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just affect this weird case, but we'll cover form loading in the regression pass for sure, so no need for specific QR.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)