### PR TITLE
Add user property to track adoption of Match Exactly

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ApplicationInitializer.java
@@ -20,6 +20,7 @@ import org.odk.collect.android.application.initialization.upgrade.AppUpgrader;
 import org.odk.collect.android.geo.MapboxUtils;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.logic.actions.setgeopoint.CollectSetGeopointActionHandler;
+import org.odk.collect.android.preferences.source.SettingsProvider;
 import org.odk.collect.android.utilities.LaunchState;
 import org.odk.collect.projects.ProjectsRepository;
 import org.odk.collect.utilities.UserAgentProvider;
@@ -38,12 +39,14 @@ public class ApplicationInitializer {
     private final AppUpgrader appUpgrader;
     private final AnalyticsInitializer analyticsInitializer;
     private final ProjectsRepository projectsRepository;
+    private final SettingsProvider settingsProvider;
 
     public ApplicationInitializer(Application context, UserAgentProvider userAgentProvider,
                                   PropertyManager propertyManager, Analytics analytics,
                                   LaunchState launchState, AppUpgrader appUpgrader,
                                   AnalyticsInitializer analyticsInitializer,
-                                  ProjectsRepository projectsRepository) {
+                                  ProjectsRepository projectsRepository,
+                                  SettingsProvider settingsProvider) {
         this.context = context;
         this.userAgentProvider = userAgentProvider;
         this.propertyManager = propertyManager;
@@ -52,6 +55,7 @@ public class ApplicationInitializer {
         this.appUpgrader = appUpgrader;
         this.analyticsInitializer = analyticsInitializer;
         this.projectsRepository = projectsRepository;
+        this.settingsProvider = settingsProvider;
     }
 
     public void initialize() {
@@ -75,7 +79,7 @@ public class ApplicationInitializer {
         initializeMapFrameworks();
         initializeJavaRosa();
         analyticsInitializer.initialize();
-        new UserPropertiesInitializer(analytics, projectsRepository).initialize();
+        new UserPropertiesInitializer(analytics, projectsRepository, settingsProvider, context).initialize();
     }
 
     private void initializeLocale() {

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
@@ -22,8 +22,13 @@ class UserPropertiesInitializer(
             "UsingLegacyFormUpdate",
             projects.any {
                 val settings = settingsProvider.getGeneralSettings(it.uuid)
+                val serverUrl = settings.getString(ProjectKeys.KEY_SERVER_URL)
                 val formUpdateMode = settings.getString(ProjectKeys.KEY_FORM_UPDATE_MODE)
-                formUpdateMode != FormUpdateMode.MATCH_EXACTLY.getValue(context)
+
+                val notUsingDefaultServer = serverUrl != ProjectKeys.defaults[ProjectKeys.KEY_SERVER_URL]
+                val notUsingMatchExactly = formUpdateMode != FormUpdateMode.MATCH_EXACTLY.getValue(context)
+
+                notUsingDefaultServer && notUsingMatchExactly
             }.toString()
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
@@ -1,12 +1,30 @@
 package org.odk.collect.android.application.initialization
 
+import android.content.Context
 import org.odk.collect.analytics.Analytics
+import org.odk.collect.android.preferences.FormUpdateMode
+import org.odk.collect.android.preferences.keys.ProjectKeys
+import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.projects.ProjectsRepository
 
-class UserPropertiesInitializer(private val analytics: Analytics, private val projectsRepository: ProjectsRepository) {
+class UserPropertiesInitializer(
+    private val analytics: Analytics,
+    private val projectsRepository: ProjectsRepository,
+    private val settingsProvider: SettingsProvider,
+    private val context: Context
+) {
 
     fun initialize() {
-        val projectsCount = projectsRepository.getAll().size
-        analytics.setUserProperty("ProjectsCount", projectsCount.toString())
+        val projects = projectsRepository.getAll()
+
+        analytics.setUserProperty("ProjectsCount", projects.size.toString())
+        analytics.setUserProperty(
+            "UsingLegacyFormUpdate",
+            projects.any {
+                val settings = settingsProvider.getGeneralSettings(it.uuid)
+                val formUpdateMode = settings.getString(ProjectKeys.KEY_FORM_UPDATE_MODE)
+                formUpdateMode != FormUpdateMode.MATCH_EXACTLY.getValue(context)
+            }.toString()
+        )
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -585,8 +585,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public ApplicationInitializer providesApplicationInitializer(Application context, UserAgentProvider userAgentProvider, PropertyManager propertyManager, Analytics analytics, LaunchState launchState, AppUpgrader appUpgrader, AnalyticsInitializer analyticsInitializer, ProjectsRepository projectsRepository) {
-        return new ApplicationInitializer(context, userAgentProvider, propertyManager, analytics, launchState, appUpgrader, analyticsInitializer, projectsRepository);
+    public ApplicationInitializer providesApplicationInitializer(Application context, UserAgentProvider userAgentProvider, PropertyManager propertyManager, Analytics analytics, LaunchState launchState, AppUpgrader appUpgrader, AnalyticsInitializer analyticsInitializer, ProjectsRepository projectsRepository, SettingsProvider settingsProvider) {
+        return new ApplicationInitializer(context, userAgentProvider, propertyManager, analytics, launchState, appUpgrader, analyticsInitializer, projectsRepository, settingsProvider);
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
@@ -31,6 +31,7 @@ class ApplicationInitializerTest {
             appUpgrader,
             mock(),
             mock(),
+            mock()
         )
 
         applicationInitializer.initialize()
@@ -54,6 +55,7 @@ class ApplicationInitializerTest {
             appUpgrader,
             mock(),
             mock(),
+            mock()
         )
 
         applicationInitializer.initialize()
@@ -73,6 +75,7 @@ class ApplicationInitializerTest {
             mock(),
             mock(),
             mock(),
+            mock()
         )
 
         applicationInitializer.initialize()

--- a/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/initialization/ApplicationInitializerTest.kt
@@ -30,7 +30,7 @@ class ApplicationInitializerTest {
             launchState,
             appUpgrader,
             mock(),
-            mock()
+            mock(),
         )
 
         applicationInitializer.initialize()
@@ -53,7 +53,7 @@ class ApplicationInitializerTest {
             launchState,
             appUpgrader,
             mock(),
-            mock()
+            mock(),
         )
 
         applicationInitializer.initialize()
@@ -72,7 +72,7 @@ class ApplicationInitializerTest {
             launchState,
             mock(),
             mock(),
-            mock()
+            mock(),
         )
 
         applicationInitializer.initialize()


### PR DESCRIPTION
Closes #4779

I've decided to just track if any project on the device is **not** using Match Exactly instead of trying to adapt user properties to be one user per project. 

~~As part of this I've also moved over to using Jetpack's [App Startup](https://developer.android.com/topic/libraries/app-startup) library for app initialization. We'd talked about doing this during the last release but didn't want to hold up what we were working on at the time.~~

#### What has been done to verify that this works as intended?

Ran tests. I don't have access to add user properties to the debug Firebase project, but we can just verify this in beta.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't be any change in behaviour. Application initialization code has changed, but I don't think there's any specific QA to be done here.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
