### PR TITLE
Fixed comparing media files in order to detect updates

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -31,6 +31,7 @@ import org.odk.collect.shared.strings.Md5;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -163,10 +164,7 @@ public class ServerFormsDetailsFetcher {
 
     private Form getFormByVersion(List<Form> forms, @Nullable String expectedVersion) {
         for (Form form : forms) {
-            if (expectedVersion == null && form.getVersion() == null) {
-                return form;
-            }
-            if (expectedVersion != null && form.getVersion() != null && expectedVersion.equals(form.getVersion())) {
+            if (Objects.equals(form.getVersion(), expectedVersion)) {
                 return form;
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -32,6 +32,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import timber.log.Timber;
 
 public class ServerFormsDetailsFetcher {
@@ -80,7 +82,7 @@ public class ServerFormsDetailsFetcher {
                     List<MediaFile> newMediaFiles = manifestFile.getMediaFiles();
 
                     if (newMediaFiles != null && !newMediaFiles.isEmpty()) {
-                        isNewerFormVersionAvailable = areNewerMediaFilesAvailable(forms.get(0), newMediaFiles);
+                        isNewerFormVersionAvailable = areNewerMediaFilesAvailable(getFormByVersion(forms, listItem.getVersion()), newMediaFiles);
                     }
                 }
             }
@@ -157,5 +159,17 @@ public class ServerFormsDetailsFetcher {
 
     private String getMd5HashWithoutPrefix(String hash) {
         return hash == null || hash.isEmpty() ? null : hash.substring("md5:".length());
+    }
+
+    private Form getFormByVersion(List<Form> forms, @Nullable String expectedVersion) {
+        for (Form form : forms) {
+            if (expectedVersion == null && form.getVersion() == null) {
+                return form;
+            }
+            if (expectedVersion != null && form.getVersion() != null && expectedVersion.equals(form.getVersion())) {
+                return form;
+            }
+        }
+        return null;
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
@@ -36,7 +36,8 @@ public class ServerFormsDetailsFetcherTest {
             new FormListItem("http://example.com/form-2", "form-2", "2", "md5:form-2-hash", "Form 2", "http://example.com/form-2-manifest")
     );
 
-    private final MediaFile mediaFile = new MediaFile("blah.txt", "md5:" + Md5.getMd5Hash(new ByteArrayInputStream("blah".getBytes())), "http://example.com/media-file");
+    private static final String FILE_CONTENT = "blah";
+    private final MediaFile mediaFile = new MediaFile("blah.txt", "md5:" + Md5.getMd5Hash(new ByteArrayInputStream(FILE_CONTENT.getBytes())), "http://example.com/media-file");
 
     private ServerFormsDetailsFetcher fetcher;
     private FormsRepository formsRepository;
@@ -143,7 +144,7 @@ public class ServerFormsDetailsFetcherTest {
                 .formMediaPath(mediaDir1.getAbsolutePath())
                 .build());
 
-        File oldMediaFile1 = TempFiles.createTempFile(mediaDir1, "blah", ".txt");
+        File oldMediaFile1 = TempFiles.createTempFile(mediaDir1, mediaFile.getFilename());
         writeToFile(oldMediaFile1, "old blah");
 
         File mediaDir2 = TempFiles.createTempDir();
@@ -156,8 +157,8 @@ public class ServerFormsDetailsFetcherTest {
                 .formMediaPath(mediaDir2.getAbsolutePath())
                 .build());
 
-        File oldMediaFile2 = TempFiles.createTempFile(mediaDir2, "blah", ".txt");
-        writeToFile(oldMediaFile2, "blah");
+        File oldMediaFile2 = TempFiles.createTempFile(mediaDir2, mediaFile.getFilename());
+        writeToFile(oldMediaFile2, FILE_CONTENT);
 
         List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
         ServerFormDetails form = getForm(serverFormDetails, "form-2");
@@ -195,7 +196,7 @@ public class ServerFormsDetailsFetcherTest {
                 .build());
 
         File mediaFile = TempFiles.createTempFile(mediaDir, "blah", ".csv");
-        writeToFile(mediaFile, "blah");
+        writeToFile(mediaFile, FILE_CONTENT);
 
         List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
         ServerFormDetails form = getForm(serverFormDetails, "form-2");
@@ -216,7 +217,7 @@ public class ServerFormsDetailsFetcherTest {
                 .build());
 
         File localMediaFile = TempFiles.createTempFile(mediaDir, "blah", ".csv");
-        writeToFile(localMediaFile, "blah");
+        writeToFile(localMediaFile, FILE_CONTENT);
 
         List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
         assertThat(getForm(serverFormDetails, "form-2").isUpdated(), is(true));

--- a/shared/src/main/java/org/odk/collect/shared/TempFiles.kt
+++ b/shared/src/main/java/org/odk/collect/shared/TempFiles.kt
@@ -13,6 +13,14 @@ object TempFiles {
     }
 
     @JvmStatic
+    fun createTempFile(parent: File, name: String): File {
+        return File(parent, name).also {
+            it.createNewFile()
+            it.deleteOnExit()
+        }
+    }
+
+    @JvmStatic
     fun createTempFile(parent: File, name: String, extension: String): File {
         return File(parent, name + extension).also {
             it.createNewFile()


### PR DESCRIPTION
Closes #4882

#### What has been done to verify that this works as intended?
I have reproduced the issue and confirmed that this fix works well. I Have also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that if we had multiple forms with the same id but different versions during comparing media files we would get media files from the first one from the list which in our case usually would be the oldest one and not the one with the version and id we are looking for https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-4882?expand=1#diff-d241c237e50a73d5233d52f1d174193cc3692fe2aa977b654ac5e02ff39f13d7L83

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that the issue no longer exists and the message about outdated forms is really displayed when it should be. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with media files.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
