### PR TITLE
Detect why database can't be accessed on crash

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/MainMenuViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/MainMenuViewModel.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.activities.viewmodels;
 
 import android.app.Application;
+import android.database.sqlite.SQLiteCantOpenDatabaseException;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -126,7 +127,7 @@ public class MainMenuViewModel extends ViewModel {
 
             try {
                 instancesAppState.update();
-            } catch (android.database.sqlite.SQLiteCantOpenDatabaseException e) {
+            } catch (SQLiteCantOpenDatabaseException e) {
                 determineWhyDatabaseCannotBeAccessed(e);
             }
 
@@ -140,7 +141,7 @@ public class MainMenuViewModel extends ViewModel {
      * Work out what has happened to make the database go missing and then throw the appropriate
      * exception. Here to determine the cause of https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/07cccfa2bbf3b4e0e4fed4f0a9fcbd76
      */
-    private void determineWhyDatabaseCannotBeAccessed(android.database.sqlite.SQLiteCantOpenDatabaseException e) {
+    private void determineWhyDatabaseCannotBeAccessed(SQLiteCantOpenDatabaseException e) {
         Collect.getInstance().testStorage(); // Check we can actually access storage
 
         StoragePathProvider storagePathProvider = new StoragePathProvider();

--- a/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/Collect.java
@@ -134,7 +134,7 @@ public class Collect extends Application implements
         setupStrictMode();
     }
 
-    private void testStorage() {
+    public void testStorage() {
         // Throw specific error to avoid later ones if the app won't be able to access storage
         try {
             File externalFilesDir = getExternalFilesDir(null);


### PR DESCRIPTION
Should provide more info for #4756.

This adds code to the crash site that checks and then throws a more specific exception in the cases where:

* The `projects` dir has been deleted (probably meaning our extrenal files dir has been cleared)
* The current project's dir has been deleted
* The current project's dir has been cleared out (ignores if `.cache` is still there)
* The current project's metadata dir has been deleted

#### What has been done to verify that this works as intended?

Checked that the cases throw the right exception manually.

#### Why is this the best possible solution? Were any other approaches considered?

I thought this would provide a way to get info on this crash without changing any behaviour which hopefully means we can get it out faster. I also think having a clearer idea of what the users are doing will help us approach a fix with more context - right now we'd probably want to add code to cover all these cases which adds more complexity, tests and risk than we might need to commit to.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This only adds code to a crash site, so shouldn't add any risk. No need for QA here.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)