### PR TITLE
Use MaterialAlertDialogBuilder instead of AlertDialog.Builder across the app

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/ColorPickerDialog.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/ColorPickerDialog.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.androidshared.databinding.ColorPickerDialogLayoutBinding
 import java.lang.Exception
 
@@ -36,7 +37,7 @@ class ColorPickerDialog : DialogFragment() {
         setListeners()
         setCurrentColor(requireArguments().getString(CURRENT_COLOR)!!)
 
-        return AlertDialog.Builder(requireContext())
+        return MaterialAlertDialogBuilder(requireContext())
             .setView(binding.root)
             .setTitle(R.string.project_color)
             .setNegativeButton(R.string.cancel) { _, _ -> dismiss() }

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -281,7 +281,7 @@ the specific language governing permissions and limitations under the License.
         <activity
             android:name=".external.AndroidShortcutsActivity"
             android:label="ODK Form"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+            android:theme="@style/Theme.MaterialComponents.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/DrawActivity.java
@@ -21,6 +21,8 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.net.Uri;
 import android.os.Bundle;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import androidx.appcompat.app.AlertDialog;
 import androidx.cardview.widget.CardView;
@@ -309,7 +311,7 @@ public class DrawActivity extends CollectAbstractActivity {
                 alertDialog.dismiss();
             }
         });
-        alertDialog = new AlertDialog.Builder(this)
+        alertDialog = new MaterialAlertDialogBuilder(this)
                 .setTitle(alertTitleString)
                 .setPositiveButton(getString(R.string.do_not_exit), null)
                 .setView(listView).create();
@@ -339,7 +341,7 @@ public class DrawActivity extends CollectAbstractActivity {
             picker.showAlpha(false);
             picker.showHex(false);
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(this);
             builder
                     .setView(picker)
                     .setPositiveButton(R.string.ok, (dialog, which) -> drawView.setColor(picker.getColor()))

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -32,6 +32,8 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.FormDownloadListViewModel;
@@ -587,7 +589,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
      * activity will exit when the user clicks "ok".
      */
     private void createAlertDialog(String title, String message, final boolean shouldExit) {
-        alertDialog = new AlertDialog.Builder(this).create();
+        alertDialog = new MaterialAlertDialogBuilder(this).create();
         alertDialog.setTitle(title);
         alertDialog.setMessage(message);
         DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -70,6 +70,8 @@ import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelProviders;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
@@ -1672,7 +1674,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             errorMsg = errorMessage + "\n\n" + errorMsg;
             errorMessage = errorMsg;
         } else {
-            alertDialog = new AlertDialog.Builder(this).create();
+            alertDialog = new MaterialAlertDialogBuilder(this).create();
             errorMessage = errorMsg;
         }
 
@@ -1815,7 +1817,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
      * Confirm clear answer dialog
      */
     private void createClearDialog(final QuestionWidget qw) {
-        alertDialog = new AlertDialog.Builder(this).create();
+        alertDialog = new MaterialAlertDialogBuilder(this).create();
         alertDialog.setTitle(getString(R.string.clear_answer_ask));
 
         String question = qw.getFormEntryPrompt().getLongText();
@@ -1865,7 +1867,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
             }
         }
-        alertDialog = new AlertDialog.Builder(this)
+        alertDialog = new MaterialAlertDialogBuilder(this)
                 .setSingleChoiceItems(languages, selected,
                         (dialog, whichButton) -> {
                             Form form = formsRepository.getOneByPath(formPath);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -32,6 +32,8 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.GroupDef;
 import org.javarosa.core.model.IFormElement;
@@ -781,7 +783,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
      * Creates and displays dialog with the given errorMsg.
      */
     protected void createErrorDialog(String errorMsg) {
-        AlertDialog alertDialog = new AlertDialog.Builder(this).create();
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(this).create();
 
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertDialog.setTitle(getString(R.string.error_occured));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -29,6 +29,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
 import org.odk.collect.android.dao.CursorLoaderFactory;
@@ -187,7 +189,7 @@ public class InstanceChooserList extends InstanceListActivity implements Adapter
     }
 
     private void createErrorDialog(String errorMsg, final boolean shouldExit) {
-        AlertDialog alertDialog = new AlertDialog.Builder(this).create();
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(this).create();
         alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertDialog.setMessage(errorMsg);
         DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -59,6 +59,8 @@ import timber.log.Timber;
 
 import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_PROTOCOL;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 /**
  * Responsible for displaying all the valid forms in the forms directory. Stores
  * the path to selected form for use by {@link MainMenuActivity}.
@@ -347,7 +349,7 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
         String[] items = {getString(R.string.show_unsent_forms),
                 getString(R.string.show_sent_and_unsent_forms)};
 
-        AlertDialog alertDialog = new AlertDialog.Builder(this)
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(this)
                 .setIcon(android.R.drawable.ic_dialog_info)
                 .setTitle(getString(R.string.change_view))
                 .setNeutralButton(getString(R.string.cancel), (dialog, id) -> {

--- a/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingErrorDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/AudioRecordingErrorDialogFragment.java
@@ -7,8 +7,9 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -36,7 +37,7 @@ public class AudioRecordingErrorDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(requireContext())
+        MaterialAlertDialogBuilder dialogBuilder = new MaterialAlertDialogBuilder(requireContext())
                 .setPositiveButton(R.string.ok, null);
 
         if (exception != null && exception.getValue() instanceof MicInUseException) {

--- a/collect_app/src/main/java/org/odk/collect/android/audio/BackgroundAudioHelpDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/audio/BackgroundAudioHelpDialogFragment.java
@@ -7,8 +7,9 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -19,7 +20,7 @@ public class BackgroundAudioHelpDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         LayoutInflater inflater = LayoutInflater.from(requireContext());
         View view = inflater.inflate(R.layout.background_audio_help_fragment_layout, null);
-        return new AlertDialog.Builder(requireContext())
+        return new MaterialAlertDialogBuilder(requireContext())
                 .setView(view)
                 .setPositiveButton(R.string.ok, null)
                 .create();

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/ShowQRCodeFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/ShowQRCodeFragment.java
@@ -41,6 +41,8 @@ import static android.view.View.VISIBLE;
 import static org.odk.collect.android.preferences.keys.ProtectedProjectKeys.KEY_ADMIN_PW;
 import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_PASSWORD;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 public class ShowQRCodeFragment extends Fragment {
     ShowQrcodeFragmentBinding binding;
 
@@ -112,7 +114,7 @@ public class ShowQRCodeFragment extends Fragment {
                     getString(R.string.admin_password),
                     getString(R.string.server_password)};
 
-            dialog = new AlertDialog.Builder(getActivity())
+            dialog = new MaterialAlertDialogBuilder(getActivity())
                     .setTitle(R.string.include_password_dialog)
                     .setMultiChoiceItems(items, checkedItems, (dialog, which, isChecked) -> checkedItems[which] = isChecked)
                     .setCancelable(false)

--- a/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.java
@@ -18,9 +18,10 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
@@ -60,7 +61,7 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
     }
 
     private void showFormListDialog(List<BlankForm> forms) {
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.select_odk_shortcut)
                 .setItems(forms.stream().map(BlankForm::getName).toArray(String[]::new), (dialog, item) -> {
                     AnalyticsUtils.logServerEvent(AnalyticsEvents.CREATE_SHORTCUT, settingsProvider.getUnprotectedSettings());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
@@ -7,10 +7,11 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -43,7 +44,7 @@ public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
         setCancelable(false);
 
         final FragmentActivity activity = requireActivity();
-        return new AlertDialog.Builder(requireContext())
+        return new MaterialAlertDialogBuilder(requireContext())
                 .setMessage(R.string.background_audio_permission_explanation)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     onOKClicked(activity);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryMenuDelegate.java
@@ -6,7 +6,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +25,8 @@ import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 
 import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_BACKGROUND_LOCATION;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormController {
 
@@ -147,14 +148,14 @@ public class FormEntryMenuDelegate implements MenuDelegate, RequiresFormControll
             boolean enabled = !item.isChecked();
 
             if (!enabled) {
-                new AlertDialog.Builder(activity)
+                new MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.stop_recording_confirmation)
                         .setPositiveButton(R.string.disable_recording, (dialog, which) -> backgroundAudioViewModel.setBackgroundRecordingEnabled(false))
                         .setNegativeButton(R.string.cancel, null)
                         .create()
                         .show();
             } else {
-                new AlertDialog.Builder(activity)
+                new MaterialAlertDialogBuilder(activity)
                         .setMessage(R.string.background_audio_recording_enabled_explanation)
                         .setCancelable(false)
                         .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
@@ -9,10 +9,10 @@ import android.widget.ListView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.common.collect.ImmutableList;
 
 import org.odk.collect.analytics.Analytics;
@@ -122,7 +122,7 @@ public class QuitFormDialogFragment extends DialogFragment {
             }
         });
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(getString(R.string.quit_application, title))
                 .setNegativeButton(getActivity().getString(R.string.do_not_exit), (dialog, id) -> {
                     dialog.cancel();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RecordingWarningDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RecordingWarningDialogFragment.java
@@ -5,8 +5,9 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -15,7 +16,7 @@ public class RecordingWarningDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        return new AlertDialog.Builder(requireActivity())
+        return new MaterialAlertDialogBuilder(requireActivity())
                 .setTitle(R.string.recording)
                 .setMessage(R.string.recording_warning)
                 .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/AddRepeatDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/AddRepeatDialog.java
@@ -10,12 +10,14 @@ import org.odk.collect.android.R;
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 public class AddRepeatDialog {
 
     private AddRepeatDialog() {}
 
     public static void show(Context context, String groupLabel, Listener listener) {
-        AlertDialog alertDialog = new AlertDialog.Builder(context).create();
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(context).create();
         DialogInterface.OnClickListener repeatListener = (dialog, i) -> {
             switch (i) {
                 case BUTTON_POSITIVE:

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/repeats/DeleteRepeatDialogFragment.java
@@ -18,6 +18,8 @@ import org.odk.collect.android.javarosawrapper.FormController;
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 import static android.content.DialogInterface.BUTTON_POSITIVE;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 public class DeleteRepeatDialogFragment extends DialogFragment {
 
     private DeleteRepeatDialogCallback callback;
@@ -43,7 +45,7 @@ public class DeleteRepeatDialogFragment extends DialogFragment {
             name += " (" + (repeatCount + 1) + ")";
         }
 
-        AlertDialog alertDialog = new AlertDialog.Builder(getActivity()).create();
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(getActivity()).create();
         alertDialog.setTitle(getActivity().getString(R.string.delete_repeat_ask));
         alertDialog.setMessage(getActivity().getString(R.string.delete_repeat_confirm, name));
         DialogInterface.OnClickListener quitListener = (dialog, i) -> {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/saving/SaveAnswerFileErrorDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/saving/SaveAnswerFileErrorDialogFragment.java
@@ -7,9 +7,10 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -34,7 +35,7 @@ public class SaveAnswerFileErrorDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        return new AlertDialog.Builder(requireContext())
+        return new MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.error_occured)
                 .setMessage(getString(R.string.answer_file_copy_failed_message, formSaveViewModel.getAnswerFileError().getValue()))
                 .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
@@ -25,6 +25,8 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.loader.content.CursorLoader;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.FormListAdapter;
 import org.odk.collect.android.dao.CursorLoaderFactory;
@@ -157,7 +159,7 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
      * Create the form delete dialog
      */
     private void createDeleteFormsDialog() {
-        alertDialog = new AlertDialog.Builder(getContext()).create();
+        alertDialog = new MaterialAlertDialogBuilder(getContext()).create();
         alertDialog.setTitle(getString(R.string.delete_file));
         alertDialog.setMessage(getString(R.string.delete_confirm,
                 String.valueOf(getCheckedCount())));

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
@@ -31,6 +31,8 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.InstanceListCursorAdapter;
@@ -144,7 +146,7 @@ public class SavedFormListFragment extends InstanceListFragment implements Delet
      * Create the instance delete dialog
      */
     private void createDeleteInstancesDialog() {
-        alertDialog = new AlertDialog.Builder(getContext()).create();
+        alertDialog = new MaterialAlertDialogBuilder(getContext()).create();
         alertDialog.setTitle(getString(R.string.delete_file));
         alertDialog.setMessage(getString(R.string.delete_confirm,
                 String.valueOf(getCheckedCount())));

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomDatePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomDatePickerDialog.java
@@ -23,9 +23,10 @@ import android.view.View;
 import android.widget.NumberPicker;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.joda.time.LocalDateTime;
 import org.odk.collect.android.R;
@@ -74,7 +75,7 @@ public abstract class CustomDatePickerDialog extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(R.string.select_date)
                 .setView(R.layout.custom_date_picker_dialog)
                 .setPositiveButton(R.string.ok, (dialog, id) -> {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ErrorDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ErrorDialog.java
@@ -1,11 +1,12 @@
 package org.odk.collect.android.fragments.dialogs;
 
 import android.app.Activity;
-import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 /*
 Copyright 2018 Theodoros Tyrovouzis
@@ -37,7 +38,7 @@ public class ErrorDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final Activity activity = getActivity();
-        return new AlertDialog.Builder(activity)
+        return new MaterialAlertDialogBuilder(activity)
                 .setMessage(getArguments().getString(ARG_MESSAGE))
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/LocationProvidersDisabledDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/LocationProvidersDisabledDialog.java
@@ -22,7 +22,8 @@ import android.os.Bundle;
 import android.provider.Settings;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
-import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -57,7 +58,7 @@ public class LocationProvidersDisabledDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         setCancelable(false);
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setIcon(R.drawable.ic_room_black_24dp)
                 .setTitle(R.string.provider_disabled_error)
                 .setMessage(R.string.location_providers_disabled_dialog_message)

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/MovingBackwardsDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/MovingBackwardsDialog.java
@@ -21,7 +21,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.fragment.app.DialogFragment;
-import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -47,7 +48,7 @@ public class MovingBackwardsDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         setCancelable(false);
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(R.string.moving_backwards_disabled_title)
                 .setMessage(R.string.moving_backwards_disabled_message)
                 .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/NumberPickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/NumberPickerDialog.java
@@ -16,7 +16,6 @@
 
 package org.odk.collect.android.fragments.dialogs;
 
-import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -25,6 +24,8 @@ import androidx.fragment.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.NumberPicker;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -73,7 +74,7 @@ public class NumberPickerDialog extends DialogFragment {
         numberPicker.setDisplayedValues((String[]) getArguments().getSerializable(DISPLAYED_VALUES));
         numberPicker.setValue(((String[]) getArguments().getSerializable(DISPLAYED_VALUES)).length - 1 - getArguments().getInt(PROGRESS));
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(R.string.number_picker_title)
                 .setView(view)
                 .setPositiveButton(R.string.ok,

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ProgressDialogFragment.java
@@ -17,6 +17,8 @@ import timber.log.Timber;
 
 import static android.content.DialogInterface.BUTTON_NEGATIVE;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 public class ProgressDialogFragment extends DialogFragment {
 
     public static final String COLLECT_PROGRESS_DIALOG_TAG = "collectProgressDialogTag";
@@ -80,7 +82,7 @@ public class ProgressDialogFragment extends DialogFragment {
         super.onCreateDialog(savedInstanceState);
 
         dialogView = requireActivity().getLayoutInflater().inflate(R.layout.progress_dialog, null, false);
-        AlertDialog dialog = new AlertDialog.Builder(requireContext())
+        AlertDialog dialog = new MaterialAlertDialogBuilder(requireContext())
                 .setView(dialogView)
                 .create();
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/RankingWidgetDialog.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.os.Bundle;
 import androidx.fragment.app.DialogFragment;
 import androidx.core.widget.NestedScrollView;
-import androidx.appcompat.app.AlertDialog.Builder;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -33,6 +32,8 @@ import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
@@ -80,7 +81,7 @@ public class RankingWidgetDialog extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        return new Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setView(setUpRankingLayout())
                 .setPositiveButton(string.ok, (dialog, id) -> {
                     listener.onRankingChanged(rankingListAdapter.getItems());

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ResetSettingsResultDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ResetSettingsResultDialog.java
@@ -16,12 +16,13 @@
 
 package org.odk.collect.android.fragments.dialogs;
 
-import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 
@@ -59,7 +60,7 @@ public class ResetSettingsResultDialog extends DialogFragment {
 
         String message = getArguments() != null ? getArguments().getString(MESSAGE) : "";
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(R.string.reset_app_state_result)
                 .setIcon(android.R.drawable.ic_dialog_info)
                 .setMessage(message)

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SimpleDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/SimpleDialog.java
@@ -16,12 +16,13 @@
 
 package org.odk.collect.android.fragments.dialogs;
 
-import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
 
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import timber.log.Timber;
 
@@ -73,7 +74,7 @@ public class SimpleDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         setCancelable(false);
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(getArguments().getString(DIALOG_TITLE))
                 .setIcon(getArguments().getInt(ICON_ID))
                 .setMessage(getArguments().getString(MESSAGE))

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleAccountNotSetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleAccountNotSetDialog.java
@@ -8,6 +8,8 @@ import org.odk.collect.android.R;
 
 import static org.odk.collect.android.utilities.DialogUtils.showDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 public final class GoogleAccountNotSetDialog {
 
     private GoogleAccountNotSetDialog() {
@@ -15,7 +17,7 @@ public final class GoogleAccountNotSetDialog {
     }
 
     public static void show(Activity activity) {
-        AlertDialog alertDialog = new AlertDialog.Builder(activity)
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(activity)
                 .setIcon(android.R.drawable.ic_dialog_info)
                 .setTitle(R.string.missing_google_account_dialog_title)
                 .setMessage(R.string.missing_google_account_dialog_desc)

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
@@ -36,6 +36,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException;
 import com.google.api.services.drive.Drive;
 
@@ -384,7 +385,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                 progressDialog.setButton(getString(R.string.cancel), loadingButtonListener);
                 return progressDialog;
             case GOOGLE_USER_DIALOG:
-                AlertDialog.Builder gudBuilder = new AlertDialog.Builder(this);
+                MaterialAlertDialogBuilder gudBuilder = new MaterialAlertDialogBuilder(this);
 
                 gudBuilder.setTitle(getString(R.string.no_google_account));
                 gudBuilder.setMessage(getString(R.string.google_set_account));
@@ -396,7 +397,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
     }
 
     private void createAlertDialog(String message) {
-        AlertDialog alertDialog = new AlertDialog.Builder(this).create();
+        AlertDialog alertDialog = new MaterialAlertDialogBuilder(this).create();
         alertDialog.setTitle(getString(R.string.download_forms_result));
         alertDialog.setMessage(message);
         DialogInterface.OnClickListener quitListener = new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
@@ -33,6 +33,7 @@ import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.gms.auth.GoogleAuthException;
 import com.google.android.gms.auth.UserRecoverableAuthException;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
@@ -280,7 +281,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
     @Override
     protected Dialog onCreateDialog(int id) {
         if (id == GOOGLE_USER_DIALOG) {
-            AlertDialog.Builder gudBuilder = new AlertDialog.Builder(this);
+            MaterialAlertDialogBuilder gudBuilder = new MaterialAlertDialogBuilder(this);
 
             gudBuilder.setTitle(getString(R.string.no_google_account));
             gudBuilder.setMessage(getString(R.string.google_set_account));
@@ -297,7 +298,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
     }
 
     private void createAlertDialog(String message) {
-        alertDialog = new AlertDialog.Builder(this).create();
+        alertDialog = new MaterialAlertDialogBuilder(this).create();
         alertDialog.setTitle(getString(R.string.upload_results));
         alertDialog.setMessage(message);
         DialogInterface.OnClickListener quitListener = (dialog, i) -> {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -25,7 +25,6 @@ import android.provider.Settings;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -47,6 +46,7 @@ import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
 import com.google.android.gms.maps.model.TileOverlay;
 import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -645,7 +645,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     private void showGpsDisabledAlert() {
-        new AlertDialog.Builder(getActivity())
+        new MaterialAlertDialogBuilder(getActivity())
             .setMessage(getString(R.string.gps_enable_message))
             .setCancelable(false)
             .setPositiveButton(getString(R.string.enable_gps),

--- a/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/OsmDroidMapFragment.java
@@ -32,13 +32,13 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.location.LocationListener;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -501,7 +501,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     }
 
     private void showGpsDisabledAlert() {
-        new AlertDialog.Builder(getContext())
+        new MaterialAlertDialogBuilder(getContext())
             .setMessage(getString(R.string.gps_enable_message))
             .setCancelable(false)
             .setPositiveButton(getString(R.string.enable_gps),

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/SplashClickListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/SplashClickListener.java
@@ -6,6 +6,8 @@ import androidx.preference.Preference;
 import android.content.DialogInterface;
 import android.content.Intent;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.preferences.screens.UserInterfacePreferencesFragment;
 
@@ -33,7 +35,7 @@ public class SplashClickListener implements Preference.OnPreferenceClickListener
             final CharSequence[] items = {preferencesFragment.getString(R.string.select_another_image),
                     preferencesFragment.getString(R.string.use_odk_default)};
 
-            AlertDialog.Builder builder = new AlertDialog.Builder(preferencesFragment.getActivity());
+            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(preferencesFragment.getActivity());
             builder.setTitle(preferencesFragment.getString(R.string.change_splash_path));
             builder.setNeutralButton(preferencesFragment.getString(R.string.cancel),
                     new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/AdminPasswordDialogFragment.kt
@@ -7,9 +7,9 @@ import android.os.Bundle
 import android.text.InputType
 import android.view.LayoutInflater
 import android.widget.CompoundButton
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
 import org.odk.collect.android.databinding.AdminPasswordDialogLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
@@ -54,7 +54,7 @@ class AdminPasswordDialogFragment : DialogFragment() {
             }
         }
 
-        return AlertDialog.Builder(requireContext())
+        return MaterialAlertDialogBuilder(requireContext())
             .setView(binding.root)
             .setTitle(getString(R.string.enter_admin_password))
             .setPositiveButton(getString(R.string.ok)) { _: DialogInterface?, _: Int ->

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ChangeAdminPasswordDialog.kt
@@ -7,9 +7,9 @@ import android.os.Bundle
 import android.text.InputType
 import android.view.LayoutInflater
 import android.widget.CompoundButton
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
 import org.odk.collect.android.databinding.PasswordDialogLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
@@ -54,7 +54,7 @@ class ChangeAdminPasswordDialog : DialogFragment() {
             }
         }
 
-        return AlertDialog.Builder(requireContext())
+        return MaterialAlertDialogBuilder(requireContext())
             .setView(binding.root)
             .setTitle(R.string.change_admin_password)
             .setView(binding.root)

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ServerAuthDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ServerAuthDialogFragment.java
@@ -7,8 +7,9 @@ import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.databinding.ServerAuthDialogBinding;
@@ -42,7 +43,7 @@ public class ServerAuthDialogFragment extends DialogFragment {
         binding.usernameEdit.setText(generalSettings.getString(ProjectKeys.KEY_USERNAME));
         binding.passwordEdit.setText(generalSettings.getString(ProjectKeys.KEY_PASSWORD));
 
-        return new AlertDialog.Builder(requireContext())
+        return new MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.server_requires_auth)
                 .setMessage(requireContext().getString(R.string.server_auth_credentials, generalSettings.getString(ProjectKeys.KEY_SERVER_URL)))
                 .setView(dialogView)

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectManagementPreferencesFragment.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.ActivityUtils
@@ -65,7 +65,7 @@ class ProjectManagementPreferencesFragment :
                     val pref = Intent(activity, QRCodeTabsActivity::class.java)
                     startActivity(pref)
                 }
-                DELETE_PROJECT_KEY -> AlertDialog.Builder(requireActivity())
+                DELETE_PROJECT_KEY -> MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.delete_project)
                     .setMessage(R.string.delete_project_confirm_message)
                     .setNegativeButton(R.string.delete_project_no) { _: DialogInterface?, _: Int -> }
@@ -82,14 +82,14 @@ class ProjectManagementPreferencesFragment :
 
         when (val deleteProjectResult = projectDeleter.deleteCurrentProject()) {
             is DeleteProjectResult.UnsentInstances -> {
-                AlertDialog.Builder(requireActivity())
+                MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.cannot_delete_project_title)
                     .setMessage(R.string.cannot_delete_project_message_one)
                     .setPositiveButton(R.string.ok, null)
                     .show()
             }
             is DeleteProjectResult.RunningBackgroundJobs -> {
-                AlertDialog.Builder(requireActivity())
+                MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.cannot_delete_project_title)
                     .setMessage(R.string.cannot_delete_project_message_two)
                     .setPositiveButton(R.string.ok, null)

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -56,6 +56,8 @@ import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_PROTOCOL;
 import static org.odk.collect.android.preferences.keys.ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT;
 import static org.odk.collect.android.utilities.DialogUtils.showDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 public class ServerPreferencesFragment extends BaseProjectPreferencesFragment implements OnBackPressedListener {
 
     private static final int REQUEST_ACCOUNT_PICKER = 1000;
@@ -276,7 +278,7 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment im
 
         if (TextUtils.isEmpty(account) && protocol.equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {
 
-            AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
+            AlertDialog alertDialog = new MaterialAlertDialogBuilder(getActivity())
                     .setIcon(android.R.drawable.ic_dialog_info)
                     .setTitle(R.string.missing_google_account_dialog_title)
                     .setMessage(R.string.missing_google_account_dialog_desc)

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/AuthDialogUtility.java
@@ -23,6 +23,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.PropertyManager;
@@ -77,7 +79,7 @@ public class AuthDialogUtility {
         username.setText(customUsername != null ? customUsername : overriddenUrl != null ? null : webCredentialsUtils.getUserNameFromPreferences());
         password.setText(customPassword != null ? customPassword : overriddenUrl != null ? null : webCredentialsUtils.getPasswordFromPreferences());
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context);
         builder.setTitle(context.getString(R.string.server_requires_auth));
         builder.setMessage(context.getString(R.string.server_auth_credentials, overriddenUrl != null ? overriddenUrl : webCredentialsUtils.getServerUrlFromPreferences()));
         builder.setView(dialogView);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -21,8 +21,6 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 
-import androidx.appcompat.app.AlertDialog;
-
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
@@ -48,6 +46,8 @@ import java.util.Locale;
 import timber.log.Timber;
 
 import static org.odk.collect.strings.format.LengthFormatterKt.formatLength;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 /**
  * Widget that allows user to take pictures, sounds or video and add them to the
@@ -219,7 +219,7 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
 
                 @Override
                 public void onRemoveClicked() {
-                    new AlertDialog.Builder(getContext())
+                    new MaterialAlertDialogBuilder(getContext())
                             .setTitle(R.string.delete_answer_file_question)
                             .setMessage(R.string.answer_file_delete_warning)
                             .setPositiveButton(R.string.delete_answer_file, (dialog, which) -> clearAnswer())

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -7,7 +7,7 @@ import android.media.MediaMetadataRetriever;
 import android.util.TypedValue;
 import android.view.View;
 
-import androidx.appcompat.app.AlertDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
@@ -174,7 +174,7 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
 
                 @Override
                 public void onRemoveClicked() {
-                    new AlertDialog.Builder(getContext())
+                    new MaterialAlertDialogBuilder(getContext())
                             .setTitle(R.string.delete_answer_file_question)
                             .setMessage(R.string.answer_file_delete_warning)
                             .setPositiveButton(R.string.delete_answer_file, (dialog, which) -> clearAnswer())

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -12,6 +12,8 @@ import android.view.View;
 
 import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
 import org.javarosa.core.model.osm.OSMTag;
@@ -128,7 +130,7 @@ public class OSMWidget extends QuestionWidget implements WidgetDataReceiver {
                 return null;
             });
         } catch (Exception ex) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+            MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(getContext());
             builder.setTitle(R.string.alert);
             builder.setMessage(R.string.install_openmapkit);
             DialogInterface.OnClickListener okClickListener = (dialog, id) -> {

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -68,9 +68,7 @@
     </style>
 
     <!-- Need to duplicate these values as they reset due to the parent. Only needed for AlertDialog.Builder. -->
-    <style name="Theme.Collect.Dialog.Alert" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorSecondary">@color/colorPrimary</item>
+    <style name="Theme.Collect.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="dialogCornerRadius">8dp</item>
     </style>
 

--- a/geo/src/main/java/org/odk/collect/geo/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPolyActivity.java
@@ -28,7 +28,8 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.VisibleForTesting;
-import androidx.appcompat.app.AlertDialog;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.androidshared.ui.ToastUtils;
@@ -515,7 +516,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
 
     private void showClearDialog() {
         if (!map.getPolyPoints(featureId).isEmpty()) {
-            new AlertDialog.Builder(this)
+            new MaterialAlertDialogBuilder(this)
                 .setMessage(R.string.geo_clear_warning)
                 .setPositiveButton(R.string.clear, (dialog, id) -> clear())
                 .setNegativeButton(R.string.cancel, null)
@@ -524,7 +525,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
     }
 
     private void showBackDialog() {
-        new AlertDialog.Builder(this)
+        new MaterialAlertDialogBuilder(this)
             .setMessage(getString(R.string.geo_exit_warning))
             .setPositiveButton(R.string.discard, (dialog, id) -> finish())
             .setNegativeButton(R.string.cancel, null)

--- a/geo/src/main/java/org/odk/collect/geo/GeoPolySettingsDialogFragment.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPolySettingsDialogFragment.java
@@ -11,8 +11,9 @@ import android.widget.Spinner;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 public class GeoPolySettingsDialogFragment extends DialogFragment {
 
@@ -98,7 +99,7 @@ public class GeoPolySettingsDialogFragment extends DialogFragment {
             accuracyThreshold.setSelection(accuracyThresholdIndex);
         }
 
-        return new AlertDialog.Builder(getActivity())
+        return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(getString(R.string.input_method))
                 .setView(settingsView)
                 .setPositiveButton(getString(R.string.start), (dialog, id) -> {

--- a/geo/src/test/java/org/odk/collect/geo/GeoPolySettingsDialogFragmentTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/GeoPolySettingsDialogFragmentTest.java
@@ -38,7 +38,7 @@ public class GeoPolySettingsDialogFragmentTest {
 
     @Before
     public void setup() {
-        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class, R.style.Theme_AppCompat);
+        FragmentActivity activity = RobolectricHelpers.createThemedActivity(FragmentActivity.class, R.style.Theme_MaterialComponents);
         fragmentManager = activity.getSupportFragmentManager();
         dialogFragment = new GeoPolySettingsDialogFragment();
 


### PR DESCRIPTION
Closes #4915 

#### What has been done to verify that this works as intended?
I reviewed implemented changes and tested some dialogs used in our app.

#### Why is this the best possible solution? Were any other approaches considered?
The first thing I changed was using `MaterialAlertDialogBuilder` instead of `AlertDialog.Builder`. Unfortunately our settings which are based on `PreferenceFragmentCompat` use `AlertDialog.Builder` under the hood so I also had to improve styling of `AlertDialog.Builder` to make sure dialogs created using that builder look the same like those created using `MaterialAlertDialogBuilder`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is related to the way our dialogs are styled so please review them to make sure they look the same.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Review dialogs used across the app and make sure 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
