### PR TITLE
Upate JAVA_HOME example

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ A problem occurred configuring project ':collect_app'.
 
 You may have a mismatch between the embedded Android SDK Java and the JDK installed on your machine. You may wish to set your **JAVA_HOME** environment variable to that SDK. For example, on macOS:
 
-`export JAVA_HOME="/Applications/Android Studio.app/Contents/jre/jdk/Contents/Home"
+`export JAVA_HOME="/Applications/Android\ Studio.app/Contents/jre/Contents/Home/"
 `
 
 Note that this change might cause problems with other Java-based applications (e.g., if you uninstall Android Studio).


### PR DESCRIPTION
This updates the `JAVA_HOME` example value for the newest Android Studio release.

#### What has been done to verify that this works as intended?

Ran `./gradlew` with Arctic Fox.

#### Why is this the best possible solution? Were any other approaches considered?

Just updating an example so no other approaches considered.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No risk here as it's just a README change. Can go in without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)