### PR TITLE
Do not crash if the old cache folder can't be deleted

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingProjectMigrator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingProjectMigrator.kt
@@ -56,7 +56,11 @@ class ExistingProjectMigrator(
             }
         }
 
-        FileUtils.deleteDirectory(File(rootDir, ".cache"))
+        try {
+            FileUtils.deleteDirectory(File(rootDir, ".cache"))
+        } catch (e: Exception) {
+            // ignore
+        }
 
         val adminSharedPrefs = context.getSharedPreferences("admin_prefs", Context.MODE_PRIVATE)
         settingsProvider.getGeneralSettings(project.uuid).saveAll(generalSharedPrefs.all)

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ExistingProjectMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ExistingProjectMigratorTest.kt
@@ -97,6 +97,24 @@ class ExistingProjectMigratorTest {
     }
 
     @Test
+    fun `if cache dir can not be deleted the app does not crash`() {
+        val cacheDir = File(rootDir, ".cache")
+        cacheDir.createNewFile()
+
+        existingProjectMigrator.run()
+        val existingProject = currentProjectProvider.getCurrentProject()
+
+        assertThat(cacheDir.exists(), `is`(true))
+
+        storagePathProvider.getProjectDirPaths(existingProject.uuid).forEach {
+            val dir = File(it)
+            assertThat(dir.exists(), `is`(true))
+            assertThat(dir.isDirectory, `is`(true))
+            assertThat(dir.listFiles()!!.isEmpty(), `is`(true))
+        }
+    }
+
+    @Test
     fun `still copies other files if a directory is missing`() {
         val legacyRootDirsWithoutForms = listOf(
             File(rootDir, "instances"),


### PR DESCRIPTION
Closes #4751

#### What has been done to verify that this works as intended?
I just reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
Catching exception should be a sufficient solution since it's not a big problem if we don't remove the old cache folder.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)