### PR TITLE
Address #4198 Display sub-meter accuracies…

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPointMapActivity.java
@@ -32,14 +32,12 @@ import androidx.annotation.VisibleForTesting;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.geo.MapFragment;
-import org.odk.collect.geo.MapPoint;
 import org.odk.collect.android.geo.MapProvider;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.screens.MapsPreferencesFragment;
-import org.odk.collect.geo.GeoUtils;
 import org.odk.collect.androidshared.utils.ToastUtils;
-
-import java.text.DecimalFormat;
+import org.odk.collect.geo.GeoUtils;
+import org.odk.collect.geo.MapPoint;
 
 import javax.inject.Inject;
 
@@ -340,7 +338,8 @@ public class GeoPointMapActivity extends BaseGeoMapActivity {
     }
 
     public String formatLocationStatus(String provider, double accuracyRadius) {
-        return getString(R.string.location_accuracy, new DecimalFormat("#.##").format(accuracyRadius))
+        //Cm accuracy #4198
+        return GeoUtils.getAccuracyUnitString(this, accuracyRadius)
                 + " " + getString(R.string.location_provider, GeoUtils.capitalizeGps(provider));
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -15,6 +15,7 @@
 package org.odk.collect.android.activities;
 
 import static org.odk.collect.android.widgets.utilities.ActivityGeoDataRequester.READ_ONLY;
+import static org.odk.collect.geo.GeoUtils.simulateAccuracy;
 
 import android.content.Context;
 import android.content.Intent;
@@ -431,7 +432,7 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
 
     private boolean isAccuracyThresholdActive() {
         int meters = ACCURACY_THRESHOLD_OPTIONS[accuracyThresholdIndex];
-        return recordingEnabled && recordingAutomatic && meters > 0;
+        return simulateAccuracy || recordingEnabled && recordingAutomatic && meters > 0;
     }
 
     private void removeLastPoint() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/GeoPolyActivity.java
@@ -30,14 +30,14 @@ import androidx.appcompat.app.AlertDialog;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.geo.MapFragment;
-import org.odk.collect.geo.MapPoint;
 import org.odk.collect.android.geo.MapProvider;
 import org.odk.collect.android.geo.SettingsDialogFragment;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.preferences.screens.MapsPreferencesFragment;
 import org.odk.collect.android.utilities.DialogUtils;
-import org.odk.collect.geo.GeoUtils;
 import org.odk.collect.androidshared.utils.ToastUtils;
+import org.odk.collect.geo.GeoUtils;
+import org.odk.collect.geo.MapPoint;
 import org.odk.collect.location.Location;
 import org.odk.collect.location.tracker.LocationTracker;
 
@@ -478,11 +478,20 @@ public class GeoPolyActivity extends BaseGeoMapActivity implements SettingsDialo
         int seconds = INTERVAL_OPTIONS[intervalIndex];
         int minutes = seconds / 60;
         int meters = ACCURACY_THRESHOLD_OPTIONS[accuracyThresholdIndex];
+        //Cm accuracy #4198
+        boolean useCm = location != null && location.sd < 1;
+        double accuracy = location != null ? location.sd * (useCm ? 100 : 1) : Double.NaN;
         locationStatus.setText(
-            location == null ? getString(R.string.location_status_searching)
-                : !usingThreshold ? getString(R.string.location_status_accuracy, location.sd)
-                : acceptable ? getString(R.string.location_status_acceptable, location.sd)
-                : getString(R.string.location_status_unacceptable, location.sd)
+                location == null ? getString(R.string.location_status_searching)
+                        : !usingThreshold ? getString(useCm ?
+                        R.string.location_status_accuracy_cm
+                        : R.string.location_status_accuracy_m, accuracy)
+                        : acceptable ? getString(useCm ?
+                        R.string.location_status_acceptable_cm
+                        : R.string.location_status_acceptable_m, accuracy)
+                        : getString(useCm ?
+                        R.string.location_status_unacceptable_cm
+                        : R.string.location_status_unacceptable_m, accuracy)
         );
         locationStatus.setBackgroundColor(
                 location == null ? themeUtils.getColorPrimary()

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -16,6 +16,9 @@
 
 package org.odk.collect.android.utilities;
 
+import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
+import static org.odk.collect.geo.GeoUtils.SIMULATED_ACCURACY;
+
 import android.content.Context;
 
 import org.javarosa.core.model.Constants;
@@ -30,6 +33,7 @@ import org.odk.collect.android.fastexternalitemset.ItemsetDao;
 import org.odk.collect.android.fastexternalitemset.ItemsetDbAdapter;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.widgets.utilities.DateTimeWidgetUtils;
+import org.odk.collect.geo.GeoUtils;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
@@ -39,8 +43,6 @@ import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
-
-import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
 
 public final class FormEntryPromptUtils {
 
@@ -114,6 +116,17 @@ public final class FormEntryPromptUtils {
             }
 
             return new ItemsetDao(new ItemsetDbAdapter()).getItemLabel(fep.getAnswerValue().getDisplayText(), formController.getMediaFolder().getAbsolutePath(), language);
+        }
+
+        //Cm accuracy #4198
+        if (GeoUtils.simulateAccuracy) {
+            String answer = fep.getAnswerText();
+            //37.4219983 -122.084 3.8246358027853735 20.0
+            if (answer != null && answer.matches("(-?\\d+\\.\\d+ ?){4}")) {
+                answer = answer.replaceAll("\\b\\d+\\.\\d$",
+                        String.valueOf(SIMULATED_ACCURACY));
+            }
+            return answer;
         }
 
         return fep.getAnswerText();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
@@ -23,12 +23,17 @@ public final class GeoWidgetUtils {
         try {
             if (answer != null && !answer.isEmpty()) {
                 String[] parts = answer.split(" ");
-                return context.getString(
-                        R.string.gps_result,
+                if (parts.length < 4) {
+                    return "";
+                }
+                double accuracy = Double.parseDouble(parts[3]);
+                boolean useCm = accuracy < 1;
+                return context.getString(useCm ? R.string.gps_result_cm
+                                : R.string.gps_result_m,
                         convertCoordinatesIntoDegreeFormat(context, Double.parseDouble(parts[0]), "lat"),
                         convertCoordinatesIntoDegreeFormat(context, Double.parseDouble(parts[1]), "lon"),
                         truncateDouble(parts[2]),
-                        truncateDouble(parts[3])
+                        accuracy * (useCm ? 100 : 1)
                 );
             }
         } catch (NumberFormatException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/GeoWidgetUtils.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.widgets.utilities;
 
+import static org.odk.collect.geo.GeoUtils.SIMULATED_ACCURACY;
+import static org.odk.collect.geo.GeoUtils.simulateAccuracy;
 import static org.odk.collect.shared.strings.StringUtils.removeEnd;
 
 import android.content.Context;
@@ -19,9 +21,14 @@ public final class GeoWidgetUtils {
 
     }
 
+    //Cm accuracy #4198
     public static String getGeoPointAnswerToDisplay(Context context, String answer) {
         try {
             if (answer != null && !answer.isEmpty()) {
+                if (simulateAccuracy) {
+                    answer = answer.replaceAll("\\b\\d+\\.\\d$",
+                            String.valueOf(SIMULATED_ACCURACY));
+                }
                 String[] parts = answer.split(" ");
                 if (parts.length < 4) {
                     return "";

--- a/collect_app/src/test/java/org/odk/collect/android/location/activities/GeoPointMapActivityTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/location/activities/GeoPointMapActivityTest.java
@@ -21,6 +21,7 @@ import org.odk.collect.android.geo.GoogleMapFragment;
 import org.odk.collect.android.geo.MapboxMapFragment;
 import org.odk.collect.android.location.client.FakeLocationClient;
 import org.odk.collect.android.support.CollectHelpers;
+import org.odk.collect.geo.GeoUtils;
 import org.odk.collect.geo.MapPoint;
 import org.odk.collect.location.LocationClientProvider;
 import org.robolectric.Robolectric;
@@ -29,6 +30,11 @@ import org.robolectric.shadows.ShadowApplication;
 
 @RunWith(AndroidJUnit4.class)
 public class GeoPointMapActivityTest {
+
+    //For 4198
+    static {
+        GeoUtils.simulateAccuracy = false;
+    }
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();

--- a/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
@@ -40,7 +40,6 @@ import org.odk.collect.location.LocationClient;
 import org.odk.collect.location.LocationClientProvider;
 import org.odk.collect.strings.localization.LocalizedActivity;
 
-import java.text.DecimalFormat;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -292,7 +291,8 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
     }
 
     public String getAccuracyMessage(@NonNull Location location) {
-        return getString(R.string.location_accuracy, truncateDouble(location.getAccuracy()));
+        //Cm accuracy #4198
+        return GeoUtils.getAccuracyUnitString(this, location.getAccuracy());
     }
 
     public String getProviderMessage(@NonNull Location location) {
@@ -301,11 +301,6 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
 
     public String getResultStringForLocation(@NonNull Location location) {
         return GeoUtils.formatLocationResultString(location);
-    }
-
-    private String truncateDouble(float number) {
-        DecimalFormat df = new DecimalFormat("#.##");
-        return df.format(number);
     }
 
     public String getDialogMessage() {

--- a/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
@@ -292,7 +292,8 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
 
     public String getAccuracyMessage(@NonNull Location location) {
         //Cm accuracy #4198
-        return GeoUtils.getAccuracyUnitString(this, location.getAccuracy());
+        return GeoUtils.getAccuracyUnitString(this,
+                GeoUtils.simulateAccuracy ? GeoUtils.SIMULATED_ACCURACY : location.getAccuracy());
     }
 
     public String getProviderMessage(@NonNull Location location) {

--- a/geo/src/main/java/org/odk/collect/geo/GeoUtils.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoUtils.java
@@ -1,5 +1,6 @@
 package org.odk.collect.geo;
 
+import android.content.Context;
 import android.location.Location;
 
 import org.odk.collect.shared.strings.StringUtils;
@@ -47,5 +48,15 @@ public final class GeoUtils {
      */
     public static String capitalizeGps(String locationProvider) {
         return "gps".equals(locationProvider) ? "GPS" : locationProvider;
+    }
+
+    //Cm accuracy #4198
+    public static String getAccuracyUnitString(Context context, double accuracy) {
+        if (accuracy != accuracy) {
+            return "";
+        }
+        boolean useCm = accuracy < 1;
+        return context.getString(useCm ? R.string.location_accuracy_cm : R.string.location_accuracy_m,
+                accuracy * (useCm ? 100 : 1));
     }
 }

--- a/geo/src/main/java/org/odk/collect/geo/GeoUtils.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoUtils.java
@@ -14,6 +14,17 @@ public final class GeoUtils {
     public static final double SIMULATED_ACCURACY = 0.2345;
     public static boolean simulateAccuracy = true;
 
+    public static final double[] TEST_ACCURACIES = {
+            0.1111,
+            0.2222,
+            0.5555,
+            0.7777,
+            1.111,
+            5.555,
+            10.01,
+            20.02
+    };
+
     private GeoUtils() {
 
     }

--- a/geo/src/main/java/org/odk/collect/geo/GeoUtils.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoUtils.java
@@ -10,6 +10,10 @@ import java.util.Locale;
 
 public final class GeoUtils {
 
+    //Cm accuracy #4198
+    public static final double SIMULATED_ACCURACY = 0.2345;
+    public static boolean simulateAccuracy = true;
+
     private GeoUtils() {
 
     }

--- a/geo/src/main/java/org/odk/collect/geo/MapPoint.java
+++ b/geo/src/main/java/org/odk/collect/geo/MapPoint.java
@@ -14,6 +14,9 @@
 
 package org.odk.collect.geo;
 
+import static org.odk.collect.geo.GeoUtils.SIMULATED_ACCURACY;
+import static org.odk.collect.geo.GeoUtils.simulateAccuracy;
+
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -46,7 +49,7 @@ public class MapPoint implements Parcelable {
         this.lat = lat;
         this.lon = lon;
         this.alt = alt;
-        this.sd = sd;
+        this.sd = simulateAccuracy ? SIMULATED_ACCURACY : sd;
     }
 
     private MapPoint(Parcel parcel) {

--- a/geo/src/test/java/org/odk/collect/geo/GeoUtilsTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/GeoUtilsTest.java
@@ -1,10 +1,12 @@
 package org.odk.collect.geo;
 
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import android.content.Context;
 import android.location.Location;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
@@ -18,6 +20,11 @@ import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
 public class GeoUtilsTest {
+
+    static {
+        GeoUtils.simulateAccuracy = false;
+    }
+
     private final List<MapPoint> points = new ArrayList<>(Arrays.asList(
             new MapPoint(11, 12, 13, 14),
             new MapPoint(21, 22, 23, 24),
@@ -58,5 +65,18 @@ public class GeoUtilsTest {
 
         String nullLocationProvider = null;
         assertNull(GeoUtils.capitalizeGps(nullLocationProvider));
+    }
+
+    @Test
+    //Cm accuracy #4198
+    public void locationAccuracyIsFormattedInAppropriateUnit() {
+        final Context context = ApplicationProvider.getApplicationContext();
+        for (double accuracy : GeoUtils.TEST_ACCURACIES) {
+            boolean useCm = accuracy < 1;
+            String expected = context.getString(useCm ? R.string.location_accuracy_cm
+                    : R.string.location_accuracy_m, accuracy * (useCm ? 100 : 1));
+            String actual = GeoUtils.getAccuracyUnitString(context, accuracy);
+            assertEquals(expected, actual);
+        }
     }
 }

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">ملء استمارة فارغة</string>
   <!--Text for an action button on the main screen.-->
@@ -391,12 +391,10 @@
   <string name="view_change_location">الاطلاع على الموقع أو تغيير الموقع</string>
   <string name="change_location">تغيير الموقع</string>
   <string name="record_geopoint">سجل نقطة</string>
-  <string name="location_accuracy">الدقة: %1$s متر </string>
   <string name="location_provider">مزود خدمة تحديد الموقع: %s</string>
   <string name="getting_location">تحميل الموقع</string>
   <string name="get_location">تسجيل الموقع</string>
   <string name="provider_disabled_error">عذراً، مزود خدمة الموقع معطّل.</string>
-  <string name="gps_result">خط العرض: %1$s\n خط الطول : %2$s\nالارتفاع : %3$s\nالدقة : %4$s متر</string>
   <string name="location_metadata">الأقمار الصناعية المتاحة: %1$d\24 \n\nالوقت المنقضي: %2$s</string>
   <string name="google_play_services_not_available">تريد هذه الاستمارة تتبع موقعك ولكن خدمات Google Play غير متوفرة.</string>
   <string name="location_providers_disabled_dialog_message">تريد هذه الاستمارة تتبع موقعك ولكن موفري الموقع معطلين. يرجى التمكين في إعدادات أندرويد.</string>
@@ -466,9 +464,6 @@
     <item quantity="other">%dمتر </item>
   </plurals>
   <string name="location_status_searching">يتم البحث عن الموقع، يرجى الإنتظار…</string>
-  <string name="location_status_accuracy">دقة الموقع: %.2f متر</string>
-  <string name="location_status_acceptable">دقة الموقع: %.2f متر (مقبول)</string>
-  <string name="location_status_unacceptable">دقة الموقع: %.2f متر (غير مقبول)</string>
   <string name="collection_status_paused">النقاط التي تم إدخالها: %d</string>
   <string name="collection_status_placement">النقاط التي تم إدخالها: %d (انقر لوضع نقاط)</string>
   <string name="collection_status_manual">النقاط التي تم إدخالها: %d (التسجيل اليدوي)</string>

--- a/strings/src/main/res/values-ca/strings.xml
+++ b/strings/src/main/res/values-ca/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Omplir nou formulari</string>
   <!--Text for an action button on the main screen.-->
@@ -228,7 +228,6 @@
   <string name="getting_location">Carregant Localització</string>
   <string name="get_location">Enregistrar Localització</string>
   <string name="provider_disabled_error">Atenció, la Locatització està desactivada!</string>
-  <string name="gps_result">Latitud: %1$s\nLongitud: %2$s\nAltitud: %3$sm\nPrecisió: %4$sm</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->
   <string name="save_point">Desar posició gps</string>

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Vyplnit dotazník</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Prohlédnout nebo změnit polohu</string>
   <string name="change_location">Změnit lokaci</string>
   <string name="record_geopoint">Zaznamenat bod</string>
-  <string name="location_accuracy">Přesnost: %1$s m</string>
   <string name="location_provider">Poskytovatel polohy: %s</string>
   <string name="getting_location">Načítám pozici</string>
   <string name="get_location">Uložit pozici</string>
   <string name="provider_disabled_error">Nástroje pro získání polohy jsou zakázané!</string>
-  <string name="gps_result">Zeměpisná šířka:%1$s \n Zeměpisná délka: %2$s \n Výška: %3$s m \n Přesnost %4$sm</string>
   <string name="location_metadata">Dostupné satelity: %1$d /24\n\nUplynulý čas: %2$s</string>
   <string name="google_play_services_not_available">Tento formulář chce sledovat vaši polohu, ale služby Google Play nejsou k dispozici.</string>
   <string name="location_providers_disabled_dialog_message">Tento formulář chce sledovat vaši polohu, ale poskytovatelé polohy jsou zakázáni. Zvolte prosím nastavení v systému Android.</string>
@@ -463,9 +461,6 @@
     <item quantity="other">%d metrů</item>
   </plurals>
   <string name="location_status_searching">Hledám polohu, počkejte prosím…</string>
-  <string name="location_status_accuracy">Přesnost polohy: %.2f m</string>
-  <string name="location_status_acceptable">Přesnost umístění:  %.2f m (přijatelná)</string>
-  <string name="location_status_unacceptable">Přesnost umístění: %.2f m (nepřijatelná)</string>
   <string name="collection_status_paused">Zadané body: %d</string>
   <string name="collection_status_placement">Zadané body: %d (klepnutím umístíte body)</string>
   <string name="collection_status_manual">Zadané body: %d (ruční nahrávání)</string>

--- a/strings/src/main/res/values-da/strings.xml
+++ b/strings/src/main/res/values-da/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Udfyld tom formular</string>
   <!--Text for an action button on the main screen.-->
@@ -247,7 +247,6 @@
   <string name="reference_layer">Referencelag</string>
   <string name="view_change_location">Se eller skift lokalitet</string>
   <string name="change_location">Skift position</string>
-  <string name="location_accuracy">Præcision: 1%1$s m</string>
   <string name="location_provider">Lokalitetsudbyder: 1%s</string>
   <string name="getting_location">Finder lokation</string>
   <string name="get_location">Gem lokation</string>
@@ -302,9 +301,6 @@
     <item quantity="other">%d meter</item>
   </plurals>
   <string name="location_status_searching">Søger efter lokation, vent venligst…</string>
-  <string name="location_status_accuracy">Lokations nøjagtighed: %.2f m</string>
-  <string name="location_status_acceptable">Lokations nøjagtighed: %.2f m (acceptabel)</string>
-  <string name="location_status_unacceptable">Lokations nøjagtighed: %.2f m (uacceptabel)</string>
   <string name="collection_status_paused">Punkter indtastet: %d</string>
   <string name="collection_status_placement">Punkter indtastet: %d(Tryk for at placere punkter)</string>
   <string name="collection_status_manual">Punkter indtastet: %d(manuel optagelse)</string>

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Leeres Formular ausfüllen</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Standort anzeigen oder ändern</string>
   <string name="change_location">Standort ändern</string>
   <string name="record_geopoint">Punkt erfassen</string>
-  <string name="location_accuracy">Genauigkeit: %1$s m</string>
   <string name="location_provider">Standortdienst: %s</string>
   <string name="getting_location">Lade Standort</string>
   <string name="get_location">Standort erfassen</string>
   <string name="provider_disabled_error">Standortdienste sind nicht aktiviert!</string>
-  <string name="gps_result">Breite (Lat.): %1$s\nLänge (Long.): %2$s\nHöhe (Alt.): %3$sm\nGenauigkeit: %4$sm</string>
   <string name="location_metadata">verfügbare Satelliten: %1$d/24\n\nabgelaufene Zeit: %2$s</string>
   <string name="google_play_services_not_available">Dieses Formular möchte Ihren Standort aufzeichnen, aber die Google Play-Dienste sind nicht verfügbar.</string>
   <string name="location_providers_disabled_dialog_message">Dieses Formular möchte Ihren Standort aufzeichnen, aber die Standortdienste sind deaktiviert. Bitte den Standortzugriff in den Android-Einstellungen aktivieren.</string>
@@ -457,9 +455,6 @@
     <item quantity="other">%d Meter</item>
   </plurals>
   <string name="location_status_searching">Suche nach Standort, bitte warten…</string>
-  <string name="location_status_accuracy">Ortungsgenauigkeit: %.2f m</string>
-  <string name="location_status_acceptable">Ortungsgenauigkeit: %.2f m (akzeptabel)</string>
-  <string name="location_status_unacceptable">Ortungsgenauigkeit: %.2f m (inakzeptabel)</string>
   <string name="collection_status_paused">erfasste Punkte: %d</string>
   <string name="collection_status_placement">erfasste Punkte: %d (tippen zum Platzieren von Punkten)</string>
   <string name="collection_status_manual">erfasste Punkte: %d (manuelle Standorterfassung)</string>

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Llenar Nuevo Formulario</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Ver o cambiar de localización</string>
   <string name="change_location">Cambiar Ubicación</string>
   <string name="record_geopoint">Registrando un punto</string>
-  <string name="location_accuracy">Precisión: %1$s m</string>
   <string name="location_provider">Proveedor de Ubicación: %s</string>
   <string name="getting_location">Cargando la Ubicación</string>
   <string name="get_location">Obtener localización</string>
   <string name="provider_disabled_error">¡Los proveedores de ubicación están deshabilitados!</string>
-  <string name="gps_result">Latitud: %1$s\nLongitud: %2$s\nAltitud: %3$sm\nPrecisión: %4$sm</string>
   <string name="location_metadata">Satélites disponibles: %1$d/24\n\nTiempo transcurrido: %2$s</string>
   <string name="google_play_services_not_available">Este formulario quiere rastrear su ubicación, pero los servicios de Google Play no están disponibles.</string>
   <string name="location_providers_disabled_dialog_message">Este formulario quiere rastrear su ubicación pero los proveedores de ubicación están deshabilitados Por favor, habilite en la configuración de Android.</string>
@@ -457,9 +455,6 @@
     <item quantity="other">%d metros</item>
   </plurals>
   <string name="location_status_searching">Buscando ubicación, espere …</string>
-  <string name="location_status_accuracy">Precisión de ubicación: %.2f m</string>
-  <string name="location_status_acceptable">Precisión de ubicación: %.2f m (aceptable)</string>
-  <string name="location_status_unacceptable">Precisión de ubicación: %.2f m (inaceptable)</string>
   <string name="collection_status_paused">Puntos ingresados: %d</string>
   <string name="collection_status_placement">Puntos ingresados: %d (toque para ublicar puntos)</string>
   <string name="collection_status_manual">Puntos ingresados: %d (registro manual)</string>

--- a/strings/src/main/res/values-et/strings.xml
+++ b/strings/src/main/res/values-et/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Täida vorm</string>
   <!--Text for an action button on the main screen.-->
@@ -234,7 +234,6 @@
   <string name="getting_location">Asukoha laadimine</string>
   <string name="get_location">Salvesta asukoht</string>
   <string name="provider_disabled_error">Kahjuks on asukoha küsimine maha keeratud!</string>
-  <string name="gps_result">Laiuskraad: %1$s\nPikkuskraad: %2$s\nKõrgus: %3$sm\nTäpsusaste: %4$sm</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->
   <string name="save_point">Salvesta asukohapunkt</string>

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Täytä tyhjä lomake</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Tarkastele tai vaihda sijaintia</string>
   <string name="change_location">Vaihda sijaintia</string>
   <string name="record_geopoint">Tallenna piste</string>
-  <string name="location_accuracy">Tarkkuus: %1$s m</string>
   <string name="location_provider">Sijaintilähde: %s</string>
   <string name="getting_location">Lataussijainti</string>
   <string name="get_location">Tallenna sijainti</string>
   <string name="provider_disabled_error">Pahoittelut, sijaintitiedot eivät ole käytössä!</string>
-  <string name="gps_result">Leveysasteet: %1$s\nPituusasteet: %2$s\nKorkeus: %3$sm\nTarkkuus: %4$sm</string>
   <string name="location_metadata">Käytettävissä sateliitteja: %1$d/24\n\nKulunut aika: %2$s</string>
   <string name="google_play_services_not_available">Tämä lomake haluaa seurata sijaintiasi mutta Google Play Services ei ole käytettävissä.</string>
   <string name="location_providers_disabled_dialog_message">Tämä lomake haluaa seurata sijaintiasi mutta sijaintipalvelut (location providers) eivät ole käytettävissä. Ole hyvä ja aktivoi ne Androidin asetuksissa.</string>
@@ -457,9 +455,6 @@
     <item quantity="other">%d metriä</item>
   </plurals>
   <string name="location_status_searching">Etsitään sijaintia, odota hetki…</string>
-  <string name="location_status_accuracy">Sijaintitarkkuus: %.2f m</string>
-  <string name="location_status_acceptable">Sijaintitarkkuus: %.2f m (riittävä)</string>
-  <string name="location_status_unacceptable">Sijaintitarkkuus: %.2f m (riittämätön)</string>
   <string name="collection_status_paused">Syötettyjä pisteitä: %d</string>
   <string name="collection_status_placement">Syötettyjä pisteitä: %d (napsauta sijoittaaksesi pisteitä)</string>
   <string name="collection_status_manual">Syötettyjä pisteitä: %d (manuaalinen tallennus)</string>

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Remplir un formulaire</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Voir ou changer la position</string>
   <string name="change_location">Modifier la localisation</string>
   <string name="record_geopoint">Enregistrer un point</string>
-  <string name="location_accuracy">Précision: %1$s m</string>
   <string name="location_provider">Fournisseur de la localisation: 1%s</string>
   <string name="getting_location">Chargement de la localisation</string>
   <string name="get_location">Enregistrement du lieu</string>
   <string name="provider_disabled_error">Désolé, le fournisseur de localisation est désactivé.</string>
-  <string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nPrécision: %4$sm</string>
   <string name="location_metadata">Satellites disponibles: %1$d/24\n\nTemps écoulé: %2$s</string>
   <string name="google_play_services_not_available">Ce formulaire souhaite suivre votre localisation, mais les Services de Google Play ne sont pas disponible</string>
   <string name="location_providers_disabled_dialog_message">Ce formulaire souhaite suivre votre localisation, mais les fournisseurs d\'emplacements sont désactivés. Merci de vérifier les paramétres Android</string>
@@ -457,9 +455,6 @@
     <item quantity="other">%d mètres</item>
   </plurals>
   <string name="location_status_searching">Recherche de la localisation, veuillez patienter…</string>
-  <string name="location_status_accuracy">Précision de la localisation: %.2f m</string>
-  <string name="location_status_acceptable">Précision de la localisation: %.2f m (acceptable)</string>
-  <string name="location_status_unacceptable">Précision de la localisation: %.2f m (inacceptable)</string>
   <string name="collection_status_paused">Points entrés: %d</string>
   <string name="collection_status_placement">Points entrés: %d (appuyez pour placer des points)</string>
   <string name="collection_status_manual">Points entrés: %d (enregistrement manuel)</string>

--- a/strings/src/main/res/values-hi/strings.xml
+++ b/strings/src/main/res/values-hi/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">खाली फॉर्म भरें</string>
   <!--Text for an action button on the main screen.-->
@@ -255,7 +255,6 @@
   <string name="getting_location">लोकेशन लोड हो रही है</string>
   <string name="get_location">लोकेशन  रिकार्ड करें </string>
   <string name="provider_disabled_error">क्षमा करें, लोकेशन प्रदाता सक्षम नही हैं!</string>
-  <string name="gps_result">अक्षांश: %1$s \n देशांतर: %2$s \n ऊंचाई: %3$sm \n शुद्धता: %4$sm</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->
   <string name="save_point">जिओपॉइंट संरक्षित करे</string>

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Isi Formulir Kosong</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Lihat atau Ubah Lokasi</string>
   <string name="change_location">Ubah Lokasi</string>
   <string name="record_geopoint">Rekam titik</string>
-  <string name="location_accuracy">Tingkat akurasi adalah %1$s meter</string>
   <string name="location_provider">Lokasi penyedia jasa: %s</string>
   <string name="getting_location">Memuat Lokasi</string>
   <string name="get_location">Rekam Lokasi</string>
   <string name="provider_disabled_error">Maaf, penyedia lokasi belum diaktifkan</string>
-  <string name="gps_result">Lintang: %1$s\nBujur: %2$s\nKetinggian: %3$s m\nAkurasi: %4$s m</string>
   <string name="location_metadata">Satelit tersedia: %1$d /24\n\nWaktu berlalu: %2$s</string>
   <string name="google_play_services_not_available">Formulir ini hendak merekam pergerakan lokasi Anda, tetapi Google Play Service tidak tersedia.</string>
   <string name="location_providers_disabled_dialog_message">Formulir ini hendak merekam pergerakan lokasi Anda, tetapi layanan lokasi tidak aktif. Mohon aktifkan terlebih dahulu di pengaturan Android.</string>
@@ -454,9 +452,6 @@
     <item quantity="other">%d meter</item>
   </plurals>
   <string name="location_status_searching">Sedang mencari lokasi, mohon menunggu…</string>
-  <string name="location_status_accuracy">Akurasi GPS: %.2f m</string>
-  <string name="location_status_acceptable">Akurasi GPS: %.2f m (GPS Sesuai)</string>
-  <string name="location_status_unacceptable">Akurasi GPS: %.2f m (GPS tidak sesuai)</string>
   <string name="collection_status_paused">Titik yang dimasukkan: %d</string>
   <string name="collection_status_placement">Titik yang dimasukkan: %d (sentuh untuk menempatkan poin)</string>
   <string name="collection_status_manual">Titik yang dimasukkan: %d (rekaman manual)</string>

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Compila Modulo Vuoto</string>
   <!--Text for an action button on the main screen.-->
@@ -394,12 +394,10 @@
   <string name="view_change_location">Vedi o Cambia Posizione</string>
   <string name="change_location">Cambiare Localizzazione</string>
   <string name="record_geopoint">Memorizza un punto</string>
-  <string name="location_accuracy">Precisione: %1$s m</string>
   <string name="location_provider">Fornitore di posizione: %s</string>
   <string name="getting_location">Posizionamento in corso</string>
   <string name="get_location">Registra Posizione</string>
   <string name="provider_disabled_error">Attenzione, i Sistemi di Posizionamento sono disabilitati!</string>
-  <string name="gps_result">Latitudine: %1$s\nLongitudine: %2$s\nAltitudine: %3$sm\nPrecisione: %4$sm</string>
   <string name="location_metadata">Satelliti disponibili:%1$d/24\n\nTempo trascorso: %2$s</string>
   <string name="google_play_services_not_available">Questo formulario vuole monitorare la tua posizione ma Google Play Services non è disponibile.</string>
   <string name="location_providers_disabled_dialog_message">Questo formulario vuole monitorare la tua posizione ma i fornitori di servizi di localizzazione sono disabilitati. Si prega di abilitare nelle impostazioni di Android.</string>
@@ -457,9 +455,6 @@
     <item quantity="other">%d metri</item>
   </plurals>
   <string name="location_status_searching">Sto ricercando la posizione, prego attendere…</string>
-  <string name="location_status_accuracy">Precisione della posizione GPS%.2f m</string>
-  <string name="location_status_acceptable">Precisione posizione: %.2fm (accettabile)</string>
-  <string name="location_status_unacceptable">Precisione posizione: %.2fm (inaccettabile)</string>
   <string name="collection_status_paused">Punti inseriti: %d</string>
   <string name="collection_status_placement">Punti inseriti: %d (tocca per inserire punti)</string>
   <string name="collection_status_manual">Punti inseriti: %d (salvataggio manuale)</string>

--- a/strings/src/main/res/values-ja/strings.xml
+++ b/strings/src/main/res/values-ja/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">空のフォームに入力してください</string>
   <!--Text for an action button on the main screen.-->
@@ -391,12 +391,10 @@
   <string name="view_change_location">場所の表示または変更</string>
   <string name="change_location">場所の変更</string>
   <string name="record_geopoint">位置を記録</string>
-  <string name="location_accuracy">精度: %1$s m</string>
   <string name="location_provider">ロケーションプロバイダー: %s</string>
   <string name="getting_location">ロケーションをロード中</string>
   <string name="get_location">記録場所</string>
   <string name="provider_disabled_error">申し訳ありません、ロケーション プロバイダーが無効です!</string>
-  <string name="gps_result">緯度: %1$s\n経度: %2$s\n高度: %3$sm\n精度: %4$sm</string>
   <string name="location_metadata">利用可能なサテライト: %1$d/24\n\n経過した時間: %2$s</string>
   <string name="google_play_services_not_available">このフォームは位置を追跡しようとしますが、Google Play サービスが利用できません。</string>
   <string name="location_providers_disabled_dialog_message">このフォームは場所を追跡しようとしますが、位置情報プロバイダーが無効になっています。 Android の設定で有効にしてください。</string>
@@ -451,9 +449,6 @@
     <item quantity="other">%d メートル</item>
   </plurals>
   <string name="location_status_searching">位置を検索しています、しばらくお待ちください…</string>
-  <string name="location_status_accuracy">位置精度: %.2f m</string>
-  <string name="location_status_acceptable">位置精度: %.2f m (許容)</string>
-  <string name="location_status_unacceptable">位置精度: %.2f m (許容不可)</string>
   <string name="collection_status_paused">入力された位置: %d</string>
   <string name="collection_status_placement">入力された位置: %d (タップして位置を配置)</string>
   <string name="collection_status_manual">入力された位置: %d (手動記録)</string>

--- a/strings/src/main/res/values-km/strings.xml
+++ b/strings/src/main/res/values-km/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">បំពេញសំណុំបែបបទទទេ</string>
   <!--Text for an action button on the main screen.-->
@@ -330,7 +330,6 @@
   <string name="getting_location">កំពុងផ្ទុកទីតាំង</string>
   <string name="get_location">ចាប់​យក​ទីតាំង</string>
   <string name="provider_disabled_error">សុំទោស, សេវាចាប់យកទីតាំងត្រូវបានបិទ</string>
-  <string name="gps_result">រយៈទទឹង: %1$s\nរយៈបណ្ដោយ: %2$s\nរយៈកំពស់: %3$sm\nភាពត្រឹមត្រូវ: %4$sm</string>
   <string name="location_metadata">ផ្កាយរណបមាន៖ %1$d/24\n\nពេលវេលាកន្លងទៅ៖ %2$s</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <string name="go_to_settings">ទៅកាន់ការកំណត់</string>

--- a/strings/src/main/res/values-mr/strings.xml
+++ b/strings/src/main/res/values-mr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">रिक्त फॉर्म भरा</string>
   <!--Text for an action button on the main screen.-->
@@ -245,7 +245,6 @@
   <string name="getting_location">स्थान लोड करत आहे</string>
   <string name="get_location">स्थान रेकॉर्ड</string>
   <string name="provider_disabled_error">क्षमस्व, स्थान प्रदाता अक्षम केले आहेत!</string>
-  <string name="gps_result">अक्षांश: %1$s\nरेखांश: %2$s\nअल्टिट्यूड: %3$sm\nअॅक्चुसीसी: %4$sm</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->
   <string name="save_point">जिओ पॉईंट जतन करा</string>

--- a/strings/src/main/res/values-pl/strings.xml
+++ b/strings/src/main/res/values-pl/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Wypełnij Pusty Formularz</string>
   <!--Text for an action button on the main screen.-->
@@ -373,7 +373,6 @@
   <string name="getting_location">Wczytywanie Lokalizacji</string>
   <string name="get_location">Zapisz Lokalizację</string>
   <string name="provider_disabled_error">Przykro mi, dostawcy usługi Lokalizacji są niedostępni.</string>
-  <string name="gps_result">Szerokość: %1$s\nDługość: %2$s\nWzniesienie: %3$sm\nDokładność: %4$sm</string>
   <string name="location_metadata">Dostępne satelity: %1$d/24\n\nUpłynęło: %2$s</string>
   <string name="google_play_services_not_available">Ten formularz chce śledzić twoją lokalizację, ale usługi Google Play nie są dostępne.</string>
   <string name="location_providers_disabled_dialog_message">Ten formularz chce śledzić twoją lokalizację, ale usługi dostawców systemu lokalizacji są wyłączone. Włącz je w ustawieniach Androida.</string>

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Formulário em Branco</string>
   <!--Text for an action button on the main screen.-->
@@ -385,12 +385,10 @@ Escolher Imagem</string>
   <string name="view_change_location">Ver ou modificar localização</string>
   <string name="change_location">Mudar Localização</string>
   <string name="record_geopoint">Registre um ponto</string>
-  <string name="location_accuracy">Precisão: %1$s m</string>
   <string name="location_provider">Provedor de localização: %s</string>
   <string name="getting_location">Carregando Localização</string>
   <string name="get_location">Gravar Localização</string>
   <string name="provider_disabled_error">Desculpe, provedor de localização desabilitado!</string>
-  <string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nPrecisão:%4$s m</string>
   <string name="location_metadata">Satélites disponíveis: %1$d/24\n\nTempo decorrido: %2$s</string>
   <string name="google_play_services_not_available">Este formulário necessita rastrear sua localização</string>
   <string name="location_providers_disabled_dialog_message">Este formulário necessita rastrear sua localização, mas a localização está desabilitada no seu dispositivo. Favor habilitar nas configurações do celular.</string>
@@ -448,9 +446,6 @@ Escolher Imagem</string>
     <item quantity="other">%d metros</item>
   </plurals>
   <string name="location_status_searching">Buscando a localização, por favor, aguarde…</string>
-  <string name="location_status_accuracy">Precisão da localização: %.2f m</string>
-  <string name="location_status_acceptable">Precisão da localização: %.2f m (aceitável)</string>
-  <string name="location_status_unacceptable">Precisão da localização: %.2f m (inaceitável)</string>
   <string name="collection_status_paused">Pontos inseridos: %d</string>
   <string name="collection_status_placement">Pontos inseridos: %d (toque na tela para inserir pontos)</string>
   <string name="collection_status_manual">Pontos inseridos: %d (registro manual)</string>

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Заполнить пустую форму</string>
   <!--Text for an action button on the main screen.-->
@@ -329,7 +329,6 @@
   <string name="getting_location">Определяется местоположение</string>
   <string name="get_location">Записать местоположение</string>
   <string name="provider_disabled_error">Включите функцию определения местоположения на вашем устройстве!</string>
-  <string name="gps_result">Широта: %1$s\nДолгота: %2$s\nВысота: %3$sм\nТочность:%4$sм</string>
   <string name="location_metadata">Спутников видно: %1$d/24\n\nВремени прошло: %2$s</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->

--- a/strings/src/main/res/values-rw/strings.xml
+++ b/strings/src/main/res/values-rw/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Uzuza ahateganyijwe muri iyi nyandiko shingiro cg ngenderwaho</string>
   <!--Text for an action button on the main screen.-->
@@ -392,12 +392,10 @@
   <string name="view_change_location">Kora igenzura cyangwa uhindure ujye ahandi</string>
   <string name="change_location">Hindura ujye ahandi</string>
   <string name="record_geopoint">Irabika amakuru</string>
-  <string name="location_accuracy">Birizewe: %1$s m</string>
   <string name="location_provider">Igitanga aho uri ubu: %s</string>
   <string name="getting_location">Iri gushakicyisha icyerekezo</string>
   <string name="get_location">Fata amakuru y\'ahantu</string>
   <string name="provider_disabled_error">Ihangane, ibituma amakuru y\'ahantu afatwa birafunze</string>
-  <string name="gps_result">Ubujy\'ejuru: %1$s \nUmurambararo: %2$s \nUbutumburuke: %3$s m\n Byizewe: %4$s m</string>
   <string name="location_metadata">Saterite iraboneka: %1$d /24\n\nIgihe
 Hashize: %2$s</string>
   <string name="google_play_services_not_available">Iyi form irashaka kugenzura aho uherereye, ariko Google Play Services ntabwo iboneka</string>
@@ -456,9 +454,6 @@ Hashize: %2$s</string>
     <item quantity="other">%d meters</item>
   </plurals>
   <string name="location_status_searching">Mwihangane Iracyashakisha location/icyerekezo</string>
-  <string name="location_status_accuracy">Indangahantu nyayo: %.2f m.</string>
-  <string name="location_status_acceptable">Indangahantu nyayo: %.2f m (yemewe)</string>
-  <string name="location_status_unacceptable">Indangahantu nyayo: %.2f m (itemewe)</string>
   <string name="collection_status_paused">Ikimenyetso ndangahantu kinjiye:%d .</string>
   <string name="collection_status_placement">Ikimenyetso ndangahantu kinjiye: %d (kanda mumwanya w\'ikimenyetso ndangahantu)</string>
   <string name="collection_status_manual">Ikimenyetso ndangahantu kinjiye: %d (mu buryo busanzwe)</string>

--- a/strings/src/main/res/values-sq/strings.xml
+++ b/strings/src/main/res/values-sq/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Mbush formular bosh</string>
   <!--Text for an action button on the main screen.-->
@@ -265,7 +265,6 @@
   <string name="getting_location">Duke ngarkuar vendnodhjen</string>
   <string name="get_location">Regjistro vendndodhjen.</string>
   <string name="provider_disabled_error">Ofruesit e vendndodhjes janë të ç\'aktivizuar!</string>
-  <string name="gps_result">Gjerësi: %1$s\nGjatësi: %2$s\nLartësi: %3$sm\nSaktësi: %4$sm</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <string name="go_to_settings">Shko tek parametrat</string>
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->

--- a/strings/src/main/res/values-sr/strings.xml
+++ b/strings/src/main/res/values-sr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Popuni prazan formular</string>
   <!--Text for an action button on the main screen.-->
@@ -338,7 +338,6 @@
   <string name="getting_location">Učitavam lokaciju</string>
   <string name="get_location">Zabilježi lokaciju</string>
   <string name="provider_disabled_error">Pronalaženje lokacije je isključeno!</string>
-  <string name="gps_result">Geografska širina:%1$s\nGeografska dužina: %2$s\nVisina: %3$sm\nPreciznost: %4$sm</string>
   <string name="location_metadata">Sateliti dostupni: %1$d/24\n\n proteklo vrijeme: %2$s</string>
   <string name="google_play_services_not_available">Ovaj formular želi da prati vašu poziciju ali Google Play Services nisu dostupne.</string>
   <string name="location_providers_disabled_dialog_message">Ovaj formular želi da prati vašu lokaciju ali provajderi lokacije su isključeni. Molim uključite ih u podešavanjima Androida.</string>

--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Fyll i tomt formulär</string>
   <!--Text for an action button on the main screen.-->
@@ -342,7 +342,6 @@
   <string name="getting_location">Laddar position</string>
   <string name="get_location">Spara position</string>
   <string name="provider_disabled_error">Tyvärr, platstjänster är inaktiverade!</string>
-  <string name="gps_result">Latitud: %1$s\nLongitud: %2$s\nAltitud: %3$sm\nNoggrannhet: %4$sm</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->
   <string name="save_point">Spara GeoPoint</string>

--- a/strings/src/main/res/values-sw/strings.xml
+++ b/strings/src/main/res/values-sw/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Jaza fomu iliyo tupu</string>
   <!--Text for an action button on the main screen.-->
@@ -349,7 +349,6 @@
   <string name="getting_location">Inatafuta mahali</string>
   <string name="get_location">Rekodi mahali</string>
   <string name="provider_disabled_error">Samahani, kionesha mahali hakijawezeshwa!</string>
-  <string name="gps_result">Latitude: %1$s \nLongitude: %2$s \nUrefumwambao:%3$s m\nUsahihi: %4$s m</string>
   <string name="location_metadata">Satelite zipo: %1$d/24\n\nMuda umepita: %2$s</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->

--- a/strings/src/main/res/values-te/strings.xml
+++ b/strings/src/main/res/values-te/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">ఖాళీ ఫారం నింపండి</string>
   <!--Text for an action button on the main screen.-->
@@ -370,12 +370,10 @@
   <string name="view_change_location">లొకేషన్ చూడండి లేదా మార్చండి</string>
   <string name="change_location">లొకేషన్ మార్చండి</string>
   <string name="record_geopoint">ఒక పాయింట్ రికార్డ్ చేయండి</string>
-  <string name="location_accuracy">%1$s ఖచ్చితత్వం</string>
   <string name="location_provider">%s ప్రదేశ అనుమతులు</string>
   <string name="getting_location">లొకేషన్ లోడ్ అవుతోంది</string>
   <string name="get_location">లొకేషన్ రికార్డు చెయ్యండి </string>
   <string name="provider_disabled_error">క్షమించండి, లొకేషన్ ప్రొవైడర్లు డిసేబుల్ చెయ్యబడ్డాయి!</string>
-  <string name="gps_result">అక్షాంశం: %1$s\n రేఖాంశం:%2$s \n ఎత్తు: %3$sm\n ఖచ్చితత్వం: %4$sm</string>
   <string name="location_metadata">అందుబాటులో ఉన్న ఉపగ్రహాలు: %1$d/ 24 \n\n ముగిసిన సమయం:%2$s</string>
   <string name="google_play_services_not_available">ఈ ఫారం మీ స్థానాన్ని ట్రాక్ చేయాలనుకుంటుంది, కానీ గూగుల్ ప్లే సేవలు అందుబాటులో లేవు.</string>
   <string name="location_providers_disabled_dialog_message">ఈ ఫారం మీ స్థానాన్ని ట్రాక్ చేయాలనుకుంటుంది కాని స్థాన ప్రొవైడర్లు నిలిపివేయబడ్డారు. దయచేసి Android సెట్టింగ్‌లలో ప్రారంభించండి.</string>

--- a/strings/src/main/res/values-tl-rPH/strings.xml
+++ b/strings/src/main/res/values-tl-rPH/strings.xml
@@ -58,7 +58,6 @@
   <string name="dont_add_repeat">Huwag I-dagdag</string>
     <string name="loading_form">Kina-karga ang Form</string>
   <string name="load_remote_form_error">May Mali sa pag-karga ng Listahan ng Form</string>
-    <string name="location_accuracy">Ang kawastuhan ay %1$s m</string>
     <string name="manage_files">Burahin ang Inimpok na Form</string>
   <string name="mark_finished">Markahan Yari ang Form</string>
   <string name="noselect_error">Paumanhin, walang form na pinili!</string>

--- a/strings/src/main/res/values-uk/strings.xml
+++ b/strings/src/main/res/values-uk/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">Заповнити анкету</string>
   <!--Text for an action button on the main screen.-->
@@ -335,7 +335,6 @@
   <string name="getting_location">Завантаження місцезнаходження</string>
   <string name="get_location">Записати місцезнаходження</string>
   <string name="provider_disabled_error">Вибачте! Джерела місцезнаходження не доступні!</string>
-  <string name="gps_result">Широта: %1$s\nДовгота: %2$s\nВисота: %3$sm\nТочність: %4$sm</string>
   <string name="location_metadata">Доступні супутники: %1$d/24\n\nПриблизний час: %2$s</string>
   <string name="google_play_services_not_available">Ця анкета хоче відслідковувати ваше розташування але Сервіси Google Play не доступні.</string>
   <string name="location_providers_disabled_dialog_message">Ця анкета хоче відслідковувати ваше розташування але розташування вимкнене. Будь ласка, увімкніть його в налаштуваннях Android.</string>

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <!--Text for an action button on the main screen.-->
   <string name="enter_data">خالی فارم پر کریں</string>
   <!--Text for an action button on the main screen.-->
@@ -338,7 +338,6 @@
   <string name="getting_location">لوکیشن لوڈ کی جارہی ہے</string>
   <string name="get_location">لوکیشن ریکارڈ کریں</string>
   <string name="provider_disabled_error">معذرت، لوکیشن فراہم کرنے والے نااہل کئے گئے ہیں</string>
-  <string name="gps_result">طول عرض:  %1$s \nطول بلد: %2$s \n اونچائی:  %3$s میٹر\n ایکیوریسی: %4$s میٹر</string>
   <string name="location_metadata">سیٹیلائٹ موجود: %1$d 24\n\n گزرا ہوا وقت:%2$s</string>
   <!--Action to go to Android settings. Displayed when location providers are disabled.-->
   <!--Label for a menu item that can be toggled to turn background location tracking on and off during form filling-->

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -482,14 +482,12 @@
     <string name="view_change_location">View or Change Location</string>
     <string name="change_location">Change Location</string>
     <string name="record_geopoint">Record a point</string>
-    <string name="location_accuracy">Accuracy: %1$s m</string>
     <string name="location_accuracy_cm">Accuracy: %.0f cm</string>
     <string name="location_accuracy_m">Accuracy: %.1f m</string>
     <string name="location_provider">Location provider: %s</string>
     <string name="getting_location">Loading Location</string>
     <string name="get_location">Record Location</string>
     <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
-    <string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$sm</string>
     <string name="gps_result_m">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$.1f m</string>
     <string name="gps_result_cm">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$.0f cm</string>
     <string name="location_metadata">Satellites available: %1$d/24\n\nTime elapsed: %2$s</string>
@@ -552,13 +550,10 @@
         <item quantity="other">%d meters</item>
     </plurals>
     <string name="location_status_searching">Searching for location, please wait&#8230;</string>
-    <string name="location_status_accuracy">Location accuracy: %.2f m</string>
     <string name="location_status_accuracy_m">Location accuracy: %.1f m</string>
     <string name="location_status_accuracy_cm">Location accuracy: %.0f cm</string>
-    <string name="location_status_acceptable">Location accuracy: %.2f m (acceptable)</string>
     <string name="location_status_acceptable_m">Location accuracy: %.1f m (acceptable)</string>
     <string name="location_status_acceptable_cm">Location accuracy: %.0f cm (acceptable)</string>
-    <string name="location_status_unacceptable">Location accuracy: %.2f m (unacceptable)</string>
     <string name="location_status_unacceptable_m">Location accuracy: %.1f m (unacceptable)</string>
     <string name="location_status_unacceptable_cm">Location accuracy: %.0f cm (unacceptable)</string>
     <string name="collection_status_paused">Points entered: %d</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -483,11 +483,15 @@
     <string name="change_location">Change Location</string>
     <string name="record_geopoint">Record a point</string>
     <string name="location_accuracy">Accuracy: %1$s m</string>
+    <string name="location_accuracy_cm">Accuracy: %.0f cm</string>
+    <string name="location_accuracy_m">Accuracy: %.1f m</string>
     <string name="location_provider">Location provider: %s</string>
     <string name="getting_location">Loading Location</string>
     <string name="get_location">Record Location</string>
     <string name="provider_disabled_error">Sorry, Location providers are disabled!</string>
     <string name="gps_result">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$sm</string>
+    <string name="gps_result_m">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$.1f m</string>
+    <string name="gps_result_cm">Latitude: %1$s\nLongitude: %2$s\nAltitude: %3$sm\nAccuracy: %4$.0f cm</string>
     <string name="location_metadata">Satellites available: %1$d/24\n\nTime elapsed: %2$s</string>
     <string name="google_play_services_not_available">This form wants to track your location but Google Play Services are not available.</string>
     <string name="location_providers_disabled_dialog_message">This form wants to track your location but location providers are disabled. Please enable in Android settings.</string>
@@ -549,8 +553,14 @@
     </plurals>
     <string name="location_status_searching">Searching for location, please wait&#8230;</string>
     <string name="location_status_accuracy">Location accuracy: %.2f m</string>
+    <string name="location_status_accuracy_m">Location accuracy: %.1f m</string>
+    <string name="location_status_accuracy_cm">Location accuracy: %.0f cm</string>
     <string name="location_status_acceptable">Location accuracy: %.2f m (acceptable)</string>
+    <string name="location_status_acceptable_m">Location accuracy: %.1f m (acceptable)</string>
+    <string name="location_status_acceptable_cm">Location accuracy: %.0f cm (acceptable)</string>
     <string name="location_status_unacceptable">Location accuracy: %.2f m (unacceptable)</string>
+    <string name="location_status_unacceptable_m">Location accuracy: %.1f m (unacceptable)</string>
+    <string name="location_status_unacceptable_cm">Location accuracy: %.0f cm (unacceptable)</string>
     <string name="collection_status_paused">Points entered: %d</string>
     <string name="collection_status_placement">Points entered: %d (tap to place points)</string>
     <string name="collection_status_manual">Points entered: %d (manual recording)</string>


### PR DESCRIPTION
Addresses #4198

#### What has been done to verify that this works as intended?
See 'Simulation' and 'Testing' below.

#### Why is this the best possible solution? Were any other approaches considered?
See 'The issue' and 'The update' below.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
None?

#### Do we need any specific form for testing your changes? If so, please attach one.
_[geowidgets.xlsx](
https://github.com/getodk/collect/files/735789/geowidgets.xlsx
)_ used for development testing, see 'Simulation' below.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)

### The issue
#4198 is essentially about display formatting, so the natural starting point in attacking it was to identify strings that display GPS accuracy. They seem to be the following:
- `gps_result` used by `getGeoPointAnswerToDisplay` in `GeoWidgetUtils`, called by `GeoPointActivity` and by `GeoPointMapActivity`
- `location_status_accuracy` etc used by `updateUi` in `GeoPolyActivity`
- `location_accuracy` used by `getAccuracyMessage` in `GeoPointActivity`, and by 
`formatLocationStatus` in `GeoPointMapActivity`

### The update
Each format string now needs two variants, for formatting accuracy as _cm_ or _m_. So code using these strings has to look at the accuracy value so as to
- decide which format to use, and
- where the answer is _cm_, scale the value to match ie multiply by 100.

This is coded independently for `gps_result` and `location_status_accuracy` etc, with the complication that `getGeoPointAnswerToDisplay` which uses `gps_result` has to extract the accuracy value from its `answer` parameter. 

To avoid duplicate code for `location_accuracy`, `getAccuracyMessage` and `formatLocationStatus` now get their formatted string from `getAccuracyUnitString` in `GeoUtils`. 

### Simulation
In addition to the formal testing described below, there was a need to simulate cm accuracy so as to confirm coverage of all occurrences in the UI. 

So for now at least `SIMULATED_ACCURACY` has been added to `GeoUtils`, for use when `simulateAccuracy` is set, and intercepts accuracy values to enable manual confirmation that _cm_ formatting is applied when appropriate (including a very dubious mod to `FormEntryPromptUtils`). 

The form defined in _[geowidgets.xlsx](
https://github.com/getodk/collect/files/735789/geowidgets.xlsx
)_ can be used to view the simulation.

### Testing
The new code is tested by three new methods added to existing classes, all called `locationAccuracyIsFormattedInAppropriateUnit` since they perform essentially the same task by iterating through the `TEST_ACCURACIES` added to `GeoUtils`. 

The variants in `GeoWidgetUtilsTest` and `GeoUtilsTest` check results for `gps_result` and `location_accuracy` as returned by their respective methods. In `GeoPolyActivityTest` the test is of the state of `locationStatus` following each fake fix. 

The new implementation of `getGeoPointAnswerToDisplay` necessitates an update to `getAnswerToDisplay…returnsAnswer` in  `GeoWidgetUtilsTest`, which in fact only tests currently for accuracies below 1 m.