### PR TITLE
Content Provider analytics

### DIFF
--- a/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
@@ -8,7 +8,6 @@ interface Analytics {
     fun logEvent(category: String, action: String, label: String)
 
     fun logEvent(event: String)
-    fun logFormEvent(event: String, formIdHash: String)
     fun logEventWithParam(event: String, key: String, value: String)
     fun logFatal(throwable: Throwable)
     fun logNonFatal(message: String)

--- a/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
@@ -9,7 +9,7 @@ interface Analytics {
 
     fun logEvent(event: String)
     fun logFormEvent(event: String, formIdHash: String)
-    fun logServerEvent(event: String, serverHash: String)
+    fun logEventWithParam(event: String, key: String, value: String)
     fun logFatal(throwable: Throwable)
     fun logNonFatal(message: String)
     fun setAnalyticsCollectionEnabled(isAnalyticsEnabled: Boolean)
@@ -29,8 +29,8 @@ interface Analytics {
         }
 
         @JvmStatic
-        fun logServer(event: String, serverHash: String) {
-            instance.logServerEvent(event, serverHash)
+        fun log(event: String, key: String, value: String) {
+            instance.logEventWithParam(event, key, value)
         }
     }
 }

--- a/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/Analytics.kt
@@ -27,5 +27,10 @@ interface Analytics {
         fun log(event: String) {
             instance.logEvent(event)
         }
+
+        @JvmStatic
+        fun logServer(event: String, serverHash: String) {
+            instance.logServerEvent(event, serverHash)
+        }
     }
 }

--- a/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
@@ -30,9 +30,7 @@ class BlockableFirebaseAnalytics(application: Application) : Analytics {
     }
 
     override fun logFormEvent(event: String, formIdHash: String) {
-        val bundle = Bundle()
-        bundle.putString("form", formIdHash)
-        firebaseAnalytics.logEvent(event, bundle)
+        logEventWithParam(event, "form", formIdHash)
     }
 
     override fun logFatal(throwable: Throwable) {
@@ -43,9 +41,9 @@ class BlockableFirebaseAnalytics(application: Application) : Analytics {
         crashlytics.log(message)
     }
 
-    override fun logServerEvent(event: String, serverHash: String) {
+    override fun logEventWithParam(event: String, key: String, value: String) {
         val bundle = Bundle()
-        bundle.putString("server", serverHash)
+        bundle.putString(key, value)
         firebaseAnalytics.logEvent(event, bundle)
     }
 

--- a/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/BlockableFirebaseAnalytics.kt
@@ -29,10 +29,6 @@ class BlockableFirebaseAnalytics(application: Application) : Analytics {
         firebaseAnalytics.logEvent(event, null)
     }
 
-    override fun logFormEvent(event: String, formIdHash: String) {
-        logEventWithParam(event, "form", formIdHash)
-    }
-
     override fun logFatal(throwable: Throwable) {
         crashlytics.recordException(throwable)
     }

--- a/analytics/src/main/java/org/odk/collect/analytics/NoopAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/NoopAnalytics.kt
@@ -5,7 +5,6 @@ class NoopAnalytics : Analytics {
     override fun logEvent(category: String, action: String, label: String) {}
 
     override fun logEvent(event: String) {}
-    override fun logFormEvent(event: String, formIdHash: String) {}
     override fun logEventWithParam(event: String, key: String, value: String) {}
     override fun logFatal(throwable: Throwable) {}
     override fun logNonFatal(message: String) {}

--- a/analytics/src/main/java/org/odk/collect/analytics/NoopAnalytics.kt
+++ b/analytics/src/main/java/org/odk/collect/analytics/NoopAnalytics.kt
@@ -6,9 +6,9 @@ class NoopAnalytics : Analytics {
 
     override fun logEvent(event: String) {}
     override fun logFormEvent(event: String, formIdHash: String) {}
+    override fun logEventWithParam(event: String, key: String, value: String) {}
     override fun logFatal(throwable: Throwable) {}
     override fun logNonFatal(message: String) {}
-    override fun logServerEvent(event: String, serverHash: String) {}
     override fun setAnalyticsCollectionEnabled(isAnalyticsEnabled: Boolean) {}
     override fun setUserProperty(name: String, value: String) {}
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -8,6 +8,8 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.support.ActivityHelpers;
 import org.odk.collect.android.utilities.FlingRegister;
 
+import java.util.concurrent.Callable;
+
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.longClick;
@@ -36,6 +38,12 @@ public class FormEntryPage extends Page<FormEntryPage> {
 
     @Override
     public FormEntryPage assertOnPage() {
+        // Make sure we wait for loading to finish
+        waitFor((Callable<Void>) () -> {
+            assertTextDoesNotExist(R.string.loading_form);
+            return null;
+        });
+
         assertToolbarTitle(formName);
         return this;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -65,6 +65,7 @@ import org.joda.time.LocalDateTime;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AMRAppender;
 import org.odk.collect.android.audio.AudioControllerView;
@@ -803,7 +804,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         switch (requestCode) {
             case RequestCodes.OSM_CAPTURE:
-                analytics.logFormEvent(OPEN_MAP_KIT_RESPONSE, Collect.getCurrentFormIdentifierHash());
+                AnalyticsUtils.logFormEvent(OPEN_MAP_KIT_RESPONSE);
                 setWidgetData(intent.getStringExtra("OSM_FILE_NAME"));
                 break;
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:
@@ -1527,7 +1528,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     List<TreeElement> attrs = p.getBindAttributes();
                     for (int i = 0; i < attrs.size(); i++) {
                         if (!autoSaved && "saveIncomplete".equals(attrs.get(i).getName())) {
-                            analytics.logEvent(SAVE_INCOMPLETE, "saveIncomplete", Collect.getCurrentFormIdentifierHash());
+                            analytics.logEvent(SAVE_INCOMPLETE, "saveIncomplete", AnalyticsUtils.getFormHash(Collect.getInstance().getFormController()));
 
                             saveForm(false, false, null, false);
                             autoSaved = true;

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -225,6 +225,10 @@ public class AnalyticsEvents {
      */
     public static final String RECONFIGURE_PROJECT = "ProjectReconfigure";
 
+    public static final String FORMS_PROVIDER_INSERT = "FormsProviderInsert";
+    public static final String FORMS_PROVIDER_UPDATE = "FormsProviderUpdate";
+    public static final String FORMS_PROVIDER_DELETE = "FormsProviderDelete";
+
     /**
      * These track how often the external edit or view actions are used for forms or instances.
      * One event tracks when a project ID is included with the action URI and the other tracks when

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -225,10 +225,12 @@ public class AnalyticsEvents {
      */
     public static final String RECONFIGURE_PROJECT = "ProjectReconfigure";
 
+    public static final String FORMS_PROVIDER_QUERY = "FormsProviderQuery";
     public static final String FORMS_PROVIDER_INSERT = "FormsProviderInsert";
     public static final String FORMS_PROVIDER_UPDATE = "FormsProviderUpdate";
     public static final String FORMS_PROVIDER_DELETE = "FormsProviderDelete";
 
+    public static final String INSTANCE_PROVIDER_QUERY = "InstanceProviderQuery";
     public static final String INSTANCE_PROVIDER_INSERT = "InstanceProviderInsert";
     public static final String INSTANCE_PROVIDER_UPDATE = "InstanceProviderUpdate";
     public static final String INSTANCE_PROVIDER_DELETE = "InstanceProviderDelete";

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -229,6 +229,10 @@ public class AnalyticsEvents {
     public static final String FORMS_PROVIDER_UPDATE = "FormsProviderUpdate";
     public static final String FORMS_PROVIDER_DELETE = "FormsProviderDelete";
 
+    public static final String INSTANCE_PROVIDER_INSERT = "InstanceProviderInsert";
+    public static final String INSTANCE_PROVIDER_UPDATE = "InstanceProviderUpdate";
+    public static final String INSTANCE_PROVIDER_DELETE = "InstanceProviderDelete";
+
     /**
      * These track how often the external edit or view actions are used for forms or instances.
      * One event tracks when a project ID is included with the action URI and the other tracks when

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
@@ -24,33 +24,12 @@ public class AnalyticsUtils {
 
     }
 
-    public static String getServerHash(Settings generalSettings) {
-        String currentServerUrl = generalSettings.getString(KEY_SERVER_URL);
-        return Md5.getMd5Hash(new ByteArrayInputStream(currentServerUrl.getBytes()));
+    public static void logServerEvent(String event, Settings generalSettings) {
+        Analytics.log(event, "server", getServerHash(generalSettings));
     }
 
     public static void logMatchExactlyCompleted(Analytics analytics, FormSourceException exception) {
         analytics.logEvent(AnalyticsEvents.MATCH_EXACTLY_SYNC_COMPLETED, getFormSourceExceptionAction(exception));
-    }
-
-    private static String getFormSourceExceptionAction(FormSourceException exception) {
-        if (exception == null) {
-            return "Success";
-        } else if (exception instanceof Unreachable) {
-            return "UNREACHABLE";
-        } else if (exception instanceof AuthRequired) {
-            return "AUTH_REQUIRED";
-        } else if (exception instanceof ServerError) {
-            return format("SERVER_ERROR_%s", ((ServerError) exception).getStatusCode());
-        } else if (exception instanceof SecurityError) {
-            return "SECURITY_ERROR";
-        } else if (exception instanceof ParseError) {
-            return "PARSE_ERROR";
-        } else if (exception instanceof FetchError) {
-            return "FETCH_ERROR";
-        } else {
-            throw new IllegalArgumentException();
-        }
     }
 
     public static void logServerConfiguration(Analytics analytics, String url) {
@@ -71,5 +50,30 @@ public class AnalyticsUtils {
 
         String urlHash = Md5.getMd5Hash(new ByteArrayInputStream(url.getBytes()));
         analytics.logEvent(SET_SERVER, scheme + " " + host, urlHash);
+    }
+
+    private static String getServerHash(Settings generalSettings) {
+        String currentServerUrl = generalSettings.getString(KEY_SERVER_URL);
+        return Md5.getMd5Hash(new ByteArrayInputStream(currentServerUrl.getBytes()));
+    }
+
+    private static String getFormSourceExceptionAction(FormSourceException exception) {
+        if (exception == null) {
+            return "Success";
+        } else if (exception instanceof Unreachable) {
+            return "UNREACHABLE";
+        } else if (exception instanceof AuthRequired) {
+            return "AUTH_REQUIRED";
+        } else if (exception instanceof ServerError) {
+            return format("SERVER_ERROR_%s", ((ServerError) exception).getStatusCode());
+        } else if (exception instanceof SecurityError) {
+            return "SECURITY_ERROR";
+        } else if (exception instanceof ParseError) {
+            return "PARSE_ERROR";
+        } else if (exception instanceof FetchError) {
+            return "FETCH_ERROR";
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
@@ -1,6 +1,8 @@
 package org.odk.collect.android.analytics;
 
 import org.odk.collect.analytics.Analytics;
+import org.odk.collect.android.application.Collect;
+import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.shared.Settings;
 import org.odk.collect.shared.strings.Md5;
@@ -22,6 +24,14 @@ public class AnalyticsUtils {
 
     private AnalyticsUtils() {
 
+    }
+
+    public static void logFormEvent(String event) {
+        Analytics.log(event, "form", getFormHash(Collect.getInstance().getFormController()));
+    }
+
+    public static void logFormEvent(String event, String formId, String formTitle) {
+        Analytics.log(event, "form", getFormHash(formId, formTitle));
     }
 
     public static void logServerEvent(String event, Settings generalSettings) {
@@ -50,6 +60,19 @@ public class AnalyticsUtils {
 
         String urlHash = Md5.getMd5Hash(new ByteArrayInputStream(url.getBytes()));
         analytics.logEvent(SET_SERVER, scheme + " " + host, urlHash);
+    }
+
+    public static String getFormHash(String formId, String formTitle) {
+        return Md5.getMd5Hash(new ByteArrayInputStream((formTitle + " " + formId).getBytes()));
+    }
+
+    public static String getFormHash(FormController formController) {
+        if (formController != null) {
+            String formID = formController.getFormDef().getMainInstance().getRoot().getAttributeValue("", "id");
+            return getFormHash(formID, formController.getFormTitle());
+        } else {
+            return "";
+        }
     }
 
     private static String getServerHash(Settings generalSettings) {

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -216,20 +216,6 @@ public class Collect extends Application implements
     }
 
     /**
-     * Gets a unique, privacy-preserving identifier for the current form.
-     *
-     * @return md5 hash of the form title, a space, the form ID
-     */
-    public static String getCurrentFormIdentifierHash() {
-        FormController formController = getInstance().getFormController();
-        if (formController != null) {
-            return formController.getCurrentFormIdentifierHash();
-        }
-
-        return "";
-    }
-
-    /**
      * Gets a unique, privacy-preserving identifier for a form based on its id and version.
      *
      * @param formId      id of a form

--- a/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.java
@@ -2,12 +2,12 @@ package org.odk.collect.android.application;
 
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler;
 import org.odk.collect.android.configure.SettingsChangeHandler;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 
-import static org.odk.collect.android.analytics.AnalyticsUtils.getServerHash;
 import static org.odk.collect.android.analytics.AnalyticsUtils.logServerConfiguration;
 import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_EXTERNAL_APP_RECORDING;
 import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_FORM_UPDATE_MODE;
@@ -38,8 +38,7 @@ public class CollectSettingsChangeHandler implements SettingsChangeHandler {
         }
 
         if (changedKey.equals(KEY_EXTERNAL_APP_RECORDING) && !((Boolean) newValue)) {
-            String serverHash = getServerHash(settingsProvider.getGeneralSettings(projectId));
-            analytics.logServerEvent(AnalyticsEvents.INTERNAL_RECORDING_OPT_IN, serverHash);
+            AnalyticsUtils.logServerEvent(AnalyticsEvents.INTERNAL_RECORDING_OPT_IN, settingsProvider.getGeneralSettings(projectId));
         }
 
         if (changedKey.equals(KEY_SERVER_URL)) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -169,7 +169,7 @@ public class CursorLoaderFactory {
             Uri formUri = newestByFormId ?
                     FormsContract.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
                     FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
-            cursorLoader = new CursorLoader(Collect.getInstance(), formUri, null, DatabaseFormColumns.DELETED_DATE + " IS NULL", new String[]{}, sortOrder);
+            cursorLoader = new CursorLoader(Collect.getInstance(), getUriWithAnalyticsParam(formUri), null, DatabaseFormColumns.DELETED_DATE + " IS NULL", new String[]{}, sortOrder);
         } else {
             String selection = DatabaseFormColumns.DISPLAY_NAME + " LIKE ? AND " + DatabaseFormColumns.DELETED_DATE + " IS NULL";
             String[] selectionArgs = {"%" + charSequence + "%"};
@@ -177,18 +177,26 @@ public class CursorLoaderFactory {
             Uri formUri = newestByFormId ?
                     FormsContract.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
                     FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
-            cursorLoader = new CursorLoader(Collect.getInstance(), formUri, null, selection, selectionArgs, sortOrder);
+            cursorLoader = new CursorLoader(Collect.getInstance(), getUriWithAnalyticsParam(formUri), null, selection, selectionArgs, sortOrder);
         }
         return cursorLoader;
     }
 
     private CursorLoader getInstancesCursorLoader(String selection, String[] selectionArgs, String sortOrder) {
+        Uri uri = InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
+
         return new CursorLoader(
                 Collect.getInstance(),
-                InstancesContract.getUri(currentProjectProvider.getCurrentProject().getUuid()),
+                getUriWithAnalyticsParam(uri),
                 null,
                 selection,
                 selectionArgs,
                 sortOrder);
+    }
+
+    private Uri getUriWithAnalyticsParam(Uri uri) {
+        return uri.buildUpon()
+                .appendQueryParameter("internal", "true")
+                .build();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -7,13 +7,14 @@ import androidx.loader.content.CursorLoader;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.forms.DatabaseFormColumns;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
-import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.external.InstancesContract;
+import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.forms.instances.Instance;
 
 public class CursorLoaderFactory {
 
+    public static final String INTERNAL_QUERY_PARAM = "internal";
     private final CurrentProjectProvider currentProjectProvider;
 
     public CursorLoaderFactory(CurrentProjectProvider currentProjectProvider) {
@@ -196,7 +197,7 @@ public class CursorLoaderFactory {
 
     private Uri getUriWithAnalyticsParam(Uri uri) {
         return uri.buildUpon()
-                .appendQueryParameter("internal", "true")
+                .appendQueryParameter(INTERNAL_QUERY_PARAM, "true")
                 .build();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.java
@@ -23,7 +23,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.analytics.AnalyticsUtils;
@@ -48,9 +47,6 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
     BlankFormsListViewModel.Factory blankFormsListViewModelFactory;
 
     @Inject
-    Analytics analytics;
-
-    @Inject
     SettingsProvider settingsProvider;
 
     @Override
@@ -67,8 +63,7 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
         new AlertDialog.Builder(this)
                 .setTitle(R.string.select_odk_shortcut)
                 .setItems(forms.stream().map(BlankForm::getName).toArray(String[]::new), (dialog, item) -> {
-                    String serverHash = AnalyticsUtils.getServerHash(settingsProvider.getGeneralSettings());
-                    analytics.logServerEvent(AnalyticsEvents.CREATE_SHORTCUT, serverHash);
+                    AnalyticsUtils.logServerEvent(AnalyticsEvents.CREATE_SHORTCUT, settingsProvider.getGeneralSettings());
 
                     Intent intent = getShortcutIntent(forms, item);
                     setResult(RESULT_OK, intent);

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
@@ -25,6 +25,7 @@ import androidx.annotation.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.analytics.AnalyticsUtils;
+import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.forms.DatabaseFormsRepository;
 import org.odk.collect.android.formmanagement.FormDeleter;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -113,6 +114,11 @@ public class FormsProvider extends ContentProvider {
         deferDaggerInit();
 
         String projectId = getProjectId(uri);
+
+        // We only want to log external calls to the content provider
+        if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) != null) {
+            logServerEvent(projectId, AnalyticsEvents.FORMS_PROVIDER_QUERY);
+        }
 
         Cursor cursor;
         switch (URI_MATCHER.match(uri)) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
@@ -23,7 +23,6 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.database.forms.DatabaseFormsRepository;
@@ -314,7 +313,7 @@ public class FormsProvider extends ContentProvider {
     }
 
     private void logServerEvent(String projectId, String event) {
-        Analytics.logServer(event, AnalyticsUtils.getServerHash(settingsProvider.getGeneralSettings(projectId)));
+        AnalyticsUtils.logServerEvent(event, settingsProvider.getGeneralSettings(projectId));
     }
 
     static {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
@@ -116,7 +116,7 @@ public class FormsProvider extends ContentProvider {
         String projectId = getProjectId(uri);
 
         // We only want to log external calls to the content provider
-        if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) != null) {
+        if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) == null) {
             logServerEvent(projectId, AnalyticsEvents.FORMS_PROVIDER_QUERY);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
@@ -90,7 +90,7 @@ public class InstanceProvider extends ContentProvider {
         String projectId = getProjectId(uri);
 
         // We only want to log external calls to the content provider
-        if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) != null) {
+        if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) == null) {
             logServerEvent(projectId, AnalyticsEvents.INSTANCE_PROVIDER_QUERY);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.analytics.AnalyticsUtils;
+import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.instances.DatabaseInstancesRepository;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.instancemanagement.InstanceDeleter;
@@ -87,6 +88,11 @@ public class InstanceProvider extends ContentProvider {
         DaggerUtils.getComponent(getContext()).inject(this);
 
         String projectId = getProjectId(uri);
+
+        // We only want to log external calls to the content provider
+        if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) != null) {
+            logServerEvent(projectId, AnalyticsEvents.INSTANCE_PROVIDER_QUERY);
+        }
 
         Cursor c;
         switch (URI_MATCHER.match(uri)) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioViewModel.java
@@ -12,8 +12,8 @@ import androidx.lifecycle.ViewModelProvider;
 
 import org.javarosa.core.model.actions.recordaudio.RecordAudioActions;
 import org.javarosa.core.model.instance.TreeReference;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
@@ -41,7 +41,6 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
     private final RecordAudioActionRegistry recordAudioActionRegistry;
     private final PermissionsChecker permissionsChecker;
     private final Clock clock;
-    private final Analytics analytics;
 
     private final MutableNonNullLiveData<Boolean> isPermissionRequired = new MutableNonNullLiveData<>(false);
     private final MutableNonNullLiveData<Boolean> isBackgroundRecordingEnabled;
@@ -54,13 +53,12 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
     private AuditEventLogger auditEventLogger;
     private FormController formController;
 
-    public BackgroundAudioViewModel(AudioRecorder audioRecorder, Settings generalSettings, RecordAudioActionRegistry recordAudioActionRegistry, PermissionsChecker permissionsChecker, Clock clock, Analytics analytics) {
+    public BackgroundAudioViewModel(AudioRecorder audioRecorder, Settings generalSettings, RecordAudioActionRegistry recordAudioActionRegistry, PermissionsChecker permissionsChecker, Clock clock) {
         this.audioRecorder = audioRecorder;
         this.generalSettings = generalSettings;
         this.recordAudioActionRegistry = recordAudioActionRegistry;
         this.permissionsChecker = permissionsChecker;
         this.clock = clock;
-        this.analytics = analytics;
 
         this.recordAudioActionRegistry.register((treeReference, quality) -> {
             new Handler(Looper.getMainLooper()).post(() -> handleRecordAction(treeReference, quality));
@@ -95,7 +93,7 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
             }
 
             if (formController != null) {
-                analytics.logFormEvent(AnalyticsEvents.BACKGROUND_AUDIO_ENABLED, formController.getCurrentFormIdentifierHash());
+                AnalyticsUtils.logFormEvent(AnalyticsEvents.BACKGROUND_AUDIO_ENABLED);
             }
         } else {
             audioRecorder.cleanUp();
@@ -105,7 +103,7 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
             }
 
             if (formController != null) {
-                analytics.logFormEvent(AnalyticsEvents.BACKGROUND_AUDIO_DISABLED, formController.getCurrentFormIdentifierHash());
+                AnalyticsUtils.logFormEvent(AnalyticsEvents.BACKGROUND_AUDIO_DISABLED);
             }
         }
 
@@ -177,15 +175,13 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
         private final Settings generalSettings;
         private final PermissionsChecker permissionsChecker;
         private final Clock clock;
-        private final Analytics analytics;
 
         @Inject
-        public Factory(AudioRecorder audioRecorder, Settings generalSettings, PermissionsChecker permissionsChecker, Clock clock, Analytics analytics) {
+        public Factory(AudioRecorder audioRecorder, Settings generalSettings, PermissionsChecker permissionsChecker, Clock clock) {
             this.audioRecorder = audioRecorder;
             this.generalSettings = generalSettings;
             this.permissionsChecker = permissionsChecker;
             this.clock = clock;
-            this.analytics = analytics;
         }
 
         @NonNull
@@ -203,7 +199,7 @@ public class BackgroundAudioViewModel extends ViewModel implements RequiresFormC
                 }
             };
 
-            return (T) new BackgroundAudioViewModel(audioRecorder, generalSettings, recordAudioActionRegistry, permissionsChecker, clock, analytics);
+            return (T) new BackgroundAudioViewModel(audioRecorder, generalSettings, recordAudioActionRegistry, permissionsChecker, clock);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -13,8 +13,8 @@ import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.actions.recordaudio.RecordAudioActionHandler;
 import org.javarosa.form.api.FormEntryController;
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.exception.JavaRosaException;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.javarosawrapper.FormController;
@@ -29,7 +29,6 @@ import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getRepeatGr
 public class FormEntryViewModel extends ViewModel implements RequiresFormController {
 
     private final Clock clock;
-    private final Analytics analytics;
 
     private final MutableLiveData<FormError> error = new MutableLiveData<>(null);
     private final MutableNonNullLiveData<Boolean> hasBackgroundRecording = new MutableNonNullLiveData<>(false);
@@ -41,9 +40,8 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     private FormIndex jumpBackIndex;
 
     @SuppressWarnings("WeakerAccess")
-    public FormEntryViewModel(Clock clock, Analytics analytics) {
+    public FormEntryViewModel(Clock clock) {
         this.clock = clock;
-        this.analytics = analytics;
     }
 
     @Override
@@ -54,7 +52,7 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         this.hasBackgroundRecording.setValue(hasBackgroundRecording);
 
         if (hasBackgroundRecording) {
-            analytics.logFormEvent(AnalyticsEvents.REQUESTS_BACKGROUND_AUDIO, getFormIdentifierHash());
+            AnalyticsUtils.logFormEvent(AnalyticsEvents.REQUESTS_BACKGROUND_AUDIO);
         }
     }
 
@@ -174,36 +172,26 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     }
 
     public void logFormEvent(String event) {
-        analytics.logFormEvent(event, getFormIdentifierHash());
+        AnalyticsUtils.logFormEvent(event);
     }
 
     public NonNullLiveData<Boolean> hasBackgroundRecording() {
         return hasBackgroundRecording;
     }
 
-    private String getFormIdentifierHash() {
-        if (formController != null) {
-            return formController.getCurrentFormIdentifierHash();
-        } else {
-            return "";
-        }
-    }
-
     public static class Factory implements ViewModelProvider.Factory {
 
         private final Clock clock;
-        private final Analytics analytics;
 
-        public Factory(Clock clock, Analytics analytics) {
+        public Factory(Clock clock) {
             this.clock = clock;
-            this.analytics = analytics;
         }
 
         @SuppressWarnings("unchecked")
         @NonNull
         @Override
         public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-            return (T) new FormEntryViewModel(clock, analytics);
+            return (T) new FormEntryViewModel(clock);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -54,6 +54,7 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.exception.ExternalParamsException;
@@ -242,7 +243,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
                 audioHelper,
                 ReferenceManager.instance(),
                 analytics,
-                Collect.getCurrentFormIdentifierHash()
+                AnalyticsUtils.getFormHash(Collect.getInstance().getFormController())
         );
 
         return promptAutoplayer.autoplayIfNeeded(firstPrompt);

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.formmanagement;
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.listeners.FormDownloaderListener;
 import org.odk.collect.android.utilities.FileUtils;
@@ -15,7 +16,6 @@ import org.odk.collect.forms.MediaFile;
 import org.odk.collect.shared.strings.Md5;
 import org.odk.collect.shared.strings.Validator;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -69,9 +69,7 @@ public class ServerFormDownloader implements FormDownloader {
         } else {
             List<Form> allSameFormIdVersion = formsRepository.getAllByFormIdAndVersion(form.getFormId(), form.getFormVersion());
             if (!allSameFormIdVersion.isEmpty() && !form.getDownloadUrl().contains("/draft.xml")) {
-                String formIdentifier = form.getFormName() + " " + form.getFormId();
-                String formIdHash = Md5.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
-                analytics.logFormEvent(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, formIdHash);
+                analytics.logEventWithParam(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, "form", AnalyticsUtils.getFormHash(form.getFormId(), form.getFormName()));
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -435,12 +435,12 @@ public class AppDependencyModule {
 
     @Provides
     public FormEntryViewModel.Factory providesFormEntryViewModelFactory(Clock clock, Analytics analytics) {
-        return new FormEntryViewModel.Factory(clock, analytics);
+        return new FormEntryViewModel.Factory(clock);
     }
 
     @Provides
     public BackgroundAudioViewModel.Factory providesBackgroundAudioViewModelFactory(AudioRecorder audioRecorder, SettingsProvider settingsProvider, PermissionsChecker permissionsChecker, Clock clock, Analytics analytics) {
-        return new BackgroundAudioViewModel.Factory(audioRecorder, settingsProvider.getGeneralSettings(), permissionsChecker, clock, analytics);
+        return new BackgroundAudioViewModel.Factory(audioRecorder, settingsProvider.getGeneralSettings(), permissionsChecker, clock);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
@@ -17,18 +17,18 @@ package org.odk.collect.android.instancemanagement;
 import android.net.Uri;
 
 import org.apache.commons.io.FileUtils;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.EncryptionException;
+import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.injection.config.AppDependencyComponent;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.CurrentProjectProvider;
-import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.tasks.SaveFormToDisk;
@@ -39,11 +39,9 @@ import org.odk.collect.android.utilities.TranslationHandler;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.forms.instances.InstancesRepository;
-import org.odk.collect.shared.strings.Md5;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedList;
@@ -63,7 +61,6 @@ public class InstanceDiskSynchronizer {
     private final SettingsProvider settingsProvider;
     private final StoragePathProvider storagePathProvider = new StoragePathProvider();
     private final InstancesRepository instancesRepository;
-    private final Analytics analytics;
 
     public String getStatusMessage() {
         return currentStatus;
@@ -73,7 +70,6 @@ public class InstanceDiskSynchronizer {
         this.settingsProvider = settingsProvider;
         instancesRepository = new InstancesRepositoryProvider(Collect.getInstance()).get();
         AppDependencyComponent component = DaggerUtils.getComponent(Collect.getInstance());
-        analytics = component.analytics();
         currentProjectProvider = component.currentProjectProvider();
     }
 
@@ -200,17 +196,11 @@ public class InstanceDiskSynchronizer {
     }
 
     private void logImport(Form form) {
-        String id = form.getFormId();
-        String title = form.getDisplayName();
-        String formIdHash = Md5.getMd5Hash(new ByteArrayInputStream((id + " " + title).getBytes()));
-        analytics.logFormEvent(AnalyticsEvents.IMPORT_INSTANCE, formIdHash);
+        AnalyticsUtils.logFormEvent(AnalyticsEvents.IMPORT_INSTANCE, form.getFormId(), form.getDisplayName());
     }
 
     private void logImportAndEncrypt(Form form) {
-        String id = form.getFormId();
-        String title = form.getDisplayName();
-        String formIdHash = Md5.getMd5Hash(new ByteArrayInputStream((id + " " + title).getBytes()));
-        analytics.logFormEvent(AnalyticsEvents.IMPORT_AND_ENCRYPT_INSTANCE, formIdHash);
+        AnalyticsUtils.logFormEvent(AnalyticsEvents.IMPORT_AND_ENCRYPT_INSTANCE, form.getFormId(), form.getDisplayName());
     }
 
     private void encryptInstance(Instance instance) throws EncryptionException, IOException {

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -14,6 +14,10 @@
 
 package org.odk.collect.android.javarosawrapper;
 
+import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getPreviousLevel;
+import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getRepeatGroupIndex;
+import static org.odk.collect.android.utilities.ApplicationConstants.Namespaces.XML_OPENDATAKIT_NAMESPACE;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -50,9 +54,7 @@ import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormNameUtils;
-import org.odk.collect.shared.strings.Md5;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,10 +63,6 @@ import java.util.List;
 import java.util.Locale;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getPreviousLevel;
-import static org.odk.collect.android.javarosawrapper.FormIndexUtils.getRepeatGroupIndex;
-import static org.odk.collect.android.utilities.ApplicationConstants.Namespaces.XML_OPENDATAKIT_NAMESPACE;
 
 /**
  * This class is a wrapper for Javarosa's FormEntryController. In theory, if you wanted to replace
@@ -281,22 +279,6 @@ public class FormController {
      */
     public String getFormTitle() {
         return formEntryController.getModel().getFormTitle();
-    }
-
-    /**
-     * Gets a unique, privacy-preserving identifier for the current form.
-     *
-     * @return md5 hash of the form title, a space, the form ID
-     */
-    public String getCurrentFormIdentifierHash() {
-        String formIdentifier = "";
-
-        if (getFormDef() != null) {
-            String formID = getFormDef().getMainInstance().getRoot().getAttributeValue("", "id");
-            formIdentifier = getFormTitle() + " " + formID;
-        }
-
-        return Md5.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -38,6 +38,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
 import org.odk.collect.android.exception.EncryptionException;
@@ -390,7 +391,7 @@ public class SaveFormToDisk {
                 EncryptionUtils.generateEncryptedSubmission(instanceXml, submissionXml, formInfo);
                 isEncrypted = true;
 
-                analytics.logEvent(ENCRYPT_SUBMISSION, Collect.getCurrentFormIdentifierHash(), "");
+                analytics.logEvent(ENCRYPT_SUBMISSION, AnalyticsUtils.getFormHash(Collect.getInstance().getFormController()), "");
             }
 
             // At this point, we have:

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -28,11 +28,12 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.audio.AudioControllerView;
 import org.odk.collect.android.databinding.AudioWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.utilities.Appearances;
+import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.AudioFileRequester;
@@ -212,7 +213,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
 
                 @Override
                 public void onPositionChanged(Integer newPosition) {
-                    analytics.logFormEvent(AnalyticsEvents.AUDIO_PLAYER_SEEK, questionDetails.getFormAnalyticsID());
+                    AnalyticsUtils.logFormEvent(AnalyticsEvents.AUDIO_PLAYER_SEEK);
                     audioPlayer.setPosition(clip.getClipID(), newPosition);
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -15,6 +15,7 @@ import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.audio.AudioControllerView;
 import org.odk.collect.android.databinding.ExAudioWidgetAnswerBinding;
@@ -172,7 +173,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
 
                 @Override
                 public void onPositionChanged(Integer newPosition) {
-                    analytics.logFormEvent(AnalyticsEvents.AUDIO_PLAYER_SEEK, questionDetails.getFormAnalyticsID());
+                    AnalyticsUtils.logFormEvent(AnalyticsEvents.AUDIO_PLAYER_SEEK);
                     audioPlayer.setPosition(clip.getClipID(), newPosition);
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/WidgetFactory.java
@@ -22,6 +22,7 @@ import androidx.lifecycle.LifecycleOwner;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.FormEntryViewModel;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
@@ -107,7 +108,7 @@ public class WidgetFactory {
 
     public QuestionWidget createWidgetFromPrompt(FormEntryPrompt prompt, PermissionsProvider permissionsProvider) {
         String appearance = Appearances.getSanitizedAppearanceHint(prompt);
-        QuestionDetails questionDetails = new QuestionDetails(prompt, Collect.getCurrentFormIdentifierHash(), readOnlyOverride);
+        QuestionDetails questionDetails = new QuestionDetails(prompt, AnalyticsUtils.getFormHash(Collect.getInstance().getFormController()), readOnlyOverride);
 
         final QuestionWidget questionWidget;
         switch (prompt.getControlType()) {

--- a/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/audio/AudioRecordingControllerFragmentTest.java
@@ -70,7 +70,7 @@ public class AudioRecordingControllerFragmentTest {
 
             @Override
             public BackgroundAudioViewModel.Factory providesBackgroundAudioViewModelFactory(AudioRecorder audioRecorder, SettingsProvider settingsProvider, PermissionsChecker permissionsChecker, Clock clock, Analytics analytics) {
-                return new BackgroundAudioViewModel.Factory(audioRecorder, settingsProvider.getGeneralSettings(), permissionsChecker, clock, analytics) {
+                return new BackgroundAudioViewModel.Factory(audioRecorder, settingsProvider.getGeneralSettings(), permissionsChecker, clock) {
                     @NonNull
                     @Override
                     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
@@ -81,7 +81,7 @@ public class AudioRecordingControllerFragmentTest {
 
             @Override
             public FormEntryViewModel.Factory providesFormEntryViewModelFactory(Clock clock, Analytics analytics) {
-                return new FormEntryViewModel.Factory(clock, analytics) {
+                return new FormEntryViewModel.Factory(clock) {
                     @NonNull
                     @Override
                     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragmentTest.java
@@ -46,7 +46,7 @@ public class BackgroundAudioPermissionDialogFragmentTest {
 
             @Override
             public BackgroundAudioViewModel.Factory providesBackgroundAudioViewModelFactory(AudioRecorder audioRecorder, SettingsProvider settingsProvider, PermissionsChecker permissionsChecker, Clock clock, Analytics analytics) {
-                return new BackgroundAudioViewModel.Factory(audioRecorder, settingsProvider.getGeneralSettings(), permissionsChecker, clock, analytics) {
+                return new BackgroundAudioViewModel.Factory(audioRecorder, settingsProvider.getGeneralSettings(), permissionsChecker, clock) {
                     @NonNull
                     @Override
                     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/BackgroundAudioViewModelTest.java
@@ -8,15 +8,14 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.TestSettingsProvider;
 import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.permissions.PermissionsChecker;
-import org.odk.collect.shared.Settings;
 import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
+import org.odk.collect.shared.Settings;
 import org.odk.collect.testshared.RobolectricHelpers;
 import org.odk.collect.utilities.Clock;
 
@@ -48,7 +47,7 @@ public class BackgroundAudioViewModelTest {
         Settings generalSettings = TestSettingsProvider.getGeneralSettings();
         generalSettings.clear();
 
-        viewModel = new BackgroundAudioViewModel(audioRecorder, generalSettings, recordAudioActionRegistry, permissionsChecker, clock, mock(Analytics.class));
+        viewModel = new BackgroundAudioViewModel(audioRecorder, generalSettings, recordAudioActionRegistry, permissionsChecker, clock);
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -8,9 +8,7 @@ import org.javarosa.core.model.instance.TreeReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.exception.JavaRosaException;
-import org.odk.collect.android.formentry.audit.AuditEvent;
 import org.odk.collect.android.formentry.audit.AuditEventLogger;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.utilities.Clock;
@@ -34,23 +32,18 @@ public class FormEntryViewModelTest {
     private FormEntryViewModel viewModel;
     private FormController formController;
     private FormIndex startingIndex;
-    private AuditEventLogger auditEventLogger;
-    private Clock clock;
 
     @Before
     public void setup() {
         formController = mock(FormController.class);
         startingIndex = new FormIndex(null, 0, 0, new TreeReference());
         when(formController.getFormIndex()).thenReturn(startingIndex);
-        when(formController.getCurrentFormIdentifierHash()).thenReturn("formIdentifierHash");
         when(formController.getFormDef()).thenReturn(new FormDef());
 
-        auditEventLogger = mock(AuditEventLogger.class);
+        AuditEventLogger auditEventLogger = mock(AuditEventLogger.class);
         when(formController.getAuditEventLogger()).thenReturn(auditEventLogger);
 
-        clock = mock(Clock.class);
-
-        viewModel = new FormEntryViewModel(clock, mock(Analytics.class));
+        viewModel = new FormEntryViewModel(mock(Clock.class));
         viewModel.formLoaded(formController);
     }
 
@@ -125,12 +118,5 @@ public class FormEntryViewModelTest {
 
         viewModel.cancelRepeatPrompt();
         assertThat(viewModel.getError().getValue(), equalTo(new NonFatal("OH NO")));
-    }
-
-    @Test
-    public void openHierarchy_logsHierarchyAuditEvent() {
-        when(clock.getCurrentTime()).thenReturn(12345L);
-        viewModel.openHierarchy();
-        verify(auditEventLogger).logEvent(AuditEvent.AuditEventType.HIERARCHY, true, 12345L);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -451,7 +451,7 @@ public class ServerFormDownloaderTest {
         String formIdentifier = form.getDisplayName() + " " + form.getFormId();
         String formIdHash = Md5.getMd5Hash(new ByteArrayInputStream(formIdentifier.getBytes()));
 
-        verify(mockAnalytics).logFormEvent(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, formIdHash);
+        verify(mockAnalytics).logEventWithParam(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, "form", formIdHash);
     }
 
     @Test


### PR DESCRIPTION
Closes #4576

I also reworked the analytics interface a little so it doesn't include anything around servers and forms. Logic around that go moved to `AnalyticsUtils`.

#### What has been done to verify that this works as intended?

Ran tests.

#### Why is this the best possible solution? Were any other approaches considered?

Only thing of note here is that I needed a way to differentiate between internal and external query calls. To do this, I made `CursorLoaderFactory` add a query param to the URI it sends so the content provider can identify calls that it's responsible for.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't be any risk here really, as it's just adding analytics. 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)