### PR TITLE
Handle null keys in OnSharedPreferenceChangeListener

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettings.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/source/SharedPreferencesSettings.kt
@@ -93,8 +93,10 @@ class SharedPreferencesSettings(
 
     override fun registerOnSettingChangeListener(listener: Settings.OnSettingChangeListener) {
         val sharedPreferencesListener =
-            SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-                listener.onSettingChanged(key)
+            SharedPreferences.OnSharedPreferenceChangeListener { _, key: String? ->
+                key?.let {
+                    listener.onSettingChanged(it)
+                }
             }
 
         listeners.add(Pair(WeakReference(listener), sharedPreferencesListener))


### PR DESCRIPTION
Closes #4854 

#### What has been done to verify that this works as intended?
The crash occurred while deleting a project on Android 11 so I verified that scenario.

#### Why is this the best possible solution? Were any other approaches considered?
The crash was caused by bumping android_target_sdk to 30 since according to the [documentation](https://developer.android.com/reference/android/content/SharedPreferences.OnSharedPreferenceChangeListener):

> Apps targeting Build.VERSION_CODES.R on devices running OS versions Android R or later, will receive a null value when preferences are cleared.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that deleting projects on Android 11 does not cause any crash.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
