### PR TITLE
Build instrumented tests while running unit tests and quality checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,11 @@ jobs:
           name: Assemble connected test build
           command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
 
+      - persist_to_workspace:
+          root: ~/work
+          paths:
+            - .
+
   test_instrumented:
     <<: *android_config
     steps:
@@ -151,9 +156,6 @@ jobs:
       - restore_cache:
           key: deps-{{ checksum "deps.txt" }}
 
-      - run:
-          name: Assemble test build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |
@@ -195,14 +197,9 @@ workflows:
       - build_instrumented:
           requires:
             - compile
-          filters:
-            branches:
-              ignore: master
       - test_instrumented:
           requires:
-            - check_quality
-            - test_modules
-            - test_app
+            - build_instrumented
           filters:
             branches:
               only: master

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx3072M -Dkotlin.daemon.jvm.options\="-Xmx3072M"
+org.gradle.jvmargs=-Xmx3072M -Dkotlin.daemon.jvm.options\="-Xmx3072M" -XX:+UseParallelGC
 robolectricHeapSize=3072m
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx3072M -Dkotlin.daemon.jvm.options\="-Xmx3072M" -XX:+UseParallelGC
-robolectricHeapSize=3072m
+org.gradle.jvmargs=-XX:MaxRAMPercentage=70 -XX:+UseParallelGC
+robolectricHeapSize=2048m
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
This should speed up the overall run time of the pipeline, which currently doesn't start compiling instrumented tests until after unit tests/quality checks. This also removes an extra build step that wasn't needed (running `assembleDebug` in `test_instrumented`) as it was being dealt with earlier in the pipeline.