### PR TITLE
Mark "run once" upgrades as run on fresh install

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingProjectMigrator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/ExistingProjectMigrator.kt
@@ -34,6 +34,11 @@ class ExistingProjectMigrator(
     }
 
     override fun run() {
+        if (settingsProvider.getMetaSettings().contains(MetaKeys.LAST_LAUNCHED)) {
+            // We're upgrading from a version with Projects so shouldn't be running this
+            return
+        }
+
         val generalSharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
 
         val newProject = projectDetailsCreator.createProjectFromDetails(

--- a/collect_app/src/test/java/org/odk/collect/android/projects/ExistingProjectMigratorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/ExistingProjectMigratorTest.kt
@@ -7,8 +7,11 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.Matchers.`is`
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.odk.collect.android.application.initialization.upgrade.AppUpgrader
+import org.odk.collect.android.application.initialization.upgrade.Upgrade
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.keys.MetaKeys
 import org.odk.collect.android.preferences.keys.ProjectKeys
@@ -27,6 +30,12 @@ class ExistingProjectMigratorTest {
     private val settingsProvider = component.settingsProvider()
     private val currentProjectProvider = component.currentProjectProvider()
     private val rootDir = storagePathProvider.odkRootDirPath
+
+    @Before
+    fun setup() {
+        // Should not run when upgrading from version with LAST_LAUNCHED
+        settingsProvider.getMetaSettings().remove(MetaKeys.LAST_LAUNCHED)
+    }
 
     @Test
     fun `creates existing project with details based on its url`() {
@@ -166,6 +175,26 @@ class ExistingProjectMigratorTest {
     @Test
     fun `has key`() {
         assertThat(existingProjectMigrator.key(), `is`(MetaKeys.EXISTING_PROJECT_IMPORTED))
+    }
+
+    /**
+     * Versions of the app before v2021.3.3 did not include a call to [AppUpgrader.install] and so
+     * this [Upgrade] would get incorrectly run on upgrades from versions after
+     * [AppUpgrader] and Projects (along with LAST_LAUNCHED) were added but before the call
+     * to [AppUpgrader.install] was introduced.
+     */
+    @Test
+    fun `does not run if previous app version already had projects`() {
+        PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .edit()
+            .putString(ProjectKeys.KEY_SERVER_URL, "https://my-server.com")
+            .apply()
+
+        settingsProvider.getMetaSettings().save(MetaKeys.LAST_LAUNCHED, 3115)
+
+        existingProjectMigrator.run()
+        assertThat(projectsRepository.getAll().size, `is`(0))
     }
 
     private fun getProjectDirPaths(projectId: String): Array<String> {


### PR DESCRIPTION
Work towards #4927 (we'll need to do another PR to fix on `master`)

This can be a little hard to get your head around. Basically, we have a way of saying upgrades should only run once, but we never considered the fact that we also didn't want those upgrades to ever run if they exist during a fresh install. This changes our upgrade process so that we mark "run once" upgrades (currently just the existing project migration) as done when doing a fresh install.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I also considered cleaning up the extra project created due to the bug but couldn't find a way to identify it safely.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the bug! Good to check upgrades (from different versions) and fresh installs. As @grzesiek2010 pointed out, installing a previous version and then this version from source will not simulate an upgrade as the version code used will be the same (it's based on the number of commits on the `master` branch). To simulate an upgrade:

1. Check out the last released version (`v2021.3.2`)
2. Set `versionCode` in `collect_app/build.gradle` to `1`
3. Install on device (make sure to uninstall first)
4. Check out the PR branch again
5. Set `versionCode` in `collect_app/build.gradle` to `2`
6. Install on device

This simulates a "real" upgrade where the version code would change as well as the code.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
