### PR TITLE
Do not try to set selection passing indexes < 0

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/ThousandsSeparatorTextWatcher.java
@@ -55,7 +55,8 @@ public class ThousandsSeparatorTextWatcher implements TextWatcher {
             }
 
             //setting the cursor back to where it was
-            editText.setSelection(editText.getText().toString().length() - cursorPosition);
+            int selectionIndex = editText.getText().toString().length() - cursorPosition;
+            editText.setSelection(Math.max(selectionIndex, 0));
             editText.addTextChangedListener(this);
         } catch (Exception ex) {
             Timber.e(ex);


### PR DESCRIPTION
Closes #4761 

#### What has been done to verify that this works as intended?
I reproduced the issue and confirmed that the fix does the job.

#### Why is this the best possible solution? Were any other approaches considered?
The issue didn't cause any crash or problem it was a silent exception. I was able to reproduce it by entering a big number and then selecting a part of it and removing at once. Since it didn't cause any problems I don't think we need tests here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)