### PR TITLE
Improve project settings dialog

### DIFF
--- a/collect_app/src/main/res/layout/project_list_item.xml
+++ b/collect_app/src/main/res/layout/project_list_item.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginTop="@dimen/margin_small"
+    android:paddingVertical="@dimen/margin_extra_small"
+    android:paddingEnd="@dimen/margin_standard"
     xmlns:tools="http://schemas.android.com/tools">
 
     <org.odk.collect.android.projects.ProjectIconView

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -44,6 +44,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_standard"
+        android:paddingEnd="@dimen/margin_standard"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
         app:layout_constraintTop_toBottomOf="@+id/close_icon" />
 
@@ -82,7 +83,6 @@
         android:id="@+id/project_list_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_small"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constrainedHeight="true"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
@@ -100,7 +100,7 @@
         android:id="@+id/bottom_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginVertical="@dimen/margin_small"
+        android:layout_marginBottom="@dimen/margin_small"
         android:alpha="0.2"
         android:background="?colorOnSurface"
         app:layout_constraintStart_toStartOf="parent"

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -75,7 +75,6 @@
         android:layout_marginTop="@dimen/margin_small"
         android:alpha="0.2"
         android:background="?colorOnSurface"
-        app:layout_constraintStart_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/admin_settings_button" />
 
@@ -85,9 +84,10 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_small"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_max="100dp"
+        app:layout_constrainedHeight="true"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@+id/top_divider">
+        app:layout_constraintTop_toBottomOf="@+id/top_divider"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_divider">
 
         <LinearLayout
             android:id="@+id/project_list"
@@ -100,18 +100,16 @@
         android:id="@+id/bottom_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginTop="@dimen/margin_small"
+        android:layout_marginVertical="@dimen/margin_small"
         android:alpha="0.2"
         android:background="?colorOnSurface"
-        app:layout_constraintStart_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/project_list_container" />
+        app:layout_constraintBottom_toTopOf="@+id/add_project_button" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/add_project_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_small"
         android:layout_marginEnd="@dimen/margin_standard"
         android:layout_marginBottom="@dimen/margin_small"
         android:background="?attr/selectableItemBackgroundBorderless"
@@ -121,21 +119,20 @@
         app:icon="@drawable/ic_baseline_qr_code_scanner_24"
         app:iconTintMode="multiply"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/guideline_center"
-        app:layout_constraintTop_toBottomOf="@+id/bottom_divider" />
+        app:layout_constraintEnd_toStartOf="@+id/guideline_center" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/about_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_standard"
-        android:layout_marginTop="@dimen/margin_small"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:gravity="center_vertical"
         android:text="@string/about_preferences"
         android:textColor="?colorOnSurface"
         app:icon="@drawable/ic_outline_info_24"
         app:iconTintMode="multiply"
+        app:layout_constraintBottom_toBottomOf="@+id/add_project_button"
         app:layout_constraintStart_toStartOf="@+id/guideline_center"
-        app:layout_constraintTop_toBottomOf="@+id/bottom_divider" />
+        app:layout_constraintTop_toTopOf="@+id/add_project_button" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This pr fixes two problems:
1. padding/margins in ProjectSettings dialog
![Screenshot_1625141758 (1)](https://user-images.githubusercontent.com/3276264/124141633-db53a980-da89-11eb-9f15-b9f8f8ee6414.jpg)

2. It fixes the height of ProjectSettings making it expandable if the list of projects is long:

| Long list of projects | Short list of projects |
| ------------- | ------------- |
| ![Screenshot_1625148802](https://user-images.githubusercontent.com/3276264/124140866-28834b80-da89-11eb-8d65-f12001c5fcd0.png)  | ![Screenshot_1625148833](https://user-images.githubusercontent.com/3276264/124140870-2a4d0f00-da89-11eb-9a99-b7be974a217c.png)  |

#### What has been done to verify that this works as intended?
I tested the changes manually and ran automated tests.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)