### PR TITLE
Make sure to build APK on same machine as test APK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
 
       - run:
           name: Assemble test build
-          command: ./gradlew assembleDebugAndroidTest
+          command: ./gradlew assembleDebug assembleDebugAndroidTest
       - run:
           name: Authorize gcloud
           command: |


### PR DESCRIPTION
This should allow instrumentation tests to run again.