### PR TITLE
Fix dependency failures when building release

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ This is encountered when Robolectric has problems downloading the jars it needs 
 ```
 
 ## Creating signed releases for Google Play Store
-Maintainers keep a folder with a clean checkout of the code and use [jenv.be](https://www.jenv.be) in that folder to ensure compilation with Java 1.8.
+Maintainers keep a folder with a clean checkout of the code and use [jenv.be](https://www.jenv.be) in that folder to ensure compilation with Java 11.
 
 Maintainers have a `local.properties` file in the root folder with the following:
 ```

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.google.firebase.crashlytics'
 apply from: '../config/quality.gradle'
 apply from: '../config/jacoco.gradle'
 apply plugin: 'kotlin-android'
@@ -414,3 +413,7 @@ dependencies {
 // Must be at bottom to prevent dependency collisions
 // https://developers.google.com/android/guides/google-services-plugin
 apply plugin: 'com.google.gms.google-services'
+
+// Must be after google-services to prevent build failure
+// https://stackoverflow.com/a/67995305
+apply plugin: 'com.google.firebase.crashlytics'

--- a/testshared/build.gradle
+++ b/testshared/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.robolectric
     implementation Dependencies.android_material
+    implementation Dependencies.androidx_fragment_testing
 
     testImplementation Dependencies.androidx_test_ext_junit
 


### PR DESCRIPTION
I can confirm that this change, plus increasing the [heap size](https://github.com/getodk/collect#changing-jvm-heap-size) gets `./gradlew assembleOdkCollectRelease` to work on my machine.