### PR TITLE
Tweak button style to have softer text

### DIFF
--- a/collect_app/src/main/res/layout/widget_answer_button.xml
+++ b/collect_app/src/main/res/layout/widget_answer_button.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/Widget.Collect.Button.Custom"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="@dimen/margin_small">

--- a/collect_app/src/main/res/values/buttons.xml
+++ b/collect_app/src/main/res/values/buttons.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Widget.Collect.Button.Custom" parent="Widget.MaterialComponents.Button">
-        <item name="android:textAllCaps">false</item>
-        <item name="android:textStyle">normal</item>
-    </style>
-
     <style name="Widget.Collect.Button.IconButton" parent="Widget.MaterialComponents.Button">
         <item name="android:insetLeft">0dp</item>
         <item name="android:insetTop">0dp</item>
@@ -35,7 +30,7 @@
         <item name="iconSize">32dp</item>
     </style>
 
-    <style name="Widget.Collect.Button.WidgetAnswer" parent="Widget.Collect.Button.Custom">
+    <style name="Widget.Collect.Button.WidgetAnswer" parent="Widget.AppCompat.ImageButton">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:padding">@dimen/margin_small</item>
@@ -44,7 +39,7 @@
 
     <!-- These use surface color rather than primary as they are secondary options on a page.
     It's likely anything using this should be replaced by a bottom nav bar or something. -->
-    <style name="Widget.Collect.Button.BottomOption" parent="Widget.Collect.Button.Custom">
+    <style name="Widget.Collect.Button.BottomOption" parent="Widget.MaterialComponents.Button">
         <item name="android:layout_weight">1</item>
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">match_parent</item>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -33,8 +33,11 @@
     </style>
 
     <style name="TextAppearance.Collect.Button" parent="TextAppearance.MaterialComponents.Button">
+        <item name="fontFamily">sans-serif</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textStyle">normal</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:letterSpacing">0.04</item>
+        <item name="android:letterSpacing">0.009375</item>
     </style>
 
     <style name="TextAppearance.Collect.Link" parent="TextAppearance.MaterialComponents.Body2">


### PR DESCRIPTION
This customizes the buttons in the app to use a lighter weight font and adapts the letter spacing to fit that.

#### What has been done to verify that this works as intended?

Eyeballed on the emulator.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed the changes with @lognaturel before implementation and we agreed that getting the button text to look more like it did before would be a good idea at the moment. We'll hopefully revise our use of the giant main menu buttons over the coming releases.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Think we can avoid QA as we'd likely catch any visual weirdness in upcoming regression testing.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
