### PR TITLE
Fixed crash when using mapbox on Android 11

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -29,6 +29,7 @@ object Dependencies {
     const val play_services_maps = "com.google.android.gms:play-services-maps:17.0.1"
     const val play_services_location = "com.google.android.gms:play-services-location:18.0.0"
     const val mapbox_android_sdk = "com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.1"
+    const val mapbox_android_telemetry = "com.mapbox.mapboxsdk:mapbox-android-telemetry:6.1.0" // We need this to fix https://github.com/mapbox/mapbox-gl-native-android/issues/425. Once we update Mapbox Android SDK we can get rid of it.
     const val mapbox_android_plugin_annotation = "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0" // Upgrading will require more changes in our codebase https://github.com/getodk/collect/issues/4305
     const val osmdroid = "org.osmdroid:osmdroid-android:6.1.11"
     const val guava = "com.google.guava:guava:30.1.1-android"

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -277,6 +277,7 @@ dependencies {
     implementation Dependencies.firebase_crashlytics
 
     implementation Dependencies.mapbox_android_sdk
+    implementation Dependencies.mapbox_android_telemetry
     implementation Dependencies.mapbox_android_plugin_annotation
 
     implementation Dependencies.guava


### PR DESCRIPTION
Closes #4851 

#### What has been done to verify that this works as intended?
I wasn't able to reproduce the bug so asked @kkrawczyk123 to take a quick look and the fix seemed to work.

#### Why is this the best possible solution? Were any other approaches considered?
The bug was reported in mapbox repository https://github.com/mapbox/mapbox-gl-native-android/issues/425
and it's already fixed.
We could just update mapbox in our codebase and it should work but I find it risky since we are about to release a new version of our app and it might introduce other bugs. That's why I decided to go with this solution also described in one of the comments: https://github.com/mapbox/mapbox-gl-native-android/issues/425#issuecomment-680753940

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the bug. We don't need to verify anything else.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with geo widgets like the `All Widgets` form

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
