### PR TITLE
Protect against issues that may come up when removing a project while a background job is running

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -594,7 +594,7 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ProjectDeleter providesProjectDeleter(ProjectsRepository projectsRepository, CurrentProjectProvider currentProjectProvider, FormUpdateScheduler formUpdateScheduler, InstanceSubmitScheduler instanceSubmitScheduler, InstancesRepositoryProvider instancesRepositoryProvider, StoragePathProvider storagePathProvider) {
-        return new ProjectDeleter(projectsRepository, currentProjectProvider, formUpdateScheduler, instanceSubmitScheduler, instancesRepositoryProvider.get(), storagePathProvider.getProjectRootDirPath(currentProjectProvider.getCurrentProject().getUuid()));
+    public ProjectDeleter providesProjectDeleter(ProjectsRepository projectsRepository, CurrentProjectProvider currentProjectProvider, FormUpdateScheduler formUpdateScheduler, InstanceSubmitScheduler instanceSubmitScheduler, InstancesRepositoryProvider instancesRepositoryProvider, StoragePathProvider storagePathProvider, ChangeLockProvider changeLockProvider) {
+        return new ProjectDeleter(projectsRepository, currentProjectProvider, formUpdateScheduler, instanceSubmitScheduler, instancesRepositoryProvider.get(), storagePathProvider.getProjectRootDirPath(currentProjectProvider.getCurrentProject().getUuid()), changeLockProvider);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/AdminPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/AdminPreferencesFragment.kt
@@ -40,6 +40,7 @@ import org.odk.collect.android.preferences.dialogs.ResetDialogPreferenceFragment
 import org.odk.collect.android.preferences.keys.AdminKeys
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.projects.DeleteProjectResult.DeletedSuccessfully
+import org.odk.collect.android.projects.DeleteProjectResult.RunningBackgroundJobs
 import org.odk.collect.android.projects.DeleteProjectResult.UnsentInstances
 import org.odk.collect.android.projects.ProjectDeleter
 import org.odk.collect.android.utilities.DialogUtils
@@ -236,7 +237,14 @@ class AdminPreferencesFragment :
             is UnsentInstances -> {
                 AlertDialog.Builder(requireActivity())
                     .setTitle(R.string.cannot_delete_project_title)
-                    .setMessage(R.string.cannot_delete_project_message)
+                    .setMessage(R.string.cannot_delete_project_message_one)
+                    .setPositiveButton(R.string.ok, null)
+                    .show()
+            }
+            is RunningBackgroundJobs -> {
+                AlertDialog.Builder(requireActivity())
+                    .setTitle(R.string.cannot_delete_project_title)
+                    .setMessage(R.string.cannot_delete_project_message_two)
                     .setPositiveButton(R.string.ok, null)
                     .show()
             }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.projects
 
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
+import org.odk.collect.android.utilities.ChangeLockProvider
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.forms.instances.InstancesRepository
 import org.odk.collect.projects.Project
@@ -14,39 +15,60 @@ class ProjectDeleter(
     private val formUpdateScheduler: FormUpdateScheduler,
     private val instanceSubmitScheduler: InstanceSubmitScheduler,
     private val instancesRepository: InstancesRepository,
-    private val projectDirPath: String
+    private val projectDirPath: String,
+    private val changeLockProvider: ChangeLockProvider
 ) {
     fun deleteCurrentProject(): DeleteProjectResult {
-        if (instancesRepository.getAllByStatus(
-                Instance.STATUS_INCOMPLETE,
-                Instance.STATUS_COMPLETE,
-                Instance.STATUS_SUBMISSION_FAILED
-            ).isNotEmpty()
-        ) {
-            return DeleteProjectResult.UnsentInstances
+        return when {
+            unsentInstancesDetected() -> DeleteProjectResult.UnsentInstances
+            runningBackgroundJobsDetected() -> DeleteProjectResult.RunningBackgroundJobs
+            else -> performProjectDeletion()
+        }
+    }
+
+    private fun unsentInstancesDetected(): Boolean {
+        return instancesRepository.getAllByStatus(
+            Instance.STATUS_INCOMPLETE,
+            Instance.STATUS_COMPLETE,
+            Instance.STATUS_SUBMISSION_FAILED
+        ).isNotEmpty()
+    }
+
+    private fun runningBackgroundJobsDetected(): Boolean {
+        val acquiredFormLock = changeLockProvider.getFormLock(currentProjectProvider.getCurrentProject().uuid).withLock {
+            it
+        }
+        val acquiredInstanceLock = changeLockProvider.getInstanceLock(currentProjectProvider.getCurrentProject().uuid).withLock {
+            it
+        }
+
+        return !acquiredFormLock || !acquiredInstanceLock
+    }
+
+    private fun performProjectDeletion(): DeleteProjectResult {
+        val currentProject = currentProjectProvider.getCurrentProject()
+
+        formUpdateScheduler.cancelUpdates(currentProject.uuid)
+        instanceSubmitScheduler.cancelSubmit(currentProject.uuid)
+
+        projectsRepository.delete(currentProject.uuid)
+
+        File(projectDirPath).deleteRecursively()
+
+        return if (projectsRepository.getAll().isNotEmpty()) {
+            val newProject = projectsRepository.getAll()[0]
+            currentProjectProvider.setCurrentProject(newProject.uuid)
+            DeleteProjectResult.DeletedSuccessfully(newProject)
         } else {
-            val currentProject = currentProjectProvider.getCurrentProject()
-
-            formUpdateScheduler.cancelUpdates(currentProject.uuid)
-            instanceSubmitScheduler.cancelSubmit(currentProject.uuid)
-
-            projectsRepository.delete(currentProject.uuid)
-
-            File(projectDirPath).deleteRecursively()
-
-            return if (projectsRepository.getAll().isNotEmpty()) {
-                val newProject = projectsRepository.getAll()[0]
-                currentProjectProvider.setCurrentProject(newProject.uuid)
-                DeleteProjectResult.DeletedSuccessfully(newProject)
-            } else {
-                DeleteProjectResult.DeletedSuccessfully(null)
-            }
+            DeleteProjectResult.DeletedSuccessfully(null)
         }
     }
 }
 
 sealed class DeleteProjectResult {
     object UnsentInstances : DeleteProjectResult()
+
+    object RunningBackgroundJobs : DeleteProjectResult()
 
     data class DeletedSuccessfully(val newCurrentProject: Project.Saved?) : DeleteProjectResult()
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
@@ -35,11 +35,11 @@ class ProjectDeleter(
     }
 
     private fun runningBackgroundJobsDetected(): Boolean {
-        val acquiredFormLock = changeLockProvider.getFormLock(currentProjectProvider.getCurrentProject().uuid).withLock {
-            it
+        val acquiredFormLock = changeLockProvider.getFormLock(currentProjectProvider.getCurrentProject().uuid).withLock { acquiredLock ->
+            acquiredLock
         }
-        val acquiredInstanceLock = changeLockProvider.getInstanceLock(currentProjectProvider.getCurrentProject().uuid).withLock {
-            it
+        val acquiredInstanceLock = changeLockProvider.getInstanceLock(currentProjectProvider.getCurrentProject().uuid).withLock { acquiredLock ->
+            acquiredLock
         }
 
         return !acquiredFormLock || !acquiredInstanceLock

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectDeleterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectDeleterTest.kt
@@ -5,16 +5,19 @@ import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.instanceOf
 import org.hamcrest.Matchers.nullValue
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
+import org.odk.collect.android.utilities.ChangeLockProvider
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.formstest.InMemInstancesRepository
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.TempFiles
+import org.odk.collect.testshared.BooleanChangeLock
 import java.io.File
 
 class ProjectDeleterTest {
@@ -27,6 +30,10 @@ class ProjectDeleterTest {
     }
     private val formUpdateManager = mock<FormUpdateScheduler>()
     private val instanceSubmitScheduler = mock<InstanceSubmitScheduler>()
+    private val changeLockProvider = mock<ChangeLockProvider> {
+        on { getFormLock(any()) } doReturn BooleanChangeLock()
+        on { getInstanceLock(any()) } doReturn BooleanChangeLock()
+    }
 
     @Test
     fun `If there are incomplete instances the project should not be deleted`() {
@@ -42,7 +49,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         deleter.deleteCurrentProject()
@@ -63,7 +71,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         deleter.deleteCurrentProject()
@@ -84,7 +93,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         deleter.deleteCurrentProject()
@@ -105,7 +115,8 @@ class ProjectDeleterTest {
             formUpdateManager,
             instanceSubmitScheduler,
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -121,7 +132,8 @@ class ProjectDeleterTest {
             formUpdateManager,
             instanceSubmitScheduler,
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         deleter.deleteCurrentProject()
@@ -139,7 +151,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         deleter.deleteCurrentProject()
@@ -154,7 +167,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -174,7 +188,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            ""
+            "",
+            changeLockProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -197,7 +212,8 @@ class ProjectDeleterTest {
             mock(),
             mock(),
             instancesRepository,
-            projectDir.absolutePath
+            projectDir.absolutePath,
+            changeLockProvider
         )
 
         deleter.deleteCurrentProject()

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1000,7 +1000,8 @@
     <string name="delete_project_yes">Yes</string>
     <string name="delete_project_no">No</string>
     <string name="cannot_delete_project_title">Project can\'t be deleted</string>
-    <string name="cannot_delete_project_message">You have unsent submissions. To delete the project, you must first send or delete those submissions.</string>
+    <string name="cannot_delete_project_message_one">You have unsent submissions. To delete the project, you must first send or delete those submissions.</string>
+    <string name="cannot_delete_project_message_two">Background jobs are running. Please try again later.</string>
     <string name="or">OR</string>
     <string name="hex_color">Hex color</string>
     <string name="invalid_hex_code">Invalid hex code</string>


### PR DESCRIPTION
Closes #4654

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I extended the existed `ProjectDeleter` which is the best option because this class is already responsible for checking other states that should block deleting projects like unsent instances. I think there is no other solution here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This will be tested later as a whole feature.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)