### PR TITLE
Update JR to 3.3.0 snapshot and update test for re-calculation in field list

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -43,7 +43,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.rarepebble:colorpicker:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "net.sf.opencsv:opencsv:2.4"
-    const val javarosa = "org.getodk:javarosa:3.2.0"
+    const val javarosa = "org.getodk:javarosa:3.3.0-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:3.6.0" // Upgrading will require minSdkVersion >=24, it uses zxing:core 3.3.2 by default

--- a/collect_app/src/androidTest/assets/forms/form_design_error.xml
+++ b/collect_app/src/androidTest/assets/forms/form_design_error.xml
@@ -1,88 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms">
     <h:head>
-        <h:title>form_design_error</h:title>
+        <h:title>Relevance and calculate loop</h:title>
         <model odk:xforms-version="1.0.0">
             <instance>
-                <data id="form_design_error">
+                <data id="form-list-relevance-issue">
                     <group>
-                        <select />
-                        <select2 />
+                        <name>A</name>
+                        <fullName/>
+                        <middleName>third</middleName>
                     </group>
                     <meta>
-                        <instanceID />
+                        <instanceID/>
                     </meta>
                 </data>
             </instance>
-            <instance id="list">
-                <root>
-                    <item>
-                        <label>A</label>
-                        <name>a</name>
-                    </item>
-                    <item>
-                        <label>B</label>
-                        <name>b</name>
-                    </item>
-                    <item>
-                        <label>C</label>
-                        <name>c</name>
-                    </item>
-                </root>
-            </instance>
-            <instance id="list2">
-                <root>
-                    <item>
-                        <label>AA</label>
-                        <list>a</list>
-                        <name>aa</name>
-                    </item>
-                    <item>
-                        <label>AB</label>
-                        <list>a</list>
-                        <name>ab</name>
-                    </item>
-                    <item>
-                        <label>BA</label>
-                        <list>b</list>
-                        <name>ba</name>
-                    </item>
-                    <item>
-                        <label>BB</label>
-                        <list>b</list>
-                        <name>bb</name>
-                    </item>
-                </root>
-            </instance>
-            <bind nodeset="/data/group/select" type="string" />
-            <bind calculate="concat( /data/group/select , 'a')" nodeset="/data/group/select2" type="string" />
-            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string" />
+            <bind nodeset="/data/group/name" type="string"/>
+            <!-- The form design issue is that calculates can't be used as dynamic defaults because they're reevaluated continuously -->
+            <bind calculate=" /data/group/name " nodeset="/data/group/fullName" type="string"/>
+            <bind nodeset="/data/group/middleName" relevant=" /data/group/name != /data/group/fullName " type="string"/>
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
         </model>
     </h:head>
     <h:body>
         <group appearance="field-list" ref="/data/group">
-            <select1 appearance="minimal" ref="/data/group/select">
-                <label>Select</label>
-                <item>
-                    <label>A</label>
-                    <value>a</value>
-                </item>
-                <item>
-                    <label>B</label>
-                    <value>b</value>
-                </item>
-                <item>
-                    <label>C</label>
-                    <value>c</value>
-                </item>
-            </select1>
-            <select1 appearance="minimal" ref="/data/group/select2">
-                <label>Select2</label>
-                <itemset nodeset="instance('list2')/root/item[list= /data/group/select ]">
-                    <value ref="name" />
-                    <label ref="label" />
-                </itemset>
-            </select1>
+            <input ref="/data/group/name">
+                <label>What is your first name</label>
+            </input>
+            <input ref="/data/group/fullName">
+                <label>Please add your second name to have your full name</label>
+            </input>
+            <input ref="/data/group/middleName">
+                <label>Please add your middle name if you have one</label>
+                <hint>Display if full name is different than first name</hint>
+            </input>
         </group>
     </h:body>
 </h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/CatchFormDesignExceptionsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/CatchFormDesignExceptionsTest.kt
@@ -23,9 +23,14 @@ class CatchFormDesignExceptionsTest {
         rule.startAtMainMenu()
             .copyForm("form_design_error.xml")
             .clickFillBlankForm()
-            .clickOnForm("form_design_error")
-            .openSelectMinimalDialog()
-            .clickOnText("A")
+            .clickOnForm("Relevance and calculate loop")
+            .answerQuestion(1, "B")
+            .scrollToAndAssertText("third")
+            .answerQuestion(2, "C")
+            // Answering C above triggers a recomputation round which resets fullName to name.
+            // They're then equal which makes the third question non-relevant. Trying to change the
+            // value of a non-relevant node throws an exception.
+            .answerQuestion(2, "D")
             .assertText(R.string.update_widgets_error)
             .clickOKOnDialog()
             .assertOnPage(MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ContextMenuTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ContextMenuTest.java
@@ -24,15 +24,15 @@ public class ContextMenuTest {
     @Test
     public void whenRemoveStringAnswer_ShouldAppropriateQuestionBeCleared() {
         new FormEntryPage("string_widgets")
-                .putTextOnIndex(0, "TestString")
-                .putTextOnIndex(1, "1234")
+                .answerQuestion(0, "TestString")
+                .answerQuestion(1, "1234")
                 .assertText("TestString")
                 .assertText("1234")
                 .longPressOnView("Question1")
                 .removeResponse()
                 .assertTextDoesNotExist("TestString")
                 .assertText("1234")
-                .putTextOnIndex(0, "TestString")
+                .answerQuestion(0, "TestString")
                 .assertText("TestString")
                 .longPressOnView("Question2")
                 .removeResponse()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FormValidationTest.java
@@ -34,13 +34,13 @@ public class FormValidationTest {
 
         new MainMenuPage()
                 .startBlankForm("OnePageFormShort")
-                .putTextOnIndex(0, "A")
+                .answerQuestion(0, "A")
                 .clickGoToArrow()
                 .clickJumpEndButton()
                 .clickSaveAndExitWithError()
                 .checkIsToastWithMessageDisplayed("Response length must be between 5 and 15")
                 .assertText("Integer")
-                .putTextOnIndex(0, "Aaaaa")
+                .answerQuestion(0, "Aaaaa")
                 .clickGoToArrow()
                 .clickJumpEndButton()
                 .clickSaveAndExit();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -1,15 +1,5 @@
 package org.odk.collect.android.support.pages;
 
-import androidx.appcompat.widget.AppCompatImageButton;
-import androidx.test.espresso.Espresso;
-
-import org.hamcrest.Matchers;
-import org.odk.collect.android.R;
-import org.odk.collect.android.support.ActivityHelpers;
-import org.odk.collect.android.utilities.FlingRegister;
-
-import java.util.concurrent.Callable;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.longClick;
@@ -27,6 +17,16 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.odk.collect.android.support.CustomMatchers.withIndex;
+
+import androidx.appcompat.widget.AppCompatImageButton;
+import androidx.test.espresso.Espresso;
+
+import org.hamcrest.Matchers;
+import org.odk.collect.android.R;
+import org.odk.collect.android.support.ActivityHelpers;
+import org.odk.collect.android.utilities.FlingRegister;
+
+import java.util.concurrent.Callable;
 
 public class FormEntryPage extends Page<FormEntryPage> {
 
@@ -171,11 +171,6 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return this;
     }
 
-    public FormEntryPage putTextOnIndex(int index, String text) {
-        onView(withIndex(withClassName(endsWith("Text")), index)).perform(replaceText(text));
-        return this;
-    }
-
     public FormEntryPage deleteGroup(String questionText) {
         onView(withText(questionText)).perform(longClick());
         onView(withText(R.string.delete_repeat)).perform(click());
@@ -281,6 +276,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
         assertText(question);
         inputText(answer);
         closeSoftKeyboard();
+        return this;
+    }
+
+    public FormEntryPage answerQuestion(int index, String answer) {
+        onView(withIndex(withClassName(endsWith("Text")), index)).perform(replaceText(answer));
         return this;
     }
 


### PR DESCRIPTION
Update JavaRosa to v3.3.0-SNAPSHOT. https://github.com/getodk/javarosa/pull/646 and https://github.com/getodk/javarosa/pull/644 have been QAed.

I've updated the test that no longer fails with the form from #4170. It's an extension of the problem that the old form displayed -- there's still a calculate being used as a default but then there's also relevance in a field list added to the mix. I'll cherry pick that commit when we have a real PR updating JR. I wanted to give @seadowg a chance to review in the meantime.

Side note, we could likely change the order of relevance update and field list re-rendering so that there wouldn't be an exception in that case. However, similar to the other problems from https://github.com/getodk/collect/issues/4750, the form is nonsense so it's good that there's a crash. As we make more improvements to field lists, it might go away and then this test can be removed.

<details><summary>Initial description for QA</summary>
NOT FOR MERGING

This is so that @getodk/testers can verify https://github.com/getodk/javarosa/pull/646 and https://github.com/getodk/javarosa/pull/644. As a side effect, the cases described at https://github.com/getodk/collect/issues/4750 should no longer show errors.

~Related to the last point, there is now a failing connected test. This is discussed at https://github.com/getodk/javarosa/pull/646#issuecomment-933337070.~
</details>