### PR TITLE
Recreate project directories if they have been deleted

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/AddNewProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/AddNewProjectTest.kt
@@ -80,7 +80,7 @@ class AddNewProjectTest {
             .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
             .openProjectSettings()
             .assertCurrentProject("Demo project", "demo.getodk.org")
-            .assertNotInactiveProject("Demo project", "demo.getodk.org")
+            .assertNotInactiveProject("Demo project")
     }
 
     @Test
@@ -111,7 +111,7 @@ class AddNewProjectTest {
             .checkIsToastWithMessageDisplayed(R.string.switched_project, "Demo project")
             .openProjectSettings()
             .assertCurrentProject("Demo project", "demo.getodk.org")
-            .assertNotInactiveProject("Demo project", "demo.getodk.org")
+            .assertNotInactiveProject("Demo project")
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
@@ -9,7 +9,6 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
-import org.odk.collect.android.support.pages.FirstLaunchPage
 import org.odk.collect.android.support.pages.MainMenuPage
 
 @RunWith(AndroidJUnit4::class)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
@@ -1,0 +1,38 @@
+package org.odk.collect.android.feature.projects
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.support.CollectTestRule
+import org.odk.collect.android.support.TestRuleChain
+import org.odk.collect.android.support.pages.FirstLaunchPage
+
+@RunWith(AndroidJUnit4::class)
+class ProjectsAdbTest {
+
+    val rule = CollectTestRule()
+
+    @get:Rule
+    var chain: RuleChain = TestRuleChain
+        .chain()
+        .around(rule)
+
+    @Test
+    fun clearingStorage_andReturningToApp_returnsToLaunchScreen_andRemovesOldProject() {
+        val fillBlankFormPage = rule.startAtMainMenu().clickFillBlankForm()
+
+        val storage = getApplicationContext<Application>().getExternalFilesDir(null)
+        storage!!.listFiles()!!.forEach { it.deleteRecursively() }
+
+        fillBlankFormPage.pressBack(FirstLaunchPage())
+            .clickManuallyEnterProjectDetails()
+            .inputUrl("https://example.com")
+            .addProject()
+            .openProjectSettings()
+            .assertNotInactiveProject("Demo project")
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.TestRuleChain
 import org.odk.collect.android.support.pages.FirstLaunchPage
+import org.odk.collect.android.support.pages.MainMenuPage
 
 @RunWith(AndroidJUnit4::class)
 class ProjectsAdbTest {
@@ -28,11 +29,7 @@ class ProjectsAdbTest {
         val storage = getApplicationContext<Application>().getExternalFilesDir(null)
         storage!!.listFiles()!!.forEach { it.deleteRecursively() }
 
-        fillBlankFormPage.pressBack(FirstLaunchPage())
-            .clickManuallyEnterProjectDetails()
-            .inputUrl("https://example.com")
-            .addProject()
-            .openProjectSettings()
-            .assertNotInactiveProject("Demo project")
+        fillBlankFormPage.pressBack(MainMenuPage())
+            .assertProjectIcon("D")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/ProjectsAdbTest.kt
@@ -23,7 +23,7 @@ class ProjectsAdbTest {
         .around(rule)
 
     @Test
-    fun clearingStorage_andReturningToApp_returnsToLaunchScreen_andRemovesOldProject() {
+    fun clearingStorage_andReturningToApp_recreatesStorageForProject() {
         val fillBlankFormPage = rule.startAtMainMenu().clickFillBlankForm()
 
         val storage = getApplicationContext<Application>().getExternalFilesDir(null)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectSettingsDialogPage.kt
@@ -45,8 +45,8 @@ internal class ProjectSettingsDialogPage() : Page<ProjectSettingsDialogPage>() {
         return this
     }
 
-    fun assertNotInactiveProject(projectName: String, subtext: String): ProjectSettingsDialogPage {
-        onView(allOf(hasDescendant(withText(projectName)), hasDescendant(withText(subtext)), withContentDescription(getTranslatedString(R.string.switch_to_project, projectName)))).check(doesNotExist())
+    fun assertNotInactiveProject(projectName: String): ProjectSettingsDialogPage {
+        onView(allOf(hasDescendant(withText(projectName)), withContentDescription(getTranslatedString(R.string.switch_to_project, projectName)))).check(doesNotExist())
         return this
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -37,7 +37,6 @@ import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.ProjectIconView;
 import org.odk.collect.android.projects.ProjectSettingsDialog;
 import org.odk.collect.android.storage.StorageInitializer;
-import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PlayServicesChecker;
@@ -72,9 +71,6 @@ public class MainMenuActivity extends CollectAbstractActivity {
 
     @Inject
     StorageInitializer storageInitializer;
-
-    @Inject
-    StoragePathProvider storagePathProvider;
 
     private MainMenuViewModel mainMenuViewModel;
 
@@ -223,14 +219,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
     @Override
     protected void onResume() {
         super.onResume();
-
-        try {
-            currentProjectViewModel.refresh();
-        } catch (CurrentProjectViewModel.NoCurrentProjectException e) {
-            ActivityUtils.startActivityAndCloseAllOthers(this, SplashScreenActivity.class);
-            return;
-        }
-
+        currentProjectViewModel.refresh();
         mainMenuViewModel.refreshInstances();
         setButtonsVisibility();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -37,9 +37,12 @@ import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.ProjectIconView;
 import org.odk.collect.android.projects.ProjectSettingsDialog;
 import org.odk.collect.android.storage.StorageInitializer;
+import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PlayServicesChecker;
+
+import java.io.File;
 
 import javax.inject.Inject;
 
@@ -71,6 +74,9 @@ public class MainMenuActivity extends CollectAbstractActivity {
 
     @Inject
     StorageInitializer storageInitializer;
+
+    @Inject
+    StoragePathProvider storagePathProvider;
 
     private MainMenuViewModel mainMenuViewModel;
 
@@ -219,10 +225,17 @@ public class MainMenuActivity extends CollectAbstractActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        mainMenuViewModel.refreshInstances();
 
-        setButtonsVisibility();
-        currentProjectViewModel.refresh();
+        if (new File(storagePathProvider.getOdkRootDirPath()).listFiles().length == 0) {
+            settingsProvider.getMetaSettings().remove(MetaKeys.CURRENT_PROJECT_ID);
+            settingsProvider.getMetaSettings().remove(MetaKeys.KEY_PROJECTS);
+            ActivityUtils.startActivityAndCloseAllOthers(this, SplashScreenActivity.class);
+        } else {
+            mainMenuViewModel.refreshInstances();
+
+            setButtonsVisibility();
+            currentProjectViewModel.refresh();
+        }
     }
 
     private void setButtonsVisibility() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -226,7 +226,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
 
         try {
             currentProjectViewModel.refresh();
-        } catch (CurrentProjectViewModel.CurrentProjectNotAccessibleException e) {
+        } catch (CurrentProjectViewModel.NoCurrentProjectException e) {
             ActivityUtils.startActivityAndCloseAllOthers(this, SplashScreenActivity.class);
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -31,8 +31,8 @@ import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel;
 import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
 import org.odk.collect.android.gdrive.GoogleDriveActivity;
 import org.odk.collect.android.injection.DaggerUtils;
-import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.android.preferences.keys.MetaKeys;
+import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.projects.ProjectIconView;
 import org.odk.collect.android.projects.ProjectSettingsDialog;
@@ -41,8 +41,6 @@ import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PlayServicesChecker;
-
-import java.io.File;
 
 import javax.inject.Inject;
 
@@ -226,16 +224,15 @@ public class MainMenuActivity extends CollectAbstractActivity {
     protected void onResume() {
         super.onResume();
 
-        if (new File(storagePathProvider.getOdkRootDirPath()).listFiles().length == 0) {
-            settingsProvider.getMetaSettings().remove(MetaKeys.CURRENT_PROJECT_ID);
-            settingsProvider.getMetaSettings().remove(MetaKeys.KEY_PROJECTS);
-            ActivityUtils.startActivityAndCloseAllOthers(this, SplashScreenActivity.class);
-        } else {
-            mainMenuViewModel.refreshInstances();
-
-            setButtonsVisibility();
+        try {
             currentProjectViewModel.refresh();
+        } catch (CurrentProjectViewModel.CurrentProjectNotAccessibleException e) {
+            ActivityUtils.startActivityAndCloseAllOthers(this, SplashScreenActivity.class);
+            return;
         }
+
+        mainMenuViewModel.refreshInstances();
+        setButtonsVisibility();
     }
 
     private void setButtonsVisibility() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
@@ -7,17 +7,16 @@ import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.storage.StoragePathProvider
+import org.odk.collect.android.utilities.FileUtils
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.projects.Project
-import org.odk.collect.projects.ProjectsRepository
 import java.io.File
 
 class CurrentProjectViewModel(
     private val currentProjectProvider: CurrentProjectProvider,
     private val analyticsInitializer: AnalyticsInitializer,
-    private val storagePathProvider: StoragePathProvider,
-    private val projectsRepository: ProjectsRepository
+    private val storagePathProvider: StoragePathProvider
 ) : ViewModel() {
 
     private val _currentProject = MutableNonNullLiveData(currentProjectProvider.getCurrentProject())
@@ -30,14 +29,11 @@ class CurrentProjectViewModel(
         updateCurrentProjectIfNeeded()
     }
 
-    @Throws(NoCurrentProjectException::class)
     fun refresh() {
         updateCurrentProjectIfNeeded()
 
-        if (File(storagePathProvider.odkRootDirPath).listFiles().isEmpty()) {
-            currentProjectProvider.clear()
-            projectsRepository.deleteAll()
-            throw NoCurrentProjectException()
+        if (!File(storagePathProvider.getProjectRootDirPath()).exists()) {
+            storagePathProvider.getProjectDirPaths(currentProject.value.uuid).forEach { FileUtils.createDir(it) }
         }
     }
 
@@ -50,19 +46,15 @@ class CurrentProjectViewModel(
     open class Factory(
         private val currentProjectProvider: CurrentProjectProvider,
         private val analyticsInitializer: AnalyticsInitializer,
-        private val storagePathProvider: StoragePathProvider,
-        private val projectsRepository: ProjectsRepository
+        private val storagePathProvider: StoragePathProvider
     ) :
         ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
             return CurrentProjectViewModel(
                 currentProjectProvider,
                 analyticsInitializer,
-                storagePathProvider,
-                projectsRepository
+                storagePathProvider
             ) as T
         }
     }
-
-    class NoCurrentProjectException : Exception()
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
@@ -33,6 +33,7 @@ class CurrentProjectViewModel(
         updateCurrentProjectIfNeeded()
 
         if (!File(storagePathProvider.getProjectRootDirPath()).exists()) {
+            Analytics.log(AnalyticsEvents.RECREATE_PROJECT_DIR)
             storagePathProvider.getProjectDirPaths(currentProject.value.uuid).forEach { FileUtils.createDir(it) }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
@@ -6,15 +6,19 @@ import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.projects.Project
+import org.odk.collect.projects.ProjectsRepository
+import java.io.File
 
 class CurrentProjectViewModel(
     private val currentProjectProvider: CurrentProjectProvider,
-    private val analyticsInitializer: AnalyticsInitializer
-) :
-    ViewModel() {
+    private val analyticsInitializer: AnalyticsInitializer,
+    private val storagePathProvider: StoragePathProvider,
+    private val projectsRepository: ProjectsRepository
+) : ViewModel() {
 
     private val _currentProject = MutableNonNullLiveData(currentProjectProvider.getCurrentProject())
     val currentProject: NonNullLiveData<Project.Saved> = _currentProject
@@ -23,19 +27,42 @@ class CurrentProjectViewModel(
         currentProjectProvider.setCurrentProject(project.uuid)
         Analytics.log(AnalyticsEvents.SWITCH_PROJECT)
         analyticsInitializer.initialize()
-        refresh()
+        updateCurrentProjectIfNeeded()
     }
 
+    @Throws(CurrentProjectNotAccessibleException::class)
     fun refresh() {
+        updateCurrentProjectIfNeeded()
+
+        if (File(storagePathProvider.odkRootDirPath).listFiles().isEmpty()) {
+            currentProjectProvider.clear()
+            projectsRepository.deleteAll()
+            throw CurrentProjectNotAccessibleException()
+        }
+    }
+
+    private fun updateCurrentProjectIfNeeded() {
         if (currentProject.value != currentProjectProvider.getCurrentProject()) {
             _currentProject.postValue(currentProjectProvider.getCurrentProject())
         }
     }
 
-    open class Factory constructor(private val currentProjectProvider: CurrentProjectProvider, private val analyticsInitializer: AnalyticsInitializer) :
+    open class Factory(
+        private val currentProjectProvider: CurrentProjectProvider,
+        private val analyticsInitializer: AnalyticsInitializer,
+        private val storagePathProvider: StoragePathProvider,
+        private val projectsRepository: ProjectsRepository
+    ) :
         ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return CurrentProjectViewModel(currentProjectProvider, analyticsInitializer) as T
+            return CurrentProjectViewModel(
+                currentProjectProvider,
+                analyticsInitializer,
+                storagePathProvider,
+                projectsRepository
+            ) as T
         }
     }
+
+    class CurrentProjectNotAccessibleException : Exception()
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModel.kt
@@ -30,14 +30,14 @@ class CurrentProjectViewModel(
         updateCurrentProjectIfNeeded()
     }
 
-    @Throws(CurrentProjectNotAccessibleException::class)
+    @Throws(NoCurrentProjectException::class)
     fun refresh() {
         updateCurrentProjectIfNeeded()
 
         if (File(storagePathProvider.odkRootDirPath).listFiles().isEmpty()) {
             currentProjectProvider.clear()
             projectsRepository.deleteAll()
-            throw CurrentProjectNotAccessibleException()
+            throw NoCurrentProjectException()
         }
     }
 
@@ -64,5 +64,5 @@ class CurrentProjectViewModel(
         }
     }
 
-    class CurrentProjectNotAccessibleException : Exception()
+    class NoCurrentProjectException : Exception()
 }

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -237,4 +237,10 @@ public class AnalyticsEvents {
      * Tracks how often an external edit or view action includes an extra we'd like to deprecate.
      */
     public static final String FORM_ACTION_WITH_FORM_MODE_EXTRA = "FormActionWithFormModeExtra";
+
+    /**
+     * Tracks how often the app needs to recreate the directory for the current project
+     * when returning to or launching the app.
+     */
+    public static final String RECREATE_PROJECT_DIR = "RecreateProjectDir";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -544,7 +544,7 @@ public class AppDependencyModule {
 
     @Provides
     public CurrentProjectViewModel.Factory providesCurrentProjectViewModel(CurrentProjectProvider currentProjectProvider, AnalyticsInitializer analyticsInitializer, StoragePathProvider storagePathProvider, ProjectsRepository projectsRepository) {
-        return new CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer, storagePathProvider, projectsRepository);
+        return new CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer, storagePathProvider);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -543,8 +543,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public CurrentProjectViewModel.Factory providesCurrentProjectViewModel(CurrentProjectProvider currentProjectProvider, AnalyticsInitializer analyticsInitializer) {
-        return new CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer);
+    public CurrentProjectViewModel.Factory providesCurrentProjectViewModel(CurrentProjectProvider currentProjectProvider, AnalyticsInitializer analyticsInitializer, StoragePathProvider storagePathProvider, ProjectsRepository projectsRepository) {
+        return new CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer, storagePathProvider, projectsRepository);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/projects/CurrentProjectProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/CurrentProjectProvider.kt
@@ -31,4 +31,8 @@ class CurrentProjectProvider(private val settingsProvider: SettingsProvider, pri
     private fun getCurrentProjectId(): String? {
         return settingsProvider.getMetaSettings().getString(MetaKeys.CURRENT_PROJECT_ID)
     }
+
+    fun clear() {
+        settingsProvider.getMetaSettings().remove(MetaKeys.CURRENT_PROJECT_ID)
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/CurrentProjectProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/CurrentProjectProvider.kt
@@ -4,7 +4,6 @@ import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
-import java.lang.IllegalStateException
 
 class CurrentProjectProvider(private val settingsProvider: SettingsProvider, private val projectsRepository: ProjectsRepository) {
 
@@ -30,9 +29,5 @@ class CurrentProjectProvider(private val settingsProvider: SettingsProvider, pri
 
     private fun getCurrentProjectId(): String? {
         return settingsProvider.getMetaSettings().getString(MetaKeys.CURRENT_PROJECT_ID)
-    }
-
-    fun clear() {
-        settingsProvider.getMetaSettings().remove(MetaKeys.CURRENT_PROJECT_ID)
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.kt
@@ -75,8 +75,7 @@ class MainMenuActivityTest {
                 return object : CurrentProjectViewModel.Factory(
                     currentProjectProvider,
                     analyticsInitializer,
-                    storagePathProvider,
-                    projectsRepository
+                    storagePathProvider
                 ) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return currentProjectViewModel as T

--- a/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/MainMenuActivityTest.kt
@@ -68,9 +68,16 @@ class MainMenuActivityTest {
 
             override fun providesCurrentProjectViewModel(
                 currentProjectProvider: CurrentProjectProvider,
-                analyticsInitializer: AnalyticsInitializer
+                analyticsInitializer: AnalyticsInitializer,
+                storagePathProvider: StoragePathProvider,
+                projectsRepository: ProjectsRepository
             ): CurrentProjectViewModel.Factory? {
-                return object : CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer) {
+                return object : CurrentProjectViewModel.Factory(
+                    currentProjectProvider,
+                    analyticsInitializer,
+                    storagePathProvider,
+                    projectsRepository
+                ) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return currentProjectViewModel as T
                     }

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModelTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.mock
 import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.storage.StoragePathProvider
-import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
 import org.odk.collect.shared.TempFiles
 
@@ -31,8 +30,7 @@ class CurrentProjectViewModelTest {
     private val currentProjectViewModel = CurrentProjectViewModel(
         currentProjectProvider,
         analyticsInitializer,
-        storagePathProvider,
-        InMemProjectsRepository()
+        storagePathProvider
     )
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/viewmodels/CurrentProjectViewModelTest.kt
@@ -10,7 +10,10 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.storage.StoragePathProvider
+import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
+import org.odk.collect.shared.TempFiles
 
 class CurrentProjectViewModelTest {
 
@@ -21,12 +24,23 @@ class CurrentProjectViewModelTest {
         on { getCurrentProject() } doReturn Project.Saved("123", "Project X", "X", "#cccccc")
     }
 
+    private val storagePathProvider =
+        StoragePathProvider(currentProjectProvider, TempFiles.createTempDir().absolutePath)
+
     private val analyticsInitializer = mock<AnalyticsInitializer>()
-    private val currentProjectViewModel = CurrentProjectViewModel(currentProjectProvider, analyticsInitializer)
+    private val currentProjectViewModel = CurrentProjectViewModel(
+        currentProjectProvider,
+        analyticsInitializer,
+        storagePathProvider,
+        InMemProjectsRepository()
+    )
 
     @Test
     fun `Initial current project should be set`() {
-        assertThat(currentProjectViewModel.currentProject.value, `is`(Project.Saved("123", "Project X", "X", "#cccccc")))
+        assertThat(
+            currentProjectViewModel.currentProject.value,
+            `is`(Project.Saved("123", "Project X", "X", "#cccccc"))
+        )
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
@@ -63,8 +63,7 @@ class ProjectSettingsDialogTest {
                 return object : CurrentProjectViewModel.Factory(
                     currentProjectProvider,
                     analyticsInitializer,
-                    storagePathProvider,
-                    projectsRepository
+                    storagePathProvider
                 ) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return currentProjectViewModel as T

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ProjectSettingsDialogTest.kt
@@ -25,6 +25,7 @@ import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.screens.ProjectPreferencesActivity
 import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.fragmentstest.DialogFragmentTest
@@ -55,9 +56,16 @@ class ProjectSettingsDialogTest {
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
             override fun providesCurrentProjectViewModel(
                 currentProjectProvider: CurrentProjectProvider,
-                analyticsInitializer: AnalyticsInitializer
+                analyticsInitializer: AnalyticsInitializer,
+                storagePathProvider: StoragePathProvider,
+                projectsRepository: ProjectsRepository
             ): CurrentProjectViewModel.Factory? {
-                return object : CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer) {
+                return object : CurrentProjectViewModel.Factory(
+                    currentProjectProvider,
+                    analyticsInitializer,
+                    storagePathProvider,
+                    projectsRepository
+                ) {
                     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                         return currentProjectViewModel as T
                     }


### PR DESCRIPTION
Closes #4756 

#### What has been done to verify that this works as intended?

New tests and verified manually by deleting directories and then returning to/restarting the app.

#### Why is this the best possible solution? Were any other approaches considered?

Lots of approaches considered! We've had long discussions about this on Slack and there are thoughts in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the issue. It'd be good to check deleting `files` (or the `org.odk.collect.android`) directory as well as the `project` or current project's directory. This solution seems to work for both returning to (multi tasking away and back after deleting files) and for restarting (killing the app and starting again after deletion).

As a heads-up, it's very likely that there are places in the app other than the main menu that will still break, but we haven't actually seen that in the wild so chose not to address that yet. It's also likely that deleting a project directory for an inactive project and then switching to it will break, but we also haven't seen that in the wild.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)