### PR TITLE
Move ToastUtils to androidshared

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/ToastUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/ToastUtils.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.android.utilities
+package org.odk.collect.androidshared.utils
 
 import android.app.Application
 import android.content.Context
@@ -6,6 +6,7 @@ import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import org.odk.collect.strings.getLocalizedString
 
 /**
  * Convenience wrapper around Android's [Toast] API.
@@ -21,7 +22,10 @@ object ToastUtils {
 
     @JvmStatic
     fun showShortToast(context: Context, messageResource: Int) {
-        showToast(context.applicationContext as Application, TranslationHandler.getString(context, messageResource))
+        showToast(
+            context.applicationContext as Application,
+            context.getLocalizedString(messageResource)
+        )
     }
 
     @JvmStatic
@@ -33,7 +37,7 @@ object ToastUtils {
     fun showLongToast(context: Context, messageResource: Int) {
         showToast(
             context.applicationContext as Application,
-            TranslationHandler.getString(context, messageResource),
+            context.getLocalizedString(messageResource),
             Toast.LENGTH_LONG
         )
     }
@@ -43,7 +47,11 @@ object ToastUtils {
         showToastInMiddle(context.applicationContext as Application, message)
     }
 
-    private fun showToast(context: Application, message: String, duration: Int = Toast.LENGTH_SHORT) {
+    private fun showToast(
+        context: Application,
+        message: String,
+        duration: Int = Toast.LENGTH_SHORT
+    ) {
         hideLastToast()
         lastToast = Toast.makeText(context, message, duration)
         lastToast.show()
@@ -69,7 +77,7 @@ object ToastUtils {
     }
 
     private fun hideLastToast() {
-        if (::lastToast.isInitialized) {
+        if (ToastUtils::lastToast.isInitialized) {
             lastToast.cancel()
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/BaseGeoMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/BaseGeoMapActivity.java
@@ -34,7 +34,7 @@ public abstract class BaseGeoMapActivity extends CollectAbstractActivity {
         previousState = savedInstanceState;
 
         if (!permissionsProvider.areLocationPermissionsGranted()) {
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(this, R.string.not_granted_permission);
             finish();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/BaseGeoMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/BaseGeoMapActivity.java
@@ -19,7 +19,7 @@ package org.odk.collect.android.activities;
 import android.os.Bundle;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 /**
  * Implementation details common to the geo activities.  (After the migration

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
@@ -22,7 +22,7 @@ import android.view.WindowManager;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.Camera2Fragment;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 public class CaptureSelfieActivity extends CollectAbstractActivity {
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieActivity.java
@@ -44,6 +44,6 @@ public class CaptureSelfieActivity extends CollectAbstractActivity {
                     .replace(R.id.container, Camera2Fragment.newInstance())
                     .commit();
         }
-        ToastUtils.showLongToast(R.string.take_picture_instruction);
+        ToastUtils.showLongToast(this, R.string.take_picture_instruction);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
@@ -40,6 +40,6 @@ public class CaptureSelfieVideoActivity extends CollectAbstractActivity {
                     .replace(R.id.container, Camera2VideoFragment.newInstance())
                     .commit();
         }
-        ToastUtils.showLongToast(getString(R.string.start_video_capture_instruction));
+        ToastUtils.showLongToast(this, getString(R.string.start_video_capture_instruction));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/CaptureSelfieVideoActivity.java
@@ -21,7 +21,7 @@ import android.os.Bundle;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.Camera2VideoFragment;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 public class CaptureSelfieVideoActivity extends CollectAbstractActivity {
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -42,8 +42,6 @@ import org.odk.collect.android.formmanagement.FormDownloader;
 import org.odk.collect.android.formmanagement.FormSourceExceptionMapper;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 import org.odk.collect.android.formmanagement.ServerFormsDetailsFetcher;
-import org.odk.collect.android.views.DayNightProgressDialog;
-import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.DownloadFormsTaskListener;
 import org.odk.collect.android.listeners.FormListDownloaderListener;
@@ -54,9 +52,11 @@ import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DialogUtils;
-import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.utilities.TranslationHandler;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
+import org.odk.collect.android.views.DayNightProgressDialog;
+import org.odk.collect.androidshared.utils.ToastUtils;
+import org.odk.collect.forms.FormSourceException;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -270,7 +270,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
      */
     private void downloadFormList() {
         if (!connectivityProvider.isDeviceOnline()) {
-            ToastUtils.showShortToast(Collect.getInstance(), R.string.no_connection);
+            ToastUtils.showShortToast(this, R.string.no_connection);
 
             if (viewModel.isDownloadOnlyMode()) {
                 setReturnResult(false, getString(R.string.no_connection), viewModel.getFormResults());
@@ -408,7 +408,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
             downloadFormsTask.execute(filesToDownload);
         } else {
-            ToastUtils.showShortToast(Collect.getInstance(), R.string.noselect_error);
+            ToastUtils.showShortToast(this, R.string.noselect_error);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -270,7 +270,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
      */
     private void downloadFormList() {
         if (!connectivityProvider.isDeviceOnline()) {
-            ToastUtils.showShortToast(R.string.no_connection);
+            ToastUtils.showShortToast(Collect.getInstance(), R.string.no_connection);
 
             if (viewModel.isDownloadOnlyMode()) {
                 setReturnResult(false, getString(R.string.no_connection), viewModel.getFormResults());
@@ -408,7 +408,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
             downloadFormsTask.execute(filesToDownload);
         } else {
-            ToastUtils.showShortToast(R.string.noselect_error);
+            ToastUtils.showShortToast(Collect.getInstance(), R.string.noselect_error);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -54,7 +54,7 @@ import org.odk.collect.android.tasks.DownloadFormsTask;
 import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.AuthDialogUtility;
 import org.odk.collect.android.utilities.DialogUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.utilities.TranslationHandler;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -807,7 +807,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         if (intent == null && requestCode != RequestCodes.DRAW_IMAGE && requestCode != RequestCodes.ANNOTATE_IMAGE
                 && requestCode != RequestCodes.SIGNATURE_CAPTURE && requestCode != RequestCodes.IMAGE_CAPTURE) {
             Timber.d("The intent has a null value for requestCode: %s", requestCode);
-            showLongToast(getString(R.string.null_intent_value));
+            showLongToast(Collect.getInstance(), getString(R.string.null_intent_value));
             return;
         }
 
@@ -913,7 +913,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             waitingForDataRegistry.cancelWaitingForData();
                         } catch (Exception e) {
                             Timber.e(e);
-                            ToastUtils.showLongToast(currentViewIfODKView.getContext().getString(R.string.error_attaching_binary_file,
+                            ToastUtils.showLongToast(Collect.getInstance(), currentViewIfODKView.getContext().getString(R.string.error_attaching_binary_file,
                                     e.getMessage()));
                         }
                         set = true;
@@ -1265,7 +1265,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             @Override
             public void onSaveClicked(boolean markAsFinalized) {
                 if (saveName.length() < 1) {
-                    showShortToast(R.string.save_as_error);
+                    showShortToast(Collect.getInstance(), R.string.save_as_error);
                 } else {
                     formSaveViewModel.saveForm(getIntent().getData(), markAsFinalized, saveName, true);
                 }
@@ -1588,7 +1588,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 return;
         }
 
-        ToastUtils.showShortToastInMiddle(constraintText);
+        ToastUtils.showShortToastInMiddle(Collect.getInstance(), constraintText);
     }
 
     /**
@@ -1696,7 +1696,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         // save current answer
         if (current) {
             if (!saveAnswersForCurrentScreen(complete)) {
-                showShortToast(R.string.data_saved_error);
+                showShortToast(Collect.getInstance(), R.string.data_saved_error);
                 return false;
             }
         }
@@ -1725,7 +1725,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
                 DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
 
-                showShortToast(R.string.data_saved_ok);
+                showShortToast(Collect.getInstance(), R.string.data_saved_ok);
 
                 if (result.getRequest().viewExiting()) {
                     if (result.getRequest().shouldFinalize()) {
@@ -1750,7 +1750,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     message = getString(R.string.data_saved_error);
                 }
 
-                showLongToast(message);
+                showLongToast(Collect.getInstance(), message);
                 formSaveViewModel.resumeFormEntry();
                 break;
 
@@ -1758,7 +1758,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
                 DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
 
-                showLongToast(String.format(getString(R.string.encryption_error_message),
+                showLongToast(Collect.getInstance(), String.format(getString(R.string.encryption_error_message),
                         result.getMessage()));
                 finishAndReturnInstance();
                 formSaveViewModel.resumeFormEntry();
@@ -2184,7 +2184,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 boolean hasUsedSavepoint = task.hasUsedSavepoint();
 
                 if (hasUsedSavepoint) {
-                    runOnUiThread(() -> showLongToast(R.string.savepoint_used));
+                    runOnUiThread(() -> showLongToast(Collect.getInstance(), R.string.savepoint_used));
                 }
 
                 if (formController.getInstanceFile() == null) {
@@ -2258,7 +2258,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         } else {
             Timber.e("FormController is null");
-            showLongToast(R.string.loading_form_failed);
+            showLongToast(Collect.getInstance(), R.string.loading_form_failed);
             finish();
         }
     }
@@ -2280,7 +2280,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         onScreenRefresh();
 
         if (warningMsg != null) {
-            showLongToast(warningMsg);
+            showLongToast(Collect.getInstance(), warningMsg);
             Timber.w(warningMsg);
         }
     }
@@ -2352,14 +2352,14 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void onSavePointError(String errorMessage) {
         if (errorMessage != null && errorMessage.trim().length() > 0) {
-            showLongToast(getString(R.string.save_point_error, errorMessage));
+            showLongToast(Collect.getInstance(), getString(R.string.save_point_error, errorMessage));
         }
     }
 
     @Override
     public void onSaveFormIndexError(String errorMessage) {
         if (errorMessage != null && errorMessage.trim().length() > 0) {
-            showLongToast(getString(R.string.save_point_error, errorMessage));
+            showLongToast(Collect.getInstance(), getString(R.string.save_point_error, errorMessage));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -14,6 +14,24 @@
 
 package org.odk.collect.android.activities;
 
+import static android.content.DialogInterface.BUTTON_NEGATIVE;
+import static android.content.DialogInterface.BUTTON_POSITIVE;
+import static android.view.animation.AnimationUtils.loadAnimation;
+import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
+import static org.odk.collect.android.analytics.AnalyticsEvents.OPEN_MAP_KIT_RESPONSE;
+import static org.odk.collect.android.analytics.AnalyticsEvents.SAVE_INCOMPLETE;
+import static org.odk.collect.android.formentry.FormIndexAnimationHandler.Direction.BACKWARDS;
+import static org.odk.collect.android.formentry.FormIndexAnimationHandler.Direction.FORWARDS;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_COMPLETED_DEFAULT;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_NAVIGATION;
+import static org.odk.collect.android.preferences.keys.ProtectedProjectKeys.KEY_MOVING_BACKWARDS;
+import static org.odk.collect.android.utilities.AnimationUtils.areAnimationsEnabled;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.DialogUtils.getDialog;
+import static org.odk.collect.android.utilities.DialogUtils.showIfNotShowing;
+import static org.odk.collect.androidshared.utils.ToastUtils.showLongToast;
+import static org.odk.collect.androidshared.utils.ToastUtils.showShortToast;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -126,8 +144,8 @@ import org.odk.collect.android.listeners.WidgetValueChangedListener;
 import org.odk.collect.android.logic.ImmutableDisplayableQuestion;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.permissions.PermissionsChecker;
-import org.odk.collect.android.preferences.keys.ProtectedProjectKeys;
 import org.odk.collect.android.preferences.keys.ProjectKeys;
+import org.odk.collect.android.preferences.keys.ProtectedProjectKeys;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
@@ -147,7 +165,6 @@ import org.odk.collect.android.utilities.PlayServicesChecker;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.SnackbarUtils;
 import org.odk.collect.android.utilities.SoftKeyboardController;
-import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangePickerDecimalWidget;
@@ -158,6 +175,7 @@ import org.odk.collect.android.widgets.utilities.FormControllerWaitingForDataReg
 import org.odk.collect.android.widgets.utilities.InternalRecordingRequester;
 import org.odk.collect.android.widgets.utilities.ViewModelAudioPlayer;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.audioclips.AudioClipViewModel;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
@@ -178,24 +196,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
 import timber.log.Timber;
-
-import static android.content.DialogInterface.BUTTON_NEGATIVE;
-import static android.content.DialogInterface.BUTTON_POSITIVE;
-import static android.view.animation.AnimationUtils.loadAnimation;
-import static org.javarosa.form.api.FormEntryController.EVENT_PROMPT_NEW_REPEAT;
-import static org.odk.collect.android.analytics.AnalyticsEvents.OPEN_MAP_KIT_RESPONSE;
-import static org.odk.collect.android.analytics.AnalyticsEvents.SAVE_INCOMPLETE;
-import static org.odk.collect.android.formentry.FormIndexAnimationHandler.Direction.BACKWARDS;
-import static org.odk.collect.android.formentry.FormIndexAnimationHandler.Direction.FORWARDS;
-import static org.odk.collect.android.preferences.keys.ProtectedProjectKeys.KEY_MOVING_BACKWARDS;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_COMPLETED_DEFAULT;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_NAVIGATION;
-import static org.odk.collect.android.utilities.AnimationUtils.areAnimationsEnabled;
-import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
-import static org.odk.collect.android.utilities.DialogUtils.getDialog;
-import static org.odk.collect.android.utilities.DialogUtils.showIfNotShowing;
-import static org.odk.collect.androidshared.utils.ToastUtils.showLongToast;
-import static org.odk.collect.androidshared.utils.ToastUtils.showShortToast;
 
 /**
  * FormEntryActivity is responsible for displaying questions, animating
@@ -807,7 +807,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         if (intent == null && requestCode != RequestCodes.DRAW_IMAGE && requestCode != RequestCodes.ANNOTATE_IMAGE
                 && requestCode != RequestCodes.SIGNATURE_CAPTURE && requestCode != RequestCodes.IMAGE_CAPTURE) {
             Timber.d("The intent has a null value for requestCode: %s", requestCode);
-            showLongToast(Collect.getInstance(), getString(R.string.null_intent_value));
+            showLongToast(this, getString(R.string.null_intent_value));
             return;
         }
 
@@ -913,7 +913,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                             waitingForDataRegistry.cancelWaitingForData();
                         } catch (Exception e) {
                             Timber.e(e);
-                            ToastUtils.showLongToast(Collect.getInstance(), currentViewIfODKView.getContext().getString(R.string.error_attaching_binary_file,
+                            ToastUtils.showLongToast(this, currentViewIfODKView.getContext().getString(R.string.error_attaching_binary_file,
                                     e.getMessage()));
                         }
                         set = true;
@@ -1265,7 +1265,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             @Override
             public void onSaveClicked(boolean markAsFinalized) {
                 if (saveName.length() < 1) {
-                    showShortToast(Collect.getInstance(), R.string.save_as_error);
+                    showShortToast(FormEntryActivity.this, R.string.save_as_error);
                 } else {
                     formSaveViewModel.saveForm(getIntent().getData(), markAsFinalized, saveName, true);
                 }
@@ -1588,7 +1588,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 return;
         }
 
-        ToastUtils.showShortToastInMiddle(Collect.getInstance(), constraintText);
+        ToastUtils.showShortToastInMiddle(this, constraintText);
     }
 
     /**
@@ -1696,7 +1696,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         // save current answer
         if (current) {
             if (!saveAnswersForCurrentScreen(complete)) {
-                showShortToast(Collect.getInstance(), R.string.data_saved_error);
+                showShortToast(this, R.string.data_saved_error);
                 return false;
             }
         }
@@ -1725,7 +1725,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
                 DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
 
-                showShortToast(Collect.getInstance(), R.string.data_saved_ok);
+                showShortToast(this, R.string.data_saved_ok);
 
                 if (result.getRequest().viewExiting()) {
                     if (result.getRequest().shouldFinalize()) {
@@ -1750,7 +1750,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     message = getString(R.string.data_saved_error);
                 }
 
-                showLongToast(Collect.getInstance(), message);
+                showLongToast(this, message);
                 formSaveViewModel.resumeFormEntry();
                 break;
 
@@ -1758,7 +1758,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 DialogUtils.dismissDialog(SaveFormProgressDialogFragment.class, getSupportFragmentManager());
                 DialogUtils.dismissDialog(ChangesReasonPromptDialogFragment.class, getSupportFragmentManager());
 
-                showLongToast(Collect.getInstance(), String.format(getString(R.string.encryption_error_message),
+                showLongToast(this, String.format(getString(R.string.encryption_error_message),
                         result.getMessage()));
                 finishAndReturnInstance();
                 formSaveViewModel.resumeFormEntry();
@@ -2184,7 +2184,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 boolean hasUsedSavepoint = task.hasUsedSavepoint();
 
                 if (hasUsedSavepoint) {
-                    runOnUiThread(() -> showLongToast(Collect.getInstance(), R.string.savepoint_used));
+                    runOnUiThread(() -> showLongToast(this, R.string.savepoint_used));
                 }
 
                 if (formController.getInstanceFile() == null) {
@@ -2258,7 +2258,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         } else {
             Timber.e("FormController is null");
-            showLongToast(Collect.getInstance(), R.string.loading_form_failed);
+            showLongToast(this, R.string.loading_form_failed);
             finish();
         }
     }
@@ -2280,7 +2280,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         onScreenRefresh();
 
         if (warningMsg != null) {
-            showLongToast(Collect.getInstance(), warningMsg);
+            showLongToast(this, warningMsg);
             Timber.w(warningMsg);
         }
     }
@@ -2352,14 +2352,14 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     @Override
     public void onSavePointError(String errorMessage) {
         if (errorMessage != null && errorMessage.trim().length() > 0) {
-            showLongToast(Collect.getInstance(), getString(R.string.save_point_error, errorMessage));
+            showLongToast(this, getString(R.string.save_point_error, errorMessage));
         }
     }
 
     @Override
     public void onSaveFormIndexError(String errorMessage) {
         if (errorMessage != null && errorMessage.trim().length() > 0) {
-            showLongToast(Collect.getInstance(), getString(R.string.save_point_error, errorMessage));
+            showLongToast(this, getString(R.string.save_point_error, errorMessage));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -147,7 +147,7 @@ import org.odk.collect.android.utilities.PlayServicesChecker;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.SnackbarUtils;
 import org.odk.collect.android.utilities.SoftKeyboardController;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.RangePickerDecimalWidget;
@@ -194,8 +194,8 @@ import static org.odk.collect.android.utilities.AnimationUtils.areAnimationsEnab
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 import static org.odk.collect.android.utilities.DialogUtils.getDialog;
 import static org.odk.collect.android.utilities.DialogUtils.showIfNotShowing;
-import static org.odk.collect.android.utilities.ToastUtils.showLongToast;
-import static org.odk.collect.android.utilities.ToastUtils.showShortToast;
+import static org.odk.collect.androidshared.utils.ToastUtils.showLongToast;
+import static org.odk.collect.androidshared.utils.ToastUtils.showShortToast;
 
 /**
  * FormEntryActivity is responsible for displaying questions, animating

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -81,7 +81,7 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
         super.onCreate(savedInstanceState);
 
         if (!permissionsProvider.areLocationPermissionsGranted()) {
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(this, R.string.not_granted_permission);
             finish();
             return;
         }
@@ -254,7 +254,7 @@ public class GeoPointActivity extends CollectAbstractActivity implements Locatio
     }
 
     private void finishOnError() {
-        ToastUtils.showShortToast(R.string.provider_disabled_error);
+        ToastUtils.showShortToast(this, R.string.provider_disabled_error);
         Intent onGPSIntent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
 
         startActivity(onGPSIntent);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointActivity.java
@@ -37,8 +37,8 @@ import com.google.android.gms.location.LocationListener;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.GeoUtils;
-import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.views.DayNightProgressDialog;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.location.GoogleFusedLocationClient;
 import org.odk.collect.location.LocationClient;
 import org.odk.collect.location.LocationClientProvider;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -14,6 +14,10 @@
 
 package org.odk.collect.android.activities;
 
+import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.DRAGGABLE_ONLY;
+import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.LOCATION;
+import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.READ_ONLY;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -40,10 +44,6 @@ import java.text.DecimalFormat;
 import javax.inject.Inject;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.DRAGGABLE_ONLY;
-import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.LOCATION;
-import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.READ_ONLY;
 
 /**
  * Allow the user to indicate a location by placing a marker on a map, either
@@ -117,7 +117,7 @@ public class GeoPointMapActivity extends BaseGeoMapActivity {
             setContentView(R.layout.geopoint_layout);
         } catch (NoClassDefFoundError e) {
             Timber.e(e, "Google maps not accessible due to: %s ", e.getMessage());
-            ToastUtils.showShortToast(R.string.google_play_services_error_occured);
+            ToastUtils.showShortToast(this, R.string.google_play_services_error_occured);
             finish();
             return;
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -37,7 +37,7 @@ import org.odk.collect.android.geo.MapProvider;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.screens.MapsPreferencesFragment;
 import org.odk.collect.android.utilities.GeoUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.text.DecimalFormat;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -37,7 +37,7 @@ import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.screens.MapsPreferencesFragment;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.GeoUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.location.Location;
 import org.odk.collect.location.tracker.LocationTracker;
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.activities;
 
+import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.READ_ONLY;
+
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -47,8 +49,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
-
-import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.READ_ONLY;
 
 public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialogFragment.SettingsDialogCallback {
     public static final String ANSWER_KEY = "answer";
@@ -264,7 +264,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
         if (map.getPolyPoints(featureId).size() > 1) {
             finishWithResult();
         } else {
-            ToastUtils.showShortToastInMiddle(getString(R.string.polyline_validator));
+            ToastUtils.showShortToastInMiddle(this, getString(R.string.polyline_validator));
         }
     }
 
@@ -278,7 +278,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
             }
             finishWithResult();
         } else {
-            ToastUtils.showShortToastInMiddle(getString(R.string.polygon_validator));
+            ToastUtils.showShortToastInMiddle(this, getString(R.string.polygon_validator));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -122,12 +122,12 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
     @OnClick({R.id.upload_button})
     public void onUploadButtonsClicked(Button button) {
         if (!connectivityProvider.isDeviceOnline()) {
-            ToastUtils.showShortToast(R.string.no_connection);
+            ToastUtils.showShortToast(this, R.string.no_connection);
             return;
         }
 
         if (autoSendOngoing) {
-            ToastUtils.showShortToast(R.string.send_in_progress);
+            ToastUtils.showShortToast(this, R.string.send_in_progress);
             return;
         }
 
@@ -141,7 +141,7 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
             uploadButton.setEnabled(false);
         } else {
             // no items selected
-            ToastUtils.showLongToast(R.string.noselect_error);
+            ToastUtils.showLongToast(this, R.string.noselect_error);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -47,7 +47,7 @@ import org.odk.collect.android.preferences.screens.ProjectPreferencesActivity;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.utilities.MultiClickGuard;
 import org.odk.collect.android.utilities.PlayServicesChecker;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.util.List;
 

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegate.java
@@ -60,7 +60,7 @@ public class QRCodeMenuDelegate implements MenuDelegate {
                 if (activityAvailability.isActivityAvailable(photoPickerIntent)) {
                     activity.startActivityForResult(photoPickerIntent, SELECT_PHOTO);
                 } else {
-                    ToastUtils.showShortToast(activity.getString(R.string.activity_not_found, activity.getString(R.string.choose_image)));
+                    ToastUtils.showShortToast(activity, activity.getString(R.string.activity_not_found, activity.getString(R.string.choose_image)));
                     Timber.w(activity.getString(R.string.activity_not_found, activity.getString(R.string.choose_image)));
                 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeMenuDelegate.java
@@ -13,7 +13,7 @@ import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.FileProvider;
 import org.odk.collect.android.utilities.MenuDelegate;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.async.Scheduler;
 
 import timber.log.Timber;

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeScannerFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeScannerFragment.kt
@@ -14,7 +14,7 @@ import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.utilities.CompressionUtils
-import org.odk.collect.android.utilities.ToastUtils.showLongToast
+import org.odk.collect.androidshared.utils.ToastUtils.showLongToast
 import java.io.File
 import java.io.IOException
 import java.util.zip.DataFormatException

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeScannerFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeScannerFragment.kt
@@ -53,13 +53,13 @@ class QRCodeScannerFragment : BarCodeScannerFragment() {
                 File(storagePathProvider.getProjectRootDirPath() + File.separator + newProjectName).createNewFile()
             }
 
-            showLongToast(getString(R.string.successfully_imported_settings))
+            showLongToast(requireContext(), getString(R.string.successfully_imported_settings))
             ActivityUtils.startActivityAndCloseAllOthers(
                 requireActivity(),
                 MainMenuActivity::class.java
             )
         } else {
-            showLongToast(getString(R.string.invalid_qrcode))
+            showLongToast(requireContext(), getString(R.string.invalid_qrcode))
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -448,11 +448,11 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
             } catch (ExternalParamsException e) {
                 Timber.e(e, "ExternalParamsException");
 
-                ToastUtils.showShortToast(e.getMessage());
+                ToastUtils.showShortToast(Collect.getInstance(), e.getMessage());
             } catch (ActivityNotFoundException e) {
                 Timber.d(e, "ActivityNotFoundExcept");
 
-                ToastUtils.showShortToast(errorString);
+                ToastUtils.showShortToast(Collect.getInstance(), errorString);
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -14,6 +14,10 @@
 
 package org.odk.collect.android.formentry;
 
+import static org.odk.collect.android.injection.DaggerUtils.getComponent;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_EXTERNAL_APP_RECORDING;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+
 import android.animation.ArgbEvaluator;
 import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
@@ -73,7 +77,6 @@ import org.odk.collect.android.utilities.QuestionFontSizeUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.ThemeUtils;
-import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.StringWidget;
 import org.odk.collect.android.widgets.WidgetFactory;
@@ -83,6 +86,7 @@ import org.odk.collect.android.widgets.utilities.ExternalAppRecordingRequester;
 import org.odk.collect.android.widgets.utilities.InternalRecordingRequester;
 import org.odk.collect.android.widgets.utilities.RecordingRequesterProvider;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.audioclips.PlaybackFailedException;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 
@@ -98,10 +102,6 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.injection.DaggerUtils.getComponent;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_EXTERNAL_APP_RECORDING;
-import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
  * Contains either one {@link QuestionWidget} if the current form element is a question or
@@ -448,11 +448,11 @@ public class ODKView extends FrameLayout implements OnLongClickListener, WidgetV
             } catch (ExternalParamsException e) {
                 Timber.e(e, "ExternalParamsException");
 
-                ToastUtils.showShortToast(Collect.getInstance(), e.getMessage());
+                ToastUtils.showShortToast(getContext(), e.getMessage());
             } catch (ActivityNotFoundException e) {
                 Timber.d(e, "ActivityNotFoundExcept");
 
-                ToastUtils.showShortToast(Collect.getInstance(), errorString);
+                ToastUtils.showShortToast(getContext(), errorString);
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -73,7 +73,7 @@ import org.odk.collect.android.utilities.QuestionFontSizeUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.ThemeUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.QuestionWidget;
 import org.odk.collect.android.widgets.StringWidget;
 import org.odk.collect.android.widgets.WidgetFactory;

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -47,8 +47,8 @@ import org.odk.collect.android.listeners.SelectItemClickListener;
 import org.odk.collect.android.utilities.ContentUriProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
-import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.HtmlUtils;
+import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.audioclips.Clip;
@@ -177,7 +177,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
             // We should have a video clip, but the file doesn't exist.
             String errorMsg = getContext().getString(R.string.file_missing, videoFile);
             Timber.d("File %s is missing", videoFile);
-            ToastUtils.showLongToast(errorMsg);
+            ToastUtils.showLongToast(getContext(), errorMsg);
             return;
         }
 
@@ -189,7 +189,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
         if (intent.resolveActivity(getContext().getPackageManager()) != null) {
             getContext().startActivity(intent);
         } else {
-            ToastUtils.showShortToast(getContext().getString(R.string.activity_not_found, getContext().getString(R.string.view_video)));
+            ToastUtils.showShortToast(getContext(), getContext().getString(R.string.activity_not_found, getContext().getString(R.string.view_video)));
         }
     }
 
@@ -254,7 +254,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
             getContext().startActivity(intent);
         } catch (ActivityNotFoundException e) {
             Timber.d(e, "No Activity found to handle due to %s", e.getMessage());
-            ToastUtils.showShortToast(getContext().getString(R.string.activity_not_found,
+            ToastUtils.showShortToast(getContext(), getContext().getString(R.string.activity_not_found,
                     getContext().getString(R.string.view_image)));
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -50,7 +50,7 @@ import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.android.utilities.HtmlUtils;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.ThemeUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.audioclips.Clip;
 
 import java.io.File;

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -37,7 +37,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.CodeCaptureManagerFactory;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.views.BarcodeViewDecoder;
 
 import java.io.IOException;

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BarCodeScannerFragment.java
@@ -13,6 +13,8 @@
 
 package org.odk.collect.android.fragments;
 
+import static org.odk.collect.android.injection.DaggerUtils.getComponent;
+
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -43,8 +45,6 @@ import java.util.Collection;
 import java.util.zip.DataFormatException;
 
 import javax.inject.Inject;
-
-import static org.odk.collect.android.injection.DaggerUtils.getComponent;
 
 public abstract class BarCodeScannerFragment extends Fragment implements DecoratedBarcodeView.TorchListener {
 
@@ -99,7 +99,7 @@ public abstract class BarCodeScannerFragment extends Fragment implements Decorat
             try {
                 handleScanningResult(barcodeResult);
             } catch (IOException | DataFormatException | IllegalArgumentException e) {
-                ToastUtils.showShortToast(getString(R.string.invalid_qrcode));
+                ToastUtils.showShortToast(requireContext(), getString(R.string.invalid_qrcode));
             }
         });
     }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
@@ -40,7 +40,7 @@ import org.odk.collect.android.tasks.FormSyncTask;
 import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import javax.inject.Inject;
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
@@ -210,7 +210,7 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
             backgroundTasks.deleteFormsTask.setDeleteListener(this);
             backgroundTasks.deleteFormsTask.execute(getCheckedIdObjects());
         } else {
-            ToastUtils.showLongToast(R.string.file_delete_in_progress);
+            ToastUtils.showLongToast(requireContext(), R.string.file_delete_in_progress);
         }
     }
 
@@ -233,11 +233,11 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
 
         if (deletedForms == toDeleteCount) {
             // all deletes were successful
-            ToastUtils.showShortToast(getString(R.string.file_deleted_ok, String.valueOf(deletedForms)));
+            ToastUtils.showShortToast(requireContext(), getString(R.string.file_deleted_ok, String.valueOf(deletedForms)));
         } else {
             // had some failures
             Timber.e("Failed to delete %d forms", toDeleteCount - deletedForms);
-            ToastUtils.showLongToast(getString(R.string.file_deleted_error, String.valueOf(getCheckedCount()
+            ToastUtils.showLongToast(requireContext(), getString(R.string.file_deleted_error, String.valueOf(getCheckedCount()
                     - deletedForms), String.valueOf(getCheckedCount())));
         }
         backgroundTasks.deleteFormsTask = null;
@@ -258,7 +258,7 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
                 if (areCheckedItems()) {
                     createDeleteFormsDialog();
                 } else {
-                    ToastUtils.showShortToast(R.string.noselect_error);
+                    ToastUtils.showShortToast(requireContext(), R.string.noselect_error);
                 }
                 break;
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -50,7 +50,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.fragments.dialogs.ErrorDialog;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.MultiClickGuard;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -369,7 +369,7 @@ public class Camera2VideoFragment extends Fragment
             mediaRecorder = new MediaRecorder();
             manager.openCamera(cameraId, stateCallback, null);
         } catch (CameraAccessException e) {
-            ToastUtils.showShortToast("Cannot access the camera.");
+            ToastUtils.showShortToast(getActivity(), "Cannot access the camera.");
             activity.finish();
         } catch (NullPointerException e) {
             // Currently an NPE is thrown when the Camera2API is used but not supported on the
@@ -430,7 +430,7 @@ public class Camera2VideoFragment extends Fragment
                         public void onConfigureFailed(@NonNull CameraCaptureSession session) {
                             Activity activity = getActivity();
                             if (null != activity) {
-                                ToastUtils.showShortToast("Failed");
+                                ToastUtils.showShortToast(getActivity(), "Failed");
                             }
                         }
                     }, backgroundHandler);
@@ -559,7 +559,7 @@ public class Camera2VideoFragment extends Fragment
 
                             // Start recording
                             mediaRecorder.start();
-                            ToastUtils.showLongToast(getActivity().getString(R.string.stop_video_capture_instruction));
+                            ToastUtils.showLongToast(getActivity(), getActivity().getString(R.string.stop_video_capture_instruction));
                         }
                     });
                 }
@@ -568,7 +568,7 @@ public class Camera2VideoFragment extends Fragment
                 public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
                     Activity activity = getActivity();
                     if (null != activity) {
-                        ToastUtils.showShortToast("Failed");
+                        ToastUtils.showShortToast(getActivity(), "Failed");
                     }
                 }
             }, backgroundHandler);

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
@@ -42,8 +42,8 @@ import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.tasks.DeleteInstancesTask;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
-import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.views.DayNightProgressDialog;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import javax.inject.Inject;
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
@@ -187,7 +187,7 @@ public class SavedFormListFragment extends InstanceListFragment implements Delet
             deleteInstancesTask.setDeleteListener(this);
             deleteInstancesTask.execute(getCheckedIdObjects());
         } else {
-            ToastUtils.showLongToast(R.string.file_delete_in_progress);
+            ToastUtils.showLongToast(requireContext(), R.string.file_delete_in_progress);
         }
     }
 
@@ -203,11 +203,11 @@ public class SavedFormListFragment extends InstanceListFragment implements Delet
 
         if (deletedInstances == toDeleteCount) {
             // all deletes were successful
-            ToastUtils.showShortToast(getString(R.string.file_deleted_ok, String.valueOf(deletedInstances)));
+            ToastUtils.showShortToast(requireContext(), getString(R.string.file_deleted_ok, String.valueOf(deletedInstances)));
         } else {
             // had some failures
             Timber.e("Failed to delete %d instances", toDeleteCount - deletedInstances);
-            ToastUtils.showLongToast(getString(R.string.file_deleted_error,
+            ToastUtils.showLongToast(requireContext(), getString(R.string.file_deleted_error,
                     String.valueOf(toDeleteCount - deletedInstances),
                     String.valueOf(toDeleteCount)));
         }
@@ -231,7 +231,7 @@ public class SavedFormListFragment extends InstanceListFragment implements Delet
                 if (checkedItemCount > 0) {
                     createDeleteInstancesDialog();
                 } else {
-                    ToastUtils.showShortToast(R.string.noselect_error);
+                    ToastUtils.showShortToast(requireContext(), R.string.noselect_error);
                 }
                 break;
 

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
@@ -20,6 +20,8 @@
 
 package org.odk.collect.android.gdrive;
 
+import static org.odk.collect.android.gdrive.GoogleSheetsUploaderProgressDialog.GOOGLE_SHEETS_UPLOADER_PROGRESS_DIALOG_TAG;
+
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -54,8 +56,6 @@ import java.util.HashMap;
 import javax.inject.Inject;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.gdrive.GoogleSheetsUploaderProgressDialog.GOOGLE_SHEETS_UPLOADER_PROGRESS_DIALOG_TAG;
 
 public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implements InstanceUploaderListener, GoogleSheetsUploaderProgressDialog.OnSendingFormsCanceledListener {
 
@@ -156,7 +156,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
         if (!accountsManager.isAccountSelected()) {
             selectAccount();
         } else if (!connectivityProvider.isDeviceOnline()) {
-            ToastUtils.showShortToast("No network connection available.");
+            ToastUtils.showShortToast(this, "No network connection available.");
         } else {
             runTask();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
@@ -48,7 +48,7 @@ import org.odk.collect.android.utilities.DialogUtils;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
 import org.odk.collect.android.utilities.InstanceUploaderUtils;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapConfigurator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapConfigurator.java
@@ -1,5 +1,8 @@
 package org.odk.collect.android.geo;
 
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_GOOGLE_MAP_STYLE;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_REFERENCE_LAYER;
+
 import android.app.ActivityManager;
 import android.content.Context;
 import android.os.Bundle;
@@ -12,17 +15,14 @@ import com.google.common.collect.ImmutableSet;
 import org.odk.collect.android.R;
 import org.odk.collect.android.geo.MbtilesFile.LayerType;
 import org.odk.collect.android.preferences.PrefUtils;
-import org.odk.collect.shared.Settings;
 import org.odk.collect.android.utilities.PlayServicesChecker;
 import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.shared.Settings;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_GOOGLE_MAP_STYLE;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_REFERENCE_LAYER;
 
 class GoogleMapConfigurator implements MapConfigurator {
     private final String prefKey;
@@ -42,7 +42,7 @@ class GoogleMapConfigurator implements MapConfigurator {
 
     @Override public void showUnavailableMessage(Context context) {
         if (!isGoogleMapsSdkAvailable(context)) {
-            ToastUtils.showLongToast(context.getString(
+            ToastUtils.showLongToast(context, context.getString(
                 R.string.basemap_source_unavailable, context.getString(sourceLabelId)));
         }
         if (!isGooglePlayServicesAvailable(context)) {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapConfigurator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapConfigurator.java
@@ -16,7 +16,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.geo.MbtilesFile.LayerType;
 import org.odk.collect.android.preferences.PrefUtils;
 import org.odk.collect.android.utilities.PlayServicesChecker;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.shared.Settings;
 
 import java.io.File;

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -56,7 +56,7 @@ import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.utilities.GeoUtils;
 import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.location.GoogleFusedLocationClient;
 import org.odk.collect.location.LocationClient;
 import org.odk.collect.location.LocationClientProvider;

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -125,7 +125,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
             .beginTransaction().replace(containerId, this).commitNow();
         getMapAsync((GoogleMap map) -> {
             if (map == null) {
-                ToastUtils.showShortToast(R.string.google_play_services_error_occured);
+                ToastUtils.showShortToast(requireContext(), R.string.google_play_services_error_occured);
                 if (errorListener != null) {
                     errorListener.onError();
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapConfigurator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapConfigurator.java
@@ -1,5 +1,8 @@
 package org.odk.collect.android.geo;
 
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_MAPBOX_MAP_STYLE;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_REFERENCE_LAYER;
+
 import android.content.Context;
 import android.os.Bundle;
 
@@ -9,16 +12,13 @@ import com.google.common.collect.ImmutableSet;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.preferences.PrefUtils;
-import org.odk.collect.shared.Settings;
 import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.shared.Settings;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_MAPBOX_MAP_STYLE;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_REFERENCE_LAYER;
 
 class MapboxMapConfigurator implements MapConfigurator {
     private final String prefKey;
@@ -37,7 +37,7 @@ class MapboxMapConfigurator implements MapConfigurator {
     }
 
     @Override public void showUnavailableMessage(Context context) {
-        ToastUtils.showLongToast(context.getString(
+        ToastUtils.showLongToast(context, context.getString(
             R.string.basemap_source_unavailable, context.getString(sourceLabelId)));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapConfigurator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapboxMapConfigurator.java
@@ -12,7 +12,7 @@ import com.google.common.collect.ImmutableSet;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.preferences.PrefUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.shared.Settings;
 
 import java.io.File;

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
@@ -61,7 +61,10 @@ class AdminPasswordDialogFragment : DialogFragment() {
                 if (adminPasswordProvider.adminPassword == binding.editText.text.toString()) {
                     projectPreferencesViewModel.setStateUnlocked()
                 } else {
-                    ToastUtils.showShortToast(R.string.admin_password_incorrect)
+                    ToastUtils.showShortToast(
+                        requireContext(),
+                        R.string.admin_password_incorrect
+                    )
                 }
                 dismiss()
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
@@ -16,7 +16,7 @@ import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.ProjectPreferencesViewModel
 import org.odk.collect.android.utilities.AdminPasswordProvider
 import org.odk.collect.android.utilities.SoftKeyboardController
-import org.odk.collect.android.utilities.ToastUtils
+import org.odk.collect.androidshared.utils.ToastUtils
 import javax.inject.Inject
 
 class AdminPasswordDialogFragment : DialogFragment() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
@@ -17,7 +17,7 @@ import org.odk.collect.android.preferences.ProjectPreferencesViewModel
 import org.odk.collect.android.preferences.keys.ProtectedProjectKeys
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.utilities.SoftKeyboardController
-import org.odk.collect.android.utilities.ToastUtils
+import org.odk.collect.androidshared.utils.ToastUtils
 import javax.inject.Inject
 
 class ChangeAdminPasswordDialog : DialogFragment() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
@@ -65,10 +65,16 @@ class ChangeAdminPasswordDialog : DialogFragment() {
 
                 if (password.isEmpty()) {
                     projectPreferencesViewModel.setStateNotProtected()
-                    ToastUtils.showShortToast(R.string.admin_password_disabled)
+                    ToastUtils.showShortToast(
+                        requireContext(),
+                        R.string.admin_password_disabled
+                    )
                 } else {
                     projectPreferencesViewModel.setStateUnlocked()
-                    ToastUtils.showShortToast(R.string.admin_password_changed)
+                    ToastUtils.showShortToast(
+                        requireContext(),
+                        R.string.admin_password_changed
+                    )
                 }
                 dismiss()
             }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ExperimentalPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ExperimentalPreferencesFragment.java
@@ -7,7 +7,7 @@ import androidx.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 public class ExperimentalPreferencesFragment extends BaseProjectPreferencesFragment {
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ExperimentalPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ExperimentalPreferencesFragment.java
@@ -22,7 +22,7 @@ public class ExperimentalPreferencesFragment extends BaseProjectPreferencesFragm
         super.onViewCreated(view, savedInstanceState);
 
         if (getPreferenceScreen().getPreferenceCount() == 0) {
-            ToastUtils.showLongToast("No experimental settings at the moment!");
+            ToastUtils.showLongToast(requireContext(), "No experimental settings at the moment!");
             getParentFragmentManager().popBackStack();
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -1,5 +1,10 @@
 package org.odk.collect.android.preferences.screens;
 
+import static org.odk.collect.android.logic.PropertyManager.PROPMGR_DEVICE_ID;
+import static org.odk.collect.android.logic.PropertyManager.PROPMGR_PHONE_NUMBER;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_METADATA_EMAIL;
+import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_METADATA_PHONENUMBER;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -19,11 +24,6 @@ import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.shared.strings.Validator;
 
 import javax.inject.Inject;
-
-import static org.odk.collect.android.logic.PropertyManager.PROPMGR_DEVICE_ID;
-import static org.odk.collect.android.logic.PropertyManager.PROPMGR_PHONE_NUMBER;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_METADATA_EMAIL;
-import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_METADATA_PHONENUMBER;
 
 public class FormMetadataPreferencesFragment extends BaseProjectPreferencesFragment {
 
@@ -79,7 +79,7 @@ public class FormMetadataPreferencesFragment extends BaseProjectPreferencesFragm
         emailPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             String newValueString = newValue.toString();
             if (!newValueString.isEmpty() && !Validator.isEmailAddressValid(newValueString)) {
-                ToastUtils.showLongToast(R.string.invalid_email_address);
+                ToastUtils.showLongToast(requireContext(), R.string.invalid_email_address);
                 return false;
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -20,7 +20,7 @@ import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.permissions.PermissionsProvider;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.shared.strings.Validator;
 
 import javax.inject.Inject;

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
@@ -103,6 +103,7 @@ class ProjectManagementPreferencesFragment :
                         MainMenuActivity::class.java
                     )
                     ToastUtils.showLongToast(
+                        requireContext(),
                         getString(
                             R.string.switched_project,
                             newCurrentProject.name

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
@@ -19,7 +19,7 @@ import org.odk.collect.android.preferences.dialogs.ResetDialogPreferenceFragment
 import org.odk.collect.android.projects.DeleteProjectResult
 import org.odk.collect.android.projects.ProjectDeleter
 import org.odk.collect.android.utilities.MultiClickGuard
-import org.odk.collect.android.utilities.ToastUtils
+import org.odk.collect.androidshared.utils.ToastUtils
 import javax.inject.Inject
 
 class ProjectManagementPreferencesFragment :

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -42,7 +42,7 @@ import org.odk.collect.android.preferences.filters.ControlCharacterFilter;
 import org.odk.collect.android.preferences.filters.WhitespaceFilter;
 import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.android.utilities.PlayServicesChecker;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.shared.strings.Md5;
 import org.odk.collect.shared.strings.Validator;
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -200,7 +200,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment im
                     if (Validator.isUrlValid(url)) {
                         preference.setSummary(newValue.toString());
                     } else {
-                        ToastUtils.showShortToast(R.string.url_error);
+                        ToastUtils.showShortToast(requireContext(), R.string.url_error);
                         return false;
                     }
                     break;
@@ -210,7 +210,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment im
 
                     // do not allow leading and trailing whitespace
                     if (!username.equals(username.trim())) {
-                        ToastUtils.showShortToast(R.string.username_error_whitespace);
+                        ToastUtils.showShortToast(requireContext(), R.string.username_error_whitespace);
                         return false;
                     }
 
@@ -222,7 +222,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment im
 
                     // do not allow leading and trailing whitespace
                     if (!pw.equals(pw.trim())) {
-                        ToastUtils.showShortToast(R.string.password_error_whitespace);
+                        ToastUtils.showShortToast(requireContext(), R.string.password_error_whitespace);
                         return false;
                     }
 
@@ -240,7 +240,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment im
                     } else if (url.length() == 0) {
                         preference.setSummary(getString(R.string.google_sheets_url_hint));
                     } else {
-                        ToastUtils.showShortToast(R.string.url_error);
+                        ToastUtils.showShortToast(requireContext(), R.string.url_error);
                         return false;
                     }
                     break;

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -35,7 +35,9 @@ import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.strings.Validator
 import javax.inject.Inject
 
-class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), DuplicateProjectConfirmationDialog.DuplicateProjectConfirmationListener {
+class ManualProjectCreatorDialog :
+    MaterialFullScreenDialogFragment(),
+    DuplicateProjectConfirmationDialog.DuplicateProjectConfirmationListener {
 
     @Inject
     lateinit var projectCreator: ProjectCreator
@@ -68,28 +70,35 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
 
     private lateinit var binding: ManualProjectCreatorDialogLayoutBinding
 
-    val googleAccountResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
-        val resultData = result.data
+    val googleAccountResultLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            val resultData = result.data
 
-        if (result.resultCode == Activity.RESULT_OK && resultData != null && resultData.extras != null) {
-            val accountName = resultData.getStringExtra(AccountManager.KEY_ACCOUNT_NAME)
-            googleAccountsManager.selectAccount(accountName)
+            if (result.resultCode == Activity.RESULT_OK && resultData != null && resultData.extras != null) {
+                val accountName = resultData.getStringExtra(AccountManager.KEY_ACCOUNT_NAME)
+                googleAccountsManager.selectAccount(accountName)
 
-            val settingsJson = appConfigurationGenerator.getAppConfigurationAsJsonWithGoogleDriveDetails(
-                accountName
-            )
+                val settingsJson =
+                    appConfigurationGenerator.getAppConfigurationAsJsonWithGoogleDriveDetails(
+                        accountName
+                    )
 
-            settingsConnectionMatcher.getProjectWithMatchingConnection(settingsJson)?.let { uuid ->
-                val confirmationArgs = Bundle()
-                confirmationArgs.putString(SETTINGS_JSON, settingsJson)
-                confirmationArgs.putString(MATCHING_PROJECT, uuid)
-                DialogUtils.showIfNotShowing(DuplicateProjectConfirmationDialog::class.java, confirmationArgs, childFragmentManager)
-            } ?: run {
-                Analytics.log(AnalyticsEvents.GOOGLE_ACCOUNT_PROJECT)
-                createProject(settingsJson)
+                settingsConnectionMatcher.getProjectWithMatchingConnection(settingsJson)
+                    ?.let { uuid ->
+                        val confirmationArgs = Bundle()
+                        confirmationArgs.putString(SETTINGS_JSON, settingsJson)
+                        confirmationArgs.putString(MATCHING_PROJECT, uuid)
+                        DialogUtils.showIfNotShowing(
+                            DuplicateProjectConfirmationDialog::class.java,
+                            confirmationArgs,
+                            childFragmentManager
+                        )
+                    } ?: run {
+                    Analytics.log(AnalyticsEvents.GOOGLE_ACCOUNT_PROJECT)
+                    createProject(settingsJson)
+                }
             }
         }
-    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -97,7 +106,11 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
         settingsConnectionMatcher = SettingsConnectionMatcher(projectsRepository, settingsProvider)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         binding = ManualProjectCreatorDialogLayoutBinding.inflate(inflater)
         return binding.root
     }
@@ -145,7 +158,7 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
 
     private fun handleAddingNewProject() {
         if (!Validator.isUrlValid(binding.urlInputText.text?.trim().toString())) {
-            ToastUtils.showShortToast(R.string.url_error)
+            ToastUtils.showShortToast(requireContext(), R.string.url_error)
         } else {
             val settingsJson = appConfigurationGenerator.getAppConfigurationAsJsonWithServerDetails(
                 binding.urlInputText.text?.trim().toString(),
@@ -157,7 +170,11 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
                 val confirmationArgs = Bundle()
                 confirmationArgs.putString(SETTINGS_JSON, settingsJson)
                 confirmationArgs.putString(MATCHING_PROJECT, uuid)
-                DialogUtils.showIfNotShowing(DuplicateProjectConfirmationDialog::class.java, confirmationArgs, childFragmentManager)
+                DialogUtils.showIfNotShowing(
+                    DuplicateProjectConfirmationDialog::class.java,
+                    confirmationArgs,
+                    childFragmentManager
+                )
             } ?: run {
                 createProject(settingsJson)
                 Analytics.log(AnalyticsEvents.MANUAL_CREATE_PROJECT)
@@ -174,7 +191,13 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
                     if (activityAvailability.isActivityAvailable(intent)) {
                         googleAccountResultLauncher.launch(intent)
                     } else {
-                        ToastUtils.showShortToast(getString(R.string.activity_not_found, getString(R.string.choose_account)))
+                        ToastUtils.showShortToast(
+                            requireContext(),
+                            getString(
+                                R.string.activity_not_found,
+                                getString(R.string.choose_account)
+                            )
+                        )
                     }
                 }
 
@@ -188,12 +211,21 @@ class ManualProjectCreatorDialog : MaterialFullScreenDialogFragment(), Duplicate
     override fun createProject(settingsJson: String) {
         projectCreator.createNewProject(settingsJson)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
-        ToastUtils.showLongToast(getString(R.string.switched_project, currentProjectProvider.getCurrentProject().name))
+        ToastUtils.showLongToast(
+            requireContext(),
+            getString(R.string.switched_project, currentProjectProvider.getCurrentProject().name)
+        )
     }
 
     override fun switchToProject(uuid: String) {
         currentProjectProvider.setCurrentProject(uuid)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
-        ToastUtils.showLongToast(getString(org.odk.collect.projects.R.string.switched_project, currentProjectProvider.getCurrentProject().name))
+        ToastUtils.showLongToast(
+            requireContext(),
+            getString(
+                org.odk.collect.projects.R.string.switched_project,
+                currentProjectProvider.getCurrentProject().name
+            )
+        )
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -29,7 +29,7 @@ import org.odk.collect.android.projects.DuplicateProjectConfirmationKeys.SETTING
 import org.odk.collect.android.utilities.ActivityAvailability
 import org.odk.collect.android.utilities.DialogUtils
 import org.odk.collect.android.utilities.SoftKeyboardController
-import org.odk.collect.android.utilities.ToastUtils
+import org.odk.collect.androidshared.utils.ToastUtils
 import org.odk.collect.material.MaterialFullScreenDialogFragment
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.strings.Validator

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -113,7 +113,10 @@ class ProjectSettingsDialog : DialogFragment() {
         currentProjectViewModel.setCurrentProject(project)
 
         ActivityUtils.startActivityAndCloseAllOthers(requireActivity(), MainMenuActivity::class.java)
-        ToastUtils.showLongToast(getString(R.string.switched_project, project.name))
+        ToastUtils.showLongToast(
+            requireContext(),
+            getString(R.string.switched_project, project.name)
+        )
         dismiss()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -20,7 +20,7 @@ import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.screens.ProjectPreferencesActivity
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.android.utilities.DialogUtils
-import org.odk.collect.android.utilities.ToastUtils
+import org.odk.collect.androidshared.utils.ToastUtils
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import javax.inject.Inject

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -30,9 +30,9 @@ import org.odk.collect.android.utilities.ActivityAvailability
 import org.odk.collect.android.utilities.CodeCaptureManagerFactory
 import org.odk.collect.android.utilities.CompressionUtils
 import org.odk.collect.android.utilities.DialogUtils
-import org.odk.collect.android.utilities.ToastUtils
-import org.odk.collect.android.utilities.ToastUtils.showShortToast
 import org.odk.collect.android.views.BarcodeViewDecoder
+import org.odk.collect.androidshared.utils.ToastUtils
+import org.odk.collect.androidshared.utils.ToastUtils.showShortToast
 import org.odk.collect.material.MaterialFullScreenDialogFragment
 import org.odk.collect.projects.ProjectsRepository
 import timber.log.Timber

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -96,9 +96,15 @@ class QrCodeProjectCreatorDialog :
                                         val settingsJson = qrCodeDecoder.decode(it)
                                         createProjectOrError(settingsJson)
                                     } catch (e: QRCodeDecoder.InvalidException) {
-                                        showShortToast(R.string.invalid_qrcode)
+                                        showShortToast(
+                                            requireContext(),
+                                            R.string.invalid_qrcode
+                                        )
                                     } catch (e: QRCodeDecoder.NotFoundException) {
-                                        showShortToast(R.string.qr_code_not_found)
+                                        showShortToast(
+                                            requireContext(),
+                                            R.string.qr_code_not_found
+                                        )
                                     }
                                 }
                             }
@@ -165,6 +171,7 @@ class QrCodeProjectCreatorDialog :
                         imageQrCodeImportResultLauncher.launch(photoPickerIntent)
                     } else {
                         showShortToast(
+                            requireContext(),
                             getString(
                                 R.string.activity_not_found,
                                 getString(R.string.choose_image)
@@ -237,7 +244,7 @@ class QrCodeProjectCreatorDialog :
                     val settingsJson = CompressionUtils.decompress(barcodeResult.text)
                     createProjectOrError(settingsJson)
                 } catch (e: Exception) {
-                    showShortToast(getString(R.string.invalid_qrcode))
+                    showShortToast(requireContext(), getString(R.string.invalid_qrcode))
                 }
             }
         )
@@ -261,7 +268,7 @@ class QrCodeProjectCreatorDialog :
                 createProject(settingsJson)
             }
         } catch (e: Exception) {
-            showShortToast(getString(R.string.invalid_qrcode))
+            showShortToast(requireContext(), getString(R.string.invalid_qrcode))
         }
     }
 
@@ -273,13 +280,14 @@ class QrCodeProjectCreatorDialog :
 
             ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
             ToastUtils.showLongToast(
+                requireContext(),
                 getString(
                     R.string.switched_project,
                     currentProjectProvider.getCurrentProject().name
                 )
             )
         } else {
-            ToastUtils.showLongToast(getString(R.string.invalid_qrcode))
+            ToastUtils.showLongToast(requireContext(), getString(R.string.invalid_qrcode))
         }
     }
 
@@ -287,6 +295,7 @@ class QrCodeProjectCreatorDialog :
         currentProjectProvider.setCurrentProject(uuid)
         ActivityUtils.startActivityAndCloseAllOthers(activity, MainMenuActivity::class.java)
         ToastUtils.showLongToast(
+            requireContext(),
             getString(
                 R.string.switched_project,
                 currentProjectProvider.getCurrentProject().name

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -23,6 +23,7 @@ import android.net.Uri;
 
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.io.File;
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.utilities;
 
+import static org.odk.collect.android.utilities.FileUtils.deleteAndReport;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -25,8 +27,6 @@ import org.odk.collect.android.R;
 import java.io.File;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.FileUtils.deleteAndReport;
 
 /**
  * Consolidate all interactions with media providers here.
@@ -58,7 +58,7 @@ public class MediaUtils {
             context.startActivity(intent);
         } else {
             String message = context.getString(R.string.activity_not_found, context.getString(R.string.open_file));
-            ToastUtils.showLongToast(message);
+            ToastUtils.showLongToast(context, message);
             Timber.w(message);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.utilities
 
+import android.app.Application
 import android.content.Context
 import android.view.Gravity
 import android.view.ViewGroup
@@ -12,23 +13,23 @@ object ToastUtils {
 
     @JvmStatic
     fun showShortToast(context: Context, message: String) {
-        showToast(context, message)
+        showToast(context.applicationContext as Application, message)
     }
 
     @JvmStatic
     fun showShortToast(context: Context, messageResource: Int) {
-        showToast(context, TranslationHandler.getString(context, messageResource))
+        showToast(context.applicationContext as Application, TranslationHandler.getString(context, messageResource))
     }
 
     @JvmStatic
     fun showLongToast(context: Context, message: String) {
-        showToast(context, message, Toast.LENGTH_LONG)
+        showToast(context.applicationContext as Application, message, Toast.LENGTH_LONG)
     }
 
     @JvmStatic
     fun showLongToast(context: Context, messageResource: Int) {
         showToast(
-            context,
+            context.applicationContext as Application,
             TranslationHandler.getString(context, messageResource),
             Toast.LENGTH_LONG
         )
@@ -36,17 +37,17 @@ object ToastUtils {
 
     @JvmStatic
     fun showShortToastInMiddle(context: Context, message: String) {
-        showToastInMiddle(context, message)
+        showToastInMiddle(context.applicationContext as Application, message)
     }
 
-    private fun showToast(context: Context, message: String, duration: Int = Toast.LENGTH_SHORT) {
+    private fun showToast(context: Application, message: String, duration: Int = Toast.LENGTH_SHORT) {
         hideLastToast()
         lastToast = Toast.makeText(context, message, duration)
         lastToast.show()
     }
 
     private fun showToastInMiddle(
-        context: Context,
+        context: Application,
         message: String,
         duration: Int = Toast.LENGTH_SHORT
     ) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
@@ -1,48 +1,57 @@
 package org.odk.collect.android.utilities
 
+import android.content.Context
 import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
-import org.odk.collect.android.application.Collect
 
 object ToastUtils {
-    lateinit var toast: Toast
+
+    private lateinit var toast: Toast
 
     @JvmStatic
-    fun showShortToast(message: String) {
-        showToast(message)
+    fun showShortToast(context: Context, message: String) {
+        showToast(context, message)
     }
 
     @JvmStatic
-    fun showShortToast(messageResource: Int) {
-        showToast(TranslationHandler.getString(Collect.getInstance(), messageResource))
+    fun showShortToast(context: Context, messageResource: Int) {
+        showToast(context, TranslationHandler.getString(context, messageResource))
     }
 
     @JvmStatic
-    fun showLongToast(message: String) {
-        showToast(message, Toast.LENGTH_LONG)
+    fun showLongToast(context: Context, message: String) {
+        showToast(context, message, Toast.LENGTH_LONG)
     }
 
     @JvmStatic
-    fun showLongToast(messageResource: Int) {
-        showToast(TranslationHandler.getString(Collect.getInstance(), messageResource), Toast.LENGTH_LONG)
+    fun showLongToast(context: Context, messageResource: Int) {
+        showToast(
+            context,
+            TranslationHandler.getString(context, messageResource),
+            Toast.LENGTH_LONG
+        )
     }
 
     @JvmStatic
-    fun showShortToastInMiddle(message: String) {
-        showToastInMiddle(message)
+    fun showShortToastInMiddle(context: Context, message: String) {
+        showToastInMiddle(context, message)
     }
 
-    private fun showToast(message: String, duration: Int = Toast.LENGTH_SHORT) {
+    private fun showToast(context: Context, message: String, duration: Int = Toast.LENGTH_SHORT) {
         hideOldToast()
-        toast = Toast.makeText(Collect.getInstance(), message, duration)
+        toast = Toast.makeText(context, message, duration)
         toast.show()
     }
 
-    private fun showToastInMiddle(message: String, duration: Int = Toast.LENGTH_SHORT) {
+    private fun showToastInMiddle(
+        context: Context,
+        message: String,
+        duration: Int = Toast.LENGTH_SHORT
+    ) {
         hideOldToast()
-        toast = Toast.makeText(Collect.getInstance(), message, duration)
+        toast = Toast.makeText(context, message, duration)
         try {
             val group = toast.view as ViewGroup?
             val messageTextView = group!!.getChildAt(0) as TextView

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
@@ -8,7 +8,7 @@ import android.widget.Toast
 
 object ToastUtils {
 
-    private lateinit var toast: Toast
+    private lateinit var lastToast: Toast
 
     @JvmStatic
     fun showShortToast(context: Context, message: String) {
@@ -40,9 +40,9 @@ object ToastUtils {
     }
 
     private fun showToast(context: Context, message: String, duration: Int = Toast.LENGTH_SHORT) {
-        hideOldToast()
-        toast = Toast.makeText(context, message, duration)
-        toast.show()
+        hideLastToast()
+        lastToast = Toast.makeText(context, message, duration)
+        lastToast.show()
     }
 
     private fun showToastInMiddle(
@@ -50,23 +50,23 @@ object ToastUtils {
         message: String,
         duration: Int = Toast.LENGTH_SHORT
     ) {
-        hideOldToast()
-        toast = Toast.makeText(context, message, duration)
+        hideLastToast()
+        lastToast = Toast.makeText(context, message, duration)
         try {
-            val group = toast.view as ViewGroup?
+            val group = lastToast.view as ViewGroup?
             val messageTextView = group!!.getChildAt(0) as TextView
             messageTextView.textSize = 21f
             messageTextView.gravity = Gravity.CENTER
         } catch (ignored: Exception) {
             // ignored
         }
-        toast.setGravity(Gravity.CENTER, 0, 0)
-        toast.show()
+        lastToast.setGravity(Gravity.CENTER, 0, 0)
+        lastToast.show()
     }
 
-    private fun hideOldToast() {
-        if (::toast.isInitialized) {
-            toast.cancel()
+    private fun hideLastToast() {
+        if (::lastToast.isInitialized) {
+            lastToast.cancel()
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ToastUtils.kt
@@ -7,6 +7,9 @@ import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 
+/**
+ * Convenience wrapper around Android's [Toast] API.
+ */
 object ToastUtils {
 
     private lateinit var lastToast: Toast

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -34,7 +34,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.PermissionListener;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.CameraUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.widgets;
 
+import static org.odk.collect.android.utilities.Appearances.FRONT;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -30,13 +32,11 @@ import org.odk.collect.android.activities.ScannerWithFlashlightActivity;
 import org.odk.collect.android.databinding.BarcodeWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.PermissionListener;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.ToastUtils;
-import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
-
-import static org.odk.collect.android.utilities.Appearances.FRONT;
 
 /**
  * Widget that allows user to scan barcodes and add them to the form.
@@ -140,7 +140,7 @@ public class BarcodeWidget extends QuestionWidget implements WidgetDataReceiver 
             if (cameraUtils.isFrontCameraAvailable()) {
                 intent.addExtra(FRONT, true);
             } else {
-                ToastUtils.showLongToast(R.string.error_front_camera_unavailable);
+                ToastUtils.showLongToast(getContext(), R.string.error_front_camera_unavailable);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -33,7 +33,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.BearingActivity;
 import org.odk.collect.android.databinding.BearingWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BearingWidget.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.widgets;
 
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -34,8 +36,6 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
-
-import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
  * BearingWidget is the widget that allows the user to get a compass heading.
@@ -120,7 +120,7 @@ public class BearingWidget extends QuestionWidget implements WidgetDataReceiver 
 
             waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
         } else {
-            ToastUtils.showLongToast(R.string.bearing_lack_of_sensors);
+            ToastUtils.showLongToast(getContext(), R.string.bearing_lack_of_sensors);
 
             binding.bearingButton.setEnabled(false);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -19,7 +19,7 @@ import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import timber.log.Timber;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -19,8 +19,8 @@ import org.odk.collect.android.utilities.ApplicationConstants;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import timber.log.Timber;
 
@@ -92,7 +92,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
+            ToastUtils.showLongToast(getContext(), e.getMessage());
         }
     }
 
@@ -101,7 +101,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_ARBITRARY_FILE_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExArbitraryFileWidget.java
@@ -92,7 +92,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(e.getMessage());
+            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
         }
     }
 
@@ -101,7 +101,7 @@ public class ExArbitraryFileWidget extends BaseArbitraryFileWidget {
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_ARBITRARY_FILE_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -115,7 +115,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(R.string.invalid_file_type);
+                ToastUtils.showLongToast(Collect.getInstance(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e("ExAudioWidget's setBinaryData must receive a audio file but received: %s", FileUtils.getMimeType((File) object));
             } else {
@@ -204,7 +204,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(e.getMessage());
+            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
         }
     }
 
@@ -213,7 +213,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_AUDIO_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -26,7 +26,7 @@ import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.utilities.AudioPlayer;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -26,11 +26,11 @@ import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.androidshared.utils.ToastUtils;
-import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
+import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.AudioPlayer;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.audioclips.Clip;
 
 import java.io.File;
@@ -115,7 +115,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(Collect.getInstance(), R.string.invalid_file_type);
+                ToastUtils.showLongToast(getContext(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e("ExAudioWidget's setBinaryData must receive a audio file but received: %s", FileUtils.getMimeType((File) object));
             } else {
@@ -204,7 +204,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
+            ToastUtils.showLongToast(getContext(), e.getMessage());
         }
     }
 
@@ -213,7 +213,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_AUDIO_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -54,7 +54,7 @@ public class ExDecimalWidget extends ExStringWidget {
             ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_DECIMAL_CAPTURE);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExDecimalWidget.java
@@ -26,7 +26,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.externaldata.ExternalAppsUtils;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.utilities.StringWidgetUtils;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import timber.log.Timber;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
@@ -22,10 +22,10 @@ import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.androidshared.utils.ToastUtils;
-import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
+import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.io.File;
 
@@ -109,7 +109,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(Collect.getInstance(), R.string.invalid_file_type);
+                ToastUtils.showLongToast(getContext(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e("ExImageWidget's setBinaryData must receive an image file but received: %s", FileUtils.getMimeType((File) object));
             } else {
@@ -137,7 +137,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
+            ToastUtils.showLongToast(getContext(), e.getMessage());
         }
     }
 
@@ -146,7 +146,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_IMAGE_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
@@ -109,7 +109,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(R.string.invalid_file_type);
+                ToastUtils.showLongToast(Collect.getInstance(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e("ExImageWidget's setBinaryData must receive an image file but received: %s", FileUtils.getMimeType((File) object));
             } else {
@@ -137,7 +137,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(e.getMessage());
+            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
         }
     }
 
@@ -146,7 +146,7 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_IMAGE_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
@@ -22,7 +22,7 @@ import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
@@ -27,7 +27,7 @@ import org.javarosa.core.model.data.IntegerData;
 import org.odk.collect.android.R;
 import org.odk.collect.android.externaldata.ExternalAppsUtils;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.utilities.StringWidgetUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExIntegerWidget.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.widgets;
 
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -25,13 +27,11 @@ import org.javarosa.core.model.data.IntegerData;
 import org.odk.collect.android.R;
 import org.odk.collect.android.externaldata.ExternalAppsUtils;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.widgets.utilities.StringWidgetUtils;
 import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.android.widgets.utilities.StringWidgetUtils;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 
 import timber.log.Timber;
-
-import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
  * Launch an external app to supply an integer value. If the app
@@ -54,7 +54,7 @@ public class ExIntegerWidget extends ExStringWidget {
             ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_INT_CAPTURE);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -128,7 +128,7 @@ public class ExStringWidget extends StringWidget implements WidgetDataReceiver, 
             ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_STRING_CAPTURE);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -35,7 +35,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExStringWidget.java
@@ -14,6 +14,11 @@
 
 package org.odk.collect.android.widgets;
 
+import static android.content.Intent.ACTION_SENDTO;
+import static org.odk.collect.android.formentry.questions.WidgetViewUtils.createSimpleButton;
+import static org.odk.collect.android.injection.DaggerUtils.getComponent;
+import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
@@ -35,19 +40,14 @@ import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.ActivityAvailability;
 import org.odk.collect.android.utilities.ExternalAppIntentProvider;
-import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import javax.inject.Inject;
 
 import timber.log.Timber;
-
-import static android.content.Intent.ACTION_SENDTO;
-import static org.odk.collect.android.formentry.questions.WidgetViewUtils.createSimpleButton;
-import static org.odk.collect.android.injection.DaggerUtils.getComponent;
-import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
 
 /**
  * <p>Launch an external app to supply a string value. If the app
@@ -128,7 +128,7 @@ public class ExStringWidget extends StringWidget implements WidgetDataReceiver, 
             ((Activity) getContext()).startActivityForResult(i, RequestCodes.EX_STRING_CAPTURE);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
@@ -104,7 +104,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(R.string.invalid_file_type);
+                ToastUtils.showLongToast(Collect.getInstance(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e("ExVideoWidget's setBinaryData must receive a video file but received: %s", FileUtils.getMimeType((File) object));
             } else {
@@ -132,7 +132,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(e.getMessage());
+            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
         }
     }
 
@@ -141,7 +141,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_VIDEO_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(R.string.not_granted_permission);
+            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
@@ -20,7 +20,7 @@ import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
@@ -20,10 +20,10 @@ import org.odk.collect.android.utilities.ExternalAppIntentProvider;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.androidshared.utils.ToastUtils;
-import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.FileWidget;
+import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 import java.io.File;
 
@@ -104,7 +104,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             }
         } else if (object != null) {
             if (object instanceof File) {
-                ToastUtils.showLongToast(Collect.getInstance(), R.string.invalid_file_type);
+                ToastUtils.showLongToast(getContext(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
                 Timber.e("ExVideoWidget's setBinaryData must receive a video file but received: %s", FileUtils.getMimeType((File) object));
             } else {
@@ -132,7 +132,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             Intent intent = externalAppIntentProvider.getIntentToRunExternalApp(getContext(), getFormEntryPrompt(), activityAvailability, Collect.getInstance().getPackageManager());
             fireActivityForResult(intent);
         } catch (Exception | Error e) {
-            ToastUtils.showLongToast(Collect.getInstance(), e.getMessage());
+            ToastUtils.showLongToast(getContext(), e.getMessage());
         }
     }
 
@@ -141,7 +141,7 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
             ((Activity) getContext()).startActivityForResult(intent, ApplicationConstants.RequestCodes.EX_VIDEO_CHOOSER);
         } catch (SecurityException e) {
             Timber.i(e);
-            ToastUtils.showLongToast(Collect.getInstance(), R.string.not_granted_permission);
+            ToastUtils.showLongToast(getContext(), R.string.not_granted_permission);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -27,7 +27,7 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.databinding.UrlWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.ExternalWebPageHelper;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 
 @SuppressLint("ViewConstructor")
 public class UrlWidget extends QuestionWidget {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/UrlWidget.java
@@ -24,7 +24,6 @@ import android.view.View;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
-
 import org.odk.collect.android.databinding.UrlWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.ExternalWebPageHelper;
@@ -53,7 +52,7 @@ public class UrlWidget extends QuestionWidget {
 
     @Override
     public void clearAnswer() {
-        ToastUtils.showShortToast("URL is readonly");
+        ToastUtils.showShortToast(getContext(), "URL is readonly");
     }
 
     @Override
@@ -87,7 +86,7 @@ public class UrlWidget extends QuestionWidget {
             externalWebPageHelper.bindCustomTabsService(getContext(), null);
             externalWebPageHelper.openWebPageInCustomTab((Activity) getContext(), Uri.parse(getFormEntryPrompt().getAnswerText()));
         } else {
-            ToastUtils.showShortToast("No URL set");
+            ToastUtils.showShortToast(getContext(), "No URL set");
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -110,7 +110,7 @@ public class VideoWidget extends QuestionWidget implements FileWidget, ButtonCli
         if (selfie) {
             if (!cameraUtils.isFrontCameraAvailable()) {
                 captureButton.setEnabled(false);
-                ToastUtils.showLongToast(R.string.error_front_camera_unavailable);
+                ToastUtils.showLongToast(getContext(), R.string.error_front_camera_unavailable);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -36,7 +36,7 @@ import org.odk.collect.android.preferences.keys.ProjectKeys;
 import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
@@ -18,7 +18,7 @@ import org.odk.collect.android.databinding.RangePickerWidgetAnswerBinding;
 import org.odk.collect.android.databinding.RangeWidgetHorizontalBinding;
 import org.odk.collect.android.databinding.RangeWidgetVerticalBinding;
 import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
-import org.odk.collect.android.utilities.ToastUtils;
+import org.odk.collect.androidshared.utils.ToastUtils;
 import org.odk.collect.android.views.TrackingTouchSlider;
 
 import java.math.BigDecimal;

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
@@ -250,13 +250,13 @@ public class RangeWidgetUtils {
     }
 
     public static boolean isRangeSliderWidgetValid(RangeQuestion rangeQuestion, TrackingTouchSlider slider) {
-        if (!isWidgetValid(rangeQuestion)) {
+        if (!isWidgetValid(slider.getContext(), rangeQuestion)) {
             slider.setEnabled(false);
         }
-        return isWidgetValid(rangeQuestion);
+        return isWidgetValid(slider.getContext(), rangeQuestion);
     }
 
-    static boolean isWidgetValid(RangeQuestion rangeQuestion) {
+    static boolean isWidgetValid(Context context, RangeQuestion rangeQuestion) {
         BigDecimal rangeStart = rangeQuestion.getRangeStart();
         BigDecimal rangeEnd = rangeQuestion.getRangeEnd();
         BigDecimal rangeStep = rangeQuestion.getRangeStep().abs();
@@ -264,16 +264,16 @@ public class RangeWidgetUtils {
         boolean result = true;
         if (rangeStep.compareTo(BigDecimal.ZERO) == 0
                 || rangeEnd.subtract(rangeStart).remainder(rangeStep).compareTo(BigDecimal.ZERO) != 0) {
-            ToastUtils.showLongToast(R.string.invalid_range_widget);
+            ToastUtils.showLongToast(context, R.string.invalid_range_widget);
             result = false;
         }
         return result;
     }
 
     private static boolean isRangePickerWidgetValid(RangeQuestion rangeQuestion, Button widgetButton) {
-        if (!isWidgetValid(rangeQuestion)) {
+        if (!isWidgetValid(widgetButton.getContext(), rangeQuestion)) {
             widgetButton.setEnabled(false);
         }
-        return isWidgetValid(rangeQuestion);
+        return isWidgetValid(widgetButton.getContext(), rangeQuestion);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtilsTest.java
@@ -10,6 +10,7 @@ import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.prom
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithReadOnlyAndQuestionDef;
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.widgetTestActivity;
 
+import android.content.Context;
 import android.view.View;
 import android.widget.TextView;
 
@@ -41,13 +42,16 @@ public class RangeWidgetUtilsTest {
     private TrackingTouchSlider slider;
     private TextView sampleTextView1;
     private TextView sampleTextView2;
+    private Context context;
 
     @Before
     public void setup() {
-        ApplicationProvider.getApplicationContext().setTheme(R.style.Theme_MaterialComponents);
-        slider = new TrackingTouchSlider(ApplicationProvider.getApplicationContext(), null);
-        sampleTextView1 = new TextView(ApplicationProvider.getApplicationContext());
-        sampleTextView2 = new TextView(ApplicationProvider.getApplicationContext());
+        context = ApplicationProvider.getApplicationContext();
+        context.setTheme(R.style.Theme_MaterialComponents);
+
+        slider = new TrackingTouchSlider(context, null);
+        sampleTextView1 = new TextView(context);
+        sampleTextView2 = new TextView(context);
 
         binding = RangePickerWidgetAnswerBinding.inflate((widgetTestActivity()).getLayoutInflater());
 
@@ -137,7 +141,7 @@ public class RangeWidgetUtilsTest {
     @Test
     public void whenRangeQuestionHasZeroRangeStep_invalidWidgetToastIsShown() {
         when(rangeQuestion.getRangeStep()).thenReturn(BigDecimal.ZERO);
-        assertThat(RangeWidgetUtils.isWidgetValid(rangeQuestion), equalTo(false));
+        assertThat(RangeWidgetUtils.isWidgetValid(context, rangeQuestion), equalTo(false));
 
         String toastText = ShadowToast.getTextOfLatestToast();
         assertThat(toastText, equalTo(ApplicationProvider.getApplicationContext().getString(R.string.invalid_range_widget)));
@@ -146,7 +150,7 @@ public class RangeWidgetUtilsTest {
     @Test
     public void whenPromptHasInvalidWidgetParameters_invalidWidgetToastIsShown() {
         when(rangeQuestion.getRangeStep()).thenReturn(new BigDecimal(2));
-        assertThat(RangeWidgetUtils.isWidgetValid(rangeQuestion), equalTo(false));
+        assertThat(RangeWidgetUtils.isWidgetValid(context, rangeQuestion), equalTo(false));
 
         String toastText = ShadowToast.getTextOfLatestToast();
         assertThat(toastText, equalTo(ApplicationProvider.getApplicationContext().getString(R.string.invalid_range_widget)));


### PR DESCRIPTION
This is prep for #4768 (need to move some files that depend on `ToastUtils` between modules)

#### What has been done to verify that this works as intended?

Ran tests

#### Why is this the best possible solution? Were any other approaches considered?

I did consider just deprecating `ToastUtils` and removing it from the files that I needed to move, but after discussing with @grzesiek2010 we decided to hold on to it. The main reason for this is that we believe the ability to hide the last toast when displaying a new one is helping keep our UI tests stable.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't be any change in behaviour as it's just moving code around. Don't think we need QA on this.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)