### PR TITLE
Guard against NPE when cancelling input events

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1329,7 +1329,10 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     private boolean moveScreen(Direction direction) {
-        currentView.cancelPendingInputEvents();
+        if (currentView != null) {
+            currentView.cancelPendingInputEvents();
+        }
+
         closeContextMenu();
         FormController formController = getFormController();
         if (formController == null) {


### PR DESCRIPTION
Related to #4896

This should prevent the crashes we're seeing, but leaves in what we **think** is the root cause - swiping is possible when there is no "current" view in form entry.

#### What has been done to verify that this works as intended?

No way to reproduce yet so just ran tests.

#### Why is this the best possible solution? Were any other approaches considered?

It would be nice to go with something like what's described in #4896, but I think we should prevent the crash people are seeing now and then follow up with a more general fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should hopefully just fix the crash. Good to give form entry a quick whirl to check, especially form loading and trying to swipe while the form is loading.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
