### PR TITLE
Add event to track number of default geopoint questions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -237,7 +237,12 @@ public final class AnalyticsEvents {
     public static final String ALLOW_MOCK_ACCURACY = "AllowMockAccuracy";
 
     /**
-     * Tracks how many forms include an accuracy threshold for `geopoint` questions
+     * Tracks how many forms include an accuracy threshold for the default `geopoint` question
      */
     public static final String ACCURACY_THRESHOLD = "AccuracyThreshold";
+
+    /**
+     * Tracks how many forms use default accuracy thresholds for the default `geopoint` question
+     */
+    public static final String ACCURACY_THRESHOLD_DEFAULT = "AccuracyThresholdDefault";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -28,6 +28,7 @@ import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.databinding.GeoWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
+import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.interfaces.GeoDataRequester;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.GeoWidgetUtils;
@@ -71,9 +72,7 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
         }
 
         GeoWidgetUtils.logAllowMockAccuracy(prompt);
-        if (prompt.getQuestion().getAdditionalAttribute(null, "accuracyThreshold") != null) {
-            AnalyticsUtils.logFormEvent(AnalyticsEvents.ACCURACY_THRESHOLD);
-        }
+        logAccuracyThresholdUse(prompt);
 
         return binding.getRoot();
     }
@@ -112,5 +111,16 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
         binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
         binding.simpleButton.setText(answerText == null || answerText.isEmpty() ? R.string.get_point : R.string.change_location);
         widgetValueChanged();
+    }
+
+    private void logAccuracyThresholdUse(FormEntryPrompt prompt) {
+        // Only default geopoint supports accuracy threshold
+        if (Appearances.getSanitizedAppearanceHint(prompt).isEmpty()) {
+            if (prompt.getQuestion().getAdditionalAttribute(null, "accuracyThreshold") != null) {
+                AnalyticsUtils.logFormEvent(AnalyticsEvents.ACCURACY_THRESHOLD);
+            } else {
+                AnalyticsUtils.logFormEvent(AnalyticsEvents.ACCURACY_THRESHOLD_DEFAULT);
+            }
+        }
     }
 }


### PR DESCRIPTION
We need this to be able to understand how common setting the accuracy threshold is.