### PR TITLE
Remove mention of admin settings

### DIFF
--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1015,7 +1015,7 @@
     <string name="generate">Generate</string>
     <string name="invalid_qrcode">QR code does not contain valid settings</string>
     <string name="qr_code_not_found">QR Code not found in the selected image</string>
-    <string name="corrupt_imported_preferences_error">Current settings are corrupt. From the admin settings, reset settings or import working ones.</string>
+    <string name="corrupt_imported_preferences_error">Current settings are corrupt. From project management settings, reset settings or import working ones.</string>
 
     <!--
      ##############################################
@@ -1098,7 +1098,7 @@
     <string name="configure_with_qr_code">Configure with QR code</string>
     <!-- Text for the button that allows for manually entering project details. Should be short -->
     <string name="configure_manually">Manually enter project details</string>
-    <string name="project_config_tip">After you add your project, you can configure it in General and Admin Settings</string>
+    <string name="project_config_tip">After you add your project, you can configure it in Settings</string>
     <!-- Immediately followed by "Configure" which is a link to configure a Google Drive project -->
     <string name="gdrive_project">My project uses Google Drive.</string>
     <!-- Preceded by "My project uses Google Drive." Tapping opens a dialog to configure a Google Drive Project -->


### PR DESCRIPTION
The project config tip text is very visible so I think it's worth changing. I had hoped to change it at the beginning of the release cycle but forgot. I can go through translations before I download them and update them where I can. I think it will be a clear change in most languages.

The other string is not common so I think it's fine to change without translations. At the beginning of the next release cycle, we should replace the few strings that still use "General settings" (#4892).