### PR TITLE
Use localized strings in `DownloadFormsTask`

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.tasks;
 
+import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
+
 import android.os.AsyncTask;
 
 import org.odk.collect.android.R;
@@ -62,7 +64,7 @@ public class DownloadFormsTask extends
                 publishProgress(serverFormDetails.getFormName(), currentFormNumber, totalForms);
 
                 formDownloader.downloadForm(serverFormDetails, count -> {
-                    String message = Collect.getInstance().getString(R.string.form_download_progress,
+                    String message = getLocalizedString(Collect.getInstance(), R.string.form_download_progress,
                             serverFormDetails.getFormName(),
                             String.valueOf(count),
                             String.valueOf(serverFormDetails.getManifest().getMediaFiles().size())
@@ -71,7 +73,7 @@ public class DownloadFormsTask extends
                     publishProgress(message, currentFormNumber, totalForms);
                 }, this::isCancelled);
 
-                results.put(serverFormDetails, Collect.getInstance().getString(R.string.success));
+                results.put(serverFormDetails, getLocalizedString(Collect.getInstance(), R.string.success));
             } catch (FormDownloadException.DownloadingInterrupted e) {
                 return emptyMap();
             } catch (FormDownloadException e) {


### PR DESCRIPTION
Work towards #4931 (we'll need to do another PR to fix on `master`)

#### What has been done to verify that this works as intended?

Verified manually. I considered writing a test but decided not to - I think instead of cherry picking this onto `master` we should look at a more thorough fix that removes the use of a translated string in our download results logic (switch to a boolean or a nullable exception would be an improvement). We might want to introduce a smoke or regression test that checks the basic app flows in a second language, but we can consider that when looking at a proper fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the bug. Good to check form downloads English and at least one other language. It'd also be good to add a case to our set of manual regression checks to carry out at least form download, entry and send in a non-English language so we have this covered in future.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
