### PR TITLE
Prompt for confirmation when duplicate project configured

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/AddNewProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/AddNewProjectTest.kt
@@ -84,7 +84,7 @@ class AddNewProjectTest {
     }
 
     @Test
-    fun createsDuplicateProject_whenDuplicateProjectScanned_andOptionToSwitchToExistingSelected() {
+    fun addsDuplicateProject_whenDuplicateProjectScanned_andOptionToAddDuplicateProjectSelected() {
         val page = rule.startAtMainMenu()
             .openProjectSettings()
             .clickAddProject()
@@ -92,6 +92,36 @@ class AddNewProjectTest {
         testDependencies.stubBarcodeViewDecoder.scan("{\"general\":{\"server_url\":\"https://demo.getodk.org\"},\"admin\":{}}")
 
         page.assertDuplicateDialogShown()
+            .addDuplicateProject()
+            .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
+            .openProjectSettings()
+            .assertCurrentProject("Demo project", "demo.getodk.org")
+            .assertInactiveProject("Demo project", "demo.getodk.org")
+    }
+
+    @Test
+    fun switchesToExistingProject_whenDuplicateProjectEnteredManually_andOptionToSwitchToExistingSelected() {
+        rule.startAtMainMenu()
+            .openProjectSettings()
+            .clickAddProject()
+            .switchToManualMode()
+            .inputUrl("https://demo.getodk.org")
+            .addProjectAndAssertDuplicateDialogShown()
+            .switchToExistingProject()
+            .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
+            .openProjectSettings()
+            .assertCurrentProject("Demo project", "demo.getodk.org")
+            .assertNotInactiveProject("Demo project", "demo.getodk.org")
+    }
+
+    @Test
+    fun addsDuplicateProject_whenDuplicateProjectEnteredManually_andOptionToAddDuplicateProjectSelected() {
+        rule.startAtMainMenu()
+            .openProjectSettings()
+            .clickAddProject()
+            .switchToManualMode()
+            .inputUrl("https://demo.getodk.org")
+            .addProjectAndAssertDuplicateDialogShown()
             .addDuplicateProject()
             .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
             .openProjectSettings()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/AddNewProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/AddNewProjectTest.kt
@@ -52,7 +52,7 @@ class AddNewProjectTest {
     }
 
     @Test
-    fun addingProjectAutomatically_addsNewProject() {
+    fun addingProjectFromQrCode_addsNewProject() {
         val page = rule.startAtMainMenu()
             .openProjectSettings()
             .clickAddProject()
@@ -64,6 +64,38 @@ class AddNewProjectTest {
             .assertOnPage()
             .openProjectSettings()
             .assertCurrentProject("my-server.com", "adam / my-server.com")
+            .assertInactiveProject("Demo project", "demo.getodk.org")
+    }
+
+    @Test
+    fun switchesToExistingProject_whenDuplicateProjectScanned_andOptionToSwitchToExistingSelected() {
+        val page = rule.startAtMainMenu()
+            .openProjectSettings()
+            .clickAddProject()
+
+        testDependencies.stubBarcodeViewDecoder.scan("{\"general\":{\"server_url\":\"https://demo.getodk.org\"},\"admin\":{}}")
+
+        page.assertDuplicateDialogShown()
+            .switchToExistingProject()
+            .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
+            .openProjectSettings()
+            .assertCurrentProject("Demo project", "demo.getodk.org")
+            .assertNotInactiveProject("Demo project", "demo.getodk.org")
+    }
+
+    @Test
+    fun createsDuplicateProject_whenDuplicateProjectScanned_andOptionToSwitchToExistingSelected() {
+        val page = rule.startAtMainMenu()
+            .openProjectSettings()
+            .clickAddProject()
+
+        testDependencies.stubBarcodeViewDecoder.scan("{\"general\":{\"server_url\":\"https://demo.getodk.org\"},\"admin\":{}}")
+
+        page.assertDuplicateDialogShown()
+            .addDuplicateProject()
+            .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
+            .openProjectSettings()
+            .assertCurrentProject("Demo project", "demo.getodk.org")
             .assertInactiveProject("Demo project", "demo.getodk.org")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ManualProjectCreatorDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ManualProjectCreatorDialogPage.kt
@@ -47,4 +47,20 @@ class ManualProjectCreatorDialogPage : Page<ManualProjectCreatorDialogPage>() {
         onView(withText(R.string.add)).perform(click())
         return MainMenuPage().assertOnPage()
     }
+
+    fun addProjectAndAssertDuplicateDialogShown(): ManualProjectCreatorDialogPage {
+        onView(withText(R.string.add)).perform(click())
+        assertText(R.string.duplicate_project_details)
+        return this
+    }
+
+    fun switchToExistingProject(): MainMenuPage {
+        clickOnString(R.string.switch_to_existing)
+        return MainMenuPage().assertOnPage()
+    }
+
+    fun addDuplicateProject(): MainMenuPage {
+        clickOnString(R.string.add_duplicate_project)
+        return MainMenuPage().assertOnPage()
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.support.pages
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -10,6 +11,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.not
 import org.odk.collect.android.R
 
 internal class ProjectSettingsDialogPage() : Page<ProjectSettingsDialogPage>() {
@@ -40,6 +42,11 @@ internal class ProjectSettingsDialogPage() : Page<ProjectSettingsDialogPage>() {
 
     fun assertInactiveProject(projectName: String, subtext: String): ProjectSettingsDialogPage {
         onView(allOf(hasDescendant(withText(projectName)), hasDescendant(withText(subtext)), withContentDescription(getTranslatedString(R.string.switch_to_project, projectName)))).check(matches(isDisplayed()))
+        return this
+    }
+
+    fun assertNotInactiveProject(projectName: String, subtext: String): ProjectSettingsDialogPage {
+        onView(allOf(hasDescendant(withText(projectName)), hasDescendant(withText(subtext)), withContentDescription(getTranslatedString(R.string.switch_to_project, projectName)))).check(doesNotExist())
         return this
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QrCodeProjectCreatorDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QrCodeProjectCreatorDialogPage.kt
@@ -12,4 +12,19 @@ class QrCodeProjectCreatorDialogPage : Page<QrCodeProjectCreatorDialogPage>() {
         clickOnString(R.string.configure_manually)
         return ManualProjectCreatorDialogPage().assertOnPage()
     }
+
+    fun assertDuplicateDialogShown(): QrCodeProjectCreatorDialogPage {
+        assertText(R.string.duplicate_project_details)
+        return this
+    }
+
+    fun switchToExistingProject(): MainMenuPage {
+        clickOnString(R.string.switch_to_existing)
+        return MainMenuPage().assertOnPage()
+    }
+
+    fun addDuplicateProject(): MainMenuPage {
+        clickOnString(R.string.add_duplicate_project)
+        return MainMenuPage().assertOnPage()
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -93,6 +93,7 @@ import org.odk.collect.android.projects.ProjectCreator;
 import org.odk.collect.android.projects.ProjectDeleter;
 import org.odk.collect.android.projects.ProjectDetailsCreator;
 import org.odk.collect.android.projects.ProjectImporter;
+import org.odk.collect.android.projects.SettingsConnectionMatcher;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -602,5 +603,10 @@ public class AppDependencyModule {
     @Provides
     public ProjectResetter providesProjectResetter(StoragePathProvider storagePathProvider, PropertyManager propertyManager, SettingsProvider settingsProvider, InstancesRepositoryProvider instancesRepositoryProvider, FormsRepositoryProvider formsRepositoryProvider) {
         return new ProjectResetter(storagePathProvider, propertyManager, settingsProvider, instancesRepositoryProvider, formsRepositoryProvider);
+    }
+
+    @Provides
+    public SettingsConnectionMatcher providesSettingsConnectionMatcher(ProjectsRepository projectsRepository, SettingsProvider settingsProvider) {
+        return new SettingsConnectionMatcher(projectsRepository, settingsProvider);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -93,7 +93,6 @@ import org.odk.collect.android.projects.ProjectCreator;
 import org.odk.collect.android.projects.ProjectDeleter;
 import org.odk.collect.android.projects.ProjectDetailsCreator;
 import org.odk.collect.android.projects.ProjectImporter;
-import org.odk.collect.android.projects.SettingsConnectionMatcher;
 import org.odk.collect.android.storage.StorageInitializer;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -603,10 +602,5 @@ public class AppDependencyModule {
     @Provides
     public ProjectResetter providesProjectResetter(StoragePathProvider storagePathProvider, PropertyManager propertyManager, SettingsProvider settingsProvider, InstancesRepositoryProvider instancesRepositoryProvider, FormsRepositoryProvider formsRepositoryProvider) {
         return new ProjectResetter(storagePathProvider, propertyManager, settingsProvider, instancesRepositoryProvider, formsRepositoryProvider);
-    }
-
-    @Provides
-    public SettingsConnectionMatcher providesSettingsConnectionMatcher(ProjectsRepository projectsRepository, SettingsProvider settingsProvider) {
-        return new SettingsConnectionMatcher(projectsRepository, settingsProvider);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/DuplicateProjectConfirmationDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/DuplicateProjectConfirmationDialog.kt
@@ -2,22 +2,36 @@ package org.odk.collect.android.projects
 
 import android.app.AlertDialog
 import android.app.Dialog
-import android.content.DialogInterface
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import org.odk.collect.android.R
+import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.MATCHING_PROJECT
+import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.SETTINGS_JSON
 
 class DuplicateProjectConfirmationDialog : DialogFragment() {
-    lateinit var listener: DialogInterface.OnClickListener
+    lateinit var listener: DuplicateProjectConfirmationListener
+
+    interface DuplicateProjectConfirmationListener {
+        fun createProject(settingsJson: String)
+        fun switchToProject(uuid: String)
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        listener = parentFragment as DialogInterface.OnClickListener
+        listener = parentFragment as DuplicateProjectConfirmationListener
+
+        val settingsJson = arguments?.getString(SETTINGS_JSON, "") ?: ""
+        val matchingProject = arguments?.getString(MATCHING_PROJECT, "") ?: ""
 
         return AlertDialog.Builder(requireContext())
             .setTitle(R.string.duplicate_project)
             .setMessage(R.string.duplicate_project_details)
-            .setPositiveButton(R.string.add_duplicate_project, listener)
-            .setNegativeButton(R.string.switch_to_existing, listener)
+            .setPositiveButton(R.string.add_duplicate_project) { _, _ -> listener.createProject(settingsJson) }
+            .setNegativeButton(R.string.switch_to_existing) { _, _ -> listener.switchToProject(matchingProject) }
             .create()
     }
+}
+
+object DuplicateProjectConfirmationKeys {
+    const val SETTINGS_JSON = "settingsJson"
+    const val MATCHING_PROJECT = "matchingProject"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/DuplicateProjectConfirmationDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/DuplicateProjectConfirmationDialog.kt
@@ -1,0 +1,23 @@
+package org.odk.collect.android.projects
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import org.odk.collect.android.R
+
+class DuplicateProjectConfirmationDialog : DialogFragment() {
+    lateinit var listener: DialogInterface.OnClickListener
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        listener = parentFragment as DialogInterface.OnClickListener
+
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.duplicate_project)
+            .setMessage(R.string.duplicate_project_details)
+            .setPositiveButton(R.string.add_duplicate_project, listener)
+            .setNegativeButton(R.string.switch_to_existing, listener)
+            .create()
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -21,12 +21,14 @@ import org.odk.collect.android.gdrive.GoogleAccountsManager
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.listeners.PermissionListener
 import org.odk.collect.android.permissions.PermissionsProvider
+import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.MATCHING_PROJECT
 import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.SETTINGS_JSON
 import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.SoftKeyboardController
 import org.odk.collect.android.utilities.ToastUtils
 import org.odk.collect.material.MaterialFullScreenDialogFragment
+import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.strings.Validator
 import javax.inject.Inject
 
@@ -45,13 +47,18 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
     lateinit var currentProjectProvider: CurrentProjectProvider
 
     @Inject
-    lateinit var settingsConnectionMatcher: SettingsConnectionMatcher
-
-    @Inject
     lateinit var permissionsProvider: PermissionsProvider
 
     @Inject
     lateinit var googleAccountsManager: GoogleAccountsManager
+
+    @Inject
+    lateinit var projectsRepository: ProjectsRepository
+
+    @Inject
+    lateinit var settingsProvider: SettingsProvider
+
+    lateinit var settingsConnectionMatcher: SettingsConnectionMatcher
 
     private lateinit var binding: ManualProjectCreatorDialogLayoutBinding
 
@@ -80,6 +87,7 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
     override fun onAttach(context: Context) {
         super.onAttach(context)
         DaggerUtils.getComponent(context).inject(this)
+        settingsConnectionMatcher = SettingsConnectionMatcher(projectsRepository, settingsProvider)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.projects
 import android.accounts.AccountManager
 import android.app.Activity
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -21,13 +22,18 @@ import org.odk.collect.android.gdrive.GoogleAccountsManager
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.listeners.PermissionListener
 import org.odk.collect.android.permissions.PermissionsProvider
+import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.SoftKeyboardController
 import org.odk.collect.android.utilities.ToastUtils
 import org.odk.collect.material.MaterialFullScreenDialogFragment
 import org.odk.collect.shared.strings.Validator
 import javax.inject.Inject
 
-class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
+class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), DialogInterface.OnClickListener {
+
+    private var lastEnteredJson: String? = null
+    private var lastMatchingUuid: String? = null
+
     @Inject
     lateinit var projectCreator: ProjectCreator
 
@@ -39,6 +45,9 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
 
     @Inject
     lateinit var currentProjectProvider: CurrentProjectProvider
+
+    @Inject
+    lateinit var settingsConnectionMatcher: SettingsConnectionMatcher
 
     @Inject
     lateinit var permissionsProvider: PermissionsProvider
@@ -58,9 +67,14 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
             val settingsJson = appConfigurationGenerator.getAppConfigurationAsJsonWithGoogleDriveDetails(
                 accountName
             )
+            lastEnteredJson = settingsJson
 
-            projectCreator.createNewProject(settingsJson)
-            ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
+            settingsConnectionMatcher.getProjectWithMatchingConnection(settingsJson)?.let { uuid ->
+                lastMatchingUuid = uuid
+                DialogUtils.showIfNotShowing(DuplicateProjectConfirmationDialog::class.java, childFragmentManager)
+            } ?: run {
+                createProject(settingsJson)
+            }
         }
     }
 
@@ -124,10 +138,14 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
                 binding.usernameInputText.text?.trim().toString(),
                 binding.passwordInputText.text?.trim().toString()
             )
+            lastEnteredJson = settingsJson
 
-            projectCreator.createNewProject(settingsJson)
-            ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
-            ToastUtils.showLongToast(getString(R.string.switched_project, currentProjectProvider.getCurrentProject().name))
+            settingsConnectionMatcher.getProjectWithMatchingConnection(settingsJson)?.let { uuid ->
+                lastMatchingUuid = uuid
+                DialogUtils.showIfNotShowing(DuplicateProjectConfirmationDialog::class.java, childFragmentManager)
+            } ?: run {
+                createProject(settingsJson)
+            }
         }
     }
 
@@ -145,5 +163,24 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment() {
                 }
             }
         )
+    }
+
+    private fun createProject(settingsJson: String) {
+        projectCreator.createNewProject(settingsJson)
+        ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
+        ToastUtils.showLongToast(getString(R.string.switched_project, currentProjectProvider.getCurrentProject().name))
+    }
+
+    private fun switchToProject(uuid: String) {
+        currentProjectProvider.setCurrentProject(uuid)
+        ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
+        ToastUtils.showLongToast(getString(org.odk.collect.projects.R.string.switched_project, currentProjectProvider.getCurrentProject().name))
+    }
+
+    override fun onClick(dialog: DialogInterface?, buttonClicked: Int) {
+        when (buttonClicked) {
+            DialogInterface.BUTTON_POSITIVE -> createProject(lastEnteredJson ?: "")
+            DialogInterface.BUTTON_NEGATIVE -> lastMatchingUuid?.let { switchToProject(it) }
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -16,12 +16,14 @@ import org.odk.collect.android.databinding.QrCodeProjectCreatorDialogLayoutBindi
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.listeners.PermissionListener
 import org.odk.collect.android.permissions.PermissionsProvider
+import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.utilities.CodeCaptureManagerFactory
 import org.odk.collect.android.utilities.CompressionUtils
 import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.ToastUtils
 import org.odk.collect.android.views.BarcodeViewDecoder
 import org.odk.collect.material.MaterialFullScreenDialogFragment
+import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.projects.R
 import javax.inject.Inject
 
@@ -43,6 +45,11 @@ class QrCodeProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
     lateinit var currentProjectProvider: CurrentProjectProvider
 
     @Inject
+    lateinit var projectsRepository: ProjectsRepository
+
+    @Inject
+    lateinit var settingsProvider: SettingsProvider
+
     lateinit var settingsConnectionMatcher: SettingsConnectionMatcher
 
     private var capture: CaptureManager? = null
@@ -53,6 +60,7 @@ class QrCodeProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
     override fun onAttach(context: Context) {
         super.onAttach(context)
         DaggerUtils.getComponent(context).inject(this)
+        settingsConnectionMatcher = SettingsConnectionMatcher(projectsRepository, settingsProvider)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -49,7 +49,7 @@ class QrCodeProjectCreatorDialog : MaterialFullScreenDialogFragment(), DialogInt
     lateinit var currentProjectProvider: CurrentProjectProvider
 
     @Inject
-    lateinit var settingsUniquenessChecker: SettingsConnectionMatcher
+    lateinit var settingsConnectionMatcher: SettingsConnectionMatcher
 
     private var capture: CaptureManager? = null
 
@@ -140,7 +140,7 @@ class QrCodeProjectCreatorDialog : MaterialFullScreenDialogFragment(), DialogInt
                     val settingsJson = CompressionUtils.decompress(barcodeResult.text)
                     lastScannedJson = settingsJson
 
-                    settingsUniquenessChecker.getProjectWithMatchingConnection(settingsJson)?.let { uuid ->
+                    settingsConnectionMatcher.getProjectWithMatchingConnection(settingsJson)?.let { uuid ->
                         lastMatchingUuid = uuid
                         DialogUtils.showIfNotShowing(DuplicateProjectConfirmationDialog::class.java, childFragmentManager)
                     } ?: run {

--- a/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
@@ -30,12 +30,12 @@ class SettingsConnectionMatcher(
                 val projectUsername = projectSettings.getString(GeneralKeys.KEY_USERNAME)
                 val projectGoogleAccount = projectSettings.getString(GeneralKeys.KEY_SELECTED_GOOGLE_ACCOUNT)
 
-                if (jsonProtocol.equals(projectProtocol) && jsonProtocol.equals(GeneralKeys.PROTOCOL_SERVER)) {
-                    if (jsonUrl.equals(projectUrl) && jsonUsername.equals(projectUsername)) {
+                if (jsonProtocol.equals(projectProtocol) && jsonProtocol.equals(GeneralKeys.PROTOCOL_GOOGLE_SHEETS)) {
+                    if (jsonGoogleAccount.equals(projectGoogleAccount)) {
                         return it.uuid
                     }
                 } else {
-                    if (jsonGoogleAccount.equals(projectGoogleAccount)) {
+                    if (jsonUrl.equals(projectUrl) && jsonUsername.equals(projectUsername)) {
                         return it.uuid
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
@@ -1,0 +1,48 @@
+package org.odk.collect.android.projects
+
+import org.json.JSONException
+import org.json.JSONObject
+import org.odk.collect.android.configure.qr.AppConfigurationKeys
+import org.odk.collect.android.preferences.keys.GeneralKeys
+import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.projects.ProjectsRepository
+
+class SettingsConnectionMatcher(
+    private val projectsRepository: ProjectsRepository,
+    private val settingsProvider: SettingsProvider
+) {
+
+    fun getProjectWithMatchingConnection(settingsJson: String): String? {
+        try {
+            val jsonObject = JSONObject(settingsJson)
+            val jsonSettings = jsonObject.getJSONObject(AppConfigurationKeys.GENERAL)
+            val jsonProtocol = try { jsonSettings.get(GeneralKeys.KEY_PROTOCOL) } catch (e: JSONException) { GeneralKeys.PROTOCOL_SERVER }
+
+            val jsonUrl = try { jsonSettings.get(GeneralKeys.KEY_SERVER_URL) } catch (e: JSONException) { "" }
+            val jsonUsername = try { jsonSettings.get(GeneralKeys.KEY_USERNAME) } catch (e: JSONException) { "" }
+
+            val jsonGoogleAccount = try { jsonSettings.get(GeneralKeys.KEY_SELECTED_GOOGLE_ACCOUNT) } catch (e: JSONException) { "" }
+
+            projectsRepository.getAll().forEach {
+                val projectSettings = settingsProvider.getGeneralSettings(it.uuid)
+                val projectProtocol = projectSettings.getString(GeneralKeys.KEY_PROTOCOL)
+                val projectUrl = projectSettings.getString(GeneralKeys.KEY_SERVER_URL)
+                val projectUsername = projectSettings.getString(GeneralKeys.KEY_USERNAME)
+                val projectGoogleAccount = projectSettings.getString(GeneralKeys.KEY_SELECTED_GOOGLE_ACCOUNT)
+
+                if (jsonProtocol.equals(projectProtocol) && jsonProtocol.equals(GeneralKeys.PROTOCOL_SERVER)) {
+                    if (jsonUrl.equals(projectUrl) && jsonUsername.equals(projectUsername)) {
+                        return it.uuid
+                    }
+                } else {
+                    if (jsonGoogleAccount.equals(projectGoogleAccount)) {
+                        return it.uuid
+                    }
+                }
+            }
+        } catch (e: JSONException) {
+            return null
+        }
+        return null
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.projects
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Before
 import org.junit.Test
 import org.odk.collect.android.preferences.keys.GeneralKeys
 import org.odk.collect.android.support.InMemSettingsProvider
@@ -15,12 +14,6 @@ class SettingsConnectionMatcherTest {
     private val inMemSettingsProvider = InMemSettingsProvider()
     private val settingsConnectionMatcher = SettingsConnectionMatcher(inMemProjectsRepository, inMemSettingsProvider)
 
-    @Before
-    fun setUp() {
-        inMemProjectsRepository.deleteAll()
-        inMemSettingsProvider.clearAll()
-    }
-
     @Test
     fun `returns null when no projects exist`() {
         val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
@@ -29,7 +22,7 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns a match when urls match`() {
+    fun `returns a matching project uuid when urls match`() {
         createServerProject("a uuid", "https://demo.getodk.org", "")
         val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
 
@@ -45,7 +38,7 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns a match when urls and usernames match`() {
+    fun `returns a matching project uuid when urls and usernames match`() {
         createServerProject("a uuid", "https://demo.getodk.org", "foo")
         val jsonSettings = getServerSettingsJson("https://demo.getodk.org", "foo")
 
@@ -53,7 +46,7 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns a match when urls and usernames match and there are other settings that don't match`() {
+    fun `returns a matching project uuid when urls and usernames match and there are other settings that don't match`() {
         createServerProject("a uuid", "https://demo.getodk.org", "foo")
         val jsonSettings = "{ \"general\": { \"server_url\": \"https://demo.getodk.org\", \"username\": \"foo\", \"password\": \"bar\" } }"
 
@@ -69,7 +62,7 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns a match when protocol is Google Drive and accounts match`() {
+    fun `returns a matching project uuid when protocol is Google Drive and accounts match`() {
         createGoogleDriveProject("a uuid", "foo@bar.baz")
         val jsonSettings = getGoogleDriveSettingsJson("foo@bar.baz")
 
@@ -77,7 +70,7 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns uuid of match when there are multiple projects`() {
+    fun `returns a matching project uuid when there are multiple projects`() {
         createServerProject("a uuid", "https://demo.getodk.org", "foo")
         createGoogleDriveProject("another uuid", "foo@bar.baz")
         val jsonSettings = getGoogleDriveSettingsJson("foo@bar.baz")
@@ -86,7 +79,7 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns uuid of first match when there are multiple matches`() {
+    fun `returns uuid of first matching project when there are multiple matching projects`() {
         createServerProject("a uuid", "https://demo.getodk.org", "foo")
         createGoogleDriveProject("another uuid", "foo@bar.baz")
         createServerProject("uuid 3", "https://foo.org", "foo")

--- a/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
@@ -1,0 +1,128 @@
+package org.odk.collect.android.projects
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.odk.collect.android.preferences.keys.GeneralKeys
+import org.odk.collect.android.support.InMemSettingsProvider
+import org.odk.collect.projects.InMemProjectsRepository
+import org.odk.collect.projects.Project
+
+class SettingsConnectionMatcherTest {
+    private val inMemProjectsRepository = InMemProjectsRepository()
+    private val inMemSettingsProvider = InMemSettingsProvider()
+    private val settingsConnectionMatcher = SettingsConnectionMatcher(inMemProjectsRepository, inMemSettingsProvider)
+
+    @Before
+    fun setUp() {
+        inMemProjectsRepository.deleteAll()
+        inMemSettingsProvider.clearAll()
+    }
+
+    @Test
+    fun `returns null when no projects exist`() {
+        val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
+    }
+
+    @Test
+    fun `returns a match when urls match`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "")
+        val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
+    }
+
+    @Test
+    fun `returns null when urls match and usernames don't match`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "")
+        val jsonSettings = getServerSettingsJson("https://demo.getodk.org", "foo")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
+    }
+
+    @Test
+    fun `returns a match when urls and usernames match`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "foo")
+        val jsonSettings = getServerSettingsJson("https://demo.getodk.org", "foo")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
+    }
+
+    @Test
+    fun `returns a match when urls and usernames match and there are other settings that don't match`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "foo")
+        val jsonSettings = "{ \"general\": { \"server_url\": \"https://demo.getodk.org\", \"username\": \"foo\", \"password\": \"bar\" } }"
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
+    }
+
+    @Test
+    fun `returns null when protocol is Google Drive and accounts don't match`() {
+        createGoogleDriveProject("a uuid", "foo@bar.baz")
+        val jsonSettings = getGoogleDriveSettingsJson("baz@bar.quux")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
+    }
+
+    @Test
+    fun `returns a match when protocol is Google Drive and accounts match`() {
+        createGoogleDriveProject("a uuid", "foo@bar.baz")
+        val jsonSettings = getGoogleDriveSettingsJson("foo@bar.baz")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
+    }
+
+    @Test
+    fun `returns uuid of match when there are multiple projects`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "foo")
+        createGoogleDriveProject("another uuid", "foo@bar.baz")
+        val jsonSettings = getGoogleDriveSettingsJson("foo@bar.baz")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("another uuid"))
+    }
+
+    @Test
+    fun `returns uuid of first match when there are multiple matches`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "foo")
+        createGoogleDriveProject("another uuid", "foo@bar.baz")
+        createServerProject("uuid 3", "https://foo.org", "foo")
+        createServerProject("uuid 4", "https://foo.org", "foo")
+
+        val jsonSettings = getServerSettingsJson("https://foo.org", "foo")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("uuid 3"))
+    }
+
+    private fun createServerProject(projectId: String, url: String, username: String) {
+        inMemProjectsRepository.save(Project.Saved(projectId, "no-op", "n", "#ffffff"))
+
+        val generalSettings = inMemSettingsProvider.getGeneralSettings(projectId)
+        generalSettings.save(GeneralKeys.KEY_PROTOCOL, GeneralKeys.PROTOCOL_SERVER)
+        generalSettings.save(GeneralKeys.KEY_SERVER_URL, url)
+        generalSettings.save(GeneralKeys.KEY_USERNAME, username)
+    }
+
+    private fun createGoogleDriveProject(projectId: String, account: String) {
+        inMemProjectsRepository.save(Project.Saved(projectId, "no-op", "n", "#ffffff"))
+
+        val generalSettings = inMemSettingsProvider.getGeneralSettings(projectId)
+        generalSettings.save(GeneralKeys.KEY_PROTOCOL, GeneralKeys.PROTOCOL_GOOGLE_SHEETS)
+        generalSettings.save(GeneralKeys.KEY_SELECTED_GOOGLE_ACCOUNT, account)
+    }
+
+    private fun getServerSettingsJson(url: String): String {
+        return "{ \"general\": { \"server_url\": \"$url\" } }"
+    }
+
+    private fun getServerSettingsJson(url: String, username: String): String {
+        return "{ \"general\": { \"server_url\": \"$url\", \"username\": \"$username\" } }"
+    }
+
+    private fun getGoogleDriveSettingsJson(account: String): String {
+        return "{ \"general\": { \"protocol\": \"google_sheets\", \"selected_google_account\": \"$account\" } }"
+    }
+}

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1012,6 +1012,15 @@
     <string name="settings">Settings</string>
     <string name="add_project">Add project</string>
     <string name="add">Add</string>
+    <!-- Title of the dialog shown when attempting to create a project with connection settings that match an existing project -->
+    <string name="duplicate_project">Duplicate project</string>
+    <!-- Detail text of the dialog shown when attempting to create a project with connection settings that match an existing project -->
+    <string name="duplicate_project_details">You already have a project with these connection settings. Do you want to switch to the existing project or add a new one?</string>
+    <!-- Button text for adding a duplicate project -->
+    <string name="add_duplicate_project">Add duplicate project</string>
+    <!-- Buton text for switching to an existing project -->
+    <string name="switch_to_existing">Switch to existing project</string>
+
     <string name="project_name">Project name</string>
     <string name="project_icon">Project icon</string>
     <string name="project_color">Project color</string>


### PR DESCRIPTION
When multiple projects with identical connection settings are configured, it's possible to get in bad states like having some submissions in one duplicate project that never get sent. This PR checks for matching connection settings and prompts the user to either switch to the existing project or actually create a duplicate.

Note: the QR code scanner scans continuously. This leads to weird behavior when scanning an invalid code or a duplicate project -- the same code is scanned over and over again. This is existing behavior and seems ok for these relatively rare cases.

Google Drive is currently untested.

#### What has been done to verify that this works as intended?
Added and ran automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I am not very satisfied with the control flow but couldn't come up with anything I liked better. I wanted to use some kind of view model but I don't see a reasonable way to communicate UI actions back to the configuration dialogs. There's also more redundancy than I'd like but it seems pragmatic for now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Everything around project creation is at risk. I think the worst outcome would be that users are prompted for confirmation to create non-duplicate projects.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes. https://github.com/getodk/docs/issues/1365

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)