### PR TITLE
Fixed error prone registerToClearAnswerOnLongPress() method for string widget

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -105,21 +105,17 @@ public class StringWidget extends QuestionWidget {
     }
 
     /**
-     * Registers all subviews except for the EditText to clear on long press. This makes it possible
-     * to long-press to paste or perform other text editing functions.
+     * Registers all subviews except for the answer_container (which contains the EditText) to clear on long press.
+     * This makes it possible to long-press to paste or perform other text editing functions.
      */
     @Override
     protected void registerToClearAnswerOnLongPress(FormEntryActivity activity, ViewGroup viewGroup) {
-        for (int i = 0; i < viewGroup.getChildCount(); i++) {
-            View child = viewGroup.getChildAt(i);
-            if (child.getId() == R.id.help_layout) {
-                child.setId(getId());
-                activity.registerForContextMenu(child);
-            } else if (child instanceof ViewGroup) {
-                registerToClearAnswerOnLongPress(activity, (ViewGroup) child);
-            } else if (!(child instanceof EditText)) {
-                child.setId(getId());
-                activity.registerForContextMenu(child);
+        ViewGroup view = findViewById(R.id.question_widget_container);
+        for (int i = 0; i < view.getChildCount(); i++) {
+            View childView = view.getChildAt(i);
+            if (childView.getId() != R.id.answer_container) {
+                childView.setId(getId());
+                activity.registerForContextMenu(childView);
             }
         }
     }


### PR DESCRIPTION
Closes #4834 

#### What has been done to verify that this works as intended?
I tested the fix manually and ran automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The issue affects all string widgets (text, integer, decimal). It is because in `StringWidget#registerToClearAnswerOnLongPress()` we override ids and then we can't react to click events in [AudioVideoImageTextLabel](https://github.com/getodk/collect/pull/4860/files#diff-22969420ab3442906012d0bb852a6b38a6ed9987ce6ebefa324a852265cfa1b0L219) by using those static ids.

The previous solution (draining all sub views and setting their ids) was error prone. We can just navigate through the first level of sub vies (only containers) and register those whole views except `answer_container` which contains the EditText to support the clipboard menu.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue but please test removing answers (especially in field-list groups) to make sure nothing is spoiled there.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
