### PR TITLE
Fix updating media files

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -430,7 +430,7 @@ public class ServerFormDownloader implements FormDownloader {
 
         if (mediaFiles != null && mediaFiles.length != 0) {
             for (File mediaFile : mediaFiles) {
-                org.apache.commons.io.FileUtils.moveFileToDirectory(mediaFile, formMediaPath, true);
+                org.apache.commons.io.FileUtils.copyFileToDirectory(mediaFile, formMediaPath);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -394,9 +394,7 @@ public class ServerFormDownloader implements FormDownloader {
                 String downloadFileHash = getMd5HashWithoutPrefix(toDownload.getHash());
 
                 if (currentFileHash != null && downloadFileHash != null && !currentFileHash.contentEquals(downloadFileHash)) {
-                    // if the hashes match, it's the same file
-                    // otherwise delete our current one and replace it with the new one
-                    FileUtils.deleteAndReport(finalMediaFile);
+                    // if the hashes match, it's the same file otherwise replace it with the new one
                     InputStream mediaFile = formSource.fetchMediaFile(toDownload.getDownloadUrl());
                     writeFile(mediaFile, tempMediaFile, tempDir, stateListener);
                 } else {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -4,16 +4,16 @@ import org.jetbrains.annotations.NotNull;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.listeners.FormDownloaderListener;
+import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.android.utilities.FormNameUtils;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormSource;
 import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.forms.MediaFile;
-import org.odk.collect.android.listeners.FormDownloaderListener;
-import org.odk.collect.android.utilities.FileUtils;
-import org.odk.collect.android.utilities.FormNameUtils;
-import org.odk.collect.shared.strings.Validator;
 import org.odk.collect.shared.strings.Md5;
+import org.odk.collect.shared.strings.Validator;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -428,7 +428,13 @@ public class ServerFormDownloader implements FormDownloader {
 
         if (mediaFiles != null && mediaFiles.length != 0) {
             for (File mediaFile : mediaFiles) {
-                org.apache.commons.io.FileUtils.copyFileToDirectory(mediaFile, formMediaPath);
+                try {
+                    org.apache.commons.io.FileUtils.copyFileToDirectory(mediaFile, formMediaPath);
+                } catch (IllegalArgumentException e) {
+                    // This can happen if copyFileToDirectory is pointed at a file instead of a dir
+                    throw new IOException(e);
+                }
+
             }
         }
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -299,7 +299,7 @@ public class ServerFormDownloaderTest {
     }
 
     @Test
-    public void whenFormHasMediaFiles_andWritingMediaFilesFails_throwsFormDownloadExceptionAndDoesNotSaveAnything() throws Exception {
+    public void whenFormHasMediaFiles_andFileExistsInMediaDirPath_throwsFormDownloadExceptionAndDoesNotSaveAnything() throws Exception {
         String xform = createXFormBody("id", "version");
         ServerFormDetails serverFormDetails = new ServerFormDetails(
                 "Form",


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I verified the fix manually and we have new tests.

#### Why is this the best possible solution? Were any other approaches considered?
As we discussed on slack we should not care about deleting outdated media files before updating them. They should be just replaced using `org.apache.commons.io.FileUtils.copyFileToDirectory` to avoid `FileExistsException`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We don't need to tests it.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)