### PR TITLE
Fixed enable auto-send schedules submission of completed forms #3980

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.R;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.NotificationDrawerRule;
 import org.odk.collect.android.support.TestDependencies;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.NotificationDrawerRule;
 import org.odk.collect.android.support.TestDependencies;
@@ -61,6 +62,27 @@ public class AutoSendTest {
         mainMenuPage
                 .clickViewSentForm(1)
                 .assertText("One Question Autosend");
+
+        notificationDrawerRule.open()
+                .assertAndDismissNotification("ODK Collect", "ODK auto-send results", "Success");
+    }
+
+    @Test
+    public void whenFormIsFinalized_enablingAutoSend_schedulesSubmitFinalizedForm() {
+        MainMenuPage mainMenuPage = rule.startAtMainMenu()
+                .setServer(testDependencies.server.getURL())
+                .copyForm("one-question.xml")
+                .startBlankForm("One Question")
+                .inputText("31")
+                .swipeToEndScreen()
+                .clickSaveAndExit()
+                .enableAutoSend();
+
+        testDependencies.scheduler.runDeferredTasks();
+
+        mainMenuPage
+                .clickViewSentForm(1)
+                .assertText("One Question");
 
         notificationDrawerRule.open()
                 .assertAndDismissNotification("ODK Collect", "ODK auto-send results", "Success");

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.java
@@ -65,25 +65,4 @@ public class AutoSendTest {
         notificationDrawerRule.open()
                 .assertAndDismissNotification("ODK Collect", "ODK auto-send results", "Success");
     }
-
-    @Test
-    public void whenFormIsFinalized_enablingAutoSend_schedulesSubmitFinalizedForm() {
-        MainMenuPage mainMenuPage = rule.startAtMainMenu()
-                .setServer(testDependencies.server.getURL())
-                .copyForm("one-question.xml")
-                .startBlankForm("One Question")
-                .inputText("31")
-                .swipeToEndScreen()
-                .clickSaveAndExit()
-                .enableAutoSend();
-
-        testDependencies.scheduler.runDeferredTasks();
-
-        mainMenuPage
-                .clickViewSentForm(1)
-                .assertText("One Question");
-
-        notificationDrawerRule.open()
-                .assertAndDismissNotification("ODK Collect", "ODK auto-send results", "Success");
-    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormManagementPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormManagementPage.java
@@ -19,4 +19,9 @@ public class FormManagementPage extends Page<FormManagementPage> {
         clickOnString(R.string.form_update_frequency_title);
         return new ListPreferenceDialog<>(R.string.form_update_frequency_title, this).assertOnPage();
     }
+
+    public ListPreferenceDialog<FormManagementPage> clickAutoSend() {
+        clickOnString(R.string.autosend);
+        return new ListPreferenceDialog<>(R.string.autosend, this).assertOnPage();
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragment.java
@@ -28,6 +28,7 @@ import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler;
+import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler;
 import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.shared.Settings;
 
@@ -53,6 +54,9 @@ public class FormManagementPreferencesFragment extends BaseProjectPreferencesFra
 
     @Inject
     FormUpdateScheduler formUpdateScheduler;
+
+    @Inject
+    InstanceSubmitScheduler instanceSubmitScheduler;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -81,6 +85,10 @@ public class FormManagementPreferencesFragment extends BaseProjectPreferencesFra
 
         if (key.equals(KEY_FORM_UPDATE_MODE) || key.equals(KEY_PERIODIC_FORM_UPDATES_CHECK)) {
             updateDisabledPrefs();
+        }
+
+        if (key.equals(KEY_AUTOSEND) && !settingsProvider.getGeneralSettings().getString(KEY_AUTOSEND).equals("off")) {
+            instanceSubmitScheduler.scheduleSubmit(currentProjectProvider.getCurrentProject().getUuid());
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
@@ -506,7 +506,7 @@ class FormManagementPreferencesFragmentTest {
 
         val scenario = FragmentScenario.launch(FormManagementPreferencesFragment::class.java)
         scenario.onFragment { fragment: FormManagementPreferencesFragment ->
-            generalSettings.save(ProjectKeys.KEY_AUTOSEND, "wifi")
+            fragment.findPreference<ListPreference>(ProjectKeys.KEY_AUTOSEND)!!.value = "wifi"
         }
         verify(instanceSubmitScheduler).scheduleSubmit(projectID)
     }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.preferences.screens
 
+import android.app.Application
 import android.content.Context
 import android.os.Looper
 import androidx.fragment.app.testing.FragmentScenario
@@ -17,20 +18,25 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.odk.collect.android.R
 import org.odk.collect.android.TestSettingsProvider
+import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.FormUpdateMode
 import org.odk.collect.android.preferences.ProjectPreferencesViewModel
 import org.odk.collect.android.preferences.keys.ProjectKeys
 import org.odk.collect.android.preferences.keys.ProtectedProjectKeys
+import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.utilities.AdminPasswordProvider
+import org.odk.collect.async.Scheduler
 import org.odk.collect.shared.Settings
 import org.robolectric.Shadows
 
 @RunWith(AndroidJUnit4::class)
 class FormManagementPreferencesFragmentTest {
+    private lateinit var projectID: String
     private lateinit var context: Context
     private lateinit var generalSettings: Settings
     private lateinit var adminSettings: Settings
@@ -38,6 +44,8 @@ class FormManagementPreferencesFragmentTest {
     private val adminPasswordProvider = mock<AdminPasswordProvider> {
         on { isAdminPasswordSet } doReturn false
     }
+    private val instanceSubmitScheduler = mock<InstanceSubmitScheduler>()
+
     private val projectPreferencesViewModel = ProjectPreferencesViewModel(adminPasswordProvider)
 
     @Before
@@ -50,9 +58,13 @@ class FormManagementPreferencesFragmentTest {
                     }
                 }
             }
+
+            override fun providesFormSubmitManager(scheduler: Scheduler, settingsProvider: SettingsProvider, application: Application): InstanceSubmitScheduler {
+                return instanceSubmitScheduler
+            }
         })
 
-        CollectHelpers.setupDemoProject()
+        projectID = CollectHelpers.setupDemoProject()
         context = ApplicationProvider.getApplicationContext()
         generalSettings = TestSettingsProvider.getGeneralSettings()
         adminSettings = TestSettingsProvider.getAdminSettings()
@@ -486,5 +498,16 @@ class FormManagementPreferencesFragmentTest {
         scenario.onFragment { fragment: FormManagementPreferencesFragment ->
             assertThat(fragment.findPreference<PreferenceCategory>("form_import")!!.isVisible, `is`(true))
         }
+    }
+
+    @Test
+    fun `When Auto send preference is enabled, finalized forms should be scheduled for submission`() {
+        generalSettings.save(ProjectKeys.KEY_AUTOSEND, "off")
+
+        val scenario = FragmentScenario.launch(FormManagementPreferencesFragment::class.java)
+        scenario.onFragment { fragment: FormManagementPreferencesFragment ->
+            generalSettings.save(ProjectKeys.KEY_AUTOSEND, "wifi")
+        }
+        verify(instanceSubmitScheduler).scheduleSubmit(projectID)
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.never
 import org.odk.collect.android.R
 import org.odk.collect.android.TestSettingsProvider
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
@@ -509,5 +510,16 @@ class FormManagementPreferencesFragmentTest {
             fragment.findPreference<ListPreference>(ProjectKeys.KEY_AUTOSEND)!!.value = "wifi"
         }
         verify(instanceSubmitScheduler).scheduleSubmit(projectID)
+    }
+
+    @Test
+    fun `When Auto send preference is disabled, no submissions should be scheduled`() {
+        generalSettings.save(ProjectKeys.KEY_AUTOSEND, "wifi")
+
+        val scenario = FragmentScenario.launch(FormManagementPreferencesFragment::class.java)
+        scenario.onFragment { fragment: FormManagementPreferencesFragment ->
+            fragment.findPreference<ListPreference>(ProjectKeys.KEY_AUTOSEND)!!.value = "off"
+        }
+        verify(instanceSubmitScheduler, never()).scheduleSubmit(projectID)
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
@@ -503,7 +503,6 @@ class FormManagementPreferencesFragmentTest {
 
     @Test
     fun `When Auto send preference is enabled, finalized forms should be scheduled for submission`() {
-        generalSettings.save(ProjectKeys.KEY_AUTOSEND, "off")
 
         val scenario = FragmentScenario.launch(FormManagementPreferencesFragment::class.java)
         scenario.onFragment { fragment: FormManagementPreferencesFragment ->
@@ -514,7 +513,6 @@ class FormManagementPreferencesFragmentTest {
 
     @Test
     fun `When Auto send preference is disabled, no submissions should be scheduled`() {
-        generalSettings.save(ProjectKeys.KEY_AUTOSEND, "wifi")
 
         val scenario = FragmentScenario.launch(FormManagementPreferencesFragment::class.java)
         scenario.onFragment { fragment: FormManagementPreferencesFragment ->

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormManagementPreferencesFragmentTest.kt
@@ -18,8 +18,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.odk.collect.android.R
 import org.odk.collect.android.TestSettingsProvider
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler


### PR DESCRIPTION
Closes #3980 

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Tested manually with device and added both Roboelectric and Espresso tests.

#### Why is this the best possible solution? Were any other approaches considered?

The desired behavior results from a change in the Auto-send form management preference, so it seems appropriate to handle that behavior with `onSettingChange` listener function in `FormManagementPreferencesFragment`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

With this change, any time the Auto-send preference is toggled to something other than "off" a new `submitSchedule` call is made to the `InstanceSubmitScheduler`. I don't think this carries any risk with it, but I am not totally sure. Is it necessary to call `cancelSubmit` if a submission has been scheduled but not yet completed and the user toggles Auto-send to something different?

#### Do we need any specific form for testing your changes? If so, please attach one.

No specific form required.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

No documentation changes required.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)