### PR TITLE
Make internal recorder the default

### DIFF
--- a/androidshared/src/main/res/layout/app_bar_layout.xml
+++ b/androidshared/src/main/res/layout/app_bar_layout.xml
@@ -2,6 +2,7 @@
 <com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/appBarLayout"
+    style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:elevation="4dp">

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AudioRecordingTest.java
@@ -17,6 +17,7 @@ import org.odk.collect.android.support.CollectTestRule;
 import org.odk.collect.android.support.TestDependencies;
 import org.odk.collect.android.support.TestRuleChain;
 import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.OkDialog;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.audiorecorder.testsupport.StubAudioRecorder;
@@ -54,6 +55,18 @@ public class AudioRecordingTest {
     public final RuleChain chain = TestRuleChain.chain(testDependencies)
             .around(GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO))
             .around(rule);
+
+    @Test
+    public void onAudioQuestion_withoutAudioQuality_canRecordInApp() {
+        new MainMenuPage()
+                .copyForm("audio-question.xml")
+                .startBlankForm("Audio Question")
+                .clickOnString(R.string.capture_audio)
+                .clickOnContentDescription(R.string.stop_recording)
+                .assertContentDescriptionNotDisplayed(R.string.stop_recording)
+                .assertTextNotDisplayed(R.string.capture_audio)
+                .assertContentDescriptionDisplayed(R.string.play_audio);
+    }
 
     @Test
     public void onAudioQuestion_withQualitySpecified_canRecordAudioInApp() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalAudioRecordingTest.java
@@ -54,22 +54,12 @@ public class ExternalAudioRecordingTest {
                 }
             }))
             .around(rule);
+
     @Test
     public void onAudioQuestion_whenAudioQualityIsExternal_usesExternalRecorder() throws Exception {
         new MainMenuPage()
                 .copyForm("external-audio-question.xml")
                 .startBlankForm("External Audio Question")
-                .clickOnString(R.string.capture_audio)
-                .assertContentDescriptionNotDisplayed(R.string.stop_recording)
-                .assertTextNotDisplayed(R.string.capture_audio)
-                .assertContentDescriptionDisplayed(R.string.play_audio);
-    }
-
-    @Test
-    public void onAudioQuestion_withoutAudioQuality_usesExternalRecorder() {
-        new MainMenuPage()
-                .copyForm("audio-question.xml")
-                .startBlankForm("Audio Question")
                 .clickOnString(R.string.capture_audio)
                 .assertContentDescriptionNotDisplayed(R.string.stop_recording)
                 .assertTextNotDisplayed(R.string.capture_audio)

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/keys/ProjectKeys.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/keys/ProjectKeys.kt
@@ -128,7 +128,7 @@ object ProjectKeys {
             hashMap[KEY_NAVIGATION] = NAVIGATION_BOTH
             hashMap[KEY_SHOW_SPLASH] = false
             hashMap[KEY_SPLASH_PATH] = Collect.getInstance().getString(R.string.default_splash_path)
-            hashMap[KEY_EXTERNAL_APP_RECORDING] = true
+            hashMap[KEY_EXTERNAL_APP_RECORDING] = false
             // map_preferences.xml
             hashMap[KEY_BASEMAP_SOURCE] = BASEMAP_SOURCE_GOOGLE
             hashMap[KEY_CARTO_MAP_STYLE] = "positron"

--- a/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
+++ b/collect_app/src/main/res/layout/audio_recording_controller_fragment.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="?colorSurface"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:baselineAligned="false"

--- a/collect_app/src/main/res/layout/changes_reason_dialog.xml
+++ b/collect_app/src/main/res/layout/changes_reason_dialog.xml
@@ -7,6 +7,7 @@
     android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
+        style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="4dp">

--- a/collect_app/src/main/res/layout/form_entry.xml
+++ b/collect_app/src/main/res/layout/form_entry.xml
@@ -20,6 +20,7 @@ the License.
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
+        style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="4dp">

--- a/collect_app/src/main/res/layout/identify_user_dialog.xml
+++ b/collect_app/src/main/res/layout/identify_user_dialog.xml
@@ -7,6 +7,7 @@
     android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
+        style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="4dp">

--- a/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/manual_project_creator_dialog_layout.xml
@@ -8,6 +8,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/add_project_toolbar"
+        style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="4dp"

--- a/collect_app/src/main/res/layout/qr_code_project_creator_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/qr_code_project_creator_dialog_layout.xml
@@ -7,6 +7,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/add_new_project_appbar"
+        style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="4dp"

--- a/collect_app/src/main/res/layout/select_minimal_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/select_minimal_dialog_layout.xml
@@ -6,6 +6,7 @@
     android:orientation="vertical">
 
     <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
+        style="@style/Widget.MaterialComponents.AppBarLayout.Surface"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:elevation="4dp">


### PR DESCRIPTION
Closes #4828

I noticed a problem where the recording interface didn't appear to be part of the app bar in dark mode so I also fixed that while I was in the neighbourhood.

#### What has been done to verify that this works as intended?

Updated existing tests for the new behaviour.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not a lot to check here really! I think we can skip QA here.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
