### PR TITLE
Add form event when `accuracyThreshold` used

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -235,4 +235,9 @@ public final class AnalyticsEvents {
      * Tracks how many forms include the `allow-mock-accuracy` parameter in `geo` questions
      */
     public static final String ALLOW_MOCK_ACCURACY = "AllowMockAccuracy";
+
+    /**
+     * Tracks how many forms include an accuracy threshold for `geopoint` questions
+     */
+    public static final String ACCURACY_THRESHOLD = "AccuracyThreshold";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -24,6 +24,8 @@ import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
+import org.odk.collect.android.analytics.AnalyticsEvents;
+import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.databinding.GeoWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.interfaces.GeoDataRequester;
@@ -69,6 +71,10 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
         }
 
         GeoWidgetUtils.logAllowMockAccuracy(prompt);
+        if (prompt.getQuestion().getAdditionalAttribute(null, "accuracyThreshold") != null) {
+            AnalyticsUtils.logFormEvent(AnalyticsEvents.ACCURACY_THRESHOLD);
+        }
+
         return binding.getRoot();
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/support/MockFormEntryPromptBuilder.java
+++ b/collect_app/src/test/java/org/odk/collect/android/support/MockFormEntryPromptBuilder.java
@@ -30,6 +30,9 @@ public class MockFormEntryPromptBuilder {
         when(prompt.getIndex()).thenReturn(mock(FormIndex.class));
         when(prompt.getIndex().toString()).thenReturn("0, 0");
         when(prompt.getFormElement()).thenReturn(mock(IFormElement.class));
+
+        // Make sure we have a non-null question
+        withQuestion(mock(QuestionDef.class));
     }
 
     public MockFormEntryPromptBuilder withIndex(String index) {


### PR DESCRIPTION
We're looking at reworking the geopoint UI (#4718) and having a better sense of how popular `accuracyThreshold` is would be very useful.

#### What has been done to verify that this works as intended?

Nothing other than double-checking the code.

#### Why is this the best possible solution? Were any other approaches considered?

Like with the `allow-mock-accuracy` analytics I've chosen to fire the event in the widget rather than the `ActivityGeoDataRequester`. This prevents us from potentially missing out events from optional questions.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No behaviour change! Just added analytics so this can go in without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
