### PR TITLE
Fixes #4480 Text added in angle brackets …

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListAdapter.java
@@ -16,13 +16,15 @@
 
 package org.odk.collect.android.adapters;
 
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
+import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.logic.HierarchyElement;
@@ -48,17 +50,24 @@ public class HierarchyListAdapter extends RecyclerView.Adapter<HierarchyListAdap
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        holder.bind(hierarchyElements.get(position), listener);
-        if (hierarchyElements.get(position).getIcon() != null) {
+        HierarchyElement element = hierarchyElements.get(position);
+        holder.bind(element, listener);
+        Drawable icon = element.getIcon();
+        if (icon != null) {
             holder.icon.setVisibility(View.VISIBLE);
-            holder.icon.setImageDrawable(hierarchyElements.get(position).getIcon());
+            holder.icon.setImageDrawable(icon);
         } else {
             holder.icon.setVisibility(View.GONE);
         }
-        holder.primaryText.setText(HtmlUtils.textToHtml(hierarchyElements.get(position).getPrimaryText()));
-        if (hierarchyElements.get(position).getSecondaryText() != null && !hierarchyElements.get(position).getSecondaryText().isEmpty()) {
+        holder.primaryText.setText(HtmlUtils.textToHtml(element.getPrimaryText()));
+        String secondaryText = element.getSecondaryText();
+        if (secondaryText != null && !secondaryText.isEmpty()) {
             holder.secondaryText.setVisibility(View.VISIBLE);
-            holder.secondaryText.setText(HtmlUtils.textToHtml(hierarchyElements.get(position).getSecondaryText()));
+            //For #4480
+            holder.secondaryText.setText(
+                    element.getType() == HierarchyElement.Type.QUESTION
+                            ? secondaryText
+                            : HtmlUtils.textToHtml(secondaryText));
         } else {
             holder.secondaryText.setVisibility(View.GONE);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListAdapter.java
@@ -16,19 +16,12 @@
 
 package org.odk.collect.android.adapters;
 
-import android.graphics.drawable.Drawable;
-import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.odk.collect.android.R;
 import org.odk.collect.android.logic.HierarchyElement;
-import org.odk.collect.android.utilities.HtmlUtils;
 
 import java.util.List;
 
@@ -45,32 +38,13 @@ public class HierarchyListAdapter extends RecyclerView.Adapter<HierarchyListAdap
 
     @Override
     public HierarchyListAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new ViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.hierarchy_element, parent, false));
+        return new ViewHolder(new HierarchyListItemView(parent.getContext()));
     }
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         HierarchyElement element = hierarchyElements.get(position);
         holder.bind(element, listener);
-        Drawable icon = element.getIcon();
-        if (icon != null) {
-            holder.icon.setVisibility(View.VISIBLE);
-            holder.icon.setImageDrawable(icon);
-        } else {
-            holder.icon.setVisibility(View.GONE);
-        }
-        holder.primaryText.setText(HtmlUtils.textToHtml(element.getPrimaryText()));
-        String secondaryText = element.getSecondaryText();
-        if (secondaryText != null && !secondaryText.isEmpty()) {
-            holder.secondaryText.setVisibility(View.VISIBLE);
-            //For #4480
-            holder.secondaryText.setText(
-                    element.getType() == HierarchyElement.Type.QUESTION
-                            ? secondaryText
-                            : HtmlUtils.textToHtml(secondaryText));
-        } else {
-            holder.secondaryText.setVisibility(View.GONE);
-        }
     }
 
     @Override
@@ -79,19 +53,17 @@ public class HierarchyListAdapter extends RecyclerView.Adapter<HierarchyListAdap
     }
 
     static class ViewHolder extends RecyclerView.ViewHolder {
-        ImageView icon;
-        TextView primaryText;
-        TextView secondaryText;
 
-        ViewHolder(View v) {
+        private final HierarchyListItemView view;
+
+        ViewHolder(HierarchyListItemView v) {
             super(v);
-            icon = v.findViewById(R.id.icon);
-            primaryText = v.findViewById(R.id.primary_text);
-            secondaryText = v.findViewById(R.id.secondary_text);
+            this.view = v;
         }
 
-        void bind(final HierarchyElement element, final OnElementClickListener listener) {
-            itemView.setOnClickListener(v -> listener.onElementClick(element));
+        public void bind(final HierarchyElement element, final OnElementClickListener listener) {
+            view.setElement(element);
+            view.setOnClickListener(v -> listener.onElementClick(element));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListItemView.kt
@@ -1,0 +1,37 @@
+package org.odk.collect.android.adapters
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import org.odk.collect.android.databinding.HierarchyElementBinding
+import org.odk.collect.android.logic.HierarchyElement
+import org.odk.collect.android.utilities.HtmlUtils
+
+class HierarchyListItemView(context: Context) : FrameLayout(context) {
+
+    private val binding = HierarchyElementBinding.inflate(LayoutInflater.from(context), this, true)
+
+    fun setElement(element: HierarchyElement) {
+        val icon = element.icon
+        if (icon != null) {
+            binding.icon.visibility = VISIBLE
+            binding.icon.setImageDrawable(icon)
+        } else {
+            binding.icon.visibility = GONE
+        }
+
+        binding.primaryText.text = HtmlUtils.textToHtml(element.primaryText)
+
+        val secondaryText = element.secondaryText
+        if (secondaryText != null && secondaryText.isNotEmpty()) {
+            binding.secondaryText.visibility = VISIBLE
+            binding.secondaryText.text = if (element.type == HierarchyElement.Type.QUESTION) {
+                secondaryText
+            } else HtmlUtils.textToHtml(
+                secondaryText
+            )
+        } else {
+            binding.secondaryText.visibility = GONE
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListItemView.kt
@@ -9,7 +9,7 @@ import org.odk.collect.android.utilities.HtmlUtils
 
 class HierarchyListItemView(context: Context) : FrameLayout(context) {
 
-    private val binding = HierarchyElementBinding.inflate(LayoutInflater.from(context), this, true)
+    val binding = HierarchyElementBinding.inflate(LayoutInflater.from(context), this, true)
 
     fun setElement(element: HierarchyElement) {
         val icon = element.icon
@@ -25,11 +25,7 @@ class HierarchyListItemView(context: Context) : FrameLayout(context) {
         val secondaryText = element.secondaryText
         if (secondaryText != null && secondaryText.isNotEmpty()) {
             binding.secondaryText.visibility = VISIBLE
-            binding.secondaryText.text = if (element.type == HierarchyElement.Type.QUESTION) {
-                secondaryText
-            } else HtmlUtils.textToHtml(
-                secondaryText
-            )
+            binding.secondaryText.text = secondaryText
         } else {
             binding.secondaryText.visibility = GONE
         }

--- a/collect_app/src/main/res/layout/hierarchy_element.xml
+++ b/collect_app/src/main/res/layout/hierarchy_element.xml
@@ -24,14 +24,14 @@ limitations under the License.
 
     <TextView
         android:id="@+id/primary_text"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="@style/TextAppearance.AppCompat.Large"
         android:layout_toEndOf="@id/icon" />
 
     <TextView
         android:id="@+id/secondary_text"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/primary_text"
         android:layout_toEndOf="@id/icon"

--- a/collect_app/src/test/java/org/odk/collect/android/adapters/HierarchyListItemViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/adapters/HierarchyListItemViewTest.kt
@@ -1,6 +1,9 @@
 package org.odk.collect.android.adapters
 
 import android.app.Application
+import android.graphics.drawable.Drawable
+import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
@@ -8,6 +11,7 @@ import org.hamcrest.Matchers.`is`
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.odk.collect.android.R
 import org.odk.collect.android.logic.HierarchyElement
 
 @RunWith(AndroidJUnit4::class)
@@ -16,10 +20,76 @@ class HierarchyListItemViewTest {
     private val context = ApplicationProvider.getApplicationContext<Application>()
 
     @Test
-    fun whenSecondaryTextIsHtml_displaysAsIs() {
+    fun `When icon is not specified should be gone`() {
         val view = HierarchyListItemView(context)
 
-        view.setElement(HierarchyElement("Blah", "<h1></h1>", null, HierarchyElement.Type.QUESTION, mock()))
-        assertThat(view.binding.secondaryText.text, `is`("<h1></h1>"))
+        view.setElement(getHierarchyElement(null, "", ""))
+
+        assertThat(view.binding.icon.visibility, `is`(View.GONE))
     }
+
+    @Test
+    fun `When icon is specified should be visible`() {
+        val view = HierarchyListItemView(context)
+
+        val icon = ContextCompat.getDrawable(context, R.drawable.ic_folder_open)
+        view.setElement(getHierarchyElement(icon, "", ""))
+
+        assertThat(view.binding.icon.drawable, `is`(icon))
+        assertThat(view.binding.icon.visibility, `is`(View.VISIBLE))
+    }
+
+    @Test
+    fun `Primary text should be visible`() {
+        val view = HierarchyListItemView(context)
+
+        view.setElement(getHierarchyElement(null, "Primary text", ""))
+
+        assertThat(view.binding.primaryText.visibility, `is`(View.VISIBLE))
+        assertThat(view.binding.primaryText.text.toString(), `is`("Primary text"))
+    }
+
+    @Test
+    fun `When primary text is html should be styled`() {
+        val view = HierarchyListItemView(context)
+
+        view.setElement(getHierarchyElement(null, "<h1>Primary text</h1>", ""))
+
+        assertThat(view.binding.primaryText.text.toString(), `is`("Primary text"))
+    }
+
+    @Test
+    fun `When secondary text is not specified should be gone`() {
+        val view = HierarchyListItemView(context)
+
+        // Empty value
+        view.setElement(getHierarchyElement(null, "", ""))
+        assertThat(view.binding.secondaryText.visibility, `is`(View.GONE))
+
+        // Null value
+        view.setElement(getHierarchyElement(null, "", null))
+        assertThat(view.binding.secondaryText.visibility, `is`(View.GONE))
+    }
+
+    @Test
+    fun `When secondary text is specified should be visible`() {
+        val view = HierarchyListItemView(context)
+
+        view.setElement(getHierarchyElement(null, "", "Secondary text"))
+
+        assertThat(view.binding.secondaryText.visibility, `is`(View.VISIBLE))
+        assertThat(view.binding.secondaryText.text.toString(), `is`("Secondary text"))
+    }
+
+    @Test
+    fun `When secondary text is html displays as is`() {
+        val view = HierarchyListItemView(context)
+
+        view.setElement(getHierarchyElement(null, "", "<h1>Secondary text</h1>"))
+
+        assertThat(view.binding.secondaryText.text.toString(), `is`("<h1>Secondary text</h1>"))
+    }
+
+    private fun getHierarchyElement(icon: Drawable?, primaryText: String, secondaryText: String?) =
+        HierarchyElement(primaryText, secondaryText, icon, HierarchyElement.Type.QUESTION, mock())
 }

--- a/collect_app/src/test/java/org/odk/collect/android/adapters/HierarchyListItemViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/adapters/HierarchyListItemViewTest.kt
@@ -1,0 +1,25 @@
+package org.odk.collect.android.adapters
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.odk.collect.android.logic.HierarchyElement
+
+@RunWith(AndroidJUnit4::class)
+class HierarchyListItemViewTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun whenSecondaryTextIsHtml_displaysAsIs() {
+        val view = HierarchyListItemView(context)
+
+        view.setElement(HierarchyElement("Blah", "<h1></h1>", null, HierarchyElement.Type.QUESTION, mock()))
+        assertThat(view.binding.secondaryText.text, `is`("<h1></h1>"))
+    }
+}


### PR DESCRIPTION
Resolves #4480

#### What has been done to verify that this works as intended?
Tested manually using [text4480.xlsx](https://github.com/getodk/collect/files/7486160/text4480.xlsx)

#### Why is this the best possible solution? Were any other approaches considered?
As described in [the docs](https://docs.getodk.org/form-styling/?highlight=markdown#inline-html), Collect supports inline HTML in label text. 

So in `HierarchyListAdapter`, `onBindViewHolder` currently treats _any_ `secondaryText` of `HierarchyElement` as HTML, including what in fact is answer text. 

Thus in the test form answers, text within <> 
- if arbitrary as in _test1_ is discarded 
- if defining valid markup as in _test2_ is rendered as such

The fix is easy - when the `Type` of the element is `QUESTION`, render `secondaryText` as is. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Bug as described in issue has been removed. Only possible regression would be in tests that depend on rendering of answers. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Developed and tested with [text4480.xlsx](https://github.com/getodk/collect/files/7486160/text4480.xlsx) which defines defaults that reproduce the issue. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No?

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)

