### PR TITLE
Use Intent.ACTION_GET_CONTENT instead of Intent.ACTION_PICK to pick an image with settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegate.java
@@ -55,7 +55,7 @@ public class QRCodeMenuDelegate implements MenuDelegate {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_item_scan_sd_card:
-                Intent photoPickerIntent = new Intent(Intent.ACTION_PICK);
+                Intent photoPickerIntent = new Intent(Intent.ACTION_GET_CONTENT);
                 photoPickerIntent.setType("image/*");
                 if (activityAvailability.isActivityAvailable(photoPickerIntent)) {
                     activity.startActivityForResult(photoPickerIntent, SELECT_PHOTO);

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -159,7 +159,7 @@ class QrCodeProjectCreatorDialog :
         binding.toolbar.setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.menu_item_scan_sd_card -> {
-                    val photoPickerIntent = Intent(Intent.ACTION_PICK)
+                    val photoPickerIntent = Intent(Intent.ACTION_GET_CONTENT)
                     photoPickerIntent.type = "image/*"
                     if (activityAvailability.isActivityAvailable(photoPickerIntent)) {
                         imageQrCodeImportResultLauncher.launch(photoPickerIntent)

--- a/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegateTest.java
@@ -57,7 +57,7 @@ public class QRCodeMenuDelegateTest {
         ShadowActivity.IntentForResult intentForResult = shadowOf(activity).getNextStartedActivityForResult();
         assertThat(intentForResult, notNullValue());
         assertThat(intentForResult.requestCode, is(SELECT_PHOTO));
-        assertThat(intentForResult.intent.getAction(), is(Intent.ACTION_PICK));
+        assertThat(intentForResult.intent.getAction(), is(Intent.ACTION_GET_CONTENT));
         assertThat(intentForResult.intent.getType(), is("image/*"));
     }
 


### PR DESCRIPTION
Closes #4776

#### What has been done to verify that this works as intended?
I tested picking images with settings.

#### Why is this the best possible solution? Were any other approaches considered?
According to the docs https://developer.android.com/reference/android/content/Intent#ACTION_GET_CONTENT we should use 
`Intent.ACTION_GET_CONTENT` instead of `Intent.ACTION_PICK`. I also confirmed that the behavior is better if we use `Intent.ACTION_PICK`.
We also discussed the issue on slack https://getodk.slack.com/archives/C35ENHA64/p1628005284054700

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test picking images with settings, not importing just picking.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)