### PR TITLE
Don't allow edits of failed submissions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/FormMapViewModel.java
@@ -122,7 +122,8 @@ public class FormMapViewModel extends ViewModel {
                     && !instance.canEditWhenComplete()) {
                 return ClickAction.NOT_VIEWABLE_TOAST;
             } else if (instance.getDbId() != null) {
-                if (instance.getStatus().equals(Instance.STATUS_SUBMITTED)) {
+                if (instance.getStatus().equals(Instance.STATUS_SUBMITTED)
+                        || instance.getStatus().equals(Instance.STATUS_SUBMISSION_FAILED)) {
                     return ClickAction.OPEN_READ_ONLY;
                 }
                 return ClickAction.OPEN_EDIT;

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapActivityTest.java
@@ -222,9 +222,8 @@ public class FormMapActivityTest {
     public void openingEditableInstances_launchesEditActivity() {
         MapPoint editableAndFinalized = new MapPoint(10.1, 125.6);
         MapPoint unfinalized = new MapPoint(10.1, 126.6);
-        MapPoint failedToSend = new MapPoint(10.3, 125.6);
 
-        MapPoint[] testPoints = {editableAndFinalized, unfinalized, failedToSend};
+        MapPoint[] testPoints = {editableAndFinalized, unfinalized};
 
         for (MapPoint toTap : testPoints) {
             int featureId = map.getFeatureIdFor(toTap);
@@ -263,15 +262,20 @@ public class FormMapActivityTest {
     @Test
     public void openingUneditableInstances_launchesViewActivity() {
         MapPoint sent = new MapPoint(10.3, 125.7);
+        MapPoint failedToSend = new MapPoint(10.3, 125.6);
 
-        int featureId = map.getFeatureIdFor(sent);
+        MapPoint[] testPoints = {sent, failedToSend};
 
-        activity.onFeatureClicked(featureId);
-        clickOnOpenFormChip();
-        Intent actual = shadowOf((Collect) ApplicationProvider.getApplicationContext()).getNextStartedActivity();
+        for (MapPoint toTap : testPoints) {
+            int featureId = map.getFeatureIdFor(toTap);
 
-        assertThat(actual.getAction(), is(Intent.ACTION_EDIT));
-        assertThat(actual.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE), is(ApplicationConstants.FormModes.VIEW_SENT));
+            activity.onFeatureClicked(featureId);
+            clickOnOpenFormChip();
+            Intent actual = shadowOf((Collect) ApplicationProvider.getApplicationContext()).getNextStartedActivity();
+
+            assertThat(actual.getAction(), is(Intent.ACTION_EDIT));
+            assertThat(actual.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE), is(ApplicationConstants.FormModes.VIEW_SENT));
+        }
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormMapViewModelTest.java
@@ -87,11 +87,12 @@ public class FormMapViewModelTest {
         assertThat(instances.get(2).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
     }
 
-    @Test public void instanceThatFailedToSend_thatCanBeEdited_hasEditableStatus() {
+    // Instances that failed to send are not editable starting in v2021.2
+    @Test public void instanceThatFailedToSend_thatCanBeEdited_hasViewableStatus() {
         FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();
 
-        assertThat(instances.get(3).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_EDIT));
+        assertThat(instances.get(3).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_READ_ONLY));
     }
 
     // Sent instances should never be editable.
@@ -102,6 +103,7 @@ public class FormMapViewModelTest {
         assertThat(instances.get(4).getClickAction(), is(FormMapViewModel.ClickAction.OPEN_READ_ONLY));
     }
 
+    // E.g. encrypted forms
     @Test public void instanceThatFailedToSend_thatCantBeEdited_returnsNotViewableStatus() {
         FormMapViewModel viewModel = new FormMapViewModel(TEST_FORM_1, testInstancesRepository);
         List<FormMapViewModel.MappableFormInstance> instances = viewModel.getMappableFormInstances();


### PR DESCRIPTION
Closes #4686

#### What has been done to verify that this works as intended?
Tried manually by creating failed submission by cancelling immediately. Updated tests to reflect new desired behavior.

#### Why is this the best possible solution? Were any other approaches considered?
This is a narrow fix that updates the logic to match the new edit rules. I considered briefly whether there'd be a straightforward way to make sure this logic is encoded in one place but given that the other places that it's used are in SQL queries, I can't think of an easy way to do that at the moment.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Risk is isolated around what action button is shown in the bottom sheet for instances in the form instance map. This doesn't seem very risky but the worst case would be that the wrong actions are shown for some states.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with a geopoint.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Part of https://github.com/getodk/docs/issues/1367

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)