### PR TITLE
Pass intent extras on to support submission edit and view

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.java
@@ -70,7 +70,8 @@ public class SendFinalizedFormTest {
 
                 .clickViewSentForm(1)
                 .clickOnForm("One Question")
-                .assertText("123");
+                .assertText("123")
+                .assertText(R.string.exit);
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -33,6 +33,7 @@ class FormUriActivity : Activity() {
             startActivity(
                 Intent(this, FormEntryActivity::class.java).also {
                     it.data = formUri
+                    intent.extras?.let { sourceExtras -> it.putExtras(sourceExtras) }
                 }
             )
         } else {


### PR DESCRIPTION
Closes #4722 

#### What has been done to verify that this works as intended?
Added a step to the view sent form test to verify that the hierarchy view is in view-only mode. Manually tried:
- Disallow backwards navigation, save an instance as not finalized, verify it can't be edited from the instance map
- Save an instance as finalized, send it, view it, verify it can't be edited

#### Why is this the best possible solution? Were any other approaches considered?
This maintains the same strategy for expressing view vs. edit submissions. The use of an extra here is fundamentally strange, I think. I've filed that under https://github.com/getodk/collect/issues/4728 for later consideration because there's no need to take on additional risk now.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is small and non-invasive. I don't think there's any regression risk. However, seeing this issue makes me think there could be other regressions related to external apps calling into Collect.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)