### PR TITLE
Fixed: EDIT action for forms will crash if there are no projects

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
@@ -1,20 +1,16 @@
 package org.odk.collect.android.feature.external
 
 import android.content.Intent
-import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.R
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.support.CollectTestRule
 import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.TestRuleChain
-import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
-import org.odk.collect.android.support.pages.OkDialog
 
 @RunWith(AndroidJUnit4::class)
 class FormEditActionTest {
@@ -35,62 +31,5 @@ class FormEditActionTest {
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
         rule.launch(intent, FormEntryPage("One Question"))
-    }
-
-    @Test
-    fun whenFormIsNotCurrentProject_showsWarningAndExits() {
-        rule.startAtMainMenu()
-            .copyAndSyncForm("one-question.xml")
-            .addAndSwitchToProject("https://example.com")
-
-        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
-        val uri = FormsContract.getUri("DEMO", formId)
-
-        val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
-        rule.launch(intent, OkDialog())
-            .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(AppClosedPage())
-    }
-
-    @Test
-    fun whenUriDoesNotHaveProjectId_andCurrentProjectIsFirstOne_opensForm() {
-        rule.startAtMainMenu()
-            .copyAndSyncForm("one-question.xml")
-            .addAndSwitchToProject("https://example.com")
-            .openProjectSettingsDialog()
-            .selectProject("Demo project")
-
-        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
-        val uri = FormsContract.getUri("DEMO", formId)
-        val uriWithoutProjectId = Uri.Builder()
-            .scheme(uri.scheme)
-            .authority(uri.authority)
-            .path(uri.path)
-            .query(null)
-            .build()
-
-        val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
-        rule.launch(intent, FormEntryPage("One Question"))
-    }
-
-    @Test
-    fun whenUriDoesNotHaveProjectId_andCurrentProjectIsNotFirstOne_showsWarningAndExits() {
-        rule.startAtMainMenu()
-            .copyAndSyncForm("one-question.xml")
-            .addAndSwitchToProject("https://example.com")
-
-        val formId = ContentProviderUtils.getFormDatabaseId("DEMO", "one_question")
-        val uri = FormsContract.getUri("DEMO", formId)
-        val uriWithoutProjectId = Uri.Builder()
-            .scheme(uri.scheme)
-            .authority(uri.authority)
-            .path(uri.path)
-            .query(null)
-            .build()
-
-        val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
-        rule.launch(intent, OkDialog())
-            .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(AppClosedPage())
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -26,26 +26,37 @@ class FormUriActivity : Activity() {
         super.onCreate(savedInstanceState)
         DaggerUtils.getComponent(this).inject(this)
 
-        val firstProject = projectsRepository.getAll().first()
-        val uri = intent.data
-        val uriProjectId = uri?.getQueryParameter("projectId")
-        val projectId = uriProjectId ?: firstProject.uuid
-
-        logAnalytics(uriProjectId)
-
-        if (projectId == currentProjectProvider.getCurrentProject().uuid) {
-            startActivity(
-                Intent(this, FormEntryActivity::class.java).also {
-                    it.data = uri
-                    intent.extras?.let { sourceExtras -> it.putExtras(sourceExtras) }
-                }
-            )
-        } else {
+        val projects = projectsRepository.getAll()
+        if (projects.isEmpty()) {
             AlertDialog.Builder(this)
-                .setMessage(R.string.wrong_project_selected_for_form)
+                .setMessage(R.string.no_projects_detected)
                 .setPositiveButton(R.string.ok) { _, _ -> finish() }
                 .create()
                 .show()
+        } else {
+            val firstProject = projects.first()
+            val uri = intent.data
+            val uriProjectId = uri?.getQueryParameter("projectId")
+            val projectId = uriProjectId ?: firstProject.uuid
+
+            logAnalytics(uriProjectId)
+
+            if (projectId == currentProjectProvider.getCurrentProject().uuid) {
+                startActivity(
+                    Intent(this, FormEntryActivity::class.java).also {
+                        it.data = uri
+                        intent.extras?.let { sourceExtras -> it.putExtras(sourceExtras) }
+                    }
+                )
+            } else {
+                AlertDialog.Builder(this)
+                    .setMessage(R.string.wrong_project_selected_for_form)
+                    .setPositiveButton(R.string.ok) { _, _ ->
+                        finish()
+                    }
+                    .create()
+                    .show()
+            }
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -29,7 +29,7 @@ class FormUriActivity : Activity() {
         val projects = projectsRepository.getAll()
         if (projects.isEmpty()) {
             MaterialAlertDialogBuilder(this)
-                .setMessage(R.string.no_projects_detected)
+                .setMessage(R.string.app_not_configured)
                 .setPositiveButton(R.string.ok) { _, _ -> finish() }
                 .create()
                 .show()

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -3,7 +3,7 @@ package org.odk.collect.android.external
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormEntryActivity
@@ -28,7 +28,7 @@ class FormUriActivity : Activity() {
 
         val projects = projectsRepository.getAll()
         if (projects.isEmpty()) {
-            AlertDialog.Builder(this)
+            MaterialAlertDialogBuilder(this)
                 .setMessage(R.string.no_projects_detected)
                 .setPositiveButton(R.string.ok) { _, _ -> finish() }
                 .create()
@@ -49,7 +49,7 @@ class FormUriActivity : Activity() {
                     }
                 )
             } else {
-                AlertDialog.Builder(this)
+                MaterialAlertDialogBuilder(this)
                     .setMessage(R.string.wrong_project_selected_for_form)
                     .setPositiveButton(R.string.ok) { _, _ ->
                         finish()

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -73,6 +73,17 @@ class FormUriActivityTest {
     }
 
     @Test
+    fun `When there are no projects then display alert dialog`() {
+        projectsRepository.deleteAll()
+
+        val scenario = ActivityScenario.launch(FormUriActivity::class.java)
+        onView(withText(R.string.no_projects_detected)).inRoot(isDialog()).check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
     fun `When there is project id specified in uri and it does not match current project id then display alert dialog`() {
         val scenario = ActivityScenario.launch<FormUriActivity>(getIntent(secondProject.uuid))
 

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -1,0 +1,147 @@
+package org.odk.collect.android.external
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.gson.Gson
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.android.R
+import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.injection.config.AppDependencyModule
+import org.odk.collect.android.preferences.source.SettingsProvider
+import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.support.CollectHelpers
+import org.odk.collect.projects.InMemProjectsRepository
+import org.odk.collect.projects.Project
+import org.odk.collect.projects.ProjectsRepository
+import org.odk.collect.shared.strings.UUIDGenerator
+
+@RunWith(AndroidJUnit4::class)
+class FormUriActivityTest {
+    private lateinit var projectsRepository: ProjectsRepository
+    private lateinit var currentProjectProvider: CurrentProjectProvider
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private val firstProject = Project.DEMO_PROJECT
+    private val secondProject = Project.Saved("123", "Second project", "S", "#cccccc")
+
+    @Before
+    fun setup() {
+        projectsRepository = InMemProjectsRepository()
+        currentProjectProvider = mock()
+
+        projectsRepository.save(firstProject)
+        projectsRepository.save(secondProject)
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(firstProject)
+
+        CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
+            override fun providesProjectsRepository(
+                uuidGenerator: UUIDGenerator?,
+                gson: Gson?,
+                settingsProvider: SettingsProvider?
+            ): ProjectsRepository {
+                return projectsRepository
+            }
+
+            override fun providesCurrentProjectProvider(
+                settingsProvider: SettingsProvider?,
+                projectsRepository: ProjectsRepository?
+            ): CurrentProjectProvider {
+                return currentProjectProvider
+            }
+        })
+    }
+
+    @Test
+    fun `When there is project id specified in uri and it does not match current project id then display alert dialog`() {
+        val scenario = ActivityScenario.launch<FormUriActivity>(getIntent(secondProject.uuid))
+
+        onView(withText(R.string.wrong_project_selected_for_form)).inRoot(isDialog()).check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When there is project id specified in uri and it matches current project id then start form filling`() {
+        Intents.init()
+
+        ActivityScenario.launch<FormUriActivity>(getIntent(firstProject.uuid))
+
+        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+
+        Intents.release()
+    }
+
+    @Test
+    fun `When there is no project id specified in uri and first available project id does not match current project id then display alert dialog`() {
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(secondProject)
+
+        val scenario = ActivityScenario.launch<FormUriActivity>(getIntent())
+
+        onView(withText(R.string.wrong_project_selected_for_form)).inRoot(isDialog()).check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When there is no project id specified in uri and first available project id matches current project id then start form filling`() {
+        Intents.init()
+
+        ActivityScenario.launch<FormUriActivity>(getIntent())
+
+        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+
+        Intents.release()
+    }
+
+    @Test
+    fun `When everything is fine form filling is started with given data`() {
+        Intents.init()
+
+        ActivityScenario.launch<FormUriActivity>(getIntent(firstProject.uuid))
+
+        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+        Intents.intended(hasData(FormsContract.getUri(firstProject.uuid, 1)))
+        Intents.intended(hasExtra("KEY_1", "Text"))
+
+        Intents.release()
+    }
+
+    // TODO: Replace the explicit FormUriActivity intent with an implicit one Intent.ACTION_EDIT once it's possible https://github.com/android/android-test/issues/496
+    private fun getIntent(projectId: String? = null) = Intent(context, FormUriActivity::class.java).apply {
+        data = if (projectId == null) {
+            val uri = FormsContract.getUri("", 1)
+            Uri.Builder()
+                .scheme(uri.scheme)
+                .authority(uri.authority)
+                .path(uri.path)
+                .query(null)
+                .build()
+        } else {
+            FormsContract.getUri(projectId, 1)
+        }
+        putExtra("KEY_1", "Text")
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -75,7 +75,7 @@ class FormUriActivityTest {
     @Test
     fun `When there are no projects then display alert dialog`() {
         val scenario = ActivityScenario.launch(FormUriActivity::class.java)
-        onView(withText(R.string.no_projects_detected)).inRoot(isDialog())
+        onView(withText(R.string.app_not_configured)).inRoot(isDialog())
             .check(matches(isDisplayed()))
         onView(withId(android.R.id.button1)).perform(click())
 

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1111,6 +1111,8 @@
 
     <!-- Error shown when a user tries to open a form that's in a different project -->
     <string name="wrong_project_selected_for_form">To open this form, you must first open ODK Collect and switch to the project that contains it.</string>
+    <!-- Error shown when a user tries to open a form when there are no projects -->
+    <string name="no_projects_detected">No projects detected.</string>
 
     <!--
     ##############################################

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1112,7 +1112,7 @@
     <!-- Error shown when a user tries to open a form that's in a different project -->
     <string name="wrong_project_selected_for_form">To open this form, you must first open ODK Collect and switch to the project that contains it.</string>
     <!-- Error shown when a user tries to open a form when there are no projects -->
-    <string name="no_projects_detected">No projects detected.</string>
+    <string name="app_not_configured">ODK Collect has not been configured. Try to open ODK Collect and configure it.\n\nIf you tapped on a shortcut, you might need to recreate it after configuring ODK Collect.</string>
 
     <!--
     ##############################################


### PR DESCRIPTION
Closes #4743 

#### What has been done to verify that this works as intended?
I tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a fix so this seems to be the only solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue and do not affect anything else so please focus on the scenario described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
