### PR TITLE
Catch exceptions that might ocurr during updating widgets

### DIFF
--- a/collect_app/src/androidTest/assets/forms/form_design_error.xml
+++ b/collect_app/src/androidTest/assets/forms/form_design_error.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>form_design_error</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="form_design_error">
+                    <group>
+                        <select />
+                        <select2 />
+                    </group>
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <instance id="list">
+                <root>
+                    <item>
+                        <label>A</label>
+                        <name>a</name>
+                    </item>
+                    <item>
+                        <label>B</label>
+                        <name>b</name>
+                    </item>
+                    <item>
+                        <label>C</label>
+                        <name>c</name>
+                    </item>
+                </root>
+            </instance>
+            <instance id="list2">
+                <root>
+                    <item>
+                        <label>AA</label>
+                        <list>a</list>
+                        <name>aa</name>
+                    </item>
+                    <item>
+                        <label>AB</label>
+                        <list>a</list>
+                        <name>ab</name>
+                    </item>
+                    <item>
+                        <label>BA</label>
+                        <list>b</list>
+                        <name>ba</name>
+                    </item>
+                    <item>
+                        <label>BB</label>
+                        <list>b</list>
+                        <name>bb</name>
+                    </item>
+                </root>
+            </instance>
+            <bind nodeset="/data/group/select" type="string" />
+            <bind calculate="concat( /data/group/select , 'a')" nodeset="/data/group/select2" type="string" />
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <group appearance="field-list" ref="/data/group">
+            <select1 appearance="minimal" ref="/data/group/select">
+                <label>Select</label>
+                <item>
+                    <label>A</label>
+                    <value>a</value>
+                </item>
+                <item>
+                    <label>B</label>
+                    <value>b</value>
+                </item>
+                <item>
+                    <label>C</label>
+                    <value>c</value>
+                </item>
+            </select1>
+            <select1 appearance="minimal" ref="/data/group/select2">
+                <label>Select2</label>
+                <itemset nodeset="instance('list2')/root/item[list= /data/group/select ]">
+                    <value ref="name" />
+                    <label ref="label" />
+                </itemset>
+            </select1>
+        </group>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/CatchFormDesignExceptionsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/CatchFormDesignExceptionsTest.kt
@@ -1,0 +1,33 @@
+package org.odk.collect.android.feature.formentry
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.R
+import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.TestRuleChain
+import org.odk.collect.android.support.pages.MainMenuPage
+
+@RunWith(AndroidJUnit4::class)
+class CatchFormDesignExceptionsTest {
+
+    private val rule = CollectTestRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = TestRuleChain.chain().around(rule)
+
+    @Test // https://github.com/getodk/collect/issues/4750
+    fun whenFormHasDesignErrors_explanationDialogShouldBeDisplayedAndTheFormShouldBeClosed() {
+        rule.startAtMainMenu()
+            .copyForm("form_design_error.xml")
+            .clickFillBlankForm()
+            .clickOnForm("form_design_error")
+            .openSelectMinimalDialog()
+            .clickOnText("A")
+            .assertText(R.string.update_widgets_error)
+            .clickOKOnDialog()
+            .assertOnPage(MainMenuPage())
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2511,6 +2511,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     } catch (FormDesignException e) {
                         Timber.e(e);
                         createErrorDialog(e.getMessage(), false);
+                    } catch (Exception | Error e) {
+                        Timber.e(e);
+                        createErrorDialog(getString(R.string.update_widgets_error), true);
                     }
                 }
             });

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -203,6 +203,9 @@
     <!-- Error displayed when opened filled form has been deleted on disk -->
     <string name="instance_deleted_message">Filled form has been deleted!</string>
 
+    <!-- Error displayed when something bad happens during updating widgets in a field-list group -->
+    <string name="update_widgets_error">Failure trying to update values. This is generally because of incorrect usage of calculations in the form design.\n\nIf you keep having this problem, report it to the person who asked you to collect data.</string>
+
     <!--
     ##############################################
     # FORM FEATURES


### PR DESCRIPTION
Closes #4750 

#### What has been done to verify that this works as intended?
I tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
As we discussed in the issue there is no easy way to detect various form design issues. Since the whole field-list has been a source of many issues catching all of them and displaying a message seems to be a bit better than just crashing the app.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe catch that shouldn't affect anything so we can focus on testing the sample form attached to the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)