### PR TITLE
Fixed detecting duplicated projects

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
@@ -30,12 +30,12 @@ class SettingsConnectionMatcher(
                 val projectUsername = projectSettings.getString(ProjectKeys.KEY_USERNAME)
                 val projectGoogleAccount = projectSettings.getString(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT)
 
-                if (jsonProtocol.equals(projectProtocol) && jsonProtocol.equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {
-                    if (jsonGoogleAccount.equals(projectGoogleAccount)) {
-                        return it.uuid
-                    }
-                } else {
-                    if (jsonUrl.equals(projectUrl) && jsonUsername.equals(projectUsername)) {
+                if (jsonProtocol.equals(projectProtocol)) {
+                    if (jsonProtocol.equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {
+                        if (jsonGoogleAccount.equals(projectGoogleAccount)) {
+                            return it.uuid
+                        }
+                    } else if (jsonUrl.equals(projectUrl) && jsonUsername.equals(projectUsername)) {
                         return it.uuid
                     }
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/SettingsConnectionMatcher.kt
@@ -16,9 +16,9 @@ class SettingsConnectionMatcher(
         try {
             val jsonObject = JSONObject(settingsJson)
             val jsonSettings = jsonObject.getJSONObject(AppConfigurationKeys.GENERAL)
-            val jsonProtocol = try { jsonSettings.get(ProjectKeys.KEY_PROTOCOL) } catch (e: JSONException) { ProjectKeys.PROTOCOL_SERVER }
+            val jsonProtocol = try { jsonSettings.get(ProjectKeys.KEY_PROTOCOL) } catch (e: JSONException) { ProjectKeys.defaults[ProjectKeys.KEY_PROTOCOL]!! }
 
-            val jsonUrl = try { jsonSettings.get(ProjectKeys.KEY_SERVER_URL) } catch (e: JSONException) { "" }
+            val jsonUrl = try { jsonSettings.get(ProjectKeys.KEY_SERVER_URL) } catch (e: JSONException) { ProjectKeys.defaults[ProjectKeys.KEY_SERVER_URL]!! }
             val jsonUsername = try { jsonSettings.get(ProjectKeys.KEY_USERNAME) } catch (e: JSONException) { "" }
 
             val jsonGoogleAccount = try { jsonSettings.get(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT) } catch (e: JSONException) { "" }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
@@ -19,47 +19,50 @@ class SettingsConnectionMatcherTest {
 
     @Test
     fun `returns null when no projects exist`() {
-        val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
+        val jsonSettings = getServerSettingsJson("https://example.com")
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
     }
 
     @Test
     fun `returns a matching project uuid when urls match`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "")
-        val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
+        createServerProject("a uuid", "https://example.com", "")
+        val jsonSettings = getServerSettingsJson("https://example.com")
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
     }
 
     @Test
-    fun `returns a matching project uuid when a Demo project exists and a user tries to add another Demo project`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "")
-        val jsonSettings = getDemoServerSettingsJson()
+    fun `returns a matching project uuid when a default project exists and a user tries to add another default project`() {
+        assertThat("Test assumes wrong default", ProjectKeys.defaults[ProjectKeys.KEY_PROTOCOL], `is`(ProjectKeys.PROTOCOL_SERVER))
+
+        val defaultUrl = ProjectKeys.defaults[ProjectKeys.KEY_SERVER_URL] as String
+        createServerProject("a uuid", defaultUrl, "")
+        val jsonSettings = getDefaultServerSettingsJson()
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
     }
 
     @Test
     fun `returns null when urls match and usernames don't match`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "")
-        val jsonSettings = getServerSettingsJson("https://demo.getodk.org", "foo")
+        createServerProject("a uuid", "https://example.com", "")
+        val jsonSettings = getServerSettingsJson("https://example.com", "foo")
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
     }
 
     @Test
     fun `returns a matching project uuid when urls and usernames match`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "foo")
-        val jsonSettings = getServerSettingsJson("https://demo.getodk.org", "foo")
+        createServerProject("a uuid", "https://example.com", "foo")
+        val jsonSettings = getServerSettingsJson("https://example.com", "foo")
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
     }
 
     @Test
     fun `returns a matching project uuid when urls and usernames match and there are other settings that don't match`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "foo")
-        val jsonSettings = "{ \"general\": { \"server_url\": \"https://demo.getodk.org\", \"username\": \"foo\", \"password\": \"bar\" } }"
+        createServerProject("a uuid", "https://example.com", "foo")
+        val jsonSettings = "{ \"general\": { \"server_url\": \"https://example.com\", \"username\": \"foo\", \"password\": \"bar\" } }"
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
     }
@@ -82,7 +85,7 @@ class SettingsConnectionMatcherTest {
 
     @Test
     fun `returns a matching project uuid when there are multiple projects`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "foo")
+        createServerProject("a uuid", "https://example.com", "foo")
         createGoogleDriveProject("another uuid", "foo@bar.baz")
         val jsonSettings = getGoogleDriveSettingsJson("foo@bar.baz")
 
@@ -91,7 +94,7 @@ class SettingsConnectionMatcherTest {
 
     @Test
     fun `returns uuid of first matching project when there are multiple matching projects`() {
-        createServerProject("a uuid", "https://demo.getodk.org", "foo")
+        createServerProject("a uuid", "https://example.com", "foo")
         createGoogleDriveProject("another uuid", "foo@bar.baz")
         createServerProject("uuid 3", "https://foo.org", "foo")
         createServerProject("uuid 4", "https://foo.org", "foo")
@@ -102,9 +105,9 @@ class SettingsConnectionMatcherTest {
     }
 
     @Test
-    fun `returns null when a project with Google Drive exists and a user tries to add Demo project`() {
+    fun `returns null when a project with Google Drive exists and a user tries to add a project with the default settings`() {
         createGoogleDriveProject("a uuid", "foo@bar.baz")
-        val jsonSettings = getDemoServerSettingsJson()
+        val jsonSettings = getDefaultServerSettingsJson()
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
     }
@@ -128,7 +131,7 @@ class SettingsConnectionMatcherTest {
         generalSettings.save(ProjectKeys.KEY_USERNAME, "")
     }
 
-    private fun getDemoServerSettingsJson(): String {
+    private fun getDefaultServerSettingsJson(): String {
         return "{\"general\":{},\"admin\":{},\"project\":{\"name\":\"Demo project\",\"icon\":\"D\",\"color\":\"#3e9fcc\"}}"
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
@@ -1,14 +1,17 @@
 package org.odk.collect.android.projects
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.odk.collect.android.preferences.keys.ProjectKeys
 import org.odk.collect.android.support.InMemSettingsProvider
 import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
 
+@RunWith(AndroidJUnit4::class)
 class SettingsConnectionMatcherTest {
     private val inMemProjectsRepository = InMemProjectsRepository()
     private val inMemSettingsProvider = InMemSettingsProvider()
@@ -25,6 +28,14 @@ class SettingsConnectionMatcherTest {
     fun `returns a matching project uuid when urls match`() {
         createServerProject("a uuid", "https://demo.getodk.org", "")
         val jsonSettings = getServerSettingsJson("https://demo.getodk.org")
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
+    }
+
+    @Test
+    fun `returns a matching project uuid when a Demo project exists and a user tries to add another Demo project`() {
+        createServerProject("a uuid", "https://demo.getodk.org", "")
+        val jsonSettings = getDemoServerSettingsJson()
 
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("a uuid"))
     }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/SettingsConnectionMatcherTest.kt
@@ -90,6 +90,14 @@ class SettingsConnectionMatcherTest {
         assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`("uuid 3"))
     }
 
+    @Test
+    fun `returns null when a project with Google Drive exists and a user tries to add Demo project`() {
+        createGoogleDriveProject("a uuid", "foo@bar.baz")
+        val jsonSettings = getDemoServerSettingsJson()
+
+        assertThat(settingsConnectionMatcher.getProjectWithMatchingConnection(jsonSettings), `is`(nullValue()))
+    }
+
     private fun createServerProject(projectId: String, url: String, username: String) {
         inMemProjectsRepository.save(Project.Saved(projectId, "no-op", "n", "#ffffff"))
 
@@ -105,6 +113,12 @@ class SettingsConnectionMatcherTest {
         val generalSettings = inMemSettingsProvider.getGeneralSettings(projectId)
         generalSettings.save(ProjectKeys.KEY_PROTOCOL, ProjectKeys.PROTOCOL_GOOGLE_SHEETS)
         generalSettings.save(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT, account)
+        generalSettings.save(ProjectKeys.KEY_SERVER_URL, "")
+        generalSettings.save(ProjectKeys.KEY_USERNAME, "")
+    }
+
+    private fun getDemoServerSettingsJson(): String {
+        return "{\"general\":{},\"admin\":{},\"project\":{\"name\":\"Demo project\",\"icon\":\"D\",\"color\":\"#3e9fcc\"}}"
     }
 
     private fun getServerSettingsJson(url: String): String {


### PR DESCRIPTION
Closes #4817

#### What has been done to verify that this works as intended?
I tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The problem took place when we tried to add a Demo project already having a Google Drive project.
- if you have a Google Drive project, server url in preferences is set to an empty string
- if you scan a qr code for a Demo project that qr code does not contain url (because default values are not included during generating qr codes) and also an an empty string is returned

then those urls were compared (and treated as equal of course) and the fact that we had two different types of projects was ignored what caused detecting a duplicated project.

The problem was difficult to test automatically because in  `SettingsConnectionMatcherTest` we use `InMemSettings` which is a replacement for `SharedPreferences` but `InMemSettings` does not return the same defaults as our `SharedPreferences` and then everything seemed to fork fine (for example we had null instead of an empty string and in our code it was treated as two different values). I had to save those defaults first: https://github.com/getodk/collect/pull/4818/files#diff-19ba577600f3b2f53559efdece854ef897e0c0eb92058fecc6f68867cf7cd693R116
In a perfect world we should return the same defaults for production code and tests but maybe let's figure it out in a separate pr? @seadowg what do you think?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix and we can just test the scenario described in the issue to confirm the bug is fixed.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)