### PR TITLE
Prevent support/feature posts being filed as issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links: 
+  - name: "Report an issue"
+    about: "For when Collect is behaving in an unexpected way"
+    url: "https://forum.getodk.org/c/support/6"
+  - name: "Request a feature"
+    about: "For when Collect is missing functionality"
+    url: "https://forum.getodk.org/c/features/9"
+  - name: "Everything else"
+    about: "For everything else"
+    url: "https://forum.getodk.org/c/support/6"


### PR DESCRIPTION
Matches what we do at https://github.com/getodk/central/blob/master/.github/ISSUE_TEMPLATE/config.yml.

I've left the issue template as is, but glad to reduce the language there.