### PR TITLE
Project delete does not fully clear state

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -590,8 +590,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ProjectDeleter providesProjectDeleter(ProjectsRepository projectsRepository, CurrentProjectProvider currentProjectProvider, FormUpdateScheduler formUpdateScheduler, InstanceSubmitScheduler instanceSubmitScheduler, InstancesRepositoryProvider instancesRepositoryProvider, StoragePathProvider storagePathProvider, ChangeLockProvider changeLockProvider) {
-        return new ProjectDeleter(projectsRepository, currentProjectProvider, formUpdateScheduler, instanceSubmitScheduler, instancesRepositoryProvider.get(), storagePathProvider.getProjectRootDirPath(currentProjectProvider.getCurrentProject().getUuid()), changeLockProvider);
+    public ProjectDeleter providesProjectDeleter(ProjectsRepository projectsRepository, CurrentProjectProvider currentProjectProvider, FormUpdateScheduler formUpdateScheduler, InstanceSubmitScheduler instanceSubmitScheduler, InstancesRepositoryProvider instancesRepositoryProvider, StoragePathProvider storagePathProvider, ChangeLockProvider changeLockProvider, SettingsProvider settingsProvider) {
+        return new ProjectDeleter(projectsRepository, currentProjectProvider, formUpdateScheduler, instanceSubmitScheduler, instancesRepositoryProvider.get(), storagePathProvider.getProjectRootDirPath(currentProjectProvider.getCurrentProject().getUuid()), changeLockProvider, settingsProvider);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.projects
 
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
+import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.utilities.ChangeLockProvider
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.forms.instances.InstancesRepository
@@ -16,7 +17,8 @@ class ProjectDeleter(
     private val instanceSubmitScheduler: InstanceSubmitScheduler,
     private val instancesRepository: InstancesRepository,
     private val projectDirPath: String,
-    private val changeLockProvider: ChangeLockProvider
+    private val changeLockProvider: ChangeLockProvider,
+    private val settingsProvider: SettingsProvider
 ) {
     fun deleteCurrentProject(): DeleteProjectResult {
         return when {
@@ -50,6 +52,9 @@ class ProjectDeleter(
 
         formUpdateScheduler.cancelUpdates(currentProject.uuid)
         instanceSubmitScheduler.cancelSubmit(currentProject.uuid)
+
+        settingsProvider.getGeneralSettings(currentProject.uuid).clear()
+        settingsProvider.getAdminSettings(currentProject.uuid).clear()
 
         projectsRepository.delete(currentProject.uuid)
 

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectDeleterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectDeleterTest.kt
@@ -13,6 +13,10 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
+import org.odk.collect.android.preferences.keys.AdminKeys
+import org.odk.collect.android.preferences.keys.GeneralKeys
+import org.odk.collect.android.preferences.keys.MetaKeys
+import org.odk.collect.android.support.InMemSettingsProvider
 import org.odk.collect.android.utilities.ChangeLockProvider
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.formstest.InMemInstancesRepository
@@ -37,6 +41,7 @@ class ProjectDeleterTest {
         on { getFormLock(any()) } doReturn BooleanChangeLock()
         on { getInstanceLock(any()) } doReturn BooleanChangeLock()
     }
+    private val settingsProvider = InMemSettingsProvider()
 
     @Before
     fun setup() {
@@ -58,7 +63,8 @@ class ProjectDeleterTest {
             mock(),
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         deleter.deleteCurrentProject()
@@ -81,7 +87,8 @@ class ProjectDeleterTest {
             mock(),
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         deleter.deleteCurrentProject()
@@ -104,7 +111,8 @@ class ProjectDeleterTest {
             mock(),
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         deleter.deleteCurrentProject()
@@ -127,7 +135,8 @@ class ProjectDeleterTest {
             instanceSubmitScheduler,
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -150,7 +159,8 @@ class ProjectDeleterTest {
             instanceSubmitScheduler,
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -172,7 +182,8 @@ class ProjectDeleterTest {
             instanceSubmitScheduler,
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -189,12 +200,50 @@ class ProjectDeleterTest {
             instanceSubmitScheduler,
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         deleter.deleteCurrentProject()
         verify(formUpdateManager).cancelUpdates(project1.uuid)
         verify(instanceSubmitScheduler).cancelSubmit(project1.uuid)
+    }
+
+    @Test
+    fun `Deleting project clears its settings`() {
+        settingsProvider.getMetaSettings().save(MetaKeys.KEY_INSTALL_ID, "1234")
+
+        settingsProvider.getGeneralSettings("1").save(GeneralKeys.KEY_SERVER_URL, "https://my-server.com")
+        settingsProvider.getAdminSettings("1").save(AdminKeys.KEY_AUTOSEND, false)
+
+        settingsProvider.getGeneralSettings("2").save(GeneralKeys.KEY_SERVER_URL, "https://my-server.com")
+        settingsProvider.getAdminSettings("2").save(AdminKeys.KEY_AUTOSEND, false)
+
+        val deleter = ProjectDeleter(
+            mock(),
+            currentProjectProvider,
+            mock(),
+            mock(),
+            mock(),
+            "",
+            changeLockProvider,
+            settingsProvider
+        )
+
+        deleter.deleteCurrentProject()
+
+        assertThat(settingsProvider.getMetaSettings().getString(MetaKeys.KEY_INSTALL_ID), `is`("1234"))
+
+        settingsProvider.getGeneralSettings("1").getAll().forEach { (key, value) ->
+            assertThat(value, `is`(GeneralKeys.getDefaults()[key]))
+        }
+
+        settingsProvider.getAdminSettings("1").getAll().forEach { (key, value) ->
+            assertThat(value, `is`(AdminKeys.getDefaults()[key]))
+        }
+
+        assertThat(settingsProvider.getGeneralSettings("2").getString(GeneralKeys.KEY_SERVER_URL), `is`("https://my-server.com"))
+        assertThat(settingsProvider.getAdminSettings("2").getBoolean(AdminKeys.KEY_AUTOSEND), `is`(false))
     }
 
     @Test
@@ -206,7 +255,8 @@ class ProjectDeleterTest {
             mock(),
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -226,7 +276,8 @@ class ProjectDeleterTest {
             mock(),
             instancesRepository,
             "",
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         val result = deleter.deleteCurrentProject()
@@ -250,7 +301,8 @@ class ProjectDeleterTest {
             mock(),
             instancesRepository,
             projectDir.absolutePath,
-            changeLockProvider
+            changeLockProvider,
+            settingsProvider
         )
 
         deleter.deleteCurrentProject()


### PR DESCRIPTION
Closes #4710 

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I added clearing settings for the project that we remove in `ProjectDeleter` which is responsible for deleting. This is the best place and I can't think of any better solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a pretty safe and isolated change so we just need to verify that the bug does not exist and that's it.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)