### PR TITLE
Detect and log potential duplicate project as user property

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.preferences.FormUpdateMode
 import org.odk.collect.android.preferences.keys.ProjectKeys
+import org.odk.collect.android.preferences.keys.ProjectKeys.KEY_SERVER_URL
+import org.odk.collect.android.preferences.keys.ProtectedProjectKeys
 import org.odk.collect.android.preferences.source.SettingsProvider
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
@@ -29,14 +31,39 @@ class UserPropertiesInitializer(
             "UsingNonDefaultTheme",
             projects.any { isNotUsingDefaultTheme(it) }.toString()
         )
+
+        analytics.setUserProperty(
+            "HasPotentialDuplicateProject",
+            hasPotentialDuplicateProject(projects).toString()
+        )
+    }
+
+    /**
+     * Looks for a potential duplicate/extra project created accidentally by [ExistingProjectMigrator]
+     */
+    private fun hasPotentialDuplicateProject(projects: List<Project.Saved>): Boolean {
+        return projects.any {
+            val generalSettings = settingsProvider.getGeneralSettings()
+            val adminSettings = settingsProvider.getAdminSettings()
+
+            val demoProjectNameButNotId =
+                it.name == Project.DEMO_PROJECT_NAME && it.uuid != Project.DEMO_PROJECT_ID
+            val hasDefaultSettings =
+                generalSettings.getAll()
+                    .all { setting -> setting.value == ProjectKeys.defaults[setting.key] } &&
+                    adminSettings.getAll()
+                        .all { setting -> setting.value == ProtectedProjectKeys.defaults[setting.key] }
+
+            demoProjectNameButNotId && hasDefaultSettings
+        }
     }
 
     private fun isNotUsingMatchExactly(project: Project.Saved, context: Context): Boolean {
         val settings = settingsProvider.getGeneralSettings(project.uuid)
-        val serverUrl = settings.getString(ProjectKeys.KEY_SERVER_URL)
+        val serverUrl = settings.getString(KEY_SERVER_URL)
         val formUpdateMode = settings.getString(ProjectKeys.KEY_FORM_UPDATE_MODE)
 
-        val notUsingDefaultServer = serverUrl != ProjectKeys.defaults[ProjectKeys.KEY_SERVER_URL]
+        val notUsingDefaultServer = serverUrl != ProjectKeys.defaults[KEY_SERVER_URL]
         val notUsingMatchExactly = formUpdateMode != FormUpdateMode.MATCH_EXACTLY.getValue(context)
 
         return notUsingDefaultServer && notUsingMatchExactly


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

Created the problem on device and then checked the user property was set to true.

#### Why is this the best possible solution? Were any other approaches considered?

I think the heuristic I've used (demo project name without demo ID and all default settings) should be good enough to detect projects created accidentally. It would also detect a project created manually named "Demo project" where no settings have been changed, but I think we can assume that they'll likely only be a handful of false positives there. Definitely interested to see if anyone can think of any edge cases other than that though!

Using a user property for this lets us quickly see how many devices are experiencing the issue (and compare to the total user base).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Shouldn't add any risk as it just changes analytics.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
