### PR TITLE
Extra analytics for `geopoint`

### DIFF
--- a/geo/build.gradle
+++ b/geo/build.gradle
@@ -44,7 +44,6 @@ android {
 }
 
 dependencies {
-    implementation project(path: ':externalapp')
     coreLibraryDesugaring Dependencies.desugar
 
     implementation Dependencies.kotlin_stdlib
@@ -58,6 +57,8 @@ dependencies {
     implementation project(path: ':strings')
     implementation project(path: ':location')
     implementation project(path: ':androidshared')
+    implementation project(path: ':externalapp')
+    implementation project(path: ':analytics')
 
     testImplementation project(path: ':testshared')
     testImplementation Dependencies.junit

--- a/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
@@ -207,16 +207,7 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
                 (dialog, which) -> {
                     switch (which) {
                         case DialogInterface.BUTTON_POSITIVE:
-                            if (System.currentTimeMillis() - startTime < 2000) {
-                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_IMMEDIATE);
-                            } else if (location.getAccuracy() > 100) {
-                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_UNACCEPTABLE);
-                            } else if (location.getAccuracy() > 10) {
-                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_POOR);
-                            } else {
-                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_ACCEPTABLE);
-                            }
-
+                            logSavePointManual();
                             returnLocation();
                             break;
                         case DialogInterface.BUTTON_NEGATIVE:
@@ -230,6 +221,23 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
         locationDialog.setButton(DialogInterface.BUTTON_NEGATIVE,
                 getString(R.string.cancel_location),
                 geoPointButtonListener);
+    }
+
+    private void logSavePointManual() {
+        String event;
+        if (System.currentTimeMillis() - startTime < 2000) {
+            event = AnalyticsEvents.SAVE_POINT_IMMEDIATE;
+        } else {
+            event = AnalyticsEvents.SAVE_POINT_MANUAL;
+        }
+
+        if (location.getAccuracy() > 100) {
+            Analytics.log(event, "accuracy", "unacceptable");
+        } else if (location.getAccuracy() > 10) {
+            Analytics.log(event, "accuracy", "poor");
+        } else {
+            Analytics.log(event, "accuracy", "acceptable");
+        }
     }
 
     private void logLastLocation() {

--- a/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
@@ -37,6 +37,7 @@ import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.location.LocationListener;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.externalapp.ExternalAppUtils;
 import org.odk.collect.location.GoogleFusedLocationClient;
@@ -205,6 +206,16 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
                 (dialog, which) -> {
                     switch (which) {
                         case DialogInterface.BUTTON_POSITIVE:
+                            if (System.currentTimeMillis() - startTime < 2000) {
+                                Analytics.log("SavePointManualImmediate");
+                            } else if (location.getAccuracy() > 100) {
+                                Analytics.log("SavePointManualUnacceptable");
+                            } else if (location.getAccuracy() > 10) {
+                                Analytics.log("SavePointManualPoor");
+                            } else {
+                                Analytics.log("SavePointManualAcceptable");
+                            }
+
                             returnLocation();
                             break;
                         case DialogInterface.BUTTON_NEGATIVE:
@@ -259,6 +270,7 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
 
             if (locationCount > 1) {
                 if (location.getAccuracy() <= targetAccuracy) {
+                    Analytics.log("SavePointAuto");
                     returnLocation();
                 }
             }

--- a/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
@@ -40,6 +40,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.externalapp.ExternalAppUtils;
+import org.odk.collect.geo.analytics.AnalyticsEvents;
 import org.odk.collect.location.GoogleFusedLocationClient;
 import org.odk.collect.location.LocationClient;
 import org.odk.collect.location.LocationClientProvider;
@@ -207,13 +208,13 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
                     switch (which) {
                         case DialogInterface.BUTTON_POSITIVE:
                             if (System.currentTimeMillis() - startTime < 2000) {
-                                Analytics.log("SavePointManualImmediate");
+                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_IMMEDIATE);
                             } else if (location.getAccuracy() > 100) {
-                                Analytics.log("SavePointManualUnacceptable");
+                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_UNACCEPTABLE);
                             } else if (location.getAccuracy() > 10) {
-                                Analytics.log("SavePointManualPoor");
+                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_POOR);
                             } else {
-                                Analytics.log("SavePointManualAcceptable");
+                                Analytics.log(AnalyticsEvents.SAVE_POINT_MANUAL_ACCEPTABLE);
                             }
 
                             returnLocation();
@@ -270,7 +271,7 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
 
             if (locationCount > 1) {
                 if (location.getAccuracy() <= targetAccuracy) {
-                    Analytics.log("SavePointAuto");
+                    Analytics.log(AnalyticsEvents.SAVE_POINT_AUTO);
                     returnLocation();
                 }
             }

--- a/geo/src/main/java/org/odk/collect/geo/analytics/AnalyticsEvents.kt
+++ b/geo/src/main/java/org/odk/collect/geo/analytics/AnalyticsEvents.kt
@@ -4,11 +4,10 @@ object AnalyticsEvents {
 
     /**
      * Compare different ways of saving geopoints: are users saving without looking at accuracy,
-     * are they waiting for the threshold autosave etc
+     * are they waiting for the threshold autosave etc. Each event should include `accuracy` param
+     * with either `unacceptable` (over 100m), `poor` (over 10m) or `acceptable` (less than 10m).
      */
     const val SAVE_POINT_AUTO = "SavePointAuto"
-    const val SAVE_POINT_MANUAL_IMMEDIATE = "SavePointManualImmediate"
-    const val SAVE_POINT_MANUAL_UNACCEPTABLE = "SavePointManualUnacceptable"
-    const val SAVE_POINT_MANUAL_POOR = "SavePointManualPoor"
-    const val SAVE_POINT_MANUAL_ACCEPTABLE = "SavePointManualAcceptable"
+    const val SAVE_POINT_MANUAL = "SavePointManual"
+    const val SAVE_POINT_IMMEDIATE = "SavePointImmediate"
 }

--- a/geo/src/main/java/org/odk/collect/geo/analytics/AnalyticsEvents.kt
+++ b/geo/src/main/java/org/odk/collect/geo/analytics/AnalyticsEvents.kt
@@ -1,0 +1,14 @@
+package org.odk.collect.geo.analytics
+
+object AnalyticsEvents {
+
+    /**
+     * Compare different ways of saving geopoints: are users saving without looking at accuracy,
+     * are they waiting for the threshold autosave etc
+     */
+    const val SAVE_POINT_AUTO = "SavePointAuto"
+    const val SAVE_POINT_MANUAL_IMMEDIATE = "SavePointManualImmediate"
+    const val SAVE_POINT_MANUAL_UNACCEPTABLE = "SavePointManualUnacceptable"
+    const val SAVE_POINT_MANUAL_POOR = "SavePointManualPoor"
+    const val SAVE_POINT_MANUAL_ACCEPTABLE = "SavePointManualAcceptable"
+}


### PR DESCRIPTION
This adds analytics to track users behaviour when saving a location using the geopoint dialog. It tracks these outcomes:

* The user saves a geopoint within 2 seconds
* The user saves a geopoint  after 2 seconds
* The geopoint is saved automatically because the accuracy threshold was matched

Both manual cases include whether the accuracy is `acceptable`, `poor` or `unacceptable`.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
