### PR TITLE
Update test to use translations

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
@@ -1,54 +1,34 @@
 package org.odk.collect.android.feature.smoke;
 
-import android.Manifest;
-import android.webkit.MimeTypeMap;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.injection.config.AppDependencyModule;
-import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.support.CollectTestRule;
-import org.odk.collect.android.support.ResetStateRule;
-import org.odk.collect.android.support.StubOpenRosaServer;
-import org.odk.collect.utilities.UserAgentProvider;
+import org.odk.collect.android.support.TestDependencies;
+import org.odk.collect.android.support.TestRuleChain;
 
 @RunWith(AndroidJUnit4.class)
 public class BadServerTest {
 
-    public final StubOpenRosaServer server = new StubOpenRosaServer();
 
-    public CollectTestRule rule = new CollectTestRule();
+    private final CollectTestRule rule = new CollectTestRule(false);
+    private final TestDependencies testDependencies = new TestDependencies();
+
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
-            .outerRule(GrantPermissionRule.grant(
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    Manifest.permission.READ_PHONE_STATE,
-                    Manifest.permission.GET_ACCOUNTS
-            ))
-            .around(new ResetStateRule(new AppDependencyModule() {
-                @Override
-                public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider) {
-                    return server;
-                }
-            }))
-            .around(rule);
+    public RuleChain chain = TestRuleChain.chain(testDependencies).around(rule);
 
     @Test
     // The hash from the form list wasn't used for a long time so some server implementations omitted it even though
     // it's required by the spec. Now we explicitly show an error.
     public void whenHashNotIncludedInFormList_showError() {
-        server.removeHashInFormList();
-        server.addForm("One Question", "one-question", "1", "one-question.xml");
+        testDependencies.server.removeHashInFormList();
+        testDependencies.server.addForm("One Question", "one-question", "1", "one-question.xml");
 
-        rule.startAtMainMenu()
-                .setServer(server.getURL())
+        rule.withProject(testDependencies.server.getURL())
                 .clickGetBlankForm()
                 .clickGetSelected()
                 .assertMessage("1 of 1 downloads failed!")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
@@ -6,9 +6,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+import org.odk.collect.android.R;
 import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.TestDependencies;
 import org.odk.collect.android.support.TestRuleChain;
+import org.odk.collect.android.support.TranslatedStringBuilder;
 
 @RunWith(AndroidJUnit4.class)
 public class BadServerTest {
@@ -33,7 +35,11 @@ public class BadServerTest {
                 .clickGetSelected()
                 .assertMessage("1 of 1 downloads failed!")
                 .showDetails()
-                .assertError("The server did not provide a hash for this form. If you keep having this problem, report it to the person who asked you to collect data.")
+                .assertError(new TranslatedStringBuilder()
+                        .addString(R.string.form_with_no_hash_error)
+                        .addString(R.string.report_to_project_lead)
+                        .build()
+                )
                 .navigateBack();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
@@ -53,7 +53,7 @@ public class BadServerTest {
                 .clickGetSelected()
                 .assertMessage("1 of 1 downloads failed!")
                 .showDetails()
-                .assertError("The form has no hash. If you keep having this problem, report it to the person who asked you to collect data.")
+                .assertError("The server did not provide a hash for this form. If you keep having this problem, report it to the person who asked you to collect data.")
                 .navigateBack();
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectTestRule.java
@@ -64,6 +64,13 @@ public class CollectTestRule implements TestRule {
         return new FirstLaunchPage().assertOnPage();
     }
 
+    public MainMenuPage withProject(String serverUrl) {
+        return new FirstLaunchPage().assertOnPage()
+                .clickManuallyEnterProjectDetails()
+                .inputUrl(serverUrl)
+                .addProject();
+    }
+
     public ShortcutsPage launchShortcuts() {
         ActivityScenario<AndroidShortcutsActivity> scenario = ActivityScenario.launch(AndroidShortcutsActivity.class);
         return new ShortcutsPage(scenario).assertOnPage();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TranslatedStringBuilder.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TranslatedStringBuilder.kt
@@ -1,0 +1,25 @@
+package org.odk.collect.android.support
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.odk.collect.strings.getLocalizedString
+
+class TranslatedStringBuilder(private val separator: String = " ") {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private var string = ""
+
+    fun addString(stringId: Int, vararg formatArgs: Any): TranslatedStringBuilder {
+        string += if (string.isEmpty()) {
+            context.getLocalizedString(stringId, formatArgs)
+        } else {
+            separator + context.getLocalizedString(stringId, formatArgs)
+        }
+
+        return this
+    }
+
+    fun build(): String {
+        return string
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -1,37 +1,5 @@
 package org.odk.collect.android.support.pages;
 
-import android.app.Activity;
-import android.content.pm.ActivityInfo;
-
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.test.core.app.ApplicationProvider;
-import androidx.test.espresso.Espresso;
-import androidx.test.espresso.NoMatchingViewException;
-import androidx.test.espresso.ViewAction;
-import androidx.test.espresso.contrib.RecyclerViewActions;
-import androidx.test.espresso.core.internal.deps.guava.collect.Iterables;
-import androidx.test.espresso.matcher.ViewMatchers;
-import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
-import androidx.test.runner.lifecycle.Stage;
-
-import junit.framework.AssertionFailedError;
-
-import org.odk.collect.android.R;
-import org.odk.collect.android.storage.StoragePathProvider;
-import org.odk.collect.android.support.AdbFormLoadingUtils;
-import org.odk.collect.android.support.actions.RotateAction;
-import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
-import org.odk.collect.android.support.matchers.ToastMatcher;
-import org.odk.collect.android.utilities.TranslationHandler;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.Callable;
-
-import kotlin.Pair;
-import timber.log.Timber;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.clearText;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -63,6 +31,37 @@ import static org.junit.Assert.assertTrue;
 import static org.odk.collect.android.support.CustomMatchers.withIndex;
 import static org.odk.collect.android.support.actions.NestedScrollToAction.nestedScrollTo;
 import static org.odk.collect.android.support.matchers.RecyclerViewMatcher.withRecyclerView;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.espresso.core.internal.deps.guava.collect.Iterables;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
+import androidx.test.runner.lifecycle.Stage;
+
+import junit.framework.AssertionFailedError;
+
+import org.odk.collect.android.R;
+import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.support.AdbFormLoadingUtils;
+import org.odk.collect.android.support.actions.RotateAction;
+import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
+import org.odk.collect.android.support.matchers.ToastMatcher;
+import org.odk.collect.android.utilities.TranslationHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import timber.log.Timber;
 
 /**
  * Base class for Page Objects used in Espresso tests. Provides shared helpers/setup.

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.java
@@ -22,12 +22,14 @@ import org.odk.collect.android.support.AdbFormLoadingUtils;
 import org.odk.collect.android.support.actions.RotateAction;
 import org.odk.collect.android.support.matchers.RecyclerViewMatcher;
 import org.odk.collect.android.support.matchers.ToastMatcher;
+import org.odk.collect.android.utilities.TranslationHandler;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import kotlin.Pair;
 import timber.log.Timber;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -204,17 +206,11 @@ public abstract class Page<T extends Page<T>> {
     }
 
     String getTranslatedString(Integer id) {
-        Activity currentActivity = getCurrentActivity();
-
-        if (currentActivity != null) {
-            return currentActivity.getString(id);
-        } else {
-            return ApplicationProvider.getApplicationContext().getString(id);
-        }
+        return TranslationHandler.getString(ApplicationProvider.getApplicationContext(), id);
     }
 
     String getTranslatedString(Integer id, Object... formatArgs) {
-        return getCurrentActivity().getString(id, formatArgs);
+        return TranslationHandler.getString(ApplicationProvider.getApplicationContext(), id, formatArgs);
     }
 
     public T clickOnAreaWithIndex(String clazz, int index) {


### PR DESCRIPTION
This updates a test that failed due to a string change to use translations rather than a fixed string. This meant adding a new helper (`TranslatedStringBuilder`) as the string being asserted on was a combination of multiple string resources, but I don't think that will be controversial at all. 