### PR TITLE
Use expicit intents for FormEntryActivity internally

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.java
@@ -33,6 +33,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.FormListAdapter;
 import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.forms.DatabaseFormColumns;
+import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.formmanagement.BlankFormListMenuDelegate;
 import org.odk.collect.android.formmanagement.BlankFormsListViewModel;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -42,7 +43,6 @@ import org.odk.collect.android.network.NetworkStateProvider;
 import org.odk.collect.android.preferences.dialogs.ServerAuthDialogFragment;
 import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.tasks.FormSyncTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.DialogUtils;
@@ -179,7 +179,9 @@ public class FillBlankFormActivity extends FormListActivity implements
                 setResult(RESULT_OK, new Intent().setData(formUri));
             } else {
                 // caller wants to view/edit a form, so launch formentryactivity
-                Intent intent = new Intent(Intent.ACTION_EDIT, formUri);
+                Intent intent = new Intent(this, FormEntryActivity.class);
+                intent.setAction(Intent.ACTION_EDIT);
+                intent.setData(formUri);
                 intent.putExtra(ApplicationConstants.BundleKeys.FORM_MODE, ApplicationConstants.FormModes.EDIT_SAVED);
                 startActivity(intent);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.java
@@ -35,6 +35,9 @@ import com.google.android.material.chip.Chip;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.FormMapViewModel;
 import org.odk.collect.android.activities.viewmodels.FormMapViewModel.MappableFormInstance;
+import org.odk.collect.android.external.FormsContract;
+import org.odk.collect.android.external.InstanceProvider;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.geo.MapFragment;
 import org.odk.collect.android.geo.MapPoint;
 import org.odk.collect.android.geo.MapProvider;
@@ -42,9 +45,6 @@ import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.keys.ProtectedProjectKeys;
 import org.odk.collect.android.preferences.screens.MapsPreferencesFragment;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.FormsContract;
-import org.odk.collect.android.external.InstanceProvider;
-import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.IconUtils;
@@ -203,7 +203,10 @@ public class FormMapActivity extends BaseGeoMapActivity {
 
         findViewById(R.id.new_instance).setOnClickListener(v -> {
             final Uri formUri = FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), viewModel.getFormId());
-            startActivity(new Intent(Intent.ACTION_EDIT, formUri));
+            Intent intent = new Intent(this, FormEntryActivity.class);
+            intent.setAction(Intent.ACTION_EDIT);
+            intent.setData(formUri);
+            startActivity(intent);
         });
 
         map.setGpsLocationEnabled(true);
@@ -396,7 +399,10 @@ public class FormMapActivity extends BaseGeoMapActivity {
 
     private Intent getEditFormInstanceIntentFor(long instanceId) {
         Uri uri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid(), instanceId);
-        return new Intent(Intent.ACTION_EDIT, uri);
+        Intent intent = new Intent(this, FormEntryActivity.class);
+        intent.setAction(Intent.ACTION_EDIT);
+        intent.setData(uri);
+        return intent;
     }
 
     private void removeEnlargedMarkerIfExist(int newSubmissionId) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -33,9 +33,9 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.forms.instances.Instance;
@@ -125,7 +125,9 @@ public class InstanceChooserList extends InstanceListActivity implements Adapter
                     }
                     // caller wants to view/edit a form, so launch formentryactivity
                     Intent parentIntent = this.getIntent();
-                    Intent intent = new Intent(Intent.ACTION_EDIT, instanceUri);
+                    Intent intent = new Intent(this, FormEntryActivity.class);
+                    intent.setAction(Intent.ACTION_EDIT);
+                    intent.setData(instanceUri);
                     String formMode = parentIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);
                     if (formMode == null || ApplicationConstants.FormModes.EDIT_SAVED.equalsIgnoreCase(formMode)) {
                         intent.putExtra(ApplicationConstants.BundleKeys.FORM_MODE, ApplicationConstants.FormModes.EDIT_SAVED);

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -224,4 +224,17 @@ public class AnalyticsEvents {
      * Tracks how often users reconfigure a project using QR codes
      */
     public static final String RECONFIGURE_PROJECT = "ProjectReconfigure";
+
+    /**
+     * These track how often the external edit or view actions are used for forms or instances.
+     * One event tracks when a project ID is included with the action URI and the other tracks when
+     * it's not included.
+     */
+    public static final String FORM_ACTION_WITH_PROJECT_ID = "FormActionWithProjectId";
+    public static final String FORM_ACTION_WITHOUT_PROJECT_ID = "FormActionWithoutProjectId";
+
+    /**
+     * Tracks how often an external edit or view action includes an extra we'd like to deprecate.
+     */
+    public static final String FORM_ACTION_WITH_FORM_MODE_EXTRA = "FormActionWithFormModeExtra";
 }


### PR DESCRIPTION
Closes #4749

#### What has been done to verify that this works as intended?

Existing tests cover this and no new tests for analytics.

#### Why is this the best possible solution? Were any other approaches considered?

We've discussed in the issue the reasoning behind doing this.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't be any risk as it will only affect internal transitions, which should all be tested. Don't think I see a neeed for QA on this one.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)