### PR TITLE
Correct testshared dependencies

### DIFF
--- a/testshared/build.gradle
+++ b/testshared/build.gradle
@@ -42,11 +42,7 @@ dependencies {
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.robolectric
     implementation Dependencies.android_material
-    implementation Dependencies.androidx_fragment_testing
-
-    testImplementation Dependencies.androidx_test_ext_junit
-
-    debugImplementation(Dependencies.androidx_fragment_testing) {
+    implementation(Dependencies.androidx_fragment_testing) {
         exclude group: 'androidx.test', module: 'monitor' //fixes issue https://github.com/android/android-test/issues/731
     }
 }


### PR DESCRIPTION
This is clean up after the build issues we had.

`testshared` should only ever really be built during debug builds (as it will only ever be a `testImplementation` dep) but the Android plugin's assemble tasks (when used on the app module) builds every module in the project annoyingly. This means that `debugImplementation` deps will be missing for release builds of test only dependencies.