### PR TITLE
Remove cache folder instead of migrating

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingProjectMigrator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingProjectMigrator.kt
@@ -46,7 +46,6 @@ class ExistingProjectMigrator(
             File(rootDir, "instances"),
             File(rootDir, "metadata"),
             File(rootDir, "layers"),
-            File(rootDir, ".cache"),
             File(rootDir, "settings")
         ).forEach {
             try {
@@ -56,6 +55,8 @@ class ExistingProjectMigrator(
                 // Original dir doesn't exist - no  need to copy
             }
         }
+
+        FileUtils.deleteDirectory(File(rootDir, ".cache"))
 
         val adminSharedPrefs = context.getSharedPreferences("admin_prefs", Context.MODE_PRIVATE)
         settingsProvider.getGeneralSettings(project.uuid).saveAll(generalSharedPrefs.all)

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ExistingProjectMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ExistingProjectMigratorTest.kt
@@ -52,7 +52,6 @@ class ExistingProjectMigratorTest {
             File(rootDir, "instances"),
             File(rootDir, "metadata"),
             File(rootDir, "layers"),
-            File(rootDir, ".cache"),
             File(rootDir, "settings")
         )
 
@@ -72,7 +71,28 @@ class ExistingProjectMigratorTest {
             val dir = File(it)
             assertThat(dir.exists(), `is`(true))
             assertThat(dir.isDirectory, `is`(true))
-            assertThat(dir.listFiles()!!.isEmpty(), `is`(false))
+            if (!it.endsWith("cache")) {
+                assertThat(dir.listFiles()!!.isEmpty(), `is`(false))
+            }
+        }
+    }
+
+    @Test
+    fun `deletes and does not move cache directory`() {
+        val cacheDir = File(rootDir, ".cache")
+        cacheDir.mkdir()
+        TempFiles.createTempFile(cacheDir, "file", ".temp")
+
+        existingProjectMigrator.run()
+        val existingProject = currentProjectProvider.getCurrentProject()
+
+        assertThat(cacheDir.exists(), `is`(false))
+
+        storagePathProvider.getProjectDirPaths(existingProject.uuid).forEach {
+            val dir = File(it)
+            assertThat(dir.exists(), `is`(true))
+            assertThat(dir.isDirectory, `is`(true))
+            assertThat(dir.listFiles()!!.isEmpty(), `is`(true))
         }
     }
 
@@ -82,7 +102,6 @@ class ExistingProjectMigratorTest {
             File(rootDir, "instances"),
             File(rootDir, "metadata"),
             File(rootDir, "layers"),
-            File(rootDir, ".cache"),
             File(rootDir, "settings")
         )
 
@@ -98,7 +117,7 @@ class ExistingProjectMigratorTest {
             assertThat(dir.exists(), `is`(true))
             assertThat(dir.isDirectory, `is`(true))
 
-            if (it.endsWith("forms")) {
+            if (it.endsWith("forms") || it.endsWith("cache")) {
                 assertThat(dir.listFiles()!!.isEmpty(), `is`(true))
             } else {
                 assertThat(dir.listFiles()!!.isEmpty(), `is`(false))


### PR DESCRIPTION
Closes #4733

#### What has been done to verify that this works as intended?
Modified `ExistingProjectMigratorTest` to reflect new intended behavior.

Deleted everything in `/sdcard/Android/data/org.odk.collect.android/files`. Filled [this simple select form](https://docs.google.com/spreadsheets/d/1wHRc5fDUZc06EyEPaGPP90uG-QgpLkuDkG6XIH5Hft0/edit#gid=0) in v1.30.1. Installed from this branch. Verified that the newly-migrated cache folder is empty. Note that this can be difficult to reproduce because meta settings stick around in ways I don't quite understand. I ended up having to change some manually.

#### Why is this the best possible solution? Were any other approaches considered?
I considered making changes to the way internal secondary instances are cached instead. I think we should possibly revisit that at some point but now doesn't feel like a good time. Blowing away the cache seems reasonable when we're making such a big change to the app.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intention is that folks who have cached files with selects in v1.30 or earlier will be able to use their forms without error after upgrading. A side effect of this change is that form load may be slower the first time each form is launched in v2021.2. I don't think this is significant enough to be a problem.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with an internal secondary instance. See issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)