### PR TITLE
Improved ProjectSettingsDialog

### DIFF
--- a/collect_app/src/main/res/layout/project_list_item.xml
+++ b/collect_app/src/main/res/layout/project_list_item.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingVertical="@dimen/margin_extra_small"
-    android:paddingEnd="@dimen/margin_standard"
     xmlns:tools="http://schemas.android.com/tools">
 
     <org.odk.collect.android.projects.ProjectIconView
@@ -16,26 +15,31 @@
         tools:text="A"/>
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="@+id/project_icon"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/project_icon"
         app:layout_constraintTop_toTopOf="@+id/project_icon">
 
         <TextView
             android:id="@+id/project_name"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:textAppearance="?textAppearanceSubtitle1"
             tools:text="A project"/>
 
         <TextView
             android:id="@+id/project_subtext"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_small"
+            android:ellipsize="end"
+            android:maxLines="2"
             android:textAppearance="@style/TextAppearance.Collect.Body2.MediumEmphasis"
             tools:text="my.cool.project.com"/>
     </LinearLayout>

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -18,6 +18,13 @@
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5" />
 
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/margin_standard" />
+
     <ImageView
         android:id="@+id/close_icon"
         android:layout_width="wrap_content"
@@ -41,10 +48,10 @@
 
     <org.odk.collect.android.projects.ProjectListItemView
         android:id="@+id/current_project"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_standard"
-        android:paddingEnd="@dimen/margin_standard"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_end"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
         app:layout_constraintTop_toBottomOf="@+id/close_icon" />
 
@@ -86,6 +93,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constrainedHeight="true"
         app:layout_constraintStart_toStartOf="@+id/guideline_start"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_end"
         app:layout_constraintTop_toBottomOf="@+id/top_divider"
         app:layout_constraintBottom_toTopOf="@+id/bottom_divider">
 

--- a/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/project_settings_dialog_layout.xml
@@ -108,39 +108,53 @@
         android:id="@+id/bottom_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginBottom="@dimen/margin_small"
         android:alpha="0.2"
         android:background="?colorOnSurface"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/add_project_button" />
 
-    <com.google.android.material.button.MaterialButton
+    <FrameLayout
         android:id="@+id/add_project_button"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/margin_standard"
-        android:layout_marginBottom="@dimen/margin_small"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:gravity="center_vertical"
-        android:text="@string/add_project"
-        android:textColor="?colorOnSurface"
-        app:icon="@drawable/ic_baseline_qr_code_scanner_24"
-        app:iconTintMode="multiply"
+        android:paddingVertical="@dimen/margin_small"
+        android:paddingHorizontal="@dimen/margin_standard"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/guideline_center" />
+        app:layout_constraintStart_toStartOf="@+id/guideline_start"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_center">
 
-    <com.google.android.material.button.MaterialButton
+        <com.google.android.material.button.MaterialButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:gravity="center_vertical"
+            android:text="@string/add_project"
+            android:textColor="?colorOnSurface"
+            android:layout_gravity="end"
+            app:icon="@drawable/ic_baseline_qr_code_scanner_24"
+            app:iconTintMode="multiply" />
+    </FrameLayout>
+
+    <FrameLayout
         android:id="@+id/about_button"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/margin_standard"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:gravity="center_vertical"
-        android:text="@string/about_preferences"
-        android:textColor="?colorOnSurface"
-        app:icon="@drawable/ic_outline_info_24"
-        app:iconTintMode="multiply"
-        app:layout_constraintBottom_toBottomOf="@+id/add_project_button"
+        android:paddingVertical="@dimen/margin_small"
+        android:paddingHorizontal="@dimen/margin_standard"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_end"
         app:layout_constraintStart_toStartOf="@+id/guideline_center"
-        app:layout_constraintTop_toTopOf="@+id/add_project_button" />
+        app:layout_constraintTop_toTopOf="@+id/add_project_button"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:gravity="center_vertical"
+            android:text="@string/about_preferences"
+            android:textColor="?colorOnSurface"
+            android:layout_gravity="start"
+            app:icon="@drawable/ic_outline_info_24"
+            app:iconTintMode="multiply" />
+    </FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes #4667 

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
I think that having one line for project name and 2 lines for url would be a good solution:

|   |  |
| ------------- | ------------- |
| ![Screenshot_1625486900](https://user-images.githubusercontent.com/3276264/124469574-d1d48500-dd9a-11eb-8b0c-ffe06083d736.png)  | ![Screenshot_1625486907](https://user-images.githubusercontent.com/3276264/124469578-d305b200-dd9a-11eb-8b1d-af385e8ebedd.png)  |

The second commit is about something different than the issue itself. I wanted to improve the buttons that are at the bottom of the dialog so that their clickable area is bigger and it's not a problem to use them.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This will be tested later as a whole feature.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)