### PR TITLE
Fixed detecting form updates

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -123,7 +123,8 @@ public class ServerFormsDetailsFetcher {
         }
 
         String hash = getMd5HashWithoutPrefix(formListItem.getHashWithPrefix());
-        return formsRepository.getOneByMd5Hash(hash) == null;
+        Form form = formsRepository.getOneByMd5Hash(hash);
+        return form == null || form.isDeleted();
     }
 
     private boolean areNewerMediaFilesAvailable(Form existingForm, List<MediaFile> newMediaFiles) {


### PR DESCRIPTION
Closes #4895

#### What has been done to verify that this works as intended?
I added automated tests and verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The bug was in this line https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-4895?expand=1#diff-d241c237e50a73d5233d52f1d174193cc3692fe2aa977b654ac5e02ff39f13d7L126

we took all forms from database by hash but we should skip those soft deleted.

So when we had two versions of the same form and the newest one was soft deleted (deleted but still present in our database because there are instances of that form) `getOneByMd5Hash` would return that deleted form and it would be treated as a form we already have.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue and have no side effects so please focus on the reproduction steps. If you have some other ideas (and time) it would be of course good to play with form updates to make sure we don't have more hidden bugs. 

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with media files like the one I attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
