### PR TITLE
Fixed No Activity found to handle CHOOSE_ACCOUNT Intent

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -26,6 +26,7 @@ import org.odk.collect.android.permissions.PermissionsProvider
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.MATCHING_PROJECT
 import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.SETTINGS_JSON
+import org.odk.collect.android.utilities.ActivityAvailability
 import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.SoftKeyboardController
 import org.odk.collect.android.utilities.ToastUtils
@@ -59,6 +60,9 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
 
     @Inject
     lateinit var settingsProvider: SettingsProvider
+
+    @Inject
+    lateinit var activityAvailability: ActivityAvailability
 
     lateinit var settingsConnectionMatcher: SettingsConnectionMatcher
 
@@ -167,7 +171,11 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
             object : PermissionListener {
                 override fun granted() {
                     val intent: Intent = googleAccountsManager.accountChooserIntent
-                    googleAccountResultLauncher.launch(intent)
+                    if (activityAvailability.isActivityAvailable(intent)) {
+                        googleAccountResultLauncher.launch(intent)
+                    } else {
+                        ToastUtils.showShortToast(getString(R.string.activity_not_found, getString(R.string.choose_account)))
+                    }
                 }
 
                 override fun denied() {

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
 
     <string name="capture_image">Take Picture</string>
     <string name="choose_image">Choose Image</string>
+    <string name="choose_account">Choose account</string>
     <string name="selected_invalid_image">Selected file is not a valid image</string>
     <string name="view_image">View Image</string>
     <string name="take_picture_instruction">Tap the screen to take a picture</string>


### PR DESCRIPTION
Closes #4753 

#### What has been done to verify that this works as intended?
I added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
If the activity to choose google account can't be found somehow handling this case and displaying a toast is the only solution. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's probably difficult to reproduce but I remember that @mmarciniak90 tested something like this so if it' possible let's test it.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)