### PR TITLE
Fix external app integrations for projects

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
@@ -1,11 +1,8 @@
 package org.odk.collect.android.feature.external
 
-import android.app.Application
 import android.content.Intent
 import android.content.Intent.EXTRA_SHORTCUT_INTENT
 import android.content.Intent.EXTRA_SHORTCUT_NAME
-import android.provider.BaseColumns
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -15,6 +12,7 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.MainMenuPage
 
@@ -54,22 +52,8 @@ class AndroidShortcutsTest {
 
         val shortcutTargetIntent =
             shortcutIntent.getParcelableExtra<Intent>(EXTRA_SHORTCUT_INTENT)!!
-        val formId = getFirstFormIdFromContentProvider("DEMO")
+        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
         assertThat(shortcutTargetIntent.action, equalTo(Intent.ACTION_EDIT))
         assertThat(shortcutTargetIntent.data, equalTo(FormsContract.getUri("DEMO", formId)))
-    }
-
-    private fun getFirstFormIdFromContentProvider(projectId: String): Long {
-        val contentResolver =
-            ApplicationProvider.getApplicationContext<Application>().contentResolver
-        val uri = FormsContract.getUri(projectId)
-        return contentResolver.query(uri, null, null, null, null, null).use {
-            if (it != null) {
-                it.moveToFirst()
-                it.getLong(it.getColumnIndex(BaseColumns._ID))
-            } else {
-                throw RuntimeException("Null cursor!")
-            }
-        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/AndroidShortcutsTest.kt
@@ -13,7 +13,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.external.FormsProviderAPI
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.MainMenuPage
@@ -56,13 +56,13 @@ class AndroidShortcutsTest {
             shortcutIntent.getParcelableExtra<Intent>(EXTRA_SHORTCUT_INTENT)!!
         val formId = getFirstFormIdFromContentProvider("DEMO")
         assertThat(shortcutTargetIntent.action, equalTo(Intent.ACTION_EDIT))
-        assertThat(shortcutTargetIntent.data, equalTo(FormsProviderAPI.getUri("DEMO", formId)))
+        assertThat(shortcutTargetIntent.data, equalTo(FormsContract.getUri("DEMO", formId)))
     }
 
     private fun getFirstFormIdFromContentProvider(projectId: String): Long {
         val contentResolver =
             ApplicationProvider.getApplicationContext<Application>().contentResolver
-        val uri = FormsProviderAPI.getUri(projectId)
+        val uri = FormsContract.getUri(projectId)
         return contentResolver.query(uri, null, null, null, null, null).use {
             if (it != null) {
                 it.moveToFirst()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
@@ -12,8 +12,8 @@ import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.TestRuleChain
+import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
-import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.OkDialog
 
 @RunWith(AndroidJUnit4::class)
@@ -49,7 +49,7 @@ class FormEditActionTest {
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, OkDialog())
             .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(MainMenuPage())
+            .clickOK(AppClosedPage())
     }
 
     @Test
@@ -91,6 +91,6 @@ class FormEditActionTest {
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
         rule.launch(intent, OkDialog())
             .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(MainMenuPage())
+            .clickOK(AppClosedPage())
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
-import org.odk.collect.android.external.FormsProviderAPI
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.FormEntryPage
@@ -33,7 +33,7 @@ class FormEditActionTest {
             .copyAndSyncForm("one-question.xml")
 
         val formId = getFirstFormIdFromContentProvider("DEMO")
-        val uri = FormsProviderAPI.getUri("DEMO", formId)
+        val uri = FormsContract.getUri("DEMO", formId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, FormEntryPage("One Question"))
@@ -46,7 +46,7 @@ class FormEditActionTest {
             .addAndSwitchToProject("https://example.com")
 
         val formId = getFirstFormIdFromContentProvider("DEMO")
-        val uri = FormsProviderAPI.getUri("DEMO", formId)
+        val uri = FormsContract.getUri("DEMO", formId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, OkDialog())
@@ -63,7 +63,7 @@ class FormEditActionTest {
             .selectProject("Demo project")
 
         val formId = getFirstFormIdFromContentProvider("DEMO")
-        val uri = FormsProviderAPI.getUri("DEMO", formId)
+        val uri = FormsContract.getUri("DEMO", formId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
             .authority(uri.authority)
@@ -82,7 +82,7 @@ class FormEditActionTest {
             .addAndSwitchToProject("https://example.com")
 
         val formId = getFirstFormIdFromContentProvider("DEMO")
-        val uri = FormsProviderAPI.getUri("DEMO", formId)
+        val uri = FormsContract.getUri("DEMO", formId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
             .authority(uri.authority)
@@ -98,7 +98,7 @@ class FormEditActionTest {
 
     private fun getFirstFormIdFromContentProvider(projectId: String): Long {
         val contentResolver = getApplicationContext<Application>().contentResolver
-        val uri = FormsProviderAPI.getUri(projectId)
+        val uri = FormsContract.getUri(projectId)
         return contentResolver.query(uri, null, null, null, null, null).use {
             if (it != null) {
                 it.moveToFirst()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
@@ -1,10 +1,7 @@
 package org.odk.collect.android.feature.external
 
-import android.app.Application
 import android.content.Intent
 import android.net.Uri
-import android.provider.BaseColumns
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
@@ -13,6 +10,7 @@ import org.junit.runner.RunWith
 import org.odk.collect.android.R
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
@@ -32,7 +30,7 @@ class FormEditActionTest {
         rule.startAtMainMenu()
             .copyAndSyncForm("one-question.xml")
 
-        val formId = getFirstFormIdFromContentProvider("DEMO")
+        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
         val uri = FormsContract.getUri("DEMO", formId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
@@ -45,7 +43,7 @@ class FormEditActionTest {
             .copyAndSyncForm("one-question.xml")
             .addAndSwitchToProject("https://example.com")
 
-        val formId = getFirstFormIdFromContentProvider("DEMO")
+        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
         val uri = FormsContract.getUri("DEMO", formId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
@@ -62,7 +60,7 @@ class FormEditActionTest {
             .openProjectSettings()
             .selectProject("Demo project")
 
-        val formId = getFirstFormIdFromContentProvider("DEMO")
+        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
         val uri = FormsContract.getUri("DEMO", formId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
@@ -81,7 +79,7 @@ class FormEditActionTest {
             .copyAndSyncForm("one-question.xml")
             .addAndSwitchToProject("https://example.com")
 
-        val formId = getFirstFormIdFromContentProvider("DEMO")
+        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
         val uri = FormsContract.getUri("DEMO", formId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
@@ -94,18 +92,5 @@ class FormEditActionTest {
         rule.launch(intent, OkDialog())
             .assertText(R.string.wrong_project_selected_for_form)
             .clickOK(MainMenuPage())
-    }
-
-    private fun getFirstFormIdFromContentProvider(projectId: String): Long {
-        val contentResolver = getApplicationContext<Application>().contentResolver
-        val uri = FormsContract.getUri(projectId)
-        return contentResolver.query(uri, null, null, null, null, null).use {
-            if (it != null) {
-                it.moveToFirst()
-                it.getLong(it.getColumnIndex(BaseColumns._ID))
-            } else {
-                throw RuntimeException("Null cursor!")
-            }
-        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormPickActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormPickActionTest.kt
@@ -1,0 +1,40 @@
+package org.odk.collect.android.feature.external
+
+import android.content.Intent
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.external.FormsContract
+import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.ContentProviderUtils
+import org.odk.collect.android.support.TestRuleChain
+import org.odk.collect.android.support.pages.FillBlankFormPage
+
+@RunWith(AndroidJUnit4::class)
+class FormPickActionTest {
+
+    private val rule = CollectTestRule()
+
+    @get:Rule
+    val chain: RuleChain = TestRuleChain.chain()
+        .around(rule)
+
+    @Test
+    fun pickForm_andTheSelectingForm_returnsFormUri() {
+        rule.startAtMainMenu()
+            .copyAndSyncForm("one-question.xml")
+
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = FormsContract.CONTENT_TYPE
+        val result = rule.launchForResult(intent, FillBlankFormPage()) {
+            it.clickOnForm("One Question")
+        }
+
+        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
+        assertThat(result.resultData.data, equalTo(FormsContract.getUri("DEMO", formId)))
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
-import org.odk.collect.android.external.InstanceProviderAPI
+import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.FormEntryPage
@@ -36,7 +36,7 @@ class InstanceEditActionTest {
             .clickSaveAndExit()
 
         val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
-        val uri = InstanceProviderAPI.getUri("DEMO", instanceId)
+        val uri = InstancesContract.getUri("DEMO", instanceId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, FormEntryPage("One Question"))
@@ -52,7 +52,7 @@ class InstanceEditActionTest {
             .addAndSwitchToProject("https://example.com")
 
         val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
-        val uri = InstanceProviderAPI.getUri("DEMO", instanceId)
+        val uri = InstancesContract.getUri("DEMO", instanceId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, OkDialog())
@@ -72,7 +72,7 @@ class InstanceEditActionTest {
             .selectProject("Demo project")
 
         val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
-        val uri = InstanceProviderAPI.getUri("DEMO", instanceId)
+        val uri = InstancesContract.getUri("DEMO", instanceId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
             .authority(uri.authority)
@@ -94,7 +94,7 @@ class InstanceEditActionTest {
             .addAndSwitchToProject("https://example.com")
 
         val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
-        val uri = InstanceProviderAPI.getUri("DEMO", instanceId)
+        val uri = InstancesContract.getUri("DEMO", instanceId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
             .authority(uri.authority)
@@ -110,7 +110,7 @@ class InstanceEditActionTest {
 
     private fun getFirstInstanceIdFromContentProvider(projectId: String): Long {
         val contentResolver = ApplicationProvider.getApplicationContext<Application>().contentResolver
-        val uri = InstanceProviderAPI.getUri(projectId)
+        val uri = InstancesContract.getUri(projectId)
         return contentResolver.query(uri, null, null, null, null, null).use {
             if (it != null) {
                 it.moveToFirst()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -16,7 +16,6 @@ import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
-import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.OkDialog
 
 @RunWith(AndroidJUnit4::class)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -14,6 +14,7 @@ import org.odk.collect.android.R
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
+import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.OkDialog
@@ -57,7 +58,7 @@ class InstanceEditActionTest {
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, OkDialog())
             .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(MainMenuPage())
+            .clickOK(AppClosedPage())
     }
 
     @Test
@@ -105,7 +106,7 @@ class InstanceEditActionTest {
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
         rule.launch(intent, OkDialog())
             .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(MainMenuPage())
+            .clickOK(AppClosedPage())
     }
 
     private fun getFirstInstanceIdFromContentProvider(projectId: String): Long {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -1,10 +1,7 @@
 package org.odk.collect.android.feature.external
 
-import android.app.Application
 import android.content.Intent
 import android.net.Uri
-import android.provider.BaseColumns
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
@@ -13,6 +10,7 @@ import org.junit.runner.RunWith
 import org.odk.collect.android.R
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
@@ -35,7 +33,7 @@ class InstanceEditActionTest {
             .swipeToEndScreen()
             .clickSaveAndExit()
 
-        val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
+        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         val uri = InstancesContract.getUri("DEMO", instanceId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
@@ -51,7 +49,7 @@ class InstanceEditActionTest {
             .clickSaveAndExit()
             .addAndSwitchToProject("https://example.com")
 
-        val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
+        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         val uri = InstancesContract.getUri("DEMO", instanceId)
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
@@ -71,7 +69,7 @@ class InstanceEditActionTest {
             .openProjectSettings()
             .selectProject("Demo project")
 
-        val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
+        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         val uri = InstancesContract.getUri("DEMO", instanceId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
@@ -93,7 +91,7 @@ class InstanceEditActionTest {
             .clickSaveAndExit()
             .addAndSwitchToProject("https://example.com")
 
-        val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
+        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         val uri = InstancesContract.getUri("DEMO", instanceId)
         val uriWithoutProjectId = Uri.Builder()
             .scheme(uri.scheme)
@@ -106,18 +104,5 @@ class InstanceEditActionTest {
         rule.launch(intent, OkDialog())
             .assertText(R.string.wrong_project_selected_for_form)
             .clickOK(AppClosedPage())
-    }
-
-    private fun getFirstInstanceIdFromContentProvider(projectId: String): Long {
-        val contentResolver = ApplicationProvider.getApplicationContext<Application>().contentResolver
-        val uri = InstancesContract.getUri(projectId)
-        return contentResolver.query(uri, null, null, null, null, null).use {
-            if (it != null) {
-                it.moveToFirst()
-                it.getLong(it.getColumnIndex(BaseColumns._ID))
-            } else {
-                throw RuntimeException("Null cursor!")
-            }
-        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
@@ -1,0 +1,61 @@
+package org.odk.collect.android.feature.external
+
+import android.app.Application
+import android.content.Intent
+import android.provider.BaseColumns
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.external.InstancesContract
+import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.TestRuleChain
+import org.odk.collect.android.support.pages.EditSavedFormPage
+
+@RunWith(AndroidJUnit4::class)
+class InstancePickActionTest {
+
+    private val rule = CollectTestRule()
+
+    @get:Rule
+    val chain: RuleChain = TestRuleChain.chain()
+        .around(rule)
+
+    @Test
+    fun pickInstance_andTheSelectingInstance_returnsInstanceUri() {
+        rule.startAtMainMenu()
+            .copyAndSyncForm("one-question.xml")
+            .startBlankForm("One Question")
+            .swipeToEndScreen()
+            .clickSaveAndExit()
+
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = InstancesContract.CONTENT_TYPE
+        val result = rule.launchForResult(intent, EditSavedFormPage()) {
+            it.clickOnForm("One Question")
+        }
+
+        val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
+        assertThat(
+            result.resultData.data,
+            equalTo(InstancesContract.getUri("DEMO", instanceId))
+        )
+    }
+
+    private fun getFirstInstanceIdFromContentProvider(projectId: String): Long {
+        val contentResolver = ApplicationProvider.getApplicationContext<Application>().contentResolver
+        val uri = InstancesContract.getUri(projectId)
+        return contentResolver.query(uri, null, null, null, null, null).use {
+            if (it != null) {
+                it.moveToFirst()
+                it.getLong(it.getColumnIndex(BaseColumns._ID))
+            } else {
+                throw RuntimeException("Null cursor!")
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
@@ -1,9 +1,6 @@
 package org.odk.collect.android.feature.external
 
-import android.app.Application
 import android.content.Intent
-import android.provider.BaseColumns
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
@@ -13,6 +10,7 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.EditSavedFormPage
 
@@ -39,23 +37,10 @@ class InstancePickActionTest {
             it.clickOnForm("One Question")
         }
 
-        val instanceId = getFirstInstanceIdFromContentProvider("DEMO")
+        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         assertThat(
             result.resultData.data,
             equalTo(InstancesContract.getUri("DEMO", instanceId))
         )
-    }
-
-    private fun getFirstInstanceIdFromContentProvider(projectId: String): Long {
-        val contentResolver = ApplicationProvider.getApplicationContext<Application>().contentResolver
-        val uri = InstancesContract.getUri(projectId)
-        return contentResolver.query(uri, null, null, null, null, null).use {
-            if (it != null) {
-                it.moveToFirst()
-                it.getLong(it.getColumnIndex(BaseColumns._ID))
-            } else {
-                throw RuntimeException("Null cursor!")
-            }
-        }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.support;
 
+import android.app.Activity;
+import android.app.Instrumentation;
 import android.content.Intent;
 
 import androidx.test.core.app.ActivityScenario;
@@ -15,6 +17,8 @@ import org.odk.collect.android.support.pages.FirstLaunchPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.Page;
 import org.odk.collect.android.support.pages.ShortcutsPage;
+
+import java.util.function.Consumer;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -73,5 +77,12 @@ public class CollectTestRule implements TestRule {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         ApplicationProvider.getApplicationContext().startActivity(intent);
         return destination.assertOnPage();
+    }
+
+    public <T extends Page<T>> Instrumentation.ActivityResult launchForResult(Intent intent, T destination, Consumer<T> actions) {
+        ActivityScenario<Activity> scenario = ActivityScenario.launch(intent);
+        destination.assertOnPage();
+        actions.accept(destination);
+        return scenario.getResult();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
@@ -5,14 +5,13 @@ import android.app.Instrumentation;
 import android.content.Intent;
 
 import androidx.test.core.app.ActivityScenario;
-import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.odk.collect.android.R;
-import org.odk.collect.android.external.AndroidShortcutsActivity;
 import org.odk.collect.android.activities.SplashScreenActivity;
+import org.odk.collect.android.external.AndroidShortcutsActivity;
 import org.odk.collect.android.support.pages.FirstLaunchPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.Page;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
@@ -71,11 +71,7 @@ public class CollectTestRule implements TestRule {
     }
 
     public <T extends Page<T>> T launch(Intent intent, T destination) {
-        /*
-        This can't use ActivityScenario.launch because of: https://github.com/android/android-test/issues/496
-         */
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        ApplicationProvider.getApplicationContext().startActivity(intent);
+        ActivityScenario.launch(intent);
         return destination.assertOnPage();
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ContentProviderUtils.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ContentProviderUtils.kt
@@ -1,0 +1,30 @@
+package org.odk.collect.android.support
+
+import android.app.Application
+import android.provider.BaseColumns
+import androidx.test.core.app.ApplicationProvider
+import org.odk.collect.android.database.forms.DatabaseFormColumns
+import org.odk.collect.android.external.FormsContract
+
+object ContentProviderUtils {
+
+    fun getFormDatabaseId(projectId: String, formId: String): Long {
+        val contentResolver =
+            ApplicationProvider.getApplicationContext<Application>().contentResolver
+        val uri = FormsContract.getUri(projectId)
+        return contentResolver.query(uri, null, null, null, null, null).use {
+            if (it != null) {
+                var dbId: Long? = null
+                while (it.moveToNext()) {
+                    if (it.getString(it.getColumnIndex(DatabaseFormColumns.JR_FORM_ID)) == formId) {
+                        dbId = it.getLong(it.getColumnIndex(BaseColumns._ID))
+                    }
+                }
+
+                dbId ?: throw IllegalArgumentException("Form does not exist!")
+            } else {
+                throw RuntimeException("Null cursor!")
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ContentProviderUtils.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ContentProviderUtils.kt
@@ -4,7 +4,9 @@ import android.app.Application
 import android.provider.BaseColumns
 import androidx.test.core.app.ApplicationProvider
 import org.odk.collect.android.database.forms.DatabaseFormColumns
+import org.odk.collect.android.database.instances.DatabaseInstanceColumns
 import org.odk.collect.android.external.FormsContract
+import org.odk.collect.android.external.InstancesContract
 
 object ContentProviderUtils {
 
@@ -17,6 +19,26 @@ object ContentProviderUtils {
                 var dbId: Long? = null
                 while (it.moveToNext()) {
                     if (it.getString(it.getColumnIndex(DatabaseFormColumns.JR_FORM_ID)) == formId) {
+                        dbId = it.getLong(it.getColumnIndex(BaseColumns._ID))
+                    }
+                }
+
+                dbId ?: throw IllegalArgumentException("Form does not exist!")
+            } else {
+                throw RuntimeException("Null cursor!")
+            }
+        }
+    }
+
+    fun getInstanceDatabaseId(projectId: String, formId: String): Long {
+        val contentResolver =
+            ApplicationProvider.getApplicationContext<Application>().contentResolver
+        val uri = InstancesContract.getUri(projectId)
+        return contentResolver.query(uri, null, null, null, null, null).use {
+            if (it != null) {
+                var dbId: Long? = null
+                while (it.moveToNext()) {
+                    if (it.getString(it.getColumnIndex(DatabaseInstanceColumns.JR_FORM_ID)) == formId) {
                         dbId = it.getLong(it.getColumnIndex(BaseColumns._ID))
                     }
                 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FormActivityTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FormActivityTestRule.java
@@ -11,7 +11,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.odk.collect.android.activities.FormEntryActivity;
 import org.odk.collect.android.injection.DaggerUtils;
-import org.odk.collect.android.external.FormsProviderAPI;
+import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.forms.Form;
 
@@ -42,7 +42,7 @@ public class FormActivityTestRule implements TestRule {
         String projectId = DaggerUtils.getComponent(application).currentProjectProvider().getCurrentProject().getUuid();
 
         Intent intent = new Intent(application, FormEntryActivity.class);
-        intent.setData(FormsProviderAPI.getUri(projectId, form.getDbId()));
+        intent.setData(FormsContract.getUri(projectId, form.getDbId()));
         return intent;
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
@@ -16,6 +16,7 @@ import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.MultiClickGuard;
+import org.odk.collect.android.views.DecoratedBarcodeView;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,6 +68,7 @@ public class ResetStateRule implements TestRule {
 
     private void setTestState() {
         MultiClickGuard.test = true;
+        DecoratedBarcodeView.TEST = true;
         CopyFormRule.projectCreated = false;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/ResetStateRule.java
@@ -68,7 +68,7 @@ public class ResetStateRule implements TestRule {
 
     private void setTestState() {
         MultiClickGuard.test = true;
-        DecoratedBarcodeView.TEST = true;
+        DecoratedBarcodeView.test = true;
         CopyFormRule.projectCreated = false;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AppClosedPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AppClosedPage.kt
@@ -1,0 +1,12 @@
+package org.odk.collect.android.support.pages
+
+import androidx.test.espresso.matcher.ViewMatchers
+import org.hamcrest.CoreMatchers
+
+class AppClosedPage : Page<AppClosedPage>() {
+
+    override fun assertOnPage(): AppClosedPage {
+        ViewMatchers.assertThat(getCurrentActivity(), CoreMatchers.equalTo(null))
+        return this
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AppClosedPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AppClosedPage.kt
@@ -1,12 +1,12 @@
 package org.odk.collect.android.support.pages
 
-import androidx.test.espresso.matcher.ViewMatchers
-import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 
 class AppClosedPage : Page<AppClosedPage>() {
 
     override fun assertOnPage(): AppClosedPage {
-        ViewMatchers.assertThat(getCurrentActivity(), CoreMatchers.equalTo(null))
+        assertThat(getCurrentActivity(), equalTo(null))
         return this
     }
 }

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -188,15 +188,8 @@ the specific language governing permissions and limitations under the License.
         <activity-alias
             android:name=".activities.FormEntryActivity"
             android:targetActivity=".activities.FormEntryActivity"
-            tools:ignore="AppLinkUrlError">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <action android:name="android.intent.action.EDIT" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:mimeType="vnd.android.cursor.item/vnd.odk.instance" />
-            </intent-filter>
+            tools:ignore="AppLinkUrlError"
+            android:exported="true">
         </activity-alias>
 
         <activity-alias
@@ -282,7 +275,7 @@ the specific language governing permissions and limitations under the License.
             </intent-filter>
         </activity>
 
-        <!-- Supports VIEW and EDIT actions for forms (documented at
+        <!-- Supports VIEW and EDIT actions for forms and instances (documented at
         https://docs.getodk.org/launch-collect-from-app/#using-a-uri-to-edit-a-form-or-instance).
         Do not use the activity directly as it's name/package might change. -->
         <activity
@@ -296,6 +289,7 @@ the specific language governing permissions and limitations under the License.
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="vnd.android.cursor.item/vnd.odk.form" />
+                <data android:mimeType="vnd.android.cursor.item/vnd.odk.instance" />
             </intent-filter>
         </activity>
 

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -199,6 +199,7 @@ the specific language governing permissions and limitations under the License.
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.EDIT" />
+                <action android:name="android.intent.action.PICK" />
 
                 <category android:name="android.intent.category.DEFAULT" />
 

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -278,7 +278,7 @@ the specific language governing permissions and limitations under the License.
 
         <!-- Supports VIEW and EDIT actions for forms and instances (documented at
         https://docs.getodk.org/launch-collect-from-app/#using-a-uri-to-edit-a-form-or-instance).
-        Do not use the activity directly as it's name/package might change. -->
+        Do not use the activity directly as its name/package might change. -->
         <activity
             android:name=".external.FormUriActivity"
             android:noHistory="true"

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
@@ -42,7 +42,7 @@ import org.odk.collect.android.network.NetworkStateProvider;
 import org.odk.collect.android.preferences.dialogs.ServerAuthDialogFragment;
 import org.odk.collect.android.preferences.keys.GeneralKeys;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.FormsProviderAPI;
+import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.tasks.FormSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DialogUtils;
@@ -171,7 +171,7 @@ public class FillBlankFormActivity extends FormListActivity implements
         if (MultiClickGuard.allowClick(getClass().getName())) {
             // get uri to form
             long idFormsTable = listView.getAdapter().getItemId(position);
-            Uri formUri = FormsProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), idFormsTable);
+            Uri formUri = FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), idFormsTable);
 
             String action = getIntent().getAction();
             if (Intent.ACTION_PICK.equals(action)) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -74,8 +74,8 @@ import org.odk.collect.android.dao.helpers.InstancesDaoHelper;
 import org.odk.collect.android.events.ReadPhoneStatePermissionRxEvent;
 import org.odk.collect.android.events.RxEventBus;
 import org.odk.collect.android.exception.JavaRosaException;
-import org.odk.collect.android.external.FormsProviderAPI;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.FormsContract;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.formentry.BackgroundAudioPermissionDialogFragment;
 import org.odk.collect.android.formentry.BackgroundAudioViewModel;
 import org.odk.collect.android.formentry.FormEndView;
@@ -597,7 +597,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             uriMimeType = getContentResolver().getType(uri);
         }
 
-        if (uriMimeType != null && uriMimeType.equals(InstanceProviderAPI.CONTENT_ITEM_TYPE)) {
+        if (uriMimeType != null && uriMimeType.equals(InstancesContract.CONTENT_ITEM_TYPE)) {
             Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
 
             if (instance == null) {
@@ -629,7 +629,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
 
             formPath = candidateForms.get(0).getFormFilePath();
-        } else if (uriMimeType != null && uriMimeType.equals(FormsProviderAPI.CONTENT_ITEM_TYPE)) {
+        } else if (uriMimeType != null && uriMimeType.equals(FormsContract.CONTENT_ITEM_TYPE)) {
             Form form = formsRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri));
             if (form != null) {
                 formPath = form.getFormFilePath();
@@ -1221,7 +1221,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
 
             if (saveName == null && uriMimeType != null
-                    && uriMimeType.equals(InstanceProviderAPI.CONTENT_ITEM_TYPE)) {
+                    && uriMimeType.equals(InstancesContract.CONTENT_ITEM_TYPE)) {
                 Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(instanceUri));
                 if (instance != null) {
                     saveName = instance.getDisplayName();
@@ -2310,7 +2310,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             if (path != null) {
                 Instance instance = new InstancesRepositoryProvider(this).get().getOneByPath(path);
                 if (instance != null) {
-                    uri = InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), instance.getDbId());
+                    uri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), instance.getDbId());
                 }
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.java
@@ -42,9 +42,9 @@ import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.keys.AdminKeys;
 import org.odk.collect.android.preferences.screens.MapsPreferencesFragment;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.FormsProviderAPI;
+import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.external.InstanceProvider;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.IconUtils;
@@ -202,7 +202,7 @@ public class FormMapActivity extends BaseGeoMapActivity {
         });
 
         findViewById(R.id.new_instance).setOnClickListener(v -> {
-            final Uri formUri = FormsProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), viewModel.getFormId());
+            final Uri formUri = FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), viewModel.getFormId());
             startActivity(new Intent(Intent.ACTION_EDIT, formUri));
         });
 
@@ -395,7 +395,7 @@ public class FormMapActivity extends BaseGeoMapActivity {
     }
 
     private Intent getEditFormInstanceIntentFor(long instanceId) {
-        Uri uri = InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), instanceId);
+        Uri uri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), instanceId);
         return new Intent(Intent.ACTION_EDIT, uri);
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -35,7 +35,7 @@ import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.forms.instances.Instance;
@@ -102,7 +102,7 @@ public class InstanceChooserList extends InstanceListActivity implements Adapter
             if (view.isEnabled()) {
                 Cursor c = (Cursor) listView.getAdapter().getItem(position);
                 long instanceId = c.getLong(c.getColumnIndex(DatabaseInstanceColumns._ID));
-                Uri instanceUri = InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), instanceId);
+                Uri instanceUri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), instanceId);
 
                 String action = getIntent().getAction();
                 if (Intent.ACTION_PICK.equals(action)) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -8,8 +8,8 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.forms.DatabaseFormColumns;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.FormsProviderAPI;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.FormsContract;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.forms.instances.Instance;
 
 public class CursorLoaderFactory {
@@ -167,16 +167,16 @@ public class CursorLoaderFactory {
 
         if (charSequence.length() == 0) {
             Uri formUri = newestByFormId ?
-                    FormsProviderAPI.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
-                    FormsProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid());
+                    FormsContract.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
+                    FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
             cursorLoader = new CursorLoader(Collect.getInstance(), formUri, null, DatabaseFormColumns.DELETED_DATE + " IS NULL", new String[]{}, sortOrder);
         } else {
             String selection = DatabaseFormColumns.DISPLAY_NAME + " LIKE ? AND " + DatabaseFormColumns.DELETED_DATE + " IS NULL";
             String[] selectionArgs = {"%" + charSequence + "%"};
 
             Uri formUri = newestByFormId ?
-                    FormsProviderAPI.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
-                    FormsProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid());
+                    FormsContract.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
+                    FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
             cursorLoader = new CursorLoader(Collect.getInstance(), formUri, null, selection, selectionArgs, sortOrder);
         }
         return cursorLoader;
@@ -185,7 +185,7 @@ public class CursorLoaderFactory {
     private CursorLoader getInstancesCursorLoader(String selection, String[] selectionArgs, String sortOrder) {
         return new CursorLoader(
                 Collect.getInstance(),
-                InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid()),
+                InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid()),
                 null,
                 selection,
                 selectionArgs,

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormsContract.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormsContract.java
@@ -27,7 +27,7 @@ import org.odk.collect.android.database.forms.DatabaseFormColumns;
  * This defines the data model for blank forms. Blank forms are unique by
  * {@link DatabaseFormColumns#JR_FORM_ID} unless multiple {@link DatabaseFormColumns#JR_VERSION}s are defined.
  */
-public final class FormsProviderAPI {
+public final class FormsContract {
 
     static final String AUTHORITY = "org.odk.collect.android.provider.odk.forms";
     public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.odk.form";
@@ -57,6 +57,6 @@ public final class FormsProviderAPI {
         return Uri.parse("content://" + AUTHORITY + "/newest_forms_by_form_id?projectId=" + projectId);
     }
 
-    private FormsProviderAPI() {
+    private FormsContract() {
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
@@ -112,7 +112,7 @@ public class FormsProvider extends ContentProvider {
         switch (URI_MATCHER.match(uri)) {
             case FORMS:
                 cursor = databaseQuery(projectId, projection, selection, selectionArgs, sortOrder, null, null);
-                cursor.setNotificationUri(getContext().getContentResolver(), FormsProviderAPI.getUri(projectId));
+                cursor.setNotificationUri(getContext().getContentResolver(), FormsContract.getUri(projectId));
                 break;
 
             case NEWEST_FORMS_BY_FORM_ID:
@@ -145,7 +145,7 @@ public class FormsProvider extends ContentProvider {
                 }
 
                 cursor = databaseQuery(projectId, maxDateColumns.toArray(new String[0]), selection, selectionArgs, sortOrder, JR_FORM_ID, maxDateProjectionMap);
-                cursor.setNotificationUri(getContext().getContentResolver(), FormsProviderAPI.getUri(projectId));
+                cursor.setNotificationUri(getContext().getContentResolver(), FormsContract.getUri(projectId));
                 break;
 
             case FORM_ID:
@@ -168,10 +168,10 @@ public class FormsProvider extends ContentProvider {
         switch (URI_MATCHER.match(uri)) {
             case FORMS:
             case NEWEST_FORMS_BY_FORM_ID:
-                return FormsProviderAPI.CONTENT_TYPE;
+                return FormsContract.CONTENT_TYPE;
 
             case FORM_ID:
-                return FormsProviderAPI.CONTENT_ITEM_TYPE;
+                return FormsContract.CONTENT_ITEM_TYPE;
 
             default:
                 throw new IllegalArgumentException("Unknown URI " + uri);
@@ -191,7 +191,7 @@ public class FormsProvider extends ContentProvider {
         String formsPath = storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, projectId);
         String cachePath = storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, projectId);
         Form form = getFormsRepository(projectId).save(getFormFromValues(initialValues, formsPath, cachePath));
-        return FormsProviderAPI.getUri(projectId, form.getDbId());
+        return FormsContract.getUri(projectId, form.getDbId());
     }
 
     /**
@@ -301,9 +301,9 @@ public class FormsProvider extends ContentProvider {
     }
 
     static {
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, "forms", FORMS);
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, "forms/#", FORM_ID);
+        URI_MATCHER.addURI(FormsContract.AUTHORITY, "forms", FORMS);
+        URI_MATCHER.addURI(FormsContract.AUTHORITY, "forms/#", FORM_ID);
         // Only available for query and type
-        URI_MATCHER.addURI(FormsProviderAPI.AUTHORITY, "newest_forms_by_form_id", NEWEST_FORMS_BY_FORM_ID);
+        URI_MATCHER.addURI(FormsContract.AUTHORITY, "newest_forms_by_form_id", NEWEST_FORMS_BY_FORM_ID);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
@@ -48,9 +48,9 @@ import static org.odk.collect.android.database.DatabaseObjectMapper.getInstanceF
 import static org.odk.collect.android.database.DatabaseObjectMapper.getInstanceFromValues;
 import static org.odk.collect.android.database.DatabaseObjectMapper.getValuesFromInstance;
 import static org.odk.collect.android.database.instances.DatabaseInstanceColumns._ID;
-import static org.odk.collect.android.external.InstanceProviderAPI.CONTENT_ITEM_TYPE;
-import static org.odk.collect.android.external.InstanceProviderAPI.CONTENT_TYPE;
-import static org.odk.collect.android.external.InstanceProviderAPI.getUri;
+import static org.odk.collect.android.external.InstancesContract.CONTENT_ITEM_TYPE;
+import static org.odk.collect.android.external.InstancesContract.CONTENT_TYPE;
+import static org.odk.collect.android.external.InstancesContract.getUri;
 
 public class InstanceProvider extends ContentProvider {
 
@@ -290,7 +290,7 @@ public class InstanceProvider extends ContentProvider {
     }
 
     static {
-        URI_MATCHER.addURI(InstanceProviderAPI.AUTHORITY, "instances", INSTANCES);
-        URI_MATCHER.addURI(InstanceProviderAPI.AUTHORITY, "instances/#", INSTANCE_ID);
+        URI_MATCHER.addURI(InstancesContract.AUTHORITY, "instances", INSTANCES);
+        URI_MATCHER.addURI(InstancesContract.AUTHORITY, "instances/#", INSTANCE_ID);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/InstancesContract.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/InstancesContract.java
@@ -18,7 +18,7 @@ package org.odk.collect.android.external;
 
 import android.net.Uri;
 
-public final class InstanceProviderAPI {
+public final class InstancesContract {
 
     public static final String AUTHORITY = "org.odk.collect.android.provider.odk.instances";
     public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.odk.instance";
@@ -33,7 +33,7 @@ public final class InstanceProviderAPI {
     }
 
     // This class cannot be instantiated
-    private InstanceProviderAPI() {
+    private InstancesContract() {
     }
 
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
@@ -24,7 +24,7 @@ import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.keys.AdminKeys;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
 import org.odk.collect.async.Scheduler;
@@ -106,7 +106,7 @@ public class QuitFormDialogFragment extends DialogFragment {
                     if (path != null) {
                         Instance instance = new InstancesRepositoryProvider(requireContext()).get().getOneByPath(path);
                         if (instance != null) {
-                            uri = InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), instance.getDbId());
+                            uri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), instance.getDbId());
                         }
                     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/BlankFormsListViewModel.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import static org.odk.collect.android.configure.SettingsUtils.getFormUpdateMode;
-import static org.odk.collect.android.external.FormsProviderAPI.getUri;
+import static org.odk.collect.android.external.FormsContract.getUri;
 
 public class BlankFormsListViewModel extends ViewModel {
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsUpdater.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsUpdater.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.analytics.AnalyticsUtils
-import org.odk.collect.android.external.FormsProviderAPI
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.matchexactly.ServerFormsSynchronizer
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusAppState
 import org.odk.collect.android.notifications.Notifier
@@ -67,7 +67,7 @@ class FormsUpdater(
                 }
             }
 
-            context.contentResolver.notifyChange(FormsProviderAPI.getUri(projectId), null)
+            context.contentResolver.notifyChange(FormsContract.getUri(projectId), null)
         } catch (_: FormSourceException) {
             // Ignored
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesAppState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesAppState.kt
@@ -3,7 +3,7 @@ package org.odk.collect.android.formmanagement
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import org.odk.collect.android.external.InstanceProviderAPI
+import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.forms.instances.Instance
@@ -48,7 +48,7 @@ class InstancesAppState(
         _editable.postValue(editableInstances)
 
         context.contentResolver.notifyChange(
-            InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().uuid),
+            InstancesContract.getUri(currentProjectProvider.getCurrentProject().uuid),
             null
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusAppState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusAppState.kt
@@ -3,7 +3,7 @@ package org.odk.collect.android.formmanagement.matchexactly
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import org.odk.collect.android.external.FormsProviderAPI
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.forms.FormSourceException
 import javax.inject.Singleton
 
@@ -28,7 +28,7 @@ class SyncStatusAppState(private val context: Context) {
     fun finishSync(projectId: String, exception: FormSourceException?) {
         getSyncErrorLiveData(projectId).postValue(exception)
         getSyncingLiveData(projectId).postValue(false)
-        context.contentResolver.notifyChange(FormsProviderAPI.getUri(projectId), null)
+        context.contentResolver.notifyChange(FormsContract.getUri(projectId), null)
     }
 
     private fun getSyncingLiveData(projectId: String) =

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -1,10 +1,8 @@
 package org.odk.collect.android.injection.config;
 
-import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.media.MediaPlayer;
-import android.telephony.TelephonyManager;
 import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
@@ -115,6 +113,7 @@ import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.ProjectResetter;
 import org.odk.collect.android.utilities.ScreenUtils;
 import org.odk.collect.android.utilities.SoftKeyboardController;
+import org.odk.collect.android.utilities.StaticCachingDeviceDetailsProvider;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.android.version.VersionInformation;
 import org.odk.collect.android.views.BarcodeViewDecoder;
@@ -245,21 +244,7 @@ public class AppDependencyModule {
 
     @Provides
     public DeviceDetailsProvider providesDeviceDetailsProvider(Context context, InstallIDProvider installIDProvider) {
-        return new DeviceDetailsProvider() {
-
-            @Override
-            @SuppressLint({"MissingPermission", "HardwareIds"})
-            public String getDeviceId() {
-                return installIDProvider.getInstallID();
-            }
-
-            @Override
-            @SuppressLint({"MissingPermission", "HardwareIds"})
-            public String getLine1Number() {
-                TelephonyManager telMgr = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-                return telMgr.getLine1Number();
-            }
-        };
+        return new StaticCachingDeviceDetailsProvider(installIDProvider, context);
     }
 
     @Provides
@@ -618,4 +603,5 @@ public class AppDependencyModule {
         ForegroundServiceLocationTracker.setNotificationIcon(IconUtils.getNotificationAppIcon());
         return new ForegroundServiceLocationTracker(application);
     }
+
 }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
@@ -28,7 +28,7 @@ import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.keys.GeneralKeys;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.tasks.SaveFormToDisk;
@@ -217,7 +217,7 @@ public class InstanceDiskSynchronizer {
         String instancePath = instance.getInstanceFilePath();
         File instanceXml = new File(instancePath);
         if (!new File(instanceXml.getParentFile(), "submission.xml.enc").exists()) {
-            Uri uri = InstanceProviderAPI.getUri(currentProjectProvider.getCurrentProject().getUuid(), instance.getDbId());
+            Uri uri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), instance.getDbId());
             FormController.InstanceMetadata instanceMetadata = new FormController.InstanceMetadata(getInstanceIdFromInstance(instancePath), null, null);
             EncryptionUtils.EncryptedFormInformation formInfo = EncryptionUtils.getEncryptedFormInformation(uri, instanceMetadata);
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormSyncTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormSyncTask.java
@@ -19,7 +19,7 @@ import android.os.AsyncTask;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.DiskSyncListener;
-import org.odk.collect.android.external.FormsProviderAPI;
+import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.utilities.FormsDirDiskFormsSynchronizer;
 
 /**
@@ -48,7 +48,7 @@ public class FormSyncTask extends AsyncTask<Void, String, String> {
 
         // Make sure content observers (CursorLoaders for instance) are notified of change
         String projectId = DaggerUtils.getComponent(Collect.getInstance()).currentProjectProvider().getCurrentProject().getUuid();
-        Collect.getInstance().getContentResolver().notifyChange(FormsProviderAPI.getUri(projectId), null);
+        Collect.getInstance().getContentResolver().notifyChange(FormsContract.getUri(projectId), null);
 
         statusMessage = result;
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -43,7 +43,7 @@ import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
 import org.odk.collect.android.exception.EncryptionException;
 import org.odk.collect.android.formentry.saving.FormSaver;
 import org.odk.collect.android.javarosawrapper.FormController;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.utilities.ContentUriHelper;
@@ -206,7 +206,7 @@ public class SaveFormToDisk {
             }
 
             Instance newInstance = new InstancesRepositoryProvider(Collect.getInstance()).get().save(instanceBuilder.build());
-            uri = InstanceProviderAPI.getUri(currentProjectId, newInstance.getDbId());
+            uri = InstancesContract.getUri(currentProjectId, newInstance.getDbId());
         } else {
             Timber.i("No instance found, creating");
             Form form = new FormsRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
@@ -231,7 +231,7 @@ public class SaveFormToDisk {
         }
 
         Instance newInstance = new InstancesRepositoryProvider(Collect.getInstance()).get().save(instanceBuilder.build());
-        uri = InstanceProviderAPI.getUri(currentProjectId, newInstance.getDbId());
+        uri = InstancesContract.getUri(currentProjectId, newInstance.getDbId());
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/EncryptionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/EncryptionUtils.java
@@ -28,8 +28,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.EncryptionException;
 import org.odk.collect.android.javarosawrapper.FormController.InstanceMetadata;
-import org.odk.collect.android.external.FormsProviderAPI;
-import org.odk.collect.android.external.InstanceProviderAPI;
+import org.odk.collect.android.external.FormsContract;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.shared.strings.Md5;
@@ -266,7 +266,7 @@ public class EncryptionUtils {
 
         Form form = null;
 
-        if (InstanceProviderAPI.CONTENT_ITEM_TYPE.equals(Collect.getInstance().getContentResolver().getType(uri))) {
+        if (InstancesContract.CONTENT_ITEM_TYPE.equals(Collect.getInstance().getContentResolver().getType(uri))) {
             Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
             if (instance == null) {
                 String msg = TranslationHandler.getString(Collect.getInstance(), R.string.not_exactly_one_record_for_this_instance);
@@ -288,7 +288,7 @@ public class EncryptionUtils {
             }
 
             form = forms.get(0);
-        } else if (FormsProviderAPI.CONTENT_ITEM_TYPE.equals(Collect.getInstance().getContentResolver().getType(uri))) {
+        } else if (FormsContract.CONTENT_ITEM_TYPE.equals(Collect.getInstance().getContentResolver().getType(uri))) {
             throw new IllegalArgumentException("Can't get encryption info for Form URI!");
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/StaticCachingDeviceDetailsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/StaticCachingDeviceDetailsProvider.java
@@ -1,0 +1,42 @@
+package org.odk.collect.android.utilities;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.telephony.TelephonyManager;
+
+import org.odk.collect.android.metadata.InstallIDProvider;
+
+public class StaticCachingDeviceDetailsProvider implements DeviceDetailsProvider {
+
+    /**
+     * We want to cache the line number statically as fetching it takes several ms and we don't
+     * expect it to change during the process lifecycle.
+     */
+    private static String lineNumber;
+    private static boolean lineNumberFetched;
+
+    private final InstallIDProvider installIDProvider;
+    private final Context context;
+
+    public StaticCachingDeviceDetailsProvider(InstallIDProvider installIDProvider, Context context) {
+        this.installIDProvider = installIDProvider;
+        this.context = context;
+    }
+
+    @Override
+    public String getDeviceId() {
+        return installIDProvider.getInstallID();
+    }
+
+    @Override
+    @SuppressLint({"MissingPermission", "HardwareIds"})
+    public String getLine1Number() {
+        if (!lineNumberFetched) {
+            TelephonyManager telMgr = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+            lineNumber = telMgr.getLine1Number();
+            lineNumberFetched = true;
+        }
+
+        return lineNumber;
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/views/DecoratedBarcodeView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/DecoratedBarcodeView.java
@@ -1,0 +1,31 @@
+package org.odk.collect.android.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+public class DecoratedBarcodeView extends com.journeyapps.barcodescanner.DecoratedBarcodeView {
+
+    public static boolean TEST = false;
+
+    public DecoratedBarcodeView(Context context) {
+        super(context);
+        initialize();
+    }
+
+    public DecoratedBarcodeView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initialize();
+    }
+
+    public DecoratedBarcodeView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initialize();
+    }
+
+    private void initialize() {
+        if (TEST) {
+            setVisibility(View.INVISIBLE);
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/views/DecoratedBarcodeView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/DecoratedBarcodeView.java
@@ -6,7 +6,7 @@ import android.view.View;
 
 public class DecoratedBarcodeView extends com.journeyapps.barcodescanner.DecoratedBarcodeView {
 
-    public static boolean TEST = false;
+    public static boolean test;
 
     public DecoratedBarcodeView(Context context) {
         super(context);
@@ -24,7 +24,7 @@ public class DecoratedBarcodeView extends com.journeyapps.barcodescanner.Decorat
     }
 
     private void initialize() {
-        if (TEST) {
+        if (test) {
             setVisibility(View.INVISIBLE);
         }
     }

--- a/collect_app/src/main/res/layout/qr_code_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/qr_code_project_creator_dialog_layout.xml
@@ -46,7 +46,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <com.journeyapps.barcodescanner.DecoratedBarcodeView
+            <org.odk.collect.android.views.DecoratedBarcodeView
                 android:id="@+id/barcode_view"
                 app:layout_constraintWidth_percent="0.75"
                 app:layout_constraintDimensionRatio="w,1:1"

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormsProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormsProviderTest.java
@@ -38,9 +38,9 @@ import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_FORM
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_VERSION;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LANGUAGE;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.MD5_HASH;
-import static org.odk.collect.android.external.FormsProviderAPI.CONTENT_ITEM_TYPE;
-import static org.odk.collect.android.external.FormsProviderAPI.CONTENT_TYPE;
-import static org.odk.collect.android.external.FormsProviderAPI.getUri;
+import static org.odk.collect.android.external.FormsContract.CONTENT_ITEM_TYPE;
+import static org.odk.collect.android.external.FormsContract.CONTENT_TYPE;
+import static org.odk.collect.android.external.FormsContract.getUri;
 
 @RunWith(AndroidJUnit4.class)
 public class FormsProviderTest {

--- a/collect_app/src/test/java/org/odk/collect/android/external/InstanceProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/external/InstanceProviderTest.java
@@ -39,9 +39,9 @@ import static org.odk.collect.android.database.instances.DatabaseInstanceColumns
 import static org.odk.collect.android.database.instances.DatabaseInstanceColumns.JR_VERSION;
 import static org.odk.collect.android.database.instances.DatabaseInstanceColumns.LAST_STATUS_CHANGE_DATE;
 import static org.odk.collect.android.database.instances.DatabaseInstanceColumns.STATUS;
-import static org.odk.collect.android.external.InstanceProviderAPI.CONTENT_ITEM_TYPE;
-import static org.odk.collect.android.external.InstanceProviderAPI.CONTENT_TYPE;
-import static org.odk.collect.android.external.InstanceProviderAPI.getUri;
+import static org.odk.collect.android.external.InstancesContract.CONTENT_ITEM_TYPE;
+import static org.odk.collect.android.external.InstancesContract.CONTENT_TYPE;
+import static org.odk.collect.android.external.InstancesContract.getUri;
 import static org.odk.collect.forms.instances.Instance.STATUS_COMPLETE;
 import static org.odk.collect.forms.instances.Instance.STATUS_INCOMPLETE;
 import static org.odk.collect.forms.instances.Instance.STATUS_SUBMITTED;
@@ -336,7 +336,7 @@ public class InstanceProviderTest {
         addInstanceToDb(firstProjectId, "/blah1", "Instance A");
         CollectHelpers.createProject(new Project.New("Another Project", "A", "#ffffff"));
 
-        Uri uriWithProject = InstanceProviderAPI.getUri("blah");
+        Uri uriWithProject = InstancesContract.getUri("blah");
         Uri uriWithoutProject = new Uri.Builder()
                 .scheme(uriWithProject.getScheme())
                 .authority(uriWithProject.getAuthority())

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsUpdaterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsUpdaterTest.kt
@@ -18,7 +18,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.odk.collect.analytics.Analytics
-import org.odk.collect.android.external.FormsProviderAPI
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusAppState
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.notifications.Notifier
@@ -80,14 +80,14 @@ class FormsUpdaterTest {
 
         val contentObserver = mock<ContentObserver>()
         application.contentResolver.registerContentObserver(
-            FormsProviderAPI.getUri(project.uuid),
+            FormsContract.getUri(project.uuid),
             false,
             contentObserver
         )
 
         updateManager.downloadUpdates(project.uuid)
 
-        verify(contentObserver).dispatchChange(false, FormsProviderAPI.getUri(project.uuid))
+        verify(contentObserver).dispatchChange(false, FormsContract.getUri(project.uuid))
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusAppStateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusAppStateTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusAppState;
-import org.odk.collect.android.external.FormsProviderAPI;
+import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.forms.FormSourceException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -80,6 +80,6 @@ public class SyncStatusAppStateTest {
         SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
         syncStatusAppState.startSync("projectId");
         syncStatusAppState.finishSync("projectId", null);
-        verify(contentResolver).notifyChange(FormsProviderAPI.getUri("projectId"), null);
+        verify(contentResolver).notifyChange(FormsContract.getUri("projectId"), null);
     }
 }


### PR DESCRIPTION
Closes #4703
Closes #4704

This ended up being pretty easy as forms and instances can very simply share the implementation for `EDIT` actions and it turns out `PICK` was already working due to us removing the old `CONTENT_URI` constants from the instances and forms contracts.

Interestingly, it looks like we don't actually support `PICK` for instances. Instead of fixing this, I propose we just amend our docs.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I'll leave comments inline on anything that stands out.

One thing to point out is there are two commits here dedicated to speeding up tests. I noticed that tests that added a project were running really slowly and found that, other than the disk write time, the slowness was caused by two things:

1. Waiting for the QR code scanner view to initialize
2. Repeatedly asking Android for the phone number while importing settings

It turns out that 1 can be fixed simply by making the view invisible in test (we stub out the decoder anyway) and that 2 could be solved by caching the phone number statically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Again, we'll test this as part of general regression.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

https://github.com/getodk/docs/issues/1375

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)