### PR TITLE
Proposal for #4059 First nested repeat not created…

### DIFF
--- a/collect_app/src/androidTest/assets/forms/NestedRepeats.xml
+++ b/collect_app/src/androidTest/assets/forms/NestedRepeats.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:odk="http://www.opendatakit.org/xforms" xmlns="http://www.w3.org/2002/xforms">
+    <h:head>
+        <h:title>NestedRepeats</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="NestedRepeats" version="2021-08-15 B">
+                    <person jr:template="">
+                        <age />
+                        <child jr:template="">
+                            <name />
+                            <pet jr:template="">
+                                <colour />
+                            </pet>
+                        </child>
+                    </person>
+                    <person>
+                        <age />
+                        <child>
+                            <name />
+                            <pet>
+                                <colour />
+                            </pet>
+                        </child>
+                    </person>
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/person/age" type="string" />
+            <bind nodeset="/data/person/child/name" type="string" />
+            <bind nodeset="/data/person/child/pet/colour" type="string" />
+            <bind nodeset="/data/meta/instanceID" readonly="true()" type="string"
+                jr:preload="uid" />
+        </model>
+    </h:head>
+    <h:body>
+        <group ref="/data/person">
+            <label>Person</label>
+            <repeat nodeset="/data/person">
+                <input ref="/data/person/age">
+                    <label>age?</label>
+                </input>
+                <group ref="/data/person/child">
+                    <label>Child</label>
+                    <repeat nodeset="/data/person/child">
+                        <input ref="/data/person/child/name">
+                            <label>name?</label>
+                        </input>
+                        <group ref="/data/person/child/pet">
+                            <label>Pet</label>
+                            <repeat nodeset="/data/person/child/pet">
+                                <input ref="/data/person/child/pet/colour">
+                                    <label>colour?</label>
+                                </input>
+                            </repeat>
+                        </group>
+                    </repeat>
+                </group>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/NestedRepeatTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/NestedRepeatTest.java
@@ -1,0 +1,45 @@
+package org.odk.collect.android.feature.formentry;
+
+import android.Manifest;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.odk.collect.android.support.CollectTestRule;
+import org.odk.collect.android.support.CopyFormRule;
+import org.odk.collect.android.support.ResetStateRule;
+import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.support.pages.MainMenuPage;
+
+@RunWith(AndroidJUnit4.class)
+public class NestedRepeatTest {
+
+    private final CollectTestRule rule = new CollectTestRule();
+
+    @Rule
+    public RuleChain copyFormChain = RuleChain
+            .outerRule(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
+            .around(new ResetStateRule())
+            .around(new CopyFormRule("NestedRepeats.xml"))
+            .around(rule);
+
+    @Test
+    public void nestedRepeatsCreatedWithOuterRepeat() {
+        new MainMenuPage()
+                .startBlankForm("NestedRepeats")
+                .assertText("Person > 1")
+                .clickPlus("Person")
+                .clickOnAdd(new FormEntryPage(""))
+                .assertText("Person > 2")
+                .swipeToNextQuestion("name?")//Already there?
+                .assertText("Person > 2 > Child > 1")
+                .swipeToNextQuestion("colour?")//Already there?
+                .assertText("Person > 2 > Child > 1 > Pet > 1");
+
+    }
+
+}

--- a/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
@@ -1,0 +1,1693 @@
+/*
+ * Copyright (C) 2009 JavaRosa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.javarosa.core.model;
+
+import org.javarosa.core.log.WrappedException;
+import org.javarosa.core.model.TriggerableDag.EventNotifierAccessor;
+import org.javarosa.core.model.actions.ActionController;
+import org.javarosa.core.model.actions.Actions;
+import org.javarosa.core.model.condition.Constraint;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.condition.IConditionExpr;
+import org.javarosa.core.model.condition.IFunctionHandler;
+import org.javarosa.core.model.condition.Triggerable;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.MultipleItemsData;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.model.instance.DataInstance;
+import org.javarosa.core.model.instance.ExternalDataInstance;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.model.instance.InvalidReferenceException;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.model.util.restorable.RestoreUtils;
+import org.javarosa.core.model.utils.QuestionPreloader;
+import org.javarosa.core.services.locale.Localizable;
+import org.javarosa.core.services.locale.Localizer;
+import org.javarosa.core.services.storage.IMetaData;
+import org.javarosa.core.services.storage.Persistable;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapListPoly;
+import org.javarosa.core.util.externalizable.ExtWrapMap;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.debug.EvaluationResult;
+import org.javarosa.debug.Event;
+import org.javarosa.debug.EventNotifier;
+import org.javarosa.debug.EventNotifierSilent;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
+import org.javarosa.model.xform.XPathReference;
+import org.javarosa.xform.parse.XFormParseException;
+import org.javarosa.xform.util.XFormAnswerDataSerializer;
+import org.javarosa.xml.InternalDataInstanceParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Definition of a form. This has some meta data about the form definition and a
+ * collection of groups together with question branching or skipping rules.
+ *
+ * @author Daniel Kayiwa, Drew Roos
+ */
+public class FormDef implements IFormElement, Localizable, Persistable, IMetaData,
+        ActionController.ActionResultProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(FormDef.class);
+
+    public static final String STORAGE_KEY = "FORMDEF";
+    public static final int TEMPLATING_RECURSION_LIMIT = 10;
+
+    private static EventNotifier defaultEventNotifier = new EventNotifierSilent();
+
+    /**
+     * Takes a (possibly relative) reference, and makes it absolute based on its parent.
+     * Moved from the parser to this class so it can be used more cleanly by ItemsetBinding.
+     */
+    public static IDataReference getAbsRef(IDataReference ref, TreeReference parentRef) {
+        TreeReference tref;
+
+        if (!parentRef.isAbsolute()) {
+            throw new RuntimeException("XFormParser.getAbsRef: parentRef must be absolute");
+        }
+
+        if (ref != null) {
+            tref = (TreeReference) ref.getReference();
+        } else {
+            tref = TreeReference.selfRef(); //only happens for <group>s with no binding
+        }
+
+        tref = tref.anchor(parentRef);
+        if (tref == null) {
+            throw new XFormParseException("Binding path [" + tref + "] not allowed with parent binding of [" + parentRef + "]");
+        }
+
+        return new XPathReference(tref);
+    }
+
+    /**
+     * A collection of group definitions
+     */
+    private List<IFormElement> children;
+    /**
+     * The numeric unique identifier of the form definition on the local device
+     */
+    private int id;
+    /**
+     * The display title of the form
+     */
+    private String title;
+
+    /**
+     * The file path to the XML form definition. Used for serialization and deserialization of the internal instances.
+     **/
+    private String formXmlPath;
+
+    private String name;
+
+    private List<XFormExtension> extensions;
+
+    /**
+     * A unique external name that is used to identify the form between machines
+     */
+    private Localizer localizer;
+
+    /**
+     * IConditionExpr contents of output tags that serve as parameterized arguments to captions
+     */
+    private List<IConditionExpr> outputFragments;
+
+    private TriggerableDag dagImpl;
+
+    private EvaluationContext exprEvalContext;
+
+    private QuestionPreloader preloader = new QuestionPreloader();
+
+    // XML ID's cannot start with numbers, so this should never conflict
+    private static String DEFAULT_SUBMISSION_PROFILE = "1";
+
+    private HashMap<String, SubmissionProfile> submissionProfiles;
+
+    private HashMap<String, DataInstance> formInstances;
+    private FormInstance mainInstance = null;
+
+    //region Actions
+    private ActionController actionController;
+    /**
+     * The names of the action types that this form includes. This allows clients to do things like let users know if
+     * location is captured in the background. Actions can nest so to dynamically figure out which ones the form
+     * includes we'd have to query the actionController on every node.
+     */
+    private Set<String> actions;
+    /**
+     * Questions and groups that have nested actions triggered by top-level events.
+     */
+    private Set<IFormElement> elementsWithActionTriggeredByToplevelEvent;
+    //endregion
+
+    private EventNotifier eventNotifier;
+
+    private List<String> parseWarnings = new ArrayList<>();
+    private List<String> parseErrors = new ArrayList<>();
+
+    public FormDef() {
+        this(defaultEventNotifier);
+    }
+
+    public FormDef(EventNotifier eventNotifier) {
+        setID(-1);
+        setChildren(null);
+        final EventNotifierAccessor ia = new EventNotifierAccessor() {
+            @Override
+            public EventNotifier getEventNotifier() {
+                return FormDef.this.getEventNotifier();
+            }
+        };
+
+        dagImpl = new TriggerableDag(ia);
+
+        // This is kind of a wreck...
+        resetEvaluationContext();
+        outputFragments = new ArrayList<>();
+        submissionProfiles = new HashMap<>();
+        formInstances = new HashMap<>();
+        extensions = new ArrayList<>();
+
+        actionController = new ActionController();
+        actions = new HashSet<>();
+        elementsWithActionTriggeredByToplevelEvent = new HashSet<>();
+
+        this.eventNotifier = eventNotifier;
+    }
+
+    public EventNotifier getEventNotifier() {
+        return eventNotifier;
+    }
+
+    public void setEventNotifier(EventNotifier eventNotifier) {
+        this.eventNotifier = eventNotifier;
+    }
+
+    /**
+     * Getters and setters for the lists
+     */
+    public void addNonMainInstance(DataInstance instance) {
+        formInstances.put(instance.getName(), instance);
+        resetEvaluationContext();
+    }
+
+    public void setFormXmlPath(String formXmlPath) {
+        this.formXmlPath = formXmlPath;
+    }
+
+    /**
+     * Get an instance based on a name
+     *
+     * @param name string name
+     * @return
+     */
+    public DataInstance getNonMainInstance(String name) {
+        HashMap<String, DataInstance> formInstances = getFormInstances();
+        if (!formInstances.containsKey(name)) {
+            return null;
+        }
+
+        return formInstances.get(name);
+    }
+
+    public Enumeration<DataInstance> getNonMainInstances() {
+        return Collections.enumeration(getFormInstances().values());
+    }
+
+    public void setInstance(FormInstance fi) {
+        mainInstance = fi;
+        fi.setFormId(getID());
+        resetEvaluationContext();
+
+        // construct the references in all the question itemsets
+        // now so that the entire main instance is available
+        // for term resolution.
+        updateItemsetReferences(getChildren());
+
+        attachControlsToInstanceData();
+    }
+
+    public FormInstance getMainInstance() {
+        return mainInstance;
+    }
+
+    public FormInstance getInstance() {
+        return getMainInstance();
+    }
+
+    public void fireEvent() {
+
+    }
+
+    // ---------- child elements
+    @Override
+    public void addChild(IFormElement fe) {
+        this.children.add(fe);
+    }
+
+    @Override
+    public IFormElement getChild(int i) {
+        if (i < this.children.size())
+            return this.children.get(i);
+
+        throw new ArrayIndexOutOfBoundsException("FormDef: invalid child index: " + i + " only "
+                + children.size() + " children");
+    }
+
+    public IFormElement getChild(FormIndex index) {
+        IFormElement element = this;
+        while (index != null && index.isInForm()) {
+            element = element.getChild(index.getLocalIndex());
+            index = index.getNextLevel();
+        }
+        return element;
+    }
+
+    /**
+     * Dereference the form index and return a List of all interstitial nodes
+     * (top-level parent first; index target last)
+     * <p/>
+     * Ignore 'new-repeat' node for now; just return/stop at ref to
+     * yet-to-be-created repeat node (similar to repeats that already exist)
+     *
+     * @param index
+     * @return
+     */
+    public List<IFormElement> explodeIndex(FormIndex index) {
+        List<Integer> indexes = new ArrayList<>();
+        List<Integer> multiplicities = new ArrayList<>();
+        List<IFormElement> elements = new ArrayList<>();
+
+        collapseIndex(index, indexes, multiplicities, elements);
+        return elements;
+    }
+
+    /**
+     * Finds the instance node a reference refers to (factoring in multiplicities)
+     */
+    public TreeReference getChildInstanceRef(FormIndex index) {
+        List<Integer> indexes = new ArrayList<>();
+        List<Integer> multiplicities = new ArrayList<>();
+        List<IFormElement> elements = new ArrayList<>();
+
+        collapseIndex(index, indexes, multiplicities, elements);
+        return getChildInstanceRef(elements, multiplicities);
+    }
+
+    public TreeReference getChildInstanceRef(List<IFormElement> elements, List<Integer> multiplicities) {
+        if (elements.size() == 0)
+            return null;
+
+        IFormElement element = elements.get(elements.size() - 1);
+        // get reference for target element
+        TreeReference ref = FormInstance.unpackReference(
+                element.getBind()).clone();
+        for (int i = 0; i < ref.size(); i++) {
+            // There has to be a better way to encapsulate this
+            if (ref.getMultiplicity(i) != TreeReference.INDEX_ATTRIBUTE) {
+                ref.setMultiplicity(i, 0);
+            }
+        }
+
+        // fill in multiplicities for repeats along the way
+        for (int i = 0; i < elements.size(); i++) {
+            IFormElement temp = elements.get(i);
+            if (temp instanceof GroupDef && ((GroupDef) temp).getRepeat()) {
+                TreeReference repRef = FormInstance.unpackReference(temp.getBind());
+                if (repRef.isAncestorOf(ref, false)) {
+                    int repMult = multiplicities.get(i);
+                    ref.setMultiplicity(repRef.size() - 1, repMult);
+                } else {
+                    return null; // question/repeat hierarchy is not consistent
+                    // with instance instance and bindings
+                }
+            }
+        }
+
+        return ref;
+    }
+
+    public void setLocalizer(Localizer l) {
+        if (this.localizer != null) {
+            this.localizer.unregisterLocalizable(this);
+        }
+
+        this.localizer = l;
+        if (this.localizer != null) {
+            this.localizer.registerLocalizable(this);
+        }
+    }
+
+    // don't think this should ever be called(!)
+    @Override
+    public IDataReference getBind() {
+        throw new RuntimeException("method not implemented");
+    }
+
+    public void setValue(IAnswerData data, TreeReference ref, boolean midSurvey) {
+        setValue(data, ref, mainInstance.resolveReference(ref), midSurvey);
+    }
+
+    public void setValue(IAnswerData data, TreeReference ref, TreeElement node,
+                         boolean midSurvey) {
+        IAnswerData oldValue = node.getValue();
+        IAnswerDataSerializer answerDataSerializer = new XFormAnswerDataSerializer();
+
+        boolean valueChanged = !objectEquals(answerDataSerializer.serializeAnswerData(oldValue),
+                answerDataSerializer.serializeAnswerData(data));
+
+        setAnswer(data, node);
+
+        QuestionDef currentQuestion = findQuestionByRef(ref, this);
+        if (valueChanged && currentQuestion != null) {
+            currentQuestion.getActionController().triggerActionsFromEvent(Actions.EVENT_QUESTION_VALUE_CHANGED, this,
+                    ref.getParentRef(), null);
+        }
+
+        Collection<QuickTriggerable> qts = triggerTriggerables(ref);
+        dagImpl.publishSummary("New value", ref, qts);
+        // TODO: pre-populate fix-count repeats here?
+    }
+
+    /**
+     * Copied from commons-lang 2.6: For reviewing purposes only.
+     * <p/>
+     * <p>
+     * Compares two objects for equality, where either one or both objects may be
+     * <code>null</code>.
+     * </p>
+     * <p/>
+     * <pre>
+     * ObjectUtils.equals(null, null)                  = true
+     * ObjectUtils.equals(null, "")                    = false
+     * ObjectUtils.equals("", null)                    = false
+     * ObjectUtils.equals("", "")                      = true
+     * ObjectUtils.equals(Boolean.TRUE, null)          = false
+     * ObjectUtils.equals(Boolean.TRUE, "true")        = false
+     * ObjectUtils.equals(Boolean.TRUE, Boolean.TRUE)  = true
+     * ObjectUtils.equals(Boolean.TRUE, Boolean.FALSE) = false
+     * </pre>
+     *
+     * @param object1 the first object, may be <code>null</code>
+     * @param object2 the second object, may be <code>null</code>
+     * @return <code>true</code> if the values of both objects are the same
+     */
+    public static boolean objectEquals(Object object1, Object object2) {
+        if (object1 == object2) {
+            return true;
+        }
+        if ((object1 == null) || (object2 == null)) {
+            return false;
+        }
+        return object1.equals(object2);
+    }
+
+    public void setAnswer(IAnswerData data, TreeReference ref) {
+        setAnswer(data, mainInstance.resolveReference(ref));
+    }
+
+    public void setAnswer(IAnswerData data, TreeElement node) {
+        node.setAnswer(data);
+    }
+
+    /**
+     * Deletes the inner-most repeat that this node belongs to and returns the
+     * corresponding FormIndex. Behavior is currently undefined if you call this
+     * method on a node that is not contained within a repeat.
+     *
+     * @param index
+     * @return
+     */
+    public FormIndex deleteRepeat(FormIndex index) {
+        List<Integer> indexes = new ArrayList<>();
+        List<Integer> multiplicities = new ArrayList<>();
+        List<IFormElement> elements = new ArrayList<>();
+        collapseIndex(index, indexes, multiplicities, elements);
+
+        // loop backwards through the elements, removing objects from each
+        // list, until we find a repeat
+        // TODO: should probably check to make sure size > 0
+        for (int i = elements.size() - 1; i >= 0; i--) {
+            IFormElement e = elements.get(i);
+            if (e instanceof GroupDef && ((GroupDef) e).getRepeat()) {
+                break;
+            } else {
+                indexes.remove(i);
+                multiplicities.remove(i);
+                elements.remove(i);
+            }
+        }
+
+        // build new formIndex which includes everything
+        // up to the node we're going to remove
+        FormIndex newIndex = buildIndex(indexes, multiplicities, elements);
+
+        TreeReference deleteRef = getChildInstanceRef(newIndex);
+        TreeElement deleteElement = mainInstance.resolveReference(deleteRef);
+        TreeReference parentRef = deleteRef.getParentRef();
+        TreeElement parentElement = mainInstance.resolveReference(parentRef);
+
+        int childMult = deleteElement.getMult();
+        parentElement.removeChild(deleteElement);
+
+        // update multiplicities of other child nodes
+        for (int i = 0; i < parentElement.getNumChildren(); i++) {
+            TreeElement child = parentElement.getChildAt(i);
+            if (child.getName().equals(deleteElement.getName()) && child.getMult() > childMult) {
+                child.setMult(child.getMult() - 1);
+
+                // When a group changes it multiplicity, then all caches of its
+                // children must clear.
+                child.clearChildrenCaches();
+            }
+        }
+
+        dagImpl.deleteRepeatInstance(getMainInstance(), getEvaluationContext(), deleteRef, deleteElement);
+
+        return newIndex;
+    }
+
+    public void createNewRepeat(FormIndex index) throws InvalidReferenceException {
+        TreeReference repeatContextRef = getChildInstanceRef(index);
+        TreeElement template = mainInstance.getTemplate(repeatContextRef);
+
+        mainInstance.copyNode(template, repeatContextRef);
+
+        TreeElement newNode = mainInstance.resolveReference(repeatContextRef);
+        preloadInstance(newNode);
+
+        // Fire events before form re-computation (calculates, relevance, etc). First trigger actions defined in the
+        // model and then trigger actions defined in the body
+        actionController.triggerActionsFromEvent(Actions.EVENT_JR_INSERT, this, repeatContextRef, this);
+        actionController.triggerActionsFromEvent(Actions.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);
+        // Trigger actions nested in the new repeat
+        getChild(index).getActionController().triggerActionsFromEvent(Actions.EVENT_ODK_NEW_REPEAT, this, repeatContextRef, this);
+
+        dagImpl.createRepeatInstance(getMainInstance(), getEvaluationContext(), repeatContextRef, newNode);
+    }
+
+    @Override
+    public void processResultOfAction(TreeReference refSetByAction, String event) {
+        if (Actions.EVENT_JR_INSERT.equals(event)) {
+            // CommCare has an implementation if needed
+        }
+    }
+
+    public boolean isRepeatRelevant(TreeReference repeatRef) {
+        boolean relev = true;
+
+        QuickTriggerable qc = dagImpl.getRelevanceForRepeat(repeatRef.genericize());
+        if (qc != null) {
+            relev = (boolean) qc.eval(mainInstance, new EvaluationContext(exprEvalContext, repeatRef));
+        }
+
+        if (relev) {
+            // Must check the template in case of static relevance expressions that wouldn't be in the DAG (e.g. false()).
+            TreeElement templNode = mainInstance.getTemplate(repeatRef);
+            // Check the relevancy of the immediate parent. Unclear whether this is needed because in a normal form-filling
+            // flow the child would not be accessible if its parent is irrelevant.
+            TreeReference parentPath = templNode.getParent().getRef().genericize();
+            TreeElement parentNode = mainInstance
+                    .resolveReference(parentPath.contextualize(repeatRef));
+            relev = parentNode.isRelevant() && templNode.isRelevant();
+        }
+
+        return relev;
+    }
+
+    public boolean canCreateRepeat(TreeReference repeatRef, FormIndex repeatIndex) {
+        GroupDef repeat = (GroupDef) this.getChild(repeatIndex);
+
+        // Check to see if this repeat can have children added by the user
+        if (repeat.noAddRemove) {
+            // Check to see if there's a count to use to determine how many
+            // children this repeat
+            // should have
+            if (repeat.getCountReference() != null) {
+                int currentMultiplicity = repeatIndex.getElementMultiplicity();
+
+                // Lu Gram: the count XPath needs to be contextualized for nested
+                // repeat groups...
+                TreeReference countRef = FormInstance.unpackReference(repeat.getCountReference());
+                TreeElement countNode = this.getMainInstance().resolveReference(
+                        countRef.contextualize(repeatRef));
+                if (countNode == null) {
+                    throw new RuntimeException("Could not locate the repeat count value expected at "
+                            + repeat.getCountReference().getReference().toString());
+                }
+                // get the total multiplicity possible
+                IAnswerData count = countNode.getValue();
+                long fullcount = count == null ? 0 : (Integer) count.getValue();
+
+                if (fullcount <= currentMultiplicity) {
+                    return false;
+                }
+            } else {
+                // Otherwise the user can never add repeat instances
+                return false;
+            }
+        }
+
+        // TODO: If we think the node is still relevant, we also need to figure
+        // out a way to test that assumption against
+        // the repeat's constraints.
+
+        return true;
+    }
+
+    public void copyItemsetAnswer(QuestionDef q, TreeElement targetNode, IAnswerData data) throws InvalidReferenceException {
+        ItemsetBinding itemset = q.getDynamicChoices();
+        TreeReference targetRef = targetNode.getRef();
+        TreeReference destRef = itemset.getDestRef().contextualize(targetRef);
+
+        List<Selection> selections = null;
+        if (data instanceof MultipleItemsData) {
+            selections = (List<Selection>) data.getValue();
+        } else if (data instanceof SelectOneData) {
+            selections = new ArrayList<>(1);
+            selections.add((Selection) data.getValue());
+        }
+        List<String> selectedValues;
+        if (itemset.valueRef != null) {
+            selectedValues = new ArrayList<>(selections.size());
+            for (Selection selection : selections) {
+                selectedValues.add(selection.choice.getValue());
+            }
+        } else {
+            selectedValues = new ArrayList<>(0);
+        }
+
+        // delete existing dest nodes that are not in the answer selection
+        HashMap<String, TreeElement> existingValues = new HashMap<>();
+        List<TreeReference> existingNodes = exprEvalContext.expandReference(destRef);
+        for (TreeReference existingNode : existingNodes) {
+            TreeElement node = getMainInstance().resolveReference(existingNode);
+
+            if (itemset.valueRef != null) {
+                String value = itemset.getRelativeValue().evalReadable(this.getMainInstance(),
+                        new EvaluationContext(exprEvalContext, node.getRef()));
+                if (selectedValues.contains(value)) {
+                    existingValues.put(value, node); // cache node if in selection
+                    // and already exists
+                }
+            }
+
+            // delete from target
+            targetNode.removeChild(node);
+        }
+
+        // copy in nodes for new answer; preserve ordering in answer
+        for (int i = 0; i < selections.size(); i++) {
+            Selection s = selections.get(i);
+            SelectChoice ch = s.choice;
+
+            TreeElement cachedNode = null;
+            if (itemset.valueRef != null) {
+                String value = ch.getValue();
+                if (existingValues.containsKey(value)) {
+                    cachedNode = existingValues.get(value);
+                }
+            }
+
+            if (cachedNode != null) {
+                cachedNode.setMult(i);
+                targetNode.addChild(cachedNode);
+            } else {
+                getMainInstance().copyItemsetNode(ch.copyNode, destRef, this);
+            }
+        }
+        dagImpl.copyItemsetAnswer(getMainInstance(), getEvaluationContext(), destRef, targetNode);
+    }
+
+    /**
+     * Adds a Condition to the form's Collection.
+     *
+     * @param t the condition to be set
+     */
+    public Triggerable addTriggerable(Triggerable t) {
+        return dagImpl.addTriggerable(t);
+    }
+
+    /**
+     * Reports any dependency cycles based upon the triggerIndex array.
+     * (Does not require that the DAG be finalized).
+     */
+    public void reportDependencyCycles() {
+        dagImpl.reportDependencyCycles();
+    }
+
+    /**
+     * Finalizes the DAG associated with the form's triggered conditions. This
+     * will create the appropriate ordering and dependencies to ensure the
+     * conditions will be evaluated in the appropriate orders.
+     *
+     * @throws IllegalStateException - If the trigger ordering contains an illegal cycle and the
+     *                               triggers can't be laid out appropriately
+     */
+    public void finalizeTriggerables() throws IllegalStateException {
+        //
+        // DAGify the triggerables based on dependencies and sort them so that
+        // triggerables come only after the triggerables they depend on
+        //
+        dagImpl.finalizeTriggerables(getMainInstance(), getEvaluationContext());
+    }
+
+    /**
+     * Walks the current set of conditions, and evaluates each of them with the
+     * current context.
+     */
+    private Collection<QuickTriggerable> initializeTriggerables(TreeReference rootRef) {
+
+        return dagImpl.initializeTriggerables(getMainInstance(), getEvaluationContext(), rootRef);
+    }
+
+    /**
+     * The entry point for the DAG cascade after a value is changed in the model.
+     *
+     * @param ref The full contextualized unambiguous reference of the value that
+     *            was changed.
+     */
+    public Collection<QuickTriggerable> triggerTriggerables(TreeReference ref) {
+        return dagImpl.triggerTriggerables(getMainInstance(), getEvaluationContext(), ref);
+    }
+
+    public ValidateOutcome validate(boolean markCompleted) {
+
+        FormEntryModel formEntryModelToBeValidated = new FormEntryModel(this);
+        FormEntryController formEntryControllerToBeValidated = new FormEntryController(formEntryModelToBeValidated);
+
+        return dagImpl.validate(formEntryControllerToBeValidated, markCompleted);
+    }
+
+    public boolean evaluateConstraint(TreeReference ref, IAnswerData data) {
+        if (data == null) {
+            return true;
+        }
+
+        TreeElement node = mainInstance.resolveReference(ref);
+        Constraint c = node.getConstraint();
+
+        if (c == null) {
+            return true;
+        }
+        EvaluationContext ec = new EvaluationContext(exprEvalContext, ref);
+        ec.isConstraint = true;
+        ec.candidateValue = data;
+
+        boolean result = c.constraint.eval(mainInstance, ec);
+
+        getEventNotifier().publishEvent(new Event("Constraint", new EvaluationResult(ref, result)));
+
+        return result;
+    }
+
+    private void resetEvaluationContext() {
+        EvaluationContext ec = new EvaluationContext(null);
+        ec = new EvaluationContext(mainInstance, getFormInstances(), ec);
+        initEvalContext(ec);
+        this.exprEvalContext = ec;
+    }
+
+    public EvaluationContext getEvaluationContext() {
+        return this.exprEvalContext;
+    }
+
+    /**
+     * @param ec The new Evaluation Context
+     */
+    private void initEvalContext(EvaluationContext ec) {
+        if (!ec.getFunctionHandlers().containsKey("jr:itext")) {
+            final FormDef f = this;
+            ec.addFunctionHandler(new IFunctionHandler() {
+                @Override
+                public String getName() {
+                    return "jr:itext";
+                }
+
+                @Override
+                public Object eval(Object[] args, EvaluationContext ec) {
+                    String textID = (String) args[0];
+                    try {
+                        // SUUUUPER HACKY
+                        String form = ec.getOutputTextForm();
+                        if (form != null) {
+                            textID = textID + ";" + form;
+                            String result = f.getLocalizer().getRawText(f.getLocalizer().getLocale(),
+                                    textID);
+                            return result == null ? "" : result;
+                        } else {
+                            String text = f.getLocalizer().getText(textID);
+                            return text == null ? "[itext:" + textID + "]" : text;
+                        }
+                    } catch (NoSuchElementException nsee) {
+                        return "[nolocale]";
+                    }
+                }
+
+                @Override
+                public List<Class[]> getPrototypes() {
+                    Class[] proto = {String.class};
+                    List<Class[]> v = new ArrayList<>(1);
+                    v.add(proto);
+                    return v;
+                }
+
+                @Override
+                public boolean rawArgs() {
+                    return false;
+                }
+
+                @Override
+                public boolean realTime() {
+                    return false;
+                }
+            });
+        }
+
+        /*
+         * Given a select value, looks the label up in the choice list defined by the given question and returns it in
+         * the currently-set language.
+         *
+         * arg 1: select value
+         * arg 2: string xpath referring to question that defines the select
+         *
+         * this won't work at all if the original label needed to be
+         * processed/calculated in some way (<output>s, etc.) (is this even
+         * allowed?) likely won't work with multi-media labels _might_ work for
+         * itemsets, but probably not very well or at all; could potentially work
+         * better if we had some context info
+         *
+         * it's mainly intended for the simple case of reversing a question with
+         * compile-time-static fields, for use inside an <output>
+         */
+        if (!ec.getFunctionHandlers().containsKey("jr:choice-name")) {
+            final FormDef f = this;
+            ec.addFunctionHandler(new IFunctionHandler() {
+                @Override
+                public String getName() {
+                    return "jr:choice-name";
+                }
+
+                @Override
+                public Object eval(Object[] args, EvaluationContext ec) {
+                    try {
+                        String value = (String) args[0];
+                        String questionXpath = (String) args[1];
+                        TreeReference ref = RestoreUtils.xfFact.ref(questionXpath);
+                        ref = ref.anchor(ec.getContextRef());
+
+                        QuestionDef q = findQuestionByRef(ref, f);
+                        if (q == null
+                                || (q.getControlType() != Constants.CONTROL_SELECT_ONE
+                                && q.getControlType() != Constants.CONTROL_SELECT_MULTI
+                                && q.getControlType() != Constants.CONTROL_RANK)) {
+                            return "";
+                        }
+
+                        List<SelectChoice> choices;
+
+                        ItemsetBinding itemset = q.getDynamicChoices();
+                        if (itemset != null) {
+                            // 2019-HM: See ChoiceNameTest for test and more explanation
+
+                            // NOTE: We have no context against which to evaluate a dynamic selection list. This will
+                            // generally cause that evaluation to break if any filtering is done, or, worst case, give
+                            // unexpected results.
+                            //
+                            // We should hook into the existing code (FormEntryPrompt) for pulling display text for select
+                            // choices. however, it's hard, because we don't really have any context to work with, and all
+                            // the situations where that context would be used don't make sense for trying to reverse a
+                            // select value back to a label in an unrelated expression
+                            if (ref.isAmbiguous()) {
+                                // SurveyCTO: We need a absolute "ref" to populate the dynamic choices,
+                                // like we do when we populate those at FormEntryPrompt (line 251).
+                                // The "ref" here is ambiguous, so we need to make it concrete first.
+                                ref = ref.contextualize(ec.getContextRef());
+                            }
+                            choices = itemset.getChoices(f, ref);
+                        } else { // static choices
+                            choices = q.getChoices();
+                        }
+                        if (choices != null) {
+                            for (SelectChoice ch : choices) {
+                                if (ch.getValue().equals(value)) {
+                                    // this is really not ideal. we should hook into the existing code (FormEntryPrompt)
+                                    // for pulling display text for select choices. however, it's hard, because we don't
+                                    // really have any context to work with, and all the situations where that context
+                                    // would be used don't make sense for trying to reverse a select value back to a
+                                    // label in an unrelated expression
+
+                                    String textID = ch.getTextID();
+                                    String templateStr;
+                                    if (textID != null) {
+                                        templateStr = f.getLocalizer().getText(textID);
+                                    } else {
+                                        templateStr = ch.getLabelInnerText();
+                                    }
+                                    return fillTemplateString(templateStr, ref);
+                                }
+                            }
+                        }
+                        return "";
+                    } catch (Exception e) {
+                        throw new WrappedException("error in evaluation of xpath function [choice-name]",
+                                e);
+                    }
+                }
+
+                @Override
+                public List<Class[]> getPrototypes() {
+                    Class[] proto = {String.class, String.class};
+                    List<Class[]> v = new ArrayList<>(1);
+                    v.add(proto);
+                    return v;
+                }
+
+                @Override
+                public boolean rawArgs() {
+                    return false;
+                }
+
+                @Override
+                public boolean realTime() {
+                    return false;
+                }
+            });
+        }
+    }
+
+    public String fillTemplateString(String template, TreeReference contextRef) {
+        return fillTemplateString(template, contextRef, new HashMap<>());
+    }
+
+    public String fillTemplateString(String template, TreeReference contextRef,
+                                     HashMap<String, ?> variables) {
+        HashMap<String, String> args = new HashMap<>();
+
+        int depth = 0;
+        List<String> outstandingArgs = Localizer.getArgs(template);
+        while (outstandingArgs.size() > 0) {
+            for (String argName : outstandingArgs) {
+                if (!args.containsKey(argName)) {
+                    int ix = -1;
+                    try {
+                        ix = Integer.parseInt(argName);
+                    } catch (NumberFormatException nfe) {
+                        logger.warn("expect arguments to be numeric [{}]", argName);
+                    }
+
+                    if (ix < 0 || ix >= outputFragments.size())
+                        continue;
+
+                    IConditionExpr expr = outputFragments.get(ix);
+                    EvaluationContext ec = new EvaluationContext(exprEvalContext, contextRef);
+                    ec.setOriginalContext(contextRef);
+                    ec.setVariables(variables);
+                    String value = expr.evalReadable(this.getMainInstance(), ec);
+                    args.put(argName, value);
+                }
+            }
+
+            template = Localizer.processArguments(template, args);
+            outstandingArgs = Localizer.getArgs(template);
+
+            depth++;
+            if (depth >= TEMPLATING_RECURSION_LIMIT) {
+                throw new RuntimeException("Dependency cycle in <output>s; recursion limit exceeded!!");
+            }
+        }
+
+        return template;
+    }
+
+    public QuestionPreloader getPreloader() {
+        return preloader;
+    }
+
+    public void setPreloader(QuestionPreloader preloads) {
+        this.preloader = preloads;
+    }
+
+    @Override
+    public void localeChanged(String locale, Localizer localizer) {
+        for (IFormElement child : children) {
+            child.localeChanged(locale, localizer);
+        }
+    }
+
+    public String toString() {
+        return getTitle();
+    }
+
+    /**
+     * Preloads the Data Model with the preload values that are enumerated in the
+     * data bindings.
+     */
+    public void preloadInstance(TreeElement node) {
+        // if (node.isLeaf()) {
+        IAnswerData preload = null;
+        if (node.getPreloadHandler() != null) {
+            preload = preloader.getQuestionPreload(node.getPreloadHandler(), node.getPreloadParams());
+        }
+        if (preload != null) { // what if we want to wipe out a value in the
+            // instance?
+            node.setAnswer(preload);
+        }
+        // } else {
+        if (!node.isLeaf()) {
+            for (int i = 0; i < node.getNumChildren(); i++) {
+                TreeElement child = node.getChildAt(i);
+                if (child.getMult() != TreeReference.INDEX_TEMPLATE)
+                    // don't preload templates; new repeats are preloaded as they're
+                    // created
+                    preloadInstance(child);
+            }
+        }
+        // }
+    }
+
+    public boolean postProcessInstance() {
+        actionController.triggerActionsFromEvent(Actions.EVENT_XFORMS_REVALIDATE, elementsWithActionTriggeredByToplevelEvent, this);
+        return postProcessInstance(mainInstance.getRoot());
+    }
+
+    /**
+     * Iterates over the form's data bindings, and evaluates all post-processing calls.
+     *
+     * @return true if the instance was modified in any way, otherwise false
+     */
+    private boolean postProcessInstance(TreeElement node) {
+        // we might have issues with ordering, for example, a handler that writes
+        // a value to a node,
+        // and a handler that does something external with the node. if both
+        // handlers are bound to the
+        // same node, we need to make sure the one that alters the node executes
+        // first. deal with that later.
+        // can we even bind multiple handlers to the same node currently?
+
+        // also have issues with conditions. it is hard to detect what conditions
+        // are affected by the actions
+        // of the post-processor. normally, it wouldn't matter because we only
+        // post-process when we are exiting
+        // the form, so the result of any triggered conditions is irrelevant.
+        // however, if we save a form in the
+        // interim, post-processing occurs, and then we continue to edit the form.
+        // it seems like having conditions
+        // dependent on data written during post-processing is a bad practice
+        // anyway, and maybe we shouldn't support it.
+
+        if (node.isLeaf()) {
+            if (node.getPreloadHandler() != null) {
+                return preloader.questionPostProcess(node, node.getPreloadHandler(),
+                        node.getPreloadParams());
+            } else {
+                return false;
+            }
+        } else {
+            boolean instanceModified = false;
+            for (int i = 0; i < node.getNumChildren(); i++) {
+                TreeElement child = node.getChildAt(i);
+                if (child.getMult() != TreeReference.INDEX_TEMPLATE)
+                    instanceModified |= postProcessInstance(child);
+            }
+            return instanceModified;
+        }
+    }
+
+    /**
+     * Reads the form definition object from the supplied stream.
+     * <p/>
+     * Requires that the instance has been set to a prototype of the instance
+     * that should be used for deserialization.
+     *
+     * @param dis - the stream to read from
+     * @throws IOException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    @Override
+    public void readExternal(DataInputStream dis, PrototypeFactory pf) throws IOException,
+            DeserializationException {
+        setID(ExtUtil.readInt(dis));
+        setName(ExtUtil.nullIfEmpty(ExtUtil.readString(dis)));
+        setTitle((String) ExtUtil.read(dis, new ExtWrapNullable(String.class), pf));
+        setChildren((List<IFormElement>) ExtUtil.read(dis, new ExtWrapListPoly(), pf));
+        setFormXmlPath(ExtUtil.nullIfEmpty(ExtUtil.readString(dis)));
+        setInstance((FormInstance) ExtUtil.read(dis, FormInstance.class, pf));
+
+        // FormInstanceParser.parseInstance is responsible for initial creation of instances. It explicitly sets the
+        // instance name to null so we force this again on deserialization because some code paths rely on the main
+        // instance not having a name. Evaluation context must be reset after this.
+        mainInstance.getBase().setInstanceName(null);
+
+        setLocalizer((Localizer) ExtUtil.read(dis, new ExtWrapNullable(Localizer.class), pf));
+
+        for (Triggerable condition : TriggerableDag.readExternalTriggerables(dis, pf))
+            addTriggerable(condition);
+        finalizeTriggerables();
+
+        outputFragments = (List<IConditionExpr>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
+
+        submissionProfiles = (HashMap<String, SubmissionProfile>) ExtUtil.read(dis, new ExtWrapMap(
+                String.class, SubmissionProfile.class));
+
+        // For backwards compatibility
+        if (formXmlPath == null) {
+            // The entire internal secondary instances were serialized
+            HashMap<String, DataInstance> formInstances = (HashMap<String, DataInstance>) ExtUtil.read(dis, new ExtWrapMap(
+                    String.class, new ExtWrapTagged()), pf);
+            for (Map.Entry<String, DataInstance> formInstanceEntry : formInstances.entrySet()) {
+                addNonMainInstance(formInstanceEntry.getValue());
+            }
+        } else {
+            HashMap<String, DataInstance> externalFormInstances = (HashMap<String, DataInstance>) ExtUtil.read(dis, new ExtWrapMap(
+                    String.class, new ExtWrapTagged()), pf);
+            // Parse internal secondary instances from the formXML file
+            HashMap<String, DataInstance> internalFormInstances = InternalDataInstanceParser.buildInstances(getFormXmlPath());
+            formInstances.putAll(externalFormInstances);
+            formInstances.putAll(internalFormInstances);
+        }
+
+        extensions = (List<XFormExtension>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
+
+        resetEvaluationContext();
+        actionController = (ActionController) ExtUtil.read(dis, new ExtWrapNullable(ActionController.class), pf);
+        actions = new HashSet<>((List<String>) ExtUtil.read(dis, new ExtWrapListPoly(), pf));
+
+        List<TreeReference> treeReferencesWithActions = (List<TreeReference>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
+        elementsWithActionTriggeredByToplevelEvent = getElementsFromReferences(treeReferencesWithActions);
+    }
+
+    /**
+     * Given one or more {@link TreeReference}, return a set of questions and/or groups corresponding to the references
+     * that are found in this form definition.
+     * <p>
+     * Note: this performs a recursive breadth-first search so is not intended to be used where performance matters.
+     */
+    private Set<IFormElement> getElementsFromReferences(Collection<TreeReference> references) {
+        Set<TreeReference> referencesRemaining = new HashSet<>();
+        referencesRemaining.addAll(references);
+
+        Set<IFormElement> elements = new HashSet<>();
+
+        getElementsFromReferences(referencesRemaining, this, elements);
+        return elements;
+    }
+
+    private static void getElementsFromReferences(Set<TreeReference> referencesRemaining, IFormElement fe, Set<IFormElement> elementsSoFar) {
+        if (referencesRemaining.size() > 0 && fe.getChildren() != null) {
+            for (IFormElement candidate : fe.getChildren()) {
+                TreeReference candidateReference = FormInstance.unpackReference(candidate.getBind());
+                for (TreeReference reference : referencesRemaining) {
+                    if (candidateReference.equals(reference)) {
+                        elementsSoFar.add(candidate);
+                        referencesRemaining.remove(candidate);
+                    }
+                }
+
+                getElementsFromReferences(referencesRemaining, candidate, elementsSoFar);
+            }
+        }
+    }
+
+    /**
+     * meant to be called after deserialization and initialization of handlers
+     *
+     * @param newInstance true if the form is to be used for a new entry interaction,
+     *                    false if it is using an existing IDataModel
+     */
+    public void initialize(boolean newInstance, InstanceInitializationFactory factory) {
+        HashMap<String, DataInstance> formInstances = getFormInstances();
+        for (String instanceId : formInstances.keySet()) {
+            DataInstance instance = formInstances.get(instanceId);
+            instance.initialize(factory, instanceId);
+        }
+        if (newInstance) {// only preload new forms (we may have to revisit
+            // this)
+            preloadInstance(mainInstance.getRoot());
+        }
+
+        if (getLocalizer() != null && getLocalizer().getLocale() == null) {
+            getLocalizer().setToDefault();
+        }
+
+        if (newInstance) {
+            actionController.triggerActionsFromEvent(Actions.EVENT_ODK_INSTANCE_FIRST_LOAD, elementsWithActionTriggeredByToplevelEvent, this);
+
+            // xforms-ready is marked as deprecated as of JavaRosa 2.14.0 but is still dispatched for compatibility with
+            // old form definitions
+            actionController.triggerActionsFromEvent(Actions.EVENT_XFORMS_READY, elementsWithActionTriggeredByToplevelEvent, this);
+        }
+
+        actionController.triggerActionsFromEvent(Actions.EVENT_ODK_INSTANCE_LOAD, elementsWithActionTriggeredByToplevelEvent, this);
+
+        Collection<QuickTriggerable> qts = initializeTriggerables(TreeReference.rootRef());
+        dagImpl.publishSummary("Form initialized", null, qts);
+    }
+
+    /**
+     * Writes the form definition object to the supplied stream.
+     *
+     * @param dos - the stream to write to
+     * @throws IOException
+     */
+    @Override
+    public void writeExternal(DataOutputStream dos) throws IOException {
+        ExtUtil.writeNumeric(dos, getID());
+        ExtUtil.writeString(dos, ExtUtil.emptyIfNull(getName()));
+        ExtUtil.write(dos, new ExtWrapNullable(getTitle()));
+        ExtUtil.write(dos, new ExtWrapListPoly(getChildren()));
+        ExtUtil.writeString(dos, ExtUtil.emptyIfNull(getFormXmlPath()));
+        ExtUtil.write(dos, getMainInstance());
+        ExtUtil.write(dos, new ExtWrapNullable(localizer));
+
+        dagImpl.writeExternalTriggerables(dos);
+
+        ExtUtil.write(dos, new ExtWrapListPoly(outputFragments));
+        ExtUtil.write(dos, new ExtWrapMap(submissionProfiles));
+
+        // for support of multi-instance forms
+        if (formXmlPath == null) {
+            // Serialize all instances if path of the form isn't known
+            ExtUtil.write(dos, new ExtWrapMap(getFormInstances(), new ExtWrapTagged()));
+        } else {
+            // Don't serialize internal instances so that they are parsed again
+            ExtUtil.write(dos, new ExtWrapMap(getExternalInstances(), new ExtWrapTagged()));
+        }
+
+        ExtUtil.write(dos, new ExtWrapListPoly(extensions));
+        ExtUtil.write(dos, new ExtWrapNullable(actionController));
+        ExtUtil.write(dos, new ExtWrapListPoly(new ArrayList<>(actions)));
+        ExtUtil.write(dos, new ExtWrapListPoly(getReferencesFromElements(elementsWithActionTriggeredByToplevelEvent)));
+    }
+
+    /**
+     * Given a collection of form elements, build and return a list of corresponding TreeReferences.
+     */
+    private static List<TreeReference> getReferencesFromElements(Collection<IFormElement> elements) {
+        List<TreeReference> references = new ArrayList<>();
+
+        for (IFormElement element : elements) {
+            references.add(FormInstance.unpackReference(element.getBind()));
+        }
+
+        return references;
+    }
+
+    public void collapseIndex(FormIndex index, List<Integer> indexes, List<Integer> multiplicities, List<IFormElement> elements) {
+        if (!index.isInForm()) {
+            return;
+        }
+
+        IFormElement element = this;
+        while (index != null) {
+            int i = index.getLocalIndex();
+            element = element.getChild(i);
+
+            indexes.add(i);
+            multiplicities.add(index.getInstanceIndex() == -1 ? 0 : index
+                    .getInstanceIndex());
+            elements.add(element);
+
+            index = index.getNextLevel();
+        }
+    }
+
+    public FormIndex buildIndex(List<Integer> indexes, List<Integer> multiplicities, List<IFormElement> elements) {
+        FormIndex cur = null;
+        List<Integer> curMultiplicities = new ArrayList<>();
+        curMultiplicities.addAll(multiplicities);
+
+        List<IFormElement> curElements = new ArrayList<>();
+        curElements.addAll(elements);
+
+        for (int i = indexes.size() - 1; i >= 0; i--) {
+            int ix = indexes.get(i);
+            int mult = multiplicities.get(i);
+
+            if (!(elements.get(i) instanceof GroupDef && ((GroupDef) elements.get(i))
+                    .getRepeat())) {
+                mult = -1;
+            }
+
+            cur = new FormIndex(cur, ix, mult, getChildInstanceRef(curElements, curMultiplicities));
+            curMultiplicities.remove(curMultiplicities.size() - 1);
+            curElements.remove(curElements.size() - 1);
+        }
+        return cur;
+    }
+
+    public int getNumRepetitions(FormIndex index) {
+        List<Integer> indexes = new ArrayList<>();
+        List<Integer> multiplicities = new ArrayList<>();
+        List<IFormElement> elements = new ArrayList<>();
+
+        if (!index.isInForm()) {
+            throw new RuntimeException("not an in-form index");
+        }
+
+        collapseIndex(index, indexes, multiplicities, elements);
+
+        if (!(elements.get(elements.size() - 1) instanceof GroupDef)
+                || !((GroupDef) elements.get(elements.size() - 1)).getRepeat()) {
+            throw new RuntimeException("current element not a repeat");
+        }
+
+        // so painful
+        TreeElement templNode = mainInstance.getTemplate(index.getReference());
+        TreeReference parentPath = templNode.getParent().getRef().genericize();
+        TreeElement parentNode = mainInstance.resolveReference(parentPath.contextualize(index
+                .getReference()));
+        return parentNode.getChildMultiplicity(templNode.getName());
+    }
+
+    // repIndex == -1 => next repetition about to be created
+    public FormIndex descendIntoRepeat(FormIndex index, int repIndex) {
+        int numRepetitions = getNumRepetitions(index);
+
+        List<Integer> indexes = new ArrayList<>();
+        List<Integer> multiplicities = new ArrayList<>();
+        List<IFormElement> elements = new ArrayList<>();
+        collapseIndex(index, indexes, multiplicities, elements);
+
+        if (repIndex == -1) {
+            repIndex = numRepetitions;
+        } else {
+            if (repIndex < 0 || repIndex >= numRepetitions) {
+                throw new RuntimeException("selection exceeds current number of repetitions");
+            }
+        }
+
+        multiplicities.set(multiplicities.size() - 1, repIndex);
+
+        return buildIndex(indexes, multiplicities, elements);
+    }
+
+    @Override
+    public int getDeepChildCount() {
+        int total = 0;
+        for (IFormElement child : children) {
+            total += child.getDeepChildCount();
+        }
+        return total;
+    }
+
+    @Override
+    public void registerStateObserver(FormElementStateListener qsl) {
+        // NO. (Or at least not yet).
+    }
+
+    @Override
+    public void unregisterStateObserver(FormElementStateListener qsl) {
+        // NO. (Or at least not yet).
+    }
+
+    @Override
+    public List<IFormElement> getChildren() {
+        return children;
+    }
+
+    @Override
+    public void setChildren(List<IFormElement> children) {
+        this.children = (children == null ? new ArrayList<>() : children);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public int getID() {
+        return id;
+    }
+
+    @Override
+    public void setID(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Localizer getLocalizer() {
+        return localizer;
+    }
+
+    public List<IConditionExpr> getOutputFragments() {
+        return outputFragments;
+    }
+
+    public void setOutputFragments(List<IConditionExpr> outputFragments) {
+        this.outputFragments = outputFragments;
+    }
+
+    @Override
+    public HashMap<String, Object> getMetaData() {
+        HashMap<String, Object> metadata = new HashMap<>();
+        String[] fields = getMetaDataFields();
+
+        for (String field : fields) {
+            try {
+                metadata.put(field, getMetaData(field));
+            } catch (NullPointerException npe) {
+                if (getMetaData(field) == null) {
+                    logger.error("ERROR! XFORM MUST HAVE A NAME!", npe);
+                }
+            }
+        }
+
+        return metadata;
+    }
+
+    @Override
+    public String getMetaData(String fieldName) {
+        if (fieldName.equals("DESCRIPTOR")) {
+            return name;
+        }
+        if (fieldName.equals("XMLNS")) {
+            return ExtUtil.emptyIfNull(mainInstance.schema);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public String[] getMetaDataFields() {
+        return new String[]{"DESCRIPTOR", "XMLNS"};
+    }
+
+    /**
+     * Recursively traverses the main instance and initializes any questions with
+     * dynamic ItemsetBindings.  We need to do this late in the process so that
+     * we have the entire main instance assembled.
+     */
+    public static void updateItemsetReferences(List<IFormElement> children) {
+        if (children != null) {
+            for (IFormElement child : children) {
+                if (child instanceof QuestionDef) {
+                    QuestionDef q = (QuestionDef) child;
+                    ItemsetBinding itemset = q.getDynamicChoices();
+                    if (itemset != null) {
+                        itemset.initReferences(q);
+                    }
+                } else {
+                    updateItemsetReferences(child.getChildren());
+                }
+            }
+        }
+    }
+
+    /**
+     * Links a deserialized instance back up with its parent FormDef. This allows
+     * select/select1 questions to be internationalizable in chatterbox, and (if
+     * using CHOICE_INDEX mode) allows the instance to be serialized to XML.
+     */
+    public void attachControlsToInstanceData() {
+        attachControlsToInstanceData(getMainInstance().getRoot());
+    }
+
+    private void attachControlsToInstanceData(TreeElement node) {
+        for (int i = 0; i < node.getNumChildren(); i++) {
+            attachControlsToInstanceData(node.getChildAt(i));
+        }
+
+        IAnswerData val = node.getValue();
+        List<Selection> selections = null;
+        if (val instanceof SelectOneData) {
+            selections = new ArrayList<>();
+            selections.add((Selection) val.getValue());
+        } else if (val instanceof MultipleItemsData) {
+            selections = (List<Selection>) val.getValue();
+        }
+
+        if (selections != null) {
+            QuestionDef q = findQuestionByRef(node.getRef(), this);
+            if (q == null) {
+                throw new RuntimeException(
+                        "FormDef.attachControlsToInstanceData: can't find question to link");
+            }
+
+            if (q.getDynamicChoices() != null) {
+                // droos: i think we should do something like initializing the
+                // itemset here, so that default answers
+                // can be linked to the selectchoices. however, there are
+                // complications. for example, the itemset might
+                // not be ready to be evaluated at form initialization; it may
+                // require certain questions to be answered
+                // first. e.g., if we evaluate an itemset and it has no choices, the
+                // xform engine will throw an error
+                // itemset TODO
+            }
+
+            for (Selection s : selections) {
+                s.attachChoice(q);
+            }
+        }
+    }
+
+    /**
+     * Traverses recursively the given {@link IFormElement} node tree and returns
+     * the first {@link QuestionDef} that matches the binding defined in the
+     * given {@link TreeReference}.
+     *
+     * @param ref reference to a form binding
+     * @param fe  the recursive {@link IFormElement}. The starting call would
+     *            typically receive a {@link FormDef}
+     * @return the question definition, {@code null} if no {@link QuestionDef}
+     * matches the given binding
+     */
+    public static QuestionDef findQuestionByRef(TreeReference ref, IFormElement fe) {
+        if (fe instanceof FormDef) {
+            ref = ref.genericize();
+        }
+
+        if (fe instanceof QuestionDef) {
+            QuestionDef q = (QuestionDef) fe;
+            TreeReference bind = FormInstance.unpackReference(q.getBind());
+            return (ref.equals(bind) ? q : null);
+        } else {
+            for (int i = 0; i < fe.getChildren().size(); i++) {
+                QuestionDef ret = findQuestionByRef(ref, fe.getChild(i));
+                if (ret != null)
+                    return ret;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Appearance isn't a valid attribute for form, but this method must be
+     * included as a result of conforming to the IFormElement interface.
+     */
+    @Override
+    public String getAppearanceAttr() {
+        throw new RuntimeException(
+                "This method call is not relevant for FormDefs getAppearanceAttr ()");
+    }
+
+    @Override
+    public ActionController getActionController() {
+        return actionController;
+    }
+
+    /**
+     * Appearance isn't a valid attribute for form, but this method must be
+     * included as a result of conforming to the IFormElement interface.
+     */
+    @Override
+    public void setAppearanceAttr(String appearanceAttr) {
+        throw new RuntimeException(
+                "This method call is not relevant for FormDefs setAppearanceAttr()");
+    }
+
+    /**
+     * Not applicable here.
+     */
+    @Override
+    public String getLabelInnerText() {
+        return null;
+    }
+
+    /**
+     * Not applicable
+     */
+    @Override
+    public String getTextID() {
+        return null;
+    }
+
+    /**
+     * Not applicable
+     */
+    @Override
+    public void setTextID(String textID) {
+        throw new RuntimeException("This method call is not relevant for FormDefs [setTextID()]");
+    }
+
+    public void setDefaultSubmission(SubmissionProfile profile) {
+        submissionProfiles.put(DEFAULT_SUBMISSION_PROFILE, profile);
+    }
+
+    public void addSubmissionProfile(String submissionId, SubmissionProfile profile) {
+        submissionProfiles.put(submissionId, profile);
+    }
+
+    public SubmissionProfile getSubmissionProfile() {
+        // At some point these profiles will be set by the <submit> control in the
+        // form.
+        // In the mean time, though, we can only promise that the default one will
+        // be used.
+
+        return submissionProfiles.get(DEFAULT_SUBMISSION_PROFILE);
+    }
+
+    @Override
+    public void setAdditionalAttribute(String namespace, String name, String value) {
+        // Do nothing. Not supported.
+    }
+
+    @Override
+    public String getAdditionalAttribute(String namespace, String name) {
+        // Not supported.
+        return null;
+    }
+
+    @Override
+    public List<TreeElement> getAdditionalAttributes() {
+        // Not supported.
+        return Collections.emptyList();
+    }
+
+    public <X extends XFormExtension> X getExtension(Class<X> extension) {
+        for (XFormExtension ex : extensions) {
+            if (ex.getClass().isAssignableFrom(extension)) {
+                return (X) ex;
+            }
+        }
+        X newEx;
+        try {
+            newEx = extension.newInstance();
+        } catch (InstantiationException e) {
+            throw new RuntimeException("Illegally Structured XForm Extension " + extension.getName());
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Illegally Structured XForm Extension " + extension.getName());
+        }
+        extensions.add(newEx);
+        return newEx;
+    }
+
+    /**
+     * Frees all of the components of this form which are no longer needed once
+     * it is completed.
+     * <p/>
+     * Once this is called, the form is no longer capable of functioning, but all
+     * data should be retained.
+     */
+    public void seal() {
+        dagImpl = null;
+        // We may need ths one, actually
+        exprEvalContext = null;
+    }
+
+    /**
+     * Records that the form definition includes an action of the given name. Clients may need to configure resources
+     * accordingly or communicate something to the user (e.g. in the case of setgeopoint).
+     */
+    public void registerAction(String actionName) {
+        actions.add(actionName);
+    }
+
+    /**
+     * Returns true if this form definition includes one or more action of the given name.
+     */
+    public boolean hasAction(String name) {
+        return actions.contains(name);
+    }
+
+    /**
+     * Records that this question or group has a nested action triggered by a top-level event so that the action can be
+     * triggered without having to traverse all elements.
+     */
+    public void registerElementWithActionTriggeredByToplevelEvent(IFormElement element) {
+        elementsWithActionTriggeredByToplevelEvent.add(element);
+    }
+
+    public List<String> getParseWarnings() {
+        return parseWarnings;
+    }
+
+    public List<String> getParseErrors() {
+        return parseErrors;
+    }
+
+    public void addParseWarning(String warning) {
+        parseWarnings.add(warning);
+    }
+
+    public void addParseError(String error) {
+        parseErrors.add(error);
+    }
+
+    private HashMap<String, DataInstance> getExternalInstances() {
+        HashMap<String, DataInstance> externalFormInstances = new HashMap<>();
+        for (Map.Entry<String, DataInstance> formInstanceEntry : formInstances.entrySet()) {
+            if (formInstanceEntry.getValue() instanceof ExternalDataInstance) {
+                externalFormInstances.put(formInstanceEntry.getKey(), formInstanceEntry.getValue());
+            }
+        }
+        return externalFormInstances;
+    }
+
+    private String getFormXmlPath() {
+        return formXmlPath;
+    }
+
+    public HashMap<String, DataInstance> getFormInstances() {
+        return formInstances;
+    }
+}

--- a/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
@@ -507,7 +507,10 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         TreeReference repeatContextRef = getChildInstanceRef(index);
         TreeElement template = mainInstance.getTemplate(repeatContextRef);
 
-        mainInstance.copyNode(template, repeatContextRef);
+        //Fix for #4059?
+        boolean for4059 = true;
+        mainInstance.copyNode(!for4059 ? template : template.deepCopyForRepeat(),
+                repeatContextRef);
 
         TreeElement newNode = mainInstance.resolveReference(repeatContextRef);
         preloadInstance(newNode);

--- a/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
@@ -85,7 +85,7 @@ import java.util.Set;
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class FormDef implements IFormElement, Localizable, Persistable, IMetaData,
         ActionController.ActionResultProcessor {
-    private static final Logger logger = LoggerFactory.getLogger(FormDef.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormDef.class);
 
     public static final String STORAGE_KEY = "FORMDEF";
     public static final int TEMPLATING_RECURSION_LIMIT = 10;
@@ -156,7 +156,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     private QuestionPreloader preloader = new QuestionPreloader();
 
     // XML ID's cannot start with numbers, so this should never conflict
-    private static String DEFAULT_SUBMISSION_PROFILE = "1";
+    private static String defaultSubmissionProfile = "1";
 
     private HashMap<String, SubmissionProfile> submissionProfiles;
 
@@ -236,7 +236,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * Get an instance based on a name
      *
      * @param name string name
-     * @return
      */
     public DataInstance getNonMainInstance(String name) {
         HashMap<String, DataInstance> formInstances = getFormInstances();
@@ -307,9 +306,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * <p/>
      * Ignore 'new-repeat' node for now; just return/stop at ref to
      * yet-to-be-created repeat node (similar to repeats that already exist)
-     *
      * @param index
-     * @return
      */
     public List<IFormElement> explodeIndex(FormIndex index) {
         List<Integer> indexes = new ArrayList<>();
@@ -455,7 +452,6 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * method on a node that is not contained within a repeat.
      *
      * @param index
-     * @return
      */
     public FormIndex deleteRepeat(FormIndex index) {
         List<Integer> indexes = new ArrayList<>();
@@ -935,7 +931,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                     try {
                         ix = Integer.parseInt(argName);
                     } catch (NumberFormatException nfe) {
-                        logger.warn("expect arguments to be numeric [{}]", argName);
+                        LOGGER.warn("expect arguments to be numeric [{}]", argName);
                     }
 
                     if (ix < 0 || ix >= outputFragments.size()) {
@@ -1066,9 +1062,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * that should be used for deserialization.
      *
      * @param dis - the stream to read from
-     * @throws IOException
-     * @throws InstantiationException
-     * @throws IllegalAccessException
+     * @throws IOException            a
+     * @throws InstantiationException b
+     * @throws IllegalAccessException c
      */
     @Override
     public void readExternal(DataInputStream dis, PrototypeFactory pf) throws IOException,
@@ -1168,7 +1164,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             DataInstance instance = formInstances.get(instanceId);
             instance.initialize(factory, instanceId);
         }
-        if (newInstance) {// only preload new forms (we may have to revisit
+        if (newInstance) { // only preload new forms (we may have to revisit
             // this)
             preloadInstance(mainInstance.getRoot());
         }
@@ -1355,7 +1351,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     @Override
     public void setChildren(List<IFormElement> children) {
-        this.children = (children == null ? new ArrayList<>() : children);
+        this.children = children == null ? new ArrayList<>() : children;
     }
 
     public String getTitle() {
@@ -1406,7 +1402,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                 metadata.put(field, getMetaData(field));
             } catch (NullPointerException npe) {
                 if (getMetaData(field) == null) {
-                    logger.error("ERROR! XFORM MUST HAVE A NAME!", npe);
+                    LOGGER.error("ERROR! XFORM MUST HAVE A NAME!", npe);
                 }
             }
         }
@@ -1519,7 +1515,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         if (fe instanceof QuestionDef) {
             QuestionDef q = (QuestionDef) fe;
             TreeReference bind = FormInstance.unpackReference(q.getBind());
-            return (ref.equals(bind) ? q : null);
+            return ref.equals(bind) ? q : null;
         } else {
             for (int i = 0; i < fe.getChildren().size(); i++) {
                 QuestionDef ret = findQuestionByRef(ref, fe.getChild(i));
@@ -1581,7 +1577,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     public void setDefaultSubmission(SubmissionProfile profile) {
-        submissionProfiles.put(DEFAULT_SUBMISSION_PROFILE, profile);
+        submissionProfiles.put(defaultSubmissionProfile, profile);
     }
 
     public void addSubmissionProfile(String submissionId, SubmissionProfile profile) {
@@ -1594,7 +1590,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         // In the mean time, though, we can only promise that the default one will
         // be used.
 
-        return submissionProfiles.get(DEFAULT_SUBMISSION_PROFILE);
+        return submissionProfiles.get(defaultSubmissionProfile);
     }
 
     @Override

--- a/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
@@ -82,6 +82,7 @@ import java.util.Set;
  *
  * @author Daniel Kayiwa, Drew Roos
  */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public class FormDef implements IFormElement, Localizable, Persistable, IMetaData,
         ActionController.ActionResultProcessor {
     private static final Logger logger = LoggerFactory.getLogger(FormDef.class);
@@ -160,7 +161,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     private HashMap<String, SubmissionProfile> submissionProfiles;
 
     private HashMap<String, DataInstance> formInstances;
-    private FormInstance mainInstance = null;
+    private FormInstance mainInstance;
 
     //region Actions
     private ActionController actionController;
@@ -178,8 +179,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     private EventNotifier eventNotifier;
 
-    private List<String> parseWarnings = new ArrayList<>();
-    private List<String> parseErrors = new ArrayList<>();
+    private final List<String> parseWarnings = new ArrayList<>();
+    private final List<String> parseErrors = new ArrayList<>();
 
     public FormDef() {
         this(defaultEventNotifier);
@@ -283,8 +284,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
     @Override
     public IFormElement getChild(int i) {
-        if (i < this.children.size())
+        if (i < this.children.size()) {
             return this.children.get(i);
+        }
 
         throw new ArrayIndexOutOfBoundsException("FormDef: invalid child index: " + i + " only "
                 + children.size() + " children");
@@ -331,8 +333,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     public TreeReference getChildInstanceRef(List<IFormElement> elements, List<Integer> multiplicities) {
-        if (elements.size() == 0)
+        if (elements.isEmpty()) {
             return null;
+        }
 
         IFormElement element = elements.get(elements.size() - 1);
         // get reference for target element
@@ -925,7 +928,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         int depth = 0;
         List<String> outstandingArgs = Localizer.getArgs(template);
-        while (outstandingArgs.size() > 0) {
+        while (outstandingArgs.isEmpty()) {
             for (String argName : outstandingArgs) {
                 if (!args.containsKey(argName)) {
                     int ix = -1;
@@ -935,8 +938,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
                         logger.warn("expect arguments to be numeric [{}]", argName);
                     }
 
-                    if (ix < 0 || ix >= outputFragments.size())
+                    if (ix < 0 || ix >= outputFragments.size()) {
                         continue;
+                    }
 
                     IConditionExpr expr = outputFragments.get(ix);
                     EvaluationContext ec = new EvaluationContext(exprEvalContext, contextRef);
@@ -996,10 +1000,11 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         if (!node.isLeaf()) {
             for (int i = 0; i < node.getNumChildren(); i++) {
                 TreeElement child = node.getChildAt(i);
-                if (child.getMult() != TreeReference.INDEX_TEMPLATE)
+                if (child.getMult() != TreeReference.INDEX_TEMPLATE) {
                     // don't preload templates; new repeats are preloaded as they're
                     // created
                     preloadInstance(child);
+                }
             }
         }
         // }
@@ -1046,8 +1051,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
             boolean instanceModified = false;
             for (int i = 0; i < node.getNumChildren(); i++) {
                 TreeElement child = node.getChildAt(i);
-                if (child.getMult() != TreeReference.INDEX_TEMPLATE)
+                if (child.getMult() != TreeReference.INDEX_TEMPLATE) {
                     instanceModified |= postProcessInstance(child);
+                }
             }
             return instanceModified;
         }
@@ -1081,8 +1087,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
 
         setLocalizer((Localizer) ExtUtil.read(dis, new ExtWrapNullable(Localizer.class), pf));
 
-        for (Triggerable condition : TriggerableDag.readExternalTriggerables(dis, pf))
+        for (Triggerable condition : TriggerableDag.readExternalTriggerables(dis, pf)) {
             addTriggerable(condition);
+        }
         finalizeTriggerables();
 
         outputFragments = (List<IConditionExpr>) ExtUtil.read(dis, new ExtWrapListPoly(), pf);
@@ -1134,7 +1141,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
     }
 
     private static void getElementsFromReferences(Set<TreeReference> referencesRemaining, IFormElement fe, Set<IFormElement> elementsSoFar) {
-        if (referencesRemaining.size() > 0 && fe.getChildren() != null) {
+        if (referencesRemaining.isEmpty() && fe.getChildren() != null) {
             for (IFormElement candidate : fe.getChildren()) {
                 TreeReference candidateReference = FormInstance.unpackReference(candidate.getBind());
                 for (TreeReference reference : referencesRemaining) {
@@ -1516,8 +1523,9 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         } else {
             for (int i = 0; i < fe.getChildren().size(); i++) {
                 QuestionDef ret = findQuestionByRef(ref, fe.getChild(i));
-                if (ret != null)
+                if (ret != null) {
                     return ret;
+                }
             }
             return null;
         }
@@ -1618,7 +1626,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
         } catch (InstantiationException e) {
             throw new RuntimeException("Illegally Structured XForm Extension " + extension.getName());
         } catch (IllegalAccessException e) {
-            throw new RuntimeException("Illegally Structured XForm Extension " + extension.getName());
+            throw new RuntimeException("Illegally Structured XForm Extension_ " + extension.getName());
         }
         extensions.add(newEx);
         return newEx;

--- a/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/FormDef.java
@@ -306,7 +306,8 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * <p/>
      * Ignore 'new-repeat' node for now; just return/stop at ref to
      * yet-to-be-created repeat node (similar to repeats that already exist)
-     * @param index
+     *
+     * @param index i
      */
     public List<IFormElement> explodeIndex(FormIndex index) {
         List<Integer> indexes = new ArrayList<>();
@@ -451,7 +452,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * corresponding FormIndex. Behavior is currently undefined if you call this
      * method on a node that is not contained within a repeat.
      *
-     * @param index
+     * @param index i
      */
     public FormIndex deleteRepeat(FormIndex index) {
         List<Integer> indexes = new ArrayList<>();
@@ -1191,7 +1192,7 @@ public class FormDef implements IFormElement, Localizable, Persistable, IMetaDat
      * Writes the form definition object to the supplied stream.
      *
      * @param dos - the stream to write to
-     * @throws IOException
+     * @throws IOException ioe
      */
     @Override
     public void writeExternal(DataOutputStream dos) throws IOException {

--- a/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -80,10 +80,10 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     /* model properties */
     protected int dataType = Constants.DATATYPE_NULL; //TODO
 
-    private Constraint constraint = null;
-    private String preloadHandler = null;
-    private String preloadParams = null;
-    private List<TreeElement> bindAttributes = new ArrayList<TreeElement>(0);
+    private Constraint constraint;
+    private String preloadHandler;
+    private String preloadParams;
+    private List<TreeElement> bindAttributes = new ArrayList<>(0);
 
     // TODO see what’s required here from commented-out code removed 2017-04-23
 
@@ -104,7 +104,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
      * The name of the instance that this node is in. The value of the id attribute in the case of a secondary
      * instance or null for the primary instance.
      */
-    private String instanceName = null;
+    private String instanceName;
 
     /**
      * TreeElement with null name and 0 multiplicity? (a "hidden root" node?)
@@ -121,7 +121,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         this.name = name;
         this.multiplicity = multiplicity;
         this.parent = null;
-        attributes = new ArrayList<TreeElement>(0);
+        attributes = new ArrayList<>(0);
     }
 
     /**
@@ -180,7 +180,9 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         }
 
         // null-valued attributes are a "remove-this" instruction... ignore them
-        if (value == null) return;
+        if (value == null) {
+            return;
+        }
 
         // create an attribute...
         TreeElement attr = TreeElement.constructAttributeElement(namespace, name, value);
@@ -353,7 +355,9 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             //Test that multiplicities must be adjusted
             boolean keepTemplateMultiplicities = false;
             //#4059
-            if (!keepTemplateMultiplicities) child.setMult(TreeReference.DEFAULT_MULTIPLICITY);
+            if (!keepTemplateMultiplicities) {
+                child.setMult(TreeReference.DEFAULT_MULTIPLICITY);
+            }
             newNode.addChild(child.deepCopyForRepeat());
         }
         return newNode;
@@ -500,8 +504,9 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     /* ==== OBSERVER PATTERN ==== */
 
     public void registerStateObserver(FormElementStateListener qsl) {
-        if (observers == null)
-            observers = new ArrayList<FormElementStateListener>(1);
+        if (observers == null) {
+            observers = new ArrayList<>(1);
+        }
 
         if (!observers.contains(qsl)) {
             observers.add(qsl);
@@ -511,8 +516,9 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     public void unregisterStateObserver(FormElementStateListener qsl) {
         if (observers != null) {
             observers.remove(qsl);
-            if (observers.isEmpty())
+            if (observers.isEmpty()) {
                 observers = null;
+            }
         }
     }
 
@@ -752,7 +758,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
                 this.setValue(answerResolver.resolveAnswer(textVal, this, f));
             }
         } else {
-            List<String> names = new ArrayList<String>(this.getNumChildren());
+            List<String> names = new ArrayList<>(this.getNumChildren());
             for (int i = 0; i < this.getNumChildren(); i++) {
                 TreeElement child = this.getChildAt(i);
                 if (!names.contains(child.getName())) {
@@ -811,7 +817,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
                     i += newChildren.size();
                 } else {
 
-                    if (newChildren.size() == 0) {
+                    if (newChildren.isEmpty()) {
                         child.setRelevant(false);
                     } else {
                         child.populate(newChildren.get(0), f);
@@ -1051,7 +1057,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             return null;
         }
 
-        List<Integer> toRemove = new ArrayList<Integer>();
+        List<Integer> toRemove = new ArrayList<>();
         List<TreeReference> selectedChildren = null;
 
         //Lazy init these until we've determined that our predicate is hintable
@@ -1074,10 +1080,10 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
                     //We're lazily initializing this, since it might actually take a while, and we
                     //don't want the overhead if our predicate is too complex anyway
                     if (indices == null) {
-                        indices = new HashMap<XPathPathExpr, String>();
+                        indices = new HashMap<>();
                         kids = this.getChildrenWithName(name);
 
-                        if (kids.size() == 0) {
+                        if (kids.isEmpty()) {
                             return null;
                         }
 
@@ -1096,7 +1102,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
                             for (TreeElement kid : kids) {
                                 if (kid.getAttributeValue(null, attributeName).equals(((XPathStringLiteral) right).s)) {
                                     if (selectedChildren == null) {
-                                        selectedChildren = new ArrayList<TreeReference>();
+                                        selectedChildren = new ArrayList<>();
                                     }
                                     selectedChildren.add(kid.getRef());
                                 }

--- a/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -55,7 +55,7 @@ import java.util.List;
  * <p>An element of a FormInstance.</p>
  *
  * <p>TreeElements represent an XML node in the instance. It may either have a value (e.g., <name>Drew</name>),
- * a number of TreeElement children (e.g., <meta><device /><timestamp /><user_id /></meta>), or neither (e.g.,<empty_node />)</p>
+ * a number of TreeElement children (e.g., <device /><timestamp /><user_id />), or neither (e.g.,<empty_node />)</p>
  *
  * <p>TreeElements can also represent attributes. Attributes are unique from normal elements in that they are
  * not "children" of their parent, and are always leaf nodes: IE cannot have children.</p>
@@ -129,8 +129,8 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
      * namespace and name.
      *
      * @param namespace - if null will be converted to empty string
-     * @param name
-     * @param value
+     * @param name      a
+     * @param value     b
      * @return A new instance of a TreeElement
      */
     public static TreeElement constructAttributeElement(String namespace, String name, String value) {
@@ -154,8 +154,8 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
      * attribute with the matching name.</p>
      *
      * @param attributes - list of attributes to search
-     * @param namespace
-     * @param name
+     * @param namespace  a
+     * @param name       b
      * @return TreeElement
      */
     public static TreeElement getAttribute(List<TreeElement> attributes, String namespace, String name) {
@@ -165,6 +165,15 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
             }
         }
         return null;
+    }
+
+    @Override
+    public TreeElement getAttribute(String namespace, String name) {
+        return getAttribute(attributes, namespace, name);
+    }
+
+    public void setAttribute(String namespace, String name, String value) {
+        setAttribute(this, attributes, namespace, name, value);
     }
 
     public static void setAttribute(TreeElement parent, List<TreeElement> attrs, String namespace, String name, String value) {
@@ -426,8 +435,8 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
                     attribute.setRelevant(newRelevant, true);
                 }
             }
-            for (TreeElement aChildren : children) {
-                aChildren.setRelevant(newRelevant, true);
+            for (TreeElement child : children) {
+                child.setRelevant(newRelevant, true);
             }
             alertStateObservers(FormElementStateListener.CHANGE_RELEVANT);
         }
@@ -493,8 +502,8 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
 
         if (isEnabled() != oldEnabled) {
             if (children != null) {
-                for (TreeElement aChildren : children) {
-                    aChildren.setEnabled(isEnabled(), true);
+                for (TreeElement child : children) {
+                    child.setEnabled(isEnabled(), true);
                 }
             }
             alertStateObservers(FormElementStateListener.CHANGE_ENABLED);
@@ -570,8 +579,7 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
     /**
      * Get the String value of the provided attribute
      *
-     * @param attribute
-     * @return
+     * @param attribute a
      */
     private String getAttributeValue(TreeElement attribute) {
         if (attribute.getValue() == null) {
@@ -581,26 +589,17 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         }
     }
 
-    public String getAttributeValue() {
-        if (!isAttribute()) {
-            throw new IllegalStateException("this is not an attribute");
-        }
-        return getValue().uncast().getString();
-    }
-
-    @Override
-    public TreeElement getAttribute(String namespace, String name) {
-        return getAttribute(attributes, namespace, name);
-    }
-
     @Override
     public String getAttributeValue(String namespace, String name) {
         TreeElement element = getAttribute(namespace, name);
         return element == null ? null : getAttributeValue(element);
     }
 
-    public void setAttribute(String namespace, String name, String value) {
-        setAttribute(this, attributes, namespace, name, value);
+    public String getAttributeValue() {
+        if (!isAttribute()) {
+            throw new IllegalStateException("this is not an attribute");
+        }
+        return getValue().uncast().getString();
     }
 
     /* ==== SERIALIZATION ==== */
@@ -895,13 +894,13 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         //TODO: Expire cache somehow;
         synchronized (refCache) {
             if (refCache[0] == null) {
-                refCache[0] = TreeElement.BuildRef(this);
+                refCache[0] = TreeElement.buildRef(this);
             }
             return refCache[0];
         }
     }
 
-    public static TreeReference BuildRef(AbstractTreeElement elem) {
+    public static TreeReference buildRef(AbstractTreeElement elem) {
         TreeReference ref = TreeReference.selfRef();
 
         while (elem != null) {
@@ -929,10 +928,10 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
 
     @Override
     public int getDepth() {
-        return TreeElement.CalculateDepth(this);
+        return TreeElement.calculateDepth(this);
     }
 
-    public static int CalculateDepth(AbstractTreeElement elem) {
+    public static int calculateDepth(AbstractTreeElement elem) {
         int depth = 0;
 
         while (elem.getName() != null) {

--- a/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -344,6 +344,21 @@ public class TreeElement implements Externalizable, AbstractTreeElement<TreeElem
         return newNode;
     }
 
+    //For #4059
+    public TreeElement deepCopyForRepeat() {
+        TreeElement newNode = shallowCopy();
+
+        newNode.children.clear();
+        for (TreeElement child : children) {
+            //Test that multiplicities must be adjusted
+            boolean keepTemplateMultiplicities = false;
+            //#4059
+            if (!keepTemplateMultiplicities) child.setMult(TreeReference.DEFAULT_MULTIPLICITY);
+            newNode.addChild(child.deepCopyForRepeat());
+        }
+        return newNode;
+    }
+
     /* ==== MODEL PROPERTIES ==== */
 
     // factoring inheritance rules

--- a/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
+++ b/collect_app/src/main/java/org/javarosa/core/model/instance/TreeElement.java
@@ -1,0 +1,1122 @@
+/*
+ * Copyright (C) 2009 JavaRosa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.javarosa.core.model.instance;
+
+import org.javarosa.core.model.Constants;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.FormElementStateListener;
+import org.javarosa.core.model.condition.Constraint;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.core.model.data.IAnswerData;
+import org.javarosa.core.model.data.MultipleItemsData;
+import org.javarosa.core.model.data.SelectOneData;
+import org.javarosa.core.model.data.UncastData;
+import org.javarosa.core.model.instance.utils.CompactInstanceWrapper;
+import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
+import org.javarosa.core.model.instance.utils.IAnswerResolver;
+import org.javarosa.core.model.instance.utils.ITreeVisitor;
+import org.javarosa.core.model.instance.utils.TreeElementChildrenList;
+import org.javarosa.core.model.util.restorable.RestoreUtils;
+import org.javarosa.core.util.DataUtil;
+import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.ExtWrapNullable;
+import org.javarosa.core.util.externalizable.ExtWrapTagged;
+import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.model.xform.XPathReference;
+import org.javarosa.xform.parse.XFormParser;
+import org.javarosa.xpath.expr.XPathEqExpr;
+import org.javarosa.xpath.expr.XPathExpression;
+import org.javarosa.xpath.expr.XPathPathExpr;
+import org.javarosa.xpath.expr.XPathStringLiteral;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * <p>An element of a FormInstance.</p>
+ *
+ * <p>TreeElements represent an XML node in the instance. It may either have a value (e.g., <name>Drew</name>),
+ * a number of TreeElement children (e.g., <meta><device /><timestamp /><user_id /></meta>), or neither (e.g.,<empty_node />)</p>
+ *
+ * <p>TreeElements can also represent attributes. Attributes are unique from normal elements in that they are
+ * not "children" of their parent, and are always leaf nodes: IE cannot have children.</p>
+ *
+ * <p>TODO: Split out the bind-able session data from this class and leave only the mandatory values to speed up
+ * new DOM-like models</p>
+ *
+ * @author Clayton Sims
+ */
+
+public class TreeElement implements Externalizable, AbstractTreeElement<TreeElement> {
+    private String name; // can be null only for hidden root node
+    protected int multiplicity = -1; // see TreeReference for special values
+    private AbstractTreeElement parent;
+
+    private IAnswerData value;
+
+    private List<FormElementStateListener> observers;
+    private List<TreeElement> attributes;
+    private final TreeElementChildrenList children = new TreeElementChildrenList();
+
+    /* model properties */
+    protected int dataType = Constants.DATATYPE_NULL; //TODO
+
+    private Constraint constraint = null;
+    private String preloadHandler = null;
+    private String preloadParams = null;
+    private List<TreeElement> bindAttributes = new ArrayList<TreeElement>(0);
+
+    // TODO see what’s required here from commented-out code removed 2017-04-23
+
+    private static final int MASK_REQUIRED = 0x01;
+    private static final int MASK_REPEATABLE = 0x02;
+    private static final int MASK_ATTRIBUTE = 0x04;
+    private static final int MASK_RELEVANT = 0x08;
+    private static final int MASK_ENABLED = 0x10;
+    private static final int MASK_RELEVANT_INH = 0x20;
+    private static final int MASK_ENABLED_INH = 0x40;
+
+    private int flags = MASK_RELEVANT | MASK_ENABLED | MASK_RELEVANT_INH | MASK_ENABLED_INH;
+
+    private String namespace;
+    private String namespacePrefix;
+
+    /**
+     * The name of the instance that this node is in. The value of the id attribute in the case of a secondary
+     * instance or null for the primary instance.
+     */
+    private String instanceName = null;
+
+    /**
+     * TreeElement with null name and 0 multiplicity? (a "hidden root" node?)
+     */
+    public TreeElement() {
+        this(null, TreeReference.DEFAULT_MULTIPLICITY);
+    }
+
+    public TreeElement(String name) {
+        this(name, TreeReference.DEFAULT_MULTIPLICITY);
+    }
+
+    public TreeElement(String name, int multiplicity) {
+        this.name = name;
+        this.multiplicity = multiplicity;
+        this.parent = null;
+        attributes = new ArrayList<TreeElement>(0);
+    }
+
+    /**
+     * Construct a TreeElement which represents an attribute with the provided
+     * namespace and name.
+     *
+     * @param namespace - if null will be converted to empty string
+     * @param name
+     * @param value
+     * @return A new instance of a TreeElement
+     */
+    public static TreeElement constructAttributeElement(String namespace, String name, String value) {
+        TreeElement element = new TreeElement(name);
+        element.setIsAttribute(true);
+        element.namespace = (namespace == null) ? "" : namespace;
+        element.multiplicity = TreeReference.INDEX_ATTRIBUTE;
+        element.value = new UncastData(value);
+        return element;
+    }
+
+    private void setIsAttribute(boolean attribute) {
+        setMaskVar(MASK_ATTRIBUTE, attribute);
+    }
+
+    /**
+     * <p>Retrieves the TreeElement representing the attribute for
+     * the provided namespace and name, or null if none exists.</p>
+     *
+     * <p>If 'null' is provided for the namespace, it will match the first
+     * attribute with the matching name.</p>
+     *
+     * @param attributes - list of attributes to search
+     * @param namespace
+     * @param name
+     * @return TreeElement
+     */
+    public static TreeElement getAttribute(List<TreeElement> attributes, String namespace, String name) {
+        for (TreeElement attribute : attributes) {
+            if (attribute.getName().equals(name) && (namespace == null || namespace.equals(attribute.namespace))) {
+                return attribute;
+            }
+        }
+        return null;
+    }
+
+    public static void setAttribute(TreeElement parent, List<TreeElement> attrs, String namespace, String name, String value) {
+
+        TreeElement attribut = getAttribute(attrs, namespace, name);
+        if (attribut != null) {
+            if (value == null) {
+                attrs.remove(attribut);
+            } else {
+                attribut.setValue(new UncastData(value));
+            }
+            return;
+        }
+
+        // null-valued attributes are a "remove-this" instruction... ignore them
+        if (value == null) return;
+
+        // create an attribute...
+        TreeElement attr = TreeElement.constructAttributeElement(namespace, name, value);
+        attr.setParent(parent);
+
+        attrs.add(attr);
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return children.isEmpty();
+    }
+
+    @Override
+    public boolean isChildable() {
+        return value == null;
+    }
+
+    @Override
+    public String getInstanceName() {
+        //CTS: I think this is a better way to do this, although I really, really don't like the duplicated code
+        if (parent != null) {
+            return parent.getInstanceName();
+        }
+        return instanceName;
+    }
+
+    public void setInstanceName(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public void setValue(IAnswerData value) {
+        if (isLeaf()) {
+            this.value = value;
+        } else {
+            throw new RuntimeException("Can't set data value for node that has children!");
+        }
+    }
+
+    @Override
+    public TreeElement getChild(String name, int multiplicity) {
+        return children.get(name, multiplicity);
+    }
+
+    @Override
+    public List<TreeElement> getChildrenWithName(String name) {
+        return children.get(name);
+    }
+
+    private int getNumChildrenWithName(String name) {
+        return children.getCount(name);
+    }
+
+    @Override
+    public int getNumChildren() {
+        return children.size();
+    }
+
+    @Override
+    public boolean hasChildren() {
+        return getNumChildren() > 0;
+    }
+
+    @Override
+    public TreeElement getChildAt(int i) {
+        return children.get(i);
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return getMaskVar(MASK_REPEATABLE);
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return getMaskVar(MASK_ATTRIBUTE);
+    }
+
+    public void setDataType(int dataType) {
+        this.dataType = dataType;
+    }
+
+    public void addChild(TreeElement child) {
+        if (!isChildable()) {
+            throw new RuntimeException("Can't add children to node that has data value!");
+        }
+
+        if (child.multiplicity == TreeReference.INDEX_UNBOUND) {
+            throw new RuntimeException("Cannot add child with an unbound index!");
+        }
+
+        children.addInOrder(child);
+        child.setParent(this);
+        child.setRelevant(isRelevant(), true);
+        child.setEnabled(isEnabled(), true);
+        child.setInstanceName(getInstanceName());
+    }
+
+    public void removeChild(TreeElement child) {
+        children.remove(child);
+    }
+
+    public void removeChild(String name, int multiplicity) {
+        children.remove(name, multiplicity);
+    }
+
+    public void removeChildren(String name) {
+        children.removeAll(name);
+    }
+
+    public void removeChildAt(int i) {
+        children.remove(i);
+    }
+
+    @Override
+    public int getChildMultiplicity(String name) {
+        return getNumChildrenWithName(name);
+    }
+
+    public TreeElement shallowCopy() {
+        TreeElement newNode = new TreeElement(name, multiplicity);
+        newNode.parent = parent;
+        newNode.setRepeatable(this.isRepeatable());
+        newNode.dataType = dataType;
+
+        // Just set the flag? side effects?
+        newNode.setMaskVar(MASK_RELEVANT, this.getMaskVar(MASK_RELEVANT));
+        newNode.setMaskVar(MASK_REQUIRED, this.getMaskVar(MASK_REQUIRED));
+        newNode.setMaskVar(MASK_ENABLED, this.getMaskVar(MASK_ENABLED));
+
+        newNode.constraint = constraint;
+        newNode.preloadHandler = preloadHandler;
+        newNode.preloadParams = preloadParams;
+        newNode.instanceName = instanceName;
+        newNode.namespace = namespace;
+        newNode.bindAttributes = bindAttributes;
+
+        newNode.attributes = new ArrayList<>(attributes.size());
+        for (TreeElement attr : attributes) {
+            newNode.setAttribute(attr.getNamespace(), attr.getName(), attr.getAttributeValue());
+        }
+
+        if (value != null) {
+            newNode.value = value.clone();
+        }
+
+        newNode.children.addAll(children);
+        return newNode;
+    }
+
+    public TreeElement deepCopy(boolean includeTemplates) {
+        TreeElement newNode = shallowCopy();
+
+        newNode.children.clear();
+        for (TreeElement child : children) {
+            if (includeTemplates || child.getMult() != TreeReference.INDEX_TEMPLATE) {
+                newNode.addChild(child.deepCopy(includeTemplates));
+            }
+        }
+
+        return newNode;
+    }
+
+    /* ==== MODEL PROPERTIES ==== */
+
+    // factoring inheritance rules
+    @Override
+    public boolean isRelevant() {
+        return getMaskVar(MASK_RELEVANT_INH) && getMaskVar(MASK_RELEVANT);
+    }
+
+    // factoring in inheritance rules
+    public boolean isEnabled() {
+        return getMaskVar(MASK_ENABLED_INH) && getMaskVar(MASK_ENABLED);
+    }
+
+    /* ==== SPECIAL SETTERS (SETTERS WITH SIDE EFFECTS) ==== */
+
+    public boolean setAnswer(IAnswerData answer) {
+        if (value != null || answer != null) {
+            setValue(answer);
+            alertStateObservers(FormElementStateListener.CHANGE_DATA);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public void setRequired(boolean required) {
+        if (getMaskVar(MASK_REQUIRED) != required) {
+            setMaskVar(MASK_REQUIRED, required);
+            alertStateObservers(FormElementStateListener.CHANGE_REQUIRED);
+        }
+    }
+
+    private boolean getMaskVar(int mask) {
+        return (flags & mask) == mask;
+    }
+
+    private void setMaskVar(int mask, boolean value) {
+        if (value) {
+            flags = flags | mask;
+        } else {
+            flags = flags & (Integer.MAX_VALUE - mask);
+        }
+    }
+
+    public void setRelevant(boolean relevant) {
+        setRelevant(relevant, false);
+    }
+
+    private void setRelevant(boolean relevant, boolean inherited) {
+        boolean oldRelevancy = isRelevant();
+        if (inherited) {
+            setMaskVar(MASK_RELEVANT_INH, relevant);
+        } else {
+            setMaskVar(MASK_RELEVANT, relevant);
+        }
+
+        boolean newRelevant = isRelevant();
+        if (newRelevant != oldRelevancy) {
+            if (attributes != null) {
+                for (TreeElement attribute : attributes) {
+                    attribute.setRelevant(newRelevant, true);
+                }
+            }
+            for (TreeElement aChildren : children) {
+                aChildren.setRelevant(newRelevant, true);
+            }
+            alertStateObservers(FormElementStateListener.CHANGE_RELEVANT);
+        }
+    }
+
+    public void setBindAttributes(List<TreeElement> bindAttributes) {
+        // create new tree elements for all the bind definitions...
+        for (TreeElement ref : bindAttributes) {
+            setBindAttribute(ref.getNamespace(), ref.getName(), ref.getAttributeValue());
+        }
+    }
+
+    public List<TreeElement> getBindAttributes() {
+        return bindAttributes;
+    }
+
+    /**
+     * <p>Retrieves the TreeElement representing an arbitrary bind attribute
+     * for this element at the provided namespace and name, or null if none exists.</p>
+     *
+     * <p>If 'null' is provided for the namespace, it will match the first
+     * attribute with the matching name.</p>
+     *
+     * @return TreeElement
+     */
+    public TreeElement getBindAttribute(String namespace, String name) {
+        return getAttribute(bindAttributes, namespace, name);
+    }
+
+    /**
+     * Returns the value of the given bind attribute from the given namespace.
+     * <p>
+     * Example:
+     * <ul>
+     * <li>Given a binding {@code <bind assertion="blah"/>}, calling {@code getBindAttributeValue(null, "assertion")} will return {@code "blah"}
+     * <li>Given a binding {@code <bind odk:assertion="blah"/>}, calling {@code getBindAttributeValue("odk", "assertion")} will return {@code "blah"}
+     * </ul>
+     * </p>
+     *
+     * @param namespace the namespace of the attribute. It can be null
+     * @param name      the name of the attribute
+     */
+    public String getBindAttributeValue(String namespace, String name) {
+        TreeElement element = getBindAttribute(namespace, name);
+        return element == null ? null : getAttributeValue(element);
+    }
+
+    public void setBindAttribute(String namespace, String name, String value) {
+        setAttribute(this, bindAttributes, namespace, name, value);
+    }
+
+    public void setEnabled(boolean enabled) {
+        setEnabled(enabled, false);
+    }
+
+    public void setEnabled(boolean enabled, boolean inherited) {
+        boolean oldEnabled = isEnabled();
+        if (inherited) {
+            setMaskVar(MASK_ENABLED_INH, enabled);
+        } else {
+            setMaskVar(MASK_ENABLED, enabled);
+        }
+
+        if (isEnabled() != oldEnabled) {
+            if (children != null) {
+                for (TreeElement aChildren : children) {
+                    aChildren.setEnabled(isEnabled(), true);
+                }
+            }
+            alertStateObservers(FormElementStateListener.CHANGE_ENABLED);
+        }
+    }
+
+    /* ==== OBSERVER PATTERN ==== */
+
+    public void registerStateObserver(FormElementStateListener qsl) {
+        if (observers == null)
+            observers = new ArrayList<FormElementStateListener>(1);
+
+        if (!observers.contains(qsl)) {
+            observers.add(qsl);
+        }
+    }
+
+    public void unregisterStateObserver(FormElementStateListener qsl) {
+        if (observers != null) {
+            observers.remove(qsl);
+            if (observers.isEmpty())
+                observers = null;
+        }
+    }
+
+    public void unregisterAll() {
+        observers = null;
+    }
+
+    public void alertStateObservers(int changeFlags) {
+        if (observers != null) {
+            for (FormElementStateListener observer : observers) {
+                observer.formElementStateChanged(this, changeFlags);
+            }
+        }
+    }
+
+    /* ==== VISITOR PATTERN ==== */
+
+    @Override
+    public void accept(ITreeVisitor visitor) {
+        visitor.visit(this);
+
+        for (TreeElement child : children) {
+            child.accept(visitor);
+        }
+    }
+
+    /* ==== Attributes ==== */
+
+    @Override
+    public int getAttributeCount() {
+        return attributes == null ? 0 : attributes.size();
+    }
+
+    @Override
+    public String getAttributeNamespace(int index) {
+        return attributes.get(index).namespace;
+    }
+
+    @Override
+    public String getAttributeName(int index) {
+        return attributes.get(index).name;
+    }
+
+    @Override
+    public String getAttributeValue(int index) {
+        return getAttributeValue(attributes.get(index));
+    }
+
+    /**
+     * Get the String value of the provided attribute
+     *
+     * @param attribute
+     * @return
+     */
+    private String getAttributeValue(TreeElement attribute) {
+        if (attribute.getValue() == null) {
+            return null;
+        } else {
+            return attribute.getValue().uncast().getString();
+        }
+    }
+
+    public String getAttributeValue() {
+        if (!isAttribute()) {
+            throw new IllegalStateException("this is not an attribute");
+        }
+        return getValue().uncast().getString();
+    }
+
+    @Override
+    public TreeElement getAttribute(String namespace, String name) {
+        return getAttribute(attributes, namespace, name);
+    }
+
+    @Override
+    public String getAttributeValue(String namespace, String name) {
+        TreeElement element = getAttribute(namespace, name);
+        return element == null ? null : getAttributeValue(element);
+    }
+
+    public void setAttribute(String namespace, String name, String value) {
+        setAttribute(this, attributes, namespace, name, value);
+    }
+
+    /* ==== SERIALIZATION ==== */
+
+    /*
+     * TODO:
+     *
+     * This new serialization scheme is kind of lame. ideally, we shouldn't have
+     * to sub-class TreeElement at all; we should have an API that can
+     * seamlessly represent complex data model objects (like weight history or
+     * immunizations) as if they were explicity XML subtrees underneath the
+     * parent TreeElement.
+     *
+     * Failing that, we should wrap this scheme in an ExternalizableWrapper.
+     */
+
+    @Override
+    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
+        name = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        multiplicity = ExtUtil.readInt(in);
+        flags = ExtUtil.readInt(in);
+        value = (IAnswerData) ExtUtil.read(in, new ExtWrapNullable(new ExtWrapTagged()), pf);
+
+        // children = ExtUtil.nullIfEmpty((List)ExtUtil.read(in, new
+        // ExtWrapList(TreeElement.class), pf));
+
+        // Jan 22, 2009 - csims@dimagi.com
+        // old line: children = ExtUtil.nullIfEmpty((List)ExtUtil.read(in, new
+        // ExtWrapList(TreeElement.class), pf));
+        // New Child deserialization
+        // 1. read null status as boolean
+        // 2. read number of children
+        // 3. for i < number of children
+        // 3.1 if read boolean true , then create TreeElement and deserialize
+        // directly.
+        // 3.2 if read boolean false then create tagged element and deserialize
+        // child
+        if (!ExtUtil.readBool(in)) {
+            // 1.
+            children.clear(); // todo is this needed?
+        } else {
+            // 2.
+            int numChildren = (int) ExtUtil.readNumeric(in);
+            children.clear();
+            // 3.
+            List<TreeElement> newChildren = new ArrayList<>(numChildren);
+            for (int i = 0; i < numChildren; ++i) {
+                boolean normal = ExtUtil.readBool(in);
+                TreeElement child;
+
+                if (normal) {
+                    // 3.1
+                    child = new TreeElement();
+                    child.readExternal(in, pf);
+                } else {
+                    // 3.2
+                    child = (TreeElement) ExtUtil.read(in, new ExtWrapTagged(), pf);
+                }
+                child.setParent(this);
+                newChildren.add(child);
+            }
+            children.addAll(newChildren);
+        }
+
+        // end Jan 22, 2009
+
+        dataType = ExtUtil.readInt(in);
+        instanceName = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        constraint = (Constraint) ExtUtil.read(in, new ExtWrapNullable(
+                Constraint.class), pf);
+        preloadHandler = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        preloadParams = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        namespace = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+
+        bindAttributes = ExtUtil.readAttributes(in, this);
+
+        attributes = ExtUtil.readAttributes(in, this);
+    }
+
+    @Override
+    public void writeExternal(DataOutputStream out) throws IOException {
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(name));
+        ExtUtil.writeNumeric(out, multiplicity);
+        ExtUtil.writeNumeric(out, flags);
+        ExtUtil.write(out, new ExtWrapNullable(value == null ? null : new ExtWrapTagged(value)));
+
+        // Jan 22, 2009 - csims@dimagi.com
+        // old line: ExtUtil.write(out, new
+        // ExtWrapList(ExtUtil.emptyIfNull(children)));
+        // New Child serialization
+        // 1. write null status as boolean
+        // 2. write number of children
+        // 3. for all child in children
+        // 3.1 if child type == TreeElement write boolean true , then serialize
+        // directly.
+        // 3.2 if child type != TreeElement, write boolean false, then tagged
+        // child
+        if (children.isEmpty()) {
+            // 1.
+            ExtUtil.writeBool(out, false);
+        } else {
+            // 1.
+            ExtUtil.writeBool(out, true);
+            // 2.
+            ExtUtil.writeNumeric(out, children.size());
+            // 3.
+            for (TreeElement child : children) {
+                if (child.getClass() == TreeElement.class) {
+                    // 3.1
+                    ExtUtil.writeBool(out, true);
+                    child.writeExternal(out);
+                } else {
+                    // 3.2
+                    ExtUtil.writeBool(out, false);
+                    ExtUtil.write(out, new ExtWrapTagged(child));
+                }
+            }
+        }
+
+        // end Jan 22, 2009
+
+        ExtUtil.writeNumeric(out, dataType);
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(instanceName));
+        ExtUtil.write(out, new ExtWrapNullable(constraint)); // TODO: inefficient for repeats
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(preloadHandler));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(preloadParams));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(namespace));
+
+        ExtUtil.writeAttributes(out, bindAttributes);
+
+        ExtUtil.writeAttributes(out, attributes);
+    }
+
+    //rebuilding a node from an imported instance
+    //  there's a lot of error checking we could do on the received instance, but it's
+    //  easier to just ignore the parts that are incorrect
+    public void populate(TreeElement incoming, FormDef f) {
+        if (this.isLeaf()) {
+            // check that incoming doesn't have children?
+
+            IAnswerData value = incoming.getValue();
+            if (value == null) {
+                this.setValue(null);
+            } else if (this.dataType == Constants.DATATYPE_TEXT
+                    || this.dataType == Constants.DATATYPE_NULL) {
+                this.setValue(value); // value is a StringData
+            } else {
+                String textVal = (String) value.getValue();
+
+                // if there is no other IAnswerResolver, use the default one.
+                IAnswerResolver answerResolver = XFormParser.getAnswerResolver();
+                if (answerResolver == null) {
+                    answerResolver = new DefaultAnswerResolver();
+                }
+                this.setValue(answerResolver.resolveAnswer(textVal, this, f));
+            }
+        } else {
+            List<String> names = new ArrayList<String>(this.getNumChildren());
+            for (int i = 0; i < this.getNumChildren(); i++) {
+                TreeElement child = this.getChildAt(i);
+                if (!names.contains(child.getName())) {
+                    names.add(child.getName());
+                }
+            }
+
+            // remove all default repetitions from skeleton data model (_preserving_ templates, though)
+            for (int i = 0; i < this.getNumChildren(); i++) {
+                TreeElement child = this.getChildAt(i);
+                if (child.getMaskVar(MASK_REPEATABLE) && child.getMult() != TreeReference.INDEX_TEMPLATE) {
+                    this.removeChildAt(i);
+                    i--;
+                }
+            }
+
+            // make sure ordering is preserved (needed for compliance with xsd schema)
+            if (this.getNumChildren() != names.size()) {
+                throw new RuntimeException("sanity check failed");
+            }
+
+            for (int i = 0; i < this.getNumChildren(); i++) {
+                TreeElement child = this.getChildAt(i);
+                String expectedName = names.get(i);
+
+                if (!child.getName().equals(expectedName)) {
+                    TreeElement child2 = null;
+                    int j;
+
+                    for (j = i + 1; j < this.getNumChildren(); j++) {
+                        child2 = this.getChildAt(j);
+                        if (child2.getName().equals(expectedName)) {
+                            break;
+                        }
+                    }
+                    if (j == this.getNumChildren()) {
+                        throw new RuntimeException("sanity check failed");
+                    }
+
+                    this.removeChildAt(j);
+                    this.children.add(i, child2);
+                }
+            }
+
+            for (int i = 0; i < this.getNumChildren(); i++) {
+                TreeElement child = this.getChildAt(i);
+                List<TreeElement> newChildren = incoming.getChildrenWithName(child.getName());
+
+                if (child.getMaskVar(MASK_REPEATABLE)) {
+                    for (int k = 0; k < newChildren.size(); k++) {
+                        TreeElement newChild = child.deepCopy(true);
+                        newChild.setMult(k);
+                        this.children.add(i + k + 1, newChild);
+                        newChild.populate(newChildren.get(k), f);
+                    }
+                    i += newChildren.size();
+                } else {
+
+                    if (newChildren.size() == 0) {
+                        child.setRelevant(false);
+                    } else {
+                        child.populate(newChildren.get(0), f);
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < incoming.getAttributeCount(); i++) {
+            String name = incoming.getAttributeName(i);
+            String ns = incoming.getAttributeNamespace(i);
+            String value = incoming.getAttributeValue(i);
+
+            this.setAttribute(ns, name, value);
+        }
+    }
+
+    //this method is for copying in the answers to an itemset. the template node of the destination
+    //is used for overall structure (including data types), and the itemset source node is used for
+    //raw data. note that data may be coerced across types, which may result in type conversion error
+    //very similar in structure to populate()
+    public void populateTemplate(TreeElement incoming, FormDef f) {
+        if (this.isLeaf()) {
+            IAnswerData value = incoming.getValue();
+            if (value == null) {
+                this.setValue(null);
+            } else {
+                Class classType = CompactInstanceWrapper.classForDataType(this.dataType);
+
+                if (classType == null) {
+                    throw new RuntimeException("data type [" + value.getClass().getName() + "] not supported inside itemset");
+                } else if (classType.isAssignableFrom(value.getClass()) &&
+                        !(value instanceof SelectOneData || value instanceof MultipleItemsData)) {
+                    this.setValue(value);
+                } else {
+                    String textVal = RestoreUtils.xfFact.serializeData(value);
+                    IAnswerData typedVal = RestoreUtils.xfFact.parseData(textVal, this.dataType, this.getRef(), f);
+                    this.setValue(typedVal);
+                }
+            }
+        } else {
+            for (int i = 0; i < this.getNumChildren(); i++) {
+                TreeElement child = this.getChildAt(i);
+                List<TreeElement> newChildren = incoming.getChildrenWithName(child.getName());
+
+                if (child.getMaskVar(MASK_REPEATABLE)) {
+                    for (int k = 0; k < newChildren.size(); k++) {
+                        TreeElement template = f.getMainInstance().getTemplate(child.getRef());
+                        TreeElement newChild = template.deepCopy(false);
+                        newChild.setMult(k);
+                        this.children.add(i + k + 1, newChild);
+                        newChild.populateTemplate(newChildren.get(k), f);
+                    }
+                    i += newChildren.size();
+                } else {
+                    child.populateTemplate(newChildren.get(0), f);
+                }
+            }
+        }
+    }
+
+    //TODO: This is probably silly because this object is likely already
+    //not thread safe in any way. Also, we should be wrapping all of the
+    //setters.
+    final TreeReference[] refCache = new TreeReference[1];
+
+    private void expireReferenceCache() {
+        synchronized (refCache) {
+            refCache[0] = null;
+        }
+    }
+
+    @Override
+    public TreeReference getRef() {
+        //TODO: Expire cache somehow;
+        synchronized (refCache) {
+            if (refCache[0] == null) {
+                refCache[0] = TreeElement.BuildRef(this);
+            }
+            return refCache[0];
+        }
+    }
+
+    public static TreeReference BuildRef(AbstractTreeElement elem) {
+        TreeReference ref = TreeReference.selfRef();
+
+        while (elem != null) {
+            TreeReference step;
+
+            if (elem.getName() != null) {
+                step = TreeReference.selfRef();
+                step.add(elem.getName(), elem.getMult());
+            } else {
+                step = TreeReference.rootRef();
+                //All TreeElements are part of a consistent tree, so the root should be in the same instance
+            }
+
+            step.setInstanceName(elem.getInstanceName());
+            if (elem.getInstanceName() != null) {
+                // it is a named instance; it should not inherit runtime context...
+                step.setContextType(TreeReference.CONTEXT_INSTANCE);
+            }
+
+            ref = ref.parent(step);
+            elem = elem.getParent();
+        }
+        return ref;
+    }
+
+    @Override
+    public int getDepth() {
+        return TreeElement.CalculateDepth(this);
+    }
+
+    public static int CalculateDepth(AbstractTreeElement elem) {
+        int depth = 0;
+
+        while (elem.getName() != null) {
+            depth++;
+            elem = elem.getParent();
+        }
+
+        return depth;
+    }
+
+    public String getPreloadHandler() {
+        return preloadHandler;
+    }
+
+    public Constraint getConstraint() {
+        return constraint;
+    }
+
+    public void setPreloadHandler(String preloadHandler) {
+        this.preloadHandler = preloadHandler;
+    }
+
+    public void setConstraint(Constraint constraint) {
+        this.constraint = constraint;
+    }
+
+    public String getPreloadParams() {
+        return preloadParams;
+    }
+
+    public void setPreloadParams(String preloadParams) {
+        this.preloadParams = preloadParams;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        expireReferenceCache();
+        this.name = name;
+    }
+
+    @Override
+    public int getMult() {
+        return multiplicity;
+    }
+
+    public void setMult(int multiplicity) {
+        expireReferenceCache();
+        this.multiplicity = multiplicity;
+    }
+
+    public void setParent(AbstractTreeElement parent) {
+        expireReferenceCache();
+        this.parent = parent;
+    }
+
+    @Override
+    public AbstractTreeElement getParent() {
+        return parent;
+    }
+
+    @Override
+    public IAnswerData getValue() {
+        return value;
+    }
+
+    public String toString() {
+        String name = "NULL";
+        if (this.name != null) {
+            name = this.name;
+        }
+
+        return name + " - Children: " + Integer.toString(this.children.size());
+    }
+
+    @Override
+    public int getDataType() {
+        return dataType;
+    }
+
+    public boolean isRequired() {
+        return getMaskVar(MASK_REQUIRED);
+    }
+
+    public void setRepeatable(boolean repeatable) {
+        setMaskVar(MASK_REPEATABLE, repeatable);
+    }
+
+    public int getMultiplicity() {
+        return multiplicity;
+    }
+
+    @Override
+    public void clearCaches() {
+        expireReferenceCache();
+    }
+
+    public void clearChildrenCaches() {
+        for (int i = 0; i < this.getNumChildren(); i++) {
+            TreeElement child = this.getChildAt(i);
+            child.clearCaches();
+            child.clearChildrenCaches();
+        }
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    @Override
+    public List<TreeReference> tryBatchChildFetch(String name, int mult, List<XPathExpression> predicates, EvaluationContext evalContext) {
+        //Only do for predicates
+        if (mult != TreeReference.INDEX_UNBOUND || predicates == null) {
+            return null;
+        }
+
+        List<Integer> toRemove = new ArrayList<Integer>();
+        List<TreeReference> selectedChildren = null;
+
+        //Lazy init these until we've determined that our predicate is hintable
+        HashMap<XPathPathExpr, String> indices = null;
+        List<TreeElement> kids = null;
+
+        predicate:
+        for (int i = 0; i < predicates.size(); ++i) {
+            XPathExpression xpe = predicates.get(i);
+            //what we want here is a static evaluation of the expression to see if it consists of evaluating
+            //something we index with something static.
+            if (xpe instanceof XPathEqExpr) {
+                XPathExpression left = ((XPathEqExpr) xpe).a;
+                XPathExpression right = ((XPathEqExpr) xpe).b;
+
+                //For now, only cheat when this is a string literal (this basically just means that we're
+                //handling attribute based referencing with very reasonable timing, but it's complex otherwise)
+                if (left instanceof XPathPathExpr && right instanceof XPathStringLiteral) {
+
+                    //We're lazily initializing this, since it might actually take a while, and we
+                    //don't want the overhead if our predicate is too complex anyway
+                    if (indices == null) {
+                        indices = new HashMap<XPathPathExpr, String>();
+                        kids = this.getChildrenWithName(name);
+
+                        if (kids.size() == 0) {
+                            return null;
+                        }
+
+                        //Anything that we're going to use across elements should be on all of them
+                        TreeElement kid = kids.get(0);
+                        for (int j = 0; j < kid.getAttributeCount(); ++j) {
+                            String attribute = kid.getAttributeName(j);
+                            indices.put(XPathReference.getPathExpr("@" + attribute), attribute);
+                        }
+                    }
+
+                    for (XPathPathExpr expr : indices.keySet()) {
+                        if (expr.equals(left)) {
+                            String attributeName = indices.get(expr);
+
+                            for (TreeElement kid : kids) {
+                                if (kid.getAttributeValue(null, attributeName).equals(((XPathStringLiteral) right).s)) {
+                                    if (selectedChildren == null) {
+                                        selectedChildren = new ArrayList<TreeReference>();
+                                    }
+                                    selectedChildren.add(kid.getRef());
+                                }
+                            }
+
+                            //Note that this predicate is evaluated and doesn't need to be evaluated in the future.
+                            toRemove.add(DataUtil.integer(i));
+                            continue predicate;
+                        }
+                    }
+                }
+            }
+            //There's only one case where we want to keep moving along, and we would have triggered it if it were going to happen,
+            //so otherwise, just get outta here.
+            break;
+        }
+
+        //if we weren't able to evaluate any predicates, signal that.
+        if (selectedChildren == null) {
+            return null;
+        }
+
+        //otherwise, remove all of the predicates we've already evaluated
+        for (int i = toRemove.size() - 1; i >= 0; i--) {
+            predicates.remove(toRemove.get(i).intValue());
+        }
+
+        return selectedChildren;
+    }
+
+    public String getNamespacePrefix() {
+        return namespacePrefix;
+    }
+
+    public void setNamespacePrefix(String namespacePrefix) {
+        this.namespacePrefix = namespacePrefix;
+    }
+}


### PR DESCRIPTION
Proposal for resolving #4059 

This is very much a draft PR since it's on the wrong repository. I tried forking Javarosa but can't build it due to Checkstyle's dislike of Windows line endings. 

As a workaround I cloned to Collect the classes that seem to need attention, then committed my proposed changes on top of them. This approach has the merit of being testable within Collect more or less as described in #4059. 

## The issue
Logging the state of the form instance shows that the crucial code is indeed in Javarosa. The initial instance tree is created with its nested repeat(s), but subsequent repeats are not. 

Stepping through creation of a repeat shows that in the template tree acquired in `FormDef.createNewRepeat` the root has the right descendants.
However when called via `FormInstance.copyNode`, `TreeElement.deepCopy` fails to copy these because their multiplicity is `INDEX_TEMPLATE` ie -2; even if it did copy them their multiplicities would stop them being indexable. 

## The fix
The obvious solution is to clone the template tree and set multiplicities to `DEFAULT_MULTIPLICITY` ie 0: this will be correct for nested repeats and the appropriate value for the repeat root is set in `copyNode`.

Both `copyNode` and `deepCopy` have multiple call sites, so modifying either will most likely (certainly?) result in regression.

However in `createNewRepeat` we can pass to `copyNode` a clone of the template with adjusted multiplicities, created using an analogue in `TreeElement` of `deepCopy`. (The subsequent copying in `copyNode` will then be harmlessly redundant.)

This small change has the desired effect and should be safe from regression.

## The code
As noted above
- the first commit clones the two Javarosa classes - incidentally generating some tens of PMD complaints 
- the second makes the proposed changes
- the third comprises the test class and form

## Testing
`NestedRepeatTest` loads the form specified in
_[NestedRepeats.xlsx](https://github.com/getodk/collect/files/7000892/NestedRepeats.xlsx)_, incidentally demonstrating that the fix works for at least one further level of nesting.
