### PR TITLE
Increase form update resilience and track analytics for badly behaved servers that don't provide form hashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.java
@@ -245,4 +245,9 @@ public final class AnalyticsEvents {
      * Tracks how many forms use default accuracy thresholds for the default `geopoint` question
      */
     public static final String ACCURACY_THRESHOLD_DEFAULT = "AccuracyThresholdDefault";
+
+    /**
+     * Tracks how often form details with null or empty hashes are provided by a server
+     */
+    public static final String NULL_OR_EMPTY_FORM_HASH = "NullOrEmptyFormHash";
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -16,6 +16,8 @@
 
 package org.odk.collect.android.formmanagement;
 
+import org.odk.collect.analytics.Analytics;
+import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.openrosa.OpenRosaFormSource;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormListItem;
@@ -75,7 +77,7 @@ public class ServerFormsDetailsFetcher {
             boolean isNewerFormVersionAvailable = false;
 
             if (!isHashValid(listItem.getHashWithPrefix())) {
-                // TODO maybe log this in analytics?
+                Analytics.log(AnalyticsEvents.NULL_OR_EMPTY_FORM_HASH);
             } else if (thisFormAlreadyDownloaded) {
                 Form form = getFormByHash(listItem.getHashWithPrefix());
                 if (form == null || form.isDeleted()) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -77,13 +77,14 @@ public class ServerFormsDetailsFetcher {
             if (!isHashValid(listItem.getHashWithPrefix())) {
                 // TODO maybe log this in analytics?
             } else if (thisFormAlreadyDownloaded) {
-                if (isNewerFormVersionAvailable(listItem.getHashWithPrefix())) {
+                Form form = getFormByHash(listItem.getHashWithPrefix());
+                if (form == null || form.isDeleted()) {
                     isNewerFormVersionAvailable = true;
                 } else if (manifestFile != null) {
                     List<MediaFile> newMediaFiles = manifestFile.getMediaFiles();
 
                     if (newMediaFiles != null && !newMediaFiles.isEmpty()) {
-                        isNewerFormVersionAvailable = areNewerMediaFilesAvailable(getFormByHash(listItem.getHashWithPrefix()), newMediaFiles);
+                        isNewerFormVersionAvailable = areNewerMediaFilesAvailable(form, newMediaFiles);
                     }
                 }
             }
@@ -115,11 +116,6 @@ public class ServerFormsDetailsFetcher {
             Timber.w(formSourceException);
             return null;
         }
-    }
-
-    private boolean isNewerFormVersionAvailable(String hashWithPrefix) {
-        Form form = getFormByHash(hashWithPrefix);
-        return form == null || form.isDeleted();
     }
 
     private boolean areNewerMediaFilesAvailable(Form existingForm, List<MediaFile> newMediaFiles) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -83,7 +83,7 @@ public class ServerFormsDetailsFetcher {
                 } else if (manifestFile != null) {
                     List<MediaFile> newMediaFiles = manifestFile.getMediaFiles();
 
-                    if (newMediaFiles != null && !newMediaFiles.isEmpty()) {
+                    if (!newMediaFiles.isEmpty()) {
                         isNewerFormVersionAvailable = areNewerMediaFilesAvailable(form, newMediaFiles);
                     }
                 }
@@ -121,14 +121,10 @@ public class ServerFormsDetailsFetcher {
     private boolean areNewerMediaFilesAvailable(Form existingForm, List<MediaFile> newMediaFiles) {
         List<File> localMediaFiles = FormUtils.getMediaFiles(existingForm);
 
-        if (localMediaFiles != null) {
-            for (MediaFile newMediaFile : newMediaFiles) {
-                if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
-                    return true;
-                }
+        for (MediaFile newMediaFile : newMediaFiles) {
+            if (!isMediaFileAlreadyDownloaded(localMediaFiles, newMediaFile)) {
+                return true;
             }
-        } else if (!newMediaFiles.isEmpty()) {
-            return true;
         }
 
         return false;

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -121,7 +121,7 @@ public class ServerFormsDetailsFetcher {
     }
 
     private boolean isNewerFormVersionAvailable(String hashWithPrefix) {
-        String hash = getMd5HashWithoutPrefix(hashWithPrefix);
+        String hash = hashWithPrefix.substring("md5:".length());
         Form form = formsRepository.getOneByMd5Hash(hash);
         return form == null || form.isDeleted();
     }
@@ -156,10 +156,6 @@ public class ServerFormsDetailsFetcher {
             }
         }
         return false;
-    }
-
-    private String getMd5HashWithoutPrefix(String hash) {
-        return hash == null || hash.isEmpty() ? null : hash.substring("md5:".length());
     }
 
     private Form getFormByVersion(List<Form> forms, @Nullable String expectedVersion) {

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -118,8 +118,7 @@ public class ServerFormsDetailsFetcher {
     }
 
     private boolean isNewerFormVersionAvailable(String hashWithPrefix) {
-        String hash = hashWithPrefix.substring("md5:".length());
-        Form form = formsRepository.getOneByMd5Hash(hash);
+        Form form = getFormByHash(hashWithPrefix);
         return form == null || form.isDeleted();
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -76,7 +76,10 @@ public class ServerFormsDetailsFetcher {
             boolean thisFormAlreadyDownloaded = !forms.isEmpty();
 
             boolean isNewerFormVersionAvailable = false;
-            if (thisFormAlreadyDownloaded) {
+
+            if (!isHashValid(listItem.getHashWithPrefix())) {
+                // TODO maybe log this in analytics?
+            } else if (thisFormAlreadyDownloaded) {
                 if (isNewerFormVersionAvailable(listItem)) {
                     isNewerFormVersionAvailable = true;
                 } else if (manifestFile != null) {
@@ -170,5 +173,9 @@ public class ServerFormsDetailsFetcher {
             }
         }
         return null;
+    }
+
+    private boolean isHashValid(String hash) {
+        return hash != null && hash.startsWith("md5:");
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -80,7 +80,7 @@ public class ServerFormsDetailsFetcher {
             if (!isHashValid(listItem.getHashWithPrefix())) {
                 // TODO maybe log this in analytics?
             } else if (thisFormAlreadyDownloaded) {
-                if (isNewerFormVersionAvailable(listItem)) {
+                if (isNewerFormVersionAvailable(listItem.getHashWithPrefix())) {
                     isNewerFormVersionAvailable = true;
                 } else if (manifestFile != null) {
                     List<MediaFile> newMediaFiles = manifestFile.getMediaFiles();
@@ -120,12 +120,8 @@ public class ServerFormsDetailsFetcher {
         }
     }
 
-    private boolean isNewerFormVersionAvailable(FormListItem formListItem) {
-        if (formListItem.getHashWithPrefix() == null) {
-            return false;
-        }
-
-        String hash = getMd5HashWithoutPrefix(formListItem.getHashWithPrefix());
+    private boolean isNewerFormVersionAvailable(String hashWithPrefix) {
+        String hash = getMd5HashWithoutPrefix(hashWithPrefix);
         Form form = formsRepository.getOneByMd5Hash(hash);
         return form == null || form.isDeleted();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcher.java
@@ -31,9 +31,6 @@ import org.odk.collect.shared.strings.Md5;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
-import javax.annotation.Nullable;
 
 import timber.log.Timber;
 
@@ -86,7 +83,7 @@ public class ServerFormsDetailsFetcher {
                     List<MediaFile> newMediaFiles = manifestFile.getMediaFiles();
 
                     if (newMediaFiles != null && !newMediaFiles.isEmpty()) {
-                        isNewerFormVersionAvailable = areNewerMediaFilesAvailable(getFormByVersion(forms, listItem.getVersion()), newMediaFiles);
+                        isNewerFormVersionAvailable = areNewerMediaFilesAvailable(getFormByHash(listItem.getHashWithPrefix()), newMediaFiles);
                     }
                 }
             }
@@ -158,13 +155,9 @@ public class ServerFormsDetailsFetcher {
         return false;
     }
 
-    private Form getFormByVersion(List<Form> forms, @Nullable String expectedVersion) {
-        for (Form form : forms) {
-            if (Objects.equals(form.getVersion(), expectedVersion)) {
-                return form;
-            }
-        }
-        return null;
+    private Form getFormByHash(String hashWithPrefix) {
+        String hash = hashWithPrefix.substring("md5:".length());
+        return formsRepository.getOneByMd5Hash(hash);
     }
 
     private boolean isHashValid(String hash) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
@@ -1,5 +1,7 @@
 package org.odk.collect.android.utilities;
 
+import androidx.annotation.NonNull;
+
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.RootTranslator;
 import org.odk.collect.android.logic.FileReferenceFactory;
@@ -16,6 +18,7 @@ public final class FormUtils {
 
     }
 
+    @NonNull
     public static List<File> getMediaFiles(Form form) {
         String formMediaPath = form.getFormMediaPath();
         return formMediaPath == null

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormUtils.java
@@ -19,7 +19,7 @@ public final class FormUtils {
     }
 
     @NonNull
-    public static List<File> getMediaFiles(Form form) {
+    public static List<File> getMediaFiles(@NonNull Form form) {
         String formMediaPath = form.getFormMediaPath();
         return formMediaPath == null
                 ? new ArrayList<>()

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsUpdaterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsUpdaterTest.kt
@@ -163,7 +163,7 @@ class FormsUpdaterTest {
                     "http://$formId",
                     formId,
                     formVersion,
-                    getMd5Hash(updatedXForm),
+                    "md5:${getMd5Hash(updatedXForm)}",
                     "blah",
                     null
                 )

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
@@ -33,7 +33,8 @@ public class ServerFormsDetailsFetcherTest {
 
     private final List<FormListItem> formList = asList(
             new FormListItem("http://example.com/form-1", "form-1", "1", "md5:form-1-hash", "Form 1", null),
-            new FormListItem("http://example.com/form-2", "form-2", "2", "md5:form-2-hash", "Form 2", "http://example.com/form-2-manifest")
+            new FormListItem("http://example.com/form-2", "form-2", "2", "md5:form-2-hash", "Form 2", "http://example.com/form-2-manifest"),
+            new FormListItem("http://example.com/form-3", "form-3", "1", null, "Form 1", "http://example.com/form-3-manifest")
     );
 
     private static final String FILE_CONTENT = "blah";
@@ -50,6 +51,10 @@ public class ServerFormsDetailsFetcherTest {
         when(formSource.fetchFormList()).thenReturn(formList);
 
         when(formSource.fetchManifest(formList.get(1).getManifestURL())).thenReturn(new ManifestFile("manifest-2-hash", asList(
+                mediaFile))
+        );
+
+        when(formSource.fetchManifest(formList.get(2).getManifestURL())).thenReturn(new ManifestFile("manifest-3-hash", asList(
                 mediaFile))
         );
 
@@ -162,6 +167,22 @@ public class ServerFormsDetailsFetcherTest {
 
         List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
         ServerFormDetails form = getForm(serverFormDetails, "form-2");
+
+        assertThat(form.isUpdated(), is(false));
+        assertThat(form.isNotOnDevice(), is(false));
+    }
+
+    @Test
+    public void whenAFormExists_andItsNewerVersionIsAvailableButHasNullHash_isNotNewOrUpdated() throws Exception {
+        formsRepository.save(new Form.Builder()
+                .formId("form-3")
+                .version("0")
+                .md5Hash("form-3-hash")
+                .formFilePath(FormUtils.createXFormFile("form-3", "1").getAbsolutePath())
+                .build());
+
+        List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
+        ServerFormDetails form = getForm(serverFormDetails, "form-3");
 
         assertThat(form.isUpdated(), is(false));
         assertThat(form.isNotOnDevice(), is(false));

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormsDetailsFetcherTest.java
@@ -34,7 +34,8 @@ public class ServerFormsDetailsFetcherTest {
     private final List<FormListItem> formList = asList(
             new FormListItem("http://example.com/form-1", "form-1", "1", "md5:form-1-hash", "Form 1", null),
             new FormListItem("http://example.com/form-2", "form-2", "2", "md5:form-2-hash", "Form 2", "http://example.com/form-2-manifest"),
-            new FormListItem("http://example.com/form-3", "form-3", "1", null, "Form 1", "http://example.com/form-3-manifest")
+            new FormListItem("http://example.com/form-3", "form-3", "1", null, "Form 1", "http://example.com/form-3-manifest"),
+            new FormListItem("http://example.com/form-4", "form-4", "1", "form-4-hash", "Form 4", null)
     );
 
     private static final String FILE_CONTENT = "blah";
@@ -167,6 +168,22 @@ public class ServerFormsDetailsFetcherTest {
 
         List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
         ServerFormDetails form = getForm(serverFormDetails, "form-2");
+
+        assertThat(form.isUpdated(), is(false));
+        assertThat(form.isNotOnDevice(), is(false));
+    }
+
+    @Test
+    public void whenAFormExists_andItsNewerVersionIsAvailableButHasHashWithoutPrefix_isNotNewOrUpdated() throws Exception {
+        formsRepository.save(new Form.Builder()
+                .formId("form-4")
+                .version("0")
+                .md5Hash("form-4-hash_v0")
+                .formFilePath(FormUtils.createXFormFile("form-4", "1").getAbsolutePath())
+                .build());
+
+        List<ServerFormDetails> serverFormDetails = fetcher.fetchFormDetails();
+        ServerFormDetails form = getForm(serverFormDetails, "form-4");
 
         assertThat(form.isUpdated(), is(false));
         assertThat(form.isNotOnDevice(), is(false));


### PR DESCRIPTION
Closes #4895

#### What has been done to verify that this works as intended?
I added automated tests and reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
The problem seems to be on a server side so this just makes the code more resistant to wrong data provided by servers.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This does not require testing since reproducing the bug is difficult.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
