### PR TITLE
Fixed DateWidget with year mode

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FixedDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FixedDatePickerDialog.java
@@ -82,7 +82,7 @@ public class FixedDatePickerDialog extends DialogFragment {
 
             dialog.getDatePicker().findViewById(Resources.getSystem().getIdentifier("month", "id", "android"))
                     .setVisibility(View.GONE);
-            dialog.getDatePicker().updateDate(date.getYear(), 1, 1);
+            dialog.getDatePicker().updateDate(date.getYear(), 0, 1);
         } else if (viewModel.getDatePickerDetails().isMonthYearMode()) {
             dialog.getDatePicker().findViewById(Resources.getSystem().getIdentifier("day", "id", "android"))
                     .setVisibility(View.GONE);

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/DateTimeWidgetUtilsTest.java
@@ -20,6 +20,8 @@ import org.odk.collect.android.logic.DatePickerDetails;
 import org.odk.collect.testshared.RobolectricHelpers;
 import org.odk.collect.android.support.TestScreenContextActivity;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -31,6 +33,8 @@ import static org.odk.collect.android.logic.DatePickerDetails.DatePickerType.GRE
 import static org.odk.collect.android.logic.DatePickerDetails.DatePickerType.ISLAMIC;
 import static org.odk.collect.android.logic.DatePickerDetails.DatePickerType.MYANMAR;
 import static org.odk.collect.android.logic.DatePickerDetails.DatePickerType.PERSIAN;
+
+import android.app.DatePickerDialog;
 
 @RunWith(AndroidJUnit4.class)
 public class DateTimeWidgetUtilsTest {
@@ -236,6 +240,19 @@ public class DateTimeWidgetUtilsTest {
     @Test
     public void displayDatePickerDialog_showsPersianDatePickerDialog_whenDatePickerTypeIsPersian() {
         assertDialogIsShowing(PERSIAN, PersianDatePickerDialog.class);
+    }
+
+    @Test
+    public void displayDatePickerDialogWithYearMode_showsDatePickerWithDayAndMonthFixedToJanuaryFirst() {
+        when(datePickerDetails.getDatePickerType()).thenReturn(GREGORIAN);
+
+        dateTimeWidgetUtils.showDatePickerDialog(activity, gregorianYear, date);
+        DialogFragment dialog = (DialogFragment) activity.getSupportFragmentManager()
+                .findFragmentByTag(FixedDatePickerDialog.class.getName());
+
+        assertThat(((DatePickerDialog) dialog.getDialog()).getDatePicker().getYear(), is(date.getYear()));
+        assertThat(((DatePickerDialog) dialog.getDialog()).getDatePicker().getMonth(), is(0));
+        assertThat(((DatePickerDialog) dialog.getDialog()).getDatePicker().getDayOfMonth(), is(1));
     }
 
     private void assertDialogIsShowing(DatePickerDetails.DatePickerType datePickerType, Class dialogClass) {


### PR DESCRIPTION
Closes #4810 

#### What has been done to verify that this works as intended?
I added automated tests and tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a bug fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix so we can just test the fix.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with `DateWidget` with `year` mode.
[DateTest.xml.txt](https://github.com/getodk/collect/files/7065316/DateTest.xml.txt)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)