### PR TITLE
Throw clearer exception when storage isn't available

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -250,7 +250,13 @@ public class AppDependencyModule {
 
     @Provides
     public StoragePathProvider providesStoragePathProvider(Context context, CurrentProjectProvider currentProjectProvider, ProjectsRepository projectsRepository) {
-        return new StoragePathProvider(currentProjectProvider, projectsRepository, context.getExternalFilesDir(null).getAbsolutePath());
+        File externalFilesDir = context.getExternalFilesDir(null);
+
+        if (externalFilesDir != null) {
+            return new StoragePathProvider(currentProjectProvider, projectsRepository, externalFilesDir.getAbsolutePath());
+        } else {
+            throw new IllegalStateException("Storage is not available!");
+        }
     }
 
     @Provides


### PR DESCRIPTION
Check for a `null` external files dir before trying to use it and throw an `IllegalArgumentException` early instead of ending up with a `NullPointerException`. This will hopefully make it clearer what's going on when we see the crash in Crashlytics.

#### What has been done to verify that this works as intended?

Ran tests to verify I hadn't broken anything.

#### Why is this the best possible solution? Were any other approaches considered?

You can see that a null check makes sense from the docs [here](https://developer.android.com/reference/android/content/Context#getExternalFilesDir(java.lang.String)). Apparently a `null` means that we can't access storage.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should look exactly the same for the user: the app will crash.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
