### PR TITLE
Improvements to CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
 
       - run:
           name: Assemble test build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug assembleDebugAndroidTest
+          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |
@@ -218,9 +218,7 @@ workflows:
               ignore: master
       - test_instrumented:
           requires:
-            - check_quality
-            - test_modules
-            - test_app
+            - compile
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
 
   test_modules:
     <<: *android_config
+    parallelism: 4
     steps:
       - attach_workspace:
           at: ~/work
@@ -67,35 +68,16 @@ jobs:
           key: deps-{{ checksum "deps.txt" }}
 
       - run:
-          name: Run shared unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 shared:test
+          name: Generate list of modules for this fork
+          command: |
+            cat .circleci/test_modules.txt | circleci tests split > .circleci/fork_test_modules.txt && \
+            echo "Modules for this fork:" && \
+            cat .circleci/fork_test_modules.txt
+
       - run:
-          name: Run androidshared unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidshared:testDebug
-      - run:
-          name: Run formtest unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 formstest:test
-      - run:
-          name: Run async unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 async:testDebug
-      - run:
-          name: Run strings unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 strings:testDebug
-      - run:
-          name: Run audioclips unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 audioclips:testDebug
-      - run:
-          name: Run audiorecorder unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 audiorecorder:testDebug
-      - run:
-          name: Run projects unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 projects:testDebug
-      - run:
-          name: Run location unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 location:testDebug
-      - run:
-          name: Run geo unit tests
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 geo:testDebug
+          name: Run module unit tests
+          command: |
+            ./gradlew -PdisablePreDex --no-daemon --max-workers=2 $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s",$i}')
 
       - store_artifacts:
           path: collect_app/build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: deps-{{ checksum "deps.txt" }}
       - run:
           name: Download dependencies
-          command: ./gradlew -PdisablePreDex androidDependencies
+          command: ./gradlew androidDependencies
       - run:
           name: Copy gradle config
           command: cp .circleci/gradle.properties ~/.gradle/gradle.properties
@@ -36,7 +36,7 @@ jobs:
 
       - run:
           name: Compile code
-          command: ./gradlew -PdisablePreDex assembleDebug
+          command: ./gradlew assembleDebug
 
       - persist_to_workspace:
           root: ~/work
@@ -53,7 +53,7 @@ jobs:
 
       - run:
           name: Run code quality checks
-          command: ./gradlew -PdisablePreDex checkCode
+          command: ./gradlew checkCode
       - store_artifacts:
           path: collect_app/build/reports
           destination: reports
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Run module unit tests
           command: |
-            ./gradlew -PdisablePreDex $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s ",$i}')
+            ./gradlew $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s ",$i}')
 
       - store_artifacts:
           path: collect_app/build/reports
@@ -108,7 +108,7 @@ jobs:
       - run:
           name: Run app unit tests
           command: |
-            ./gradlew -PdisablePreDex collect_app:testDebug $(cat .circleci/fork_test_classes.txt | awk '{for (i=1; i<=NF; i++) printf "--tests %s ",$i}')
+            ./gradlew collect_app:testDebug $(cat .circleci/fork_test_classes.txt | awk '{for (i=1; i<=NF; i++) printf "--tests %s ",$i}')
 
       - store_artifacts:
           path: collect_app/build/reports
@@ -126,7 +126,7 @@ jobs:
 
       - run:
           name: Assemble connected test build
-          command: ./gradlew -PdisablePreDex assembleDebugAndroidTest
+          command: ./gradlew assembleDebugAndroidTest
 
   build_release:
     <<: *android_config
@@ -138,7 +138,7 @@ jobs:
 
       - run:
           name: Assemble self signed release build
-          command: ./gradlew -PdisablePreDex assembleSelfSignedRelease
+          command: ./gradlew assembleSelfSignedRelease
 
   test_instrumented:
     <<: *android_config
@@ -150,7 +150,7 @@ jobs:
 
       - run:
           name: Assemble test build
-          command: ./gradlew -PdisablePreDex assembleDebugAndroidTest
+          command: ./gradlew assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: deps-{{ checksum "deps.txt" }}
       - run:
           name: Download dependencies
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 androidDependencies
+          command: ./gradlew -PdisablePreDex androidDependencies
       - run:
           name: Copy gradle config
           command: cp .circleci/gradle.properties ~/.gradle/gradle.properties
@@ -36,7 +36,7 @@ jobs:
 
       - run:
           name: Compile code
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebug
+          command: ./gradlew -PdisablePreDex assembleDebug
 
       - persist_to_workspace:
           root: ~/work
@@ -53,7 +53,7 @@ jobs:
 
       - run:
           name: Run code quality checks
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 checkCode
+          command: ./gradlew -PdisablePreDex checkCode
       - store_artifacts:
           path: collect_app/build/reports
           destination: reports
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Run module unit tests
           command: |
-            ./gradlew -PdisablePreDex --no-daemon --max-workers=2 $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s ",$i}')
+            ./gradlew -PdisablePreDex $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s ",$i}')
 
       - store_artifacts:
           path: collect_app/build/reports
@@ -108,7 +108,7 @@ jobs:
       - run:
           name: Run app unit tests
           command: |
-            ./gradlew -PdisablePreDex --no-daemon --max-workers=2 collect_app:testDebug $(cat .circleci/fork_test_classes.txt | awk '{for (i=1; i<=NF; i++) printf "--tests %s ",$i}')
+            ./gradlew -PdisablePreDex collect_app:testDebug $(cat .circleci/fork_test_classes.txt | awk '{for (i=1; i<=NF; i++) printf "--tests %s ",$i}')
 
       - store_artifacts:
           path: collect_app/build/reports
@@ -126,7 +126,7 @@ jobs:
 
       - run:
           name: Assemble connected test build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
+          command: ./gradlew -PdisablePreDex assembleDebugAndroidTest
 
   build_release:
     <<: *android_config
@@ -138,7 +138,7 @@ jobs:
 
       - run:
           name: Assemble self signed release build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleSelfSignedRelease
+          command: ./gradlew -PdisablePreDex assembleSelfSignedRelease
 
   test_instrumented:
     <<: *android_config
@@ -150,7 +150,7 @@ jobs:
 
       - run:
           name: Assemble test build
-          command: ./gradlew -PdisablePreDex --no-daemon --max-workers=2 assembleDebugAndroidTest
+          command: ./gradlew -PdisablePreDex assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Run module unit tests
           command: |
-            ./gradlew -PdisablePreDex --no-daemon --max-workers=2 $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s",$i}')
+            ./gradlew -PdisablePreDex --no-daemon --max-workers=2 $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s ",$i}')
 
       - store_artifacts:
           path: collect_app/build/reports

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,4 +1,6 @@
 org.gradle.jvmargs=-Xmx2096M -XX:+UseParallelGC -Dkotlin.daemon.jvm.options\="-Xmx2096M"
 robolectricHeapSize=2096m
+org.gradle.workers.max=2
+org.gradle.daemon=false
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx3072M -Dkotlin.daemon.jvm.options\="-Xmx3072M"
-robolectricHeapSize=3072m
+org.gradle.jvmargs=-Xmx2096M -Dkotlin.daemon.jvm.options\="-Xmx2096M"
+robolectricHeapSize=2096m
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2096M -Dkotlin.daemon.jvm.options\="-Xmx2096M"
+org.gradle.jvmargs=-Xmx2096M -XX:+UseParallelGC -Dkotlin.daemon.jvm.options\="-Xmx2096M"
 robolectricHeapSize=2096m
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process

--- a/.circleci/test_modules.txt
+++ b/.circleci/test_modules.txt
@@ -1,0 +1,10 @@
+shared:test
+androidshared:testDebug
+formstest:test
+async:testDebug
+strings:testDebug
+audioclips:testDebug
+audiorecorder:testDebug
+projects:testDebug
+location:testDebug
+geo:testDebug

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+project.ext {
+    preDexLibs = !project.hasProperty('disablePreDex');
+}
+
 allprojects {
     repositories {
         // Needs to go first to get specialty libraries https://stackoverflow.com/a/48438866/137744
@@ -35,6 +39,16 @@ allprojects {
         maven {
             url 'https://staging.dev.medicmobile.org/_couch/maven-repo'
             metadataSources { artifact() }
+        }
+    }
+}
+
+subprojects {
+    project.plugins.whenPluginAdded { plugin ->
+        if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)) {
+            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+        } else if ("com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
+            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,6 @@ buildscript {
     }
 }
 
-project.ext {
-    preDexLibs = !project.hasProperty('disablePreDex');
-}
-
 allprojects {
     repositories {
         // Needs to go first to get specialty libraries https://stackoverflow.com/a/48438866/137744
@@ -39,16 +35,6 @@ allprojects {
         maven {
             url 'https://staging.dev.medicmobile.org/_couch/maven-repo'
             metadataSources { artifact() }
-        }
-    }
-}
-
-subprojects {
-    project.plugins.whenPluginAdded { plugin ->
-        if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name)) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
-        } else if ("com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
         }
     }
 }


### PR DESCRIPTION
This drops the heap size we use on CI in an attempt to make our workflow more stable (avoiding OOM errors) and also cleans up some duplicated/unused CI config. I've also added parallelism to our `test_modules` which cuts its run time from around 5 mins (becoming the longest job in that part of the workflow) to around 2 mins.

#### What has been done to verify that this works as intended?

Ran CI as part of this PR.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No changes in behaviour. Can skip QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
