### PR TITLE
Do not dismiss QrCodeProjectCreatorDialog when camera permission is not granted

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -118,7 +118,6 @@ class QrCodeProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
                 }
 
                 override fun denied() {
-                    dismiss()
                 }
             }
         )

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -24,7 +24,10 @@ import org.mockito.kotlin.mock
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.MainMenuActivity
 import org.odk.collect.android.configure.SettingsImporter
+import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.android.injection.config.AppDependencyModule
+import org.odk.collect.android.permissions.PermissionsChecker
+import org.odk.collect.android.permissions.PermissionsProvider
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.utilities.CodeCaptureManagerFactory
@@ -36,14 +39,30 @@ import org.odk.collect.testshared.RobolectricHelpers
 class QrCodeProjectCreatorDialogTest {
 
     private val codeCaptureManagerFactory: CodeCaptureManagerFactory = mock {}
+    private val permissionsProvider = FakePermissionsProvider()
 
     @Before
     fun setup() {
+        permissionsProvider.setPermissionGranted(true)
+
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
             override fun providesCodeCaptureManagerFactory(): CodeCaptureManagerFactory {
                 return codeCaptureManagerFactory
             }
+
+            override fun providesPermissionsProvider(permissionsChecker: PermissionsChecker?): PermissionsProvider {
+                return permissionsProvider
+            }
         })
+    }
+
+    @Test
+    fun `If camera permission is not granted the dialog should not be dismissed`() {
+        permissionsProvider.setPermissionGranted(false)
+        val scenario = RobolectricHelpers.launchDialogFragmentInContainer(QrCodeProjectCreatorDialog::class.java, R.style.Theme_MaterialComponents)
+        scenario.onFragment {
+            assertThat(it.isVisible, `is`(true))
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #4721

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a simple fix so it's the only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe and simple fix so verifying that the issue no longer exist would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)