### PR TITLE
Make landing screen layout more robust to different button text lengths

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/GroupClickListener.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/GroupClickListener.kt
@@ -1,0 +1,13 @@
+package org.odk.collect.androidshared.ui
+
+import android.view.View
+import androidx.constraintlayout.widget.Group
+
+// https://stackoverflow.com/questions/59020818/group-multiple-views-in-constraint-layout-to-set-only-one-click-listener
+object GroupClickListener {
+    fun Group.addOnClickListener(listener: (view: View) -> Unit) {
+        referencedIds.forEach { id ->
+            rootView.findViewById<View>(id).setOnClickListener(listener)
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FirstLaunchActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FirstLaunchActivity.kt
@@ -13,6 +13,7 @@ import org.odk.collect.android.projects.QrCodeProjectCreatorDialog
 import org.odk.collect.android.utilities.ThemeUtils
 import org.odk.collect.android.version.VersionInformation
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
+import org.odk.collect.androidshared.ui.GroupClickListener.addOnClickListener
 import org.odk.collect.projects.Project
 import javax.inject.Inject
 
@@ -57,7 +58,7 @@ class FirstLaunchActivity : CollectAbstractActivity() {
             versionInformation.versionToDisplay
         )
 
-        binding.configureLater.setOnClickListener {
+        binding.configureLater.addOnClickListener {
             Analytics.log(AnalyticsEvents.TRY_DEMO)
 
             projectImporter.importNewProject(Project.DEMO_PROJECT)

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -93,49 +93,46 @@
             android:id="@+id/app_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
             android:layout_marginBottom="@dimen/margin_extra_small"
             android:textAppearance="?textAppearanceBody1"
             android:textColor="@color/color_on_surface_medium_emphasis"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            app:layout_constraintBottom_toTopOf="@+id/configure_later"
+            app:layout_constraintBottom_toTopOf="@id/dont_have_server"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintVertical_bias="1"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/center"
+            app:layout_constraintTop_toBottomOf="@id/center"
+            app:layout_constraintVertical_bias="1"
             tools:text="ODK Collect v2022.3" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/configure_later"
+        <TextView
+            android:id="@+id/dont_have_server"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_standard"
-            android:background="?attr/selectableItemBackgroundBorderless"
+            android:layout_marginBottom="@dimen/margin"
+            android:text="@string/dont_have_project"
+            android:textAppearance="?textAppearanceBody2"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/try_collect"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <TextView
+            android:id="@+id/try_collect"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_extra_small"
+            android:text="@string/try_demo"
+            android:textAppearance="@style/TextAppearance.Collect.Link"
+            app:layout_constraintBottom_toBottomOf="@+id/dont_have_server"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintVertical_bias="1"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/center">
+            app:layout_constraintStart_toEndOf="@+id/dont_have_server"
+            app:layout_constraintTop_toTopOf="@+id/dont_have_server" />
 
-            <TextView
-                android:id="@+id/dont_have_server"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/dont_have_project"
-                android:textAppearance="?textAppearanceBody2"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <TextView
-                android:id="@+id/try_collect"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_extra_small"
-                android:text="@string/try_demo"
-                android:textAppearance="@style/TextAppearance.Collect.Link"
-                app:layout_constraintStart_toEndOf="@+id/dont_have_server"
-                app:layout_constraintTop_toTopOf="@+id/dont_have_server" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/configureLater"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            app:constraint_referenced_ids="dont_have_server,try_collect" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -43,48 +43,39 @@
                 android:lines="2"
                 android:text="@string/tagline"
                 android:textAppearance="?textAppearanceHeadline4"
-                app:layout_constraintBottom_toTopOf="@+id/configuration_buttons"
-                app:layout_constraintStart_toStartOf="@+id/configuration_buttons"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/configuration_buttons"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/configure_via_qr_button"
+                style="@style/Widget.Collect.Button.OutlinedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin"
+                android:backgroundTint="?colorPrimary"
+                android:text="@string/configure_with_qr_code"
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:textColor="@android:color/white"
+                android:layout_marginTop="@dimen/margin_standard"
+                app:icon="@drawable/ic_baseline_qr_code_scanner_24"
+                app:iconTint="@android:color/white"
+                app:layout_constraintTop_toBottomOf="@id/tagline"
+                app:layout_constraintBottom_toTopOf="@+id/configure_manually_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/configure_manually_button"
+                style="@style/Widget.Collect.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/configure_manually"
+                android:textAppearance="?attr/textAppearanceBody1"
+                app:icon="@drawable/ic_outline_edit_24"
+                app:iconTint="?colorOnSurface"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tagline">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/configure_via_qr_button"
-                    style="@style/Widget.Collect.Button.OutlinedButton"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:backgroundTint="?colorPrimary"
-                    android:text="@string/configure_with_qr_code"
-                    android:textAppearance="?attr/textAppearanceBody1"
-                    android:textColor="@android:color/white"
-                    app:icon="@drawable/ic_baseline_qr_code_scanner_24"
-                    app:iconTint="@android:color/white"
-                    app:layout_constraintBottom_toTopOf="@+id/configure_manually_button"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/configure_manually_button"
-                    style="@style/Widget.Collect.Button.OutlinedButton"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:text="@string/configure_manually"
-                    android:textAppearance="?attr/textAppearanceBody1"
-                    app:icon="@drawable/ic_outline_edit_24"
-                    app:iconTint="?colorOnSurface"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/configure_via_qr_button" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                app:layout_constraintTop_toBottomOf="@id/configure_via_qr_button" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -49,7 +49,7 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/configure_via_qr_button"
                 style="@style/Widget.Collect.Button.OutlinedButton"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:backgroundTint="?colorPrimary"
                 android:text="@string/configure_with_qr_code"
@@ -60,22 +60,33 @@
                 app:iconTint="@android:color/white"
                 app:layout_constraintTop_toBottomOf="@id/tagline"
                 app:layout_constraintBottom_toTopOf="@+id/configure_manually_button"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintEnd_toEndOf="@+id/barrierEnd"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintWidth_min="wrap"/>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/configure_manually_button"
                 style="@style/Widget.Collect.Button.OutlinedButton"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
                 android:text="@string/configure_manually"
                 android:textAppearance="?attr/textAppearanceBody1"
                 app:icon="@drawable/ic_outline_edit_24"
                 app:iconTint="?colorOnSurface"
-                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintEnd_toEndOf="@+id/barrierEnd"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/configure_via_qr_button" />
+                app:layout_constraintTop_toBottomOf="@id/configure_via_qr_button"
+                app:layout_constraintWidth_min="wrap"/>
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/barrierEnd"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:barrierDirection="end"
+                app:constraint_referenced_ids="configure_via_qr_button,configure_manually_button"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -26,11 +26,12 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/center"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_large"
+            android:paddingHorizontal="@dimen/margin_large"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.5">
@@ -48,7 +49,7 @@
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/configuration_buttons"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -58,7 +59,7 @@
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/configure_via_qr_button"
                     style="@style/Widget.Collect.Button.OutlinedButton"
-                    android:layout_width="0dp"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:backgroundTint="?colorPrimary"
                     android:text="@string/configure_with_qr_code"
@@ -67,13 +68,13 @@
                     app:icon="@drawable/ic_baseline_qr_code_scanner_24"
                     app:iconTint="@android:color/white"
                     app:layout_constraintBottom_toTopOf="@+id/configure_manually_button"
-                    app:layout_constraintEnd_toEndOf="@+id/configure_manually_button"
-                    app:layout_constraintStart_toStartOf="@+id/configure_manually_button" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/configure_manually_button"
                     style="@style/Widget.Collect.Button.OutlinedButton"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_small"
                     android:text="@string/configure_manually"

--- a/collect_app/src/main/res/layout/first_launch_layout.xml
+++ b/collect_app/src/main/res/layout/first_launch_layout.xml
@@ -26,7 +26,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/center"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/margin_large"
             android:paddingHorizontal="@dimen/margin_large"


### PR DESCRIPTION
Closes #4693 

#### What has been done to verify that this works as intended?
I tested the fix manually hardcodding strings with different length.

#### Why is this the best possible solution? Were any other approaches considered?
I think it's best that both buttons take the whole space horizonatlly no matter how long their strings are:

| Original strings | First string shorter | Second string shorter |
| ------------- | ------------- | ------------- |
| ![Screenshot_1638187850](https://user-images.githubusercontent.com/3276264/143866281-2c43e972-8cfb-43ae-b0a6-9a78348afd4c.png) | ![Screenshot_1638187513](https://user-images.githubusercontent.com/3276264/143866278-f5d84bda-13be-4c43-ab73-fc67af55b197.png) | ![Screenshot_1638187532](https://user-images.githubusercontent.com/3276264/143866280-bd2f6c58-ed3e-4716-9e23-71b78d41d4eb.png)  |

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a pretty safe change so maybe just test the `First Launch` screen in two different languages ( to verify different string lengths).

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
