### PR TITLE
Catch exceptions creating project name file

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectDisplayPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectDisplayPreferencesFragment.kt
@@ -18,11 +18,13 @@ import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.MultiClickGuard
+import org.odk.collect.android.utilities.StringUtils
 import org.odk.collect.androidshared.ColorPickerDialog
 import org.odk.collect.androidshared.ColorPickerViewModel
 import org.odk.collect.androidshared.ui.OneSignTextWatcher
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
+import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
@@ -137,8 +139,17 @@ class ProjectDisplayPreferencesFragment :
             PROJECT_NAME_KEY -> {
                 Analytics.log(AnalyticsEvents.CHANGE_PROJECT_NAME)
 
-                File(storagePathProvider.getProjectRootDirPath() + File.separator + name).delete()
-                File(storagePathProvider.getProjectRootDirPath() + File.separator + newValue).createNewFile()
+                try {
+                    File(storagePathProvider.getProjectRootDirPath() + File.separator + name).delete()
+                } catch (e: Exception) {
+                    Timber.e(StringUtils.getFilenameError(name))
+                }
+
+                try {
+                    File(storagePathProvider.getProjectRootDirPath() + File.separator + newValue).createNewFile()
+                } catch (e: Exception) {
+                    Timber.e(StringUtils.getFilenameError(newValue as String))
+                }
 
                 projectsRepository.save(
                     Project.Saved(

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectCreator.kt
@@ -2,7 +2,9 @@ package org.odk.collect.android.projects
 
 import org.odk.collect.android.configure.SettingsImporter
 import org.odk.collect.android.storage.StoragePathProvider
+import org.odk.collect.android.utilities.StringUtils
 import org.odk.collect.projects.ProjectsRepository
+import timber.log.Timber
 import java.io.File
 
 class ProjectCreator(
@@ -20,7 +22,11 @@ class ProjectCreator(
 
         return if (settingsImportedSuccessfully) {
             currentProjectProvider.setCurrentProject(savedProject.uuid)
-            File((storagePathProvider.getProjectRootDirPath() + File.separator + currentProjectProvider.getCurrentProject().name)).createNewFile()
+            try {
+                File((storagePathProvider.getProjectRootDirPath() + File.separator + currentProjectProvider.getCurrentProject().name)).createNewFile()
+            } catch (e: Exception) {
+                Timber.e(StringUtils.getFilenameError(currentProjectProvider.getCurrentProject().name))
+            }
             true
         } else {
             projectsRepository.delete(savedProject.uuid)

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/StringUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/StringUtils.java
@@ -18,6 +18,8 @@ import android.text.Html;
 
 import androidx.annotation.NonNull;
 
+import com.google.common.base.CharMatcher;
+
 import java.util.Iterator;
 import java.util.regex.MatchResult;
 
@@ -189,6 +191,14 @@ public class StringUtils {
         }
 
         return str;
+    }
+
+    public static String getFilenameError(String filename) {
+        String possiblyRestricted = "?:\"*|/\\<>\u0000";
+        boolean containsAt = filename.contains("@");
+        boolean containsNonAscii = CharMatcher.ascii().matchesAllOf(filename);
+        boolean containsPossiblyRestricted = CharMatcher.anyOf(possiblyRestricted).matchesAnyOf(possiblyRestricted);
+        return "Problem with project name file. Contains @: " + containsAt + ", Contains non-ascii: " + containsNonAscii + ", Contains restricted: " + containsPossiblyRestricted;
     }
 }
 


### PR DESCRIPTION
Closes #4747

#### What has been done to verify that this works as intended?
Ensured the app compiles and runs. We can't reproduce this so it's the best we can do.

#### Why is this the best possible solution? Were any other approaches considered?
The goal for now is to not block on creating this file and to learn more about why there might be an exception. @seadowg and I briefly considered escaping the project name in some way but we don't know enough about what's causing the issue to know how to do so. Something like URL-encoding would distort the name to the point of being unusable in many cases. It doesn't seem like a good option given that all the devices we've tried can write any filename we can think of.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
All this does is wrap non-essential behavior in try/catch. It should just mean that users who have experienced crashes no longer do and should present no regression risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)