### PR TITLE
Stop using localized strings in `DownloadFormsTask`

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/GetBlankFormsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/GetBlankFormsTest.java
@@ -15,7 +15,7 @@ import org.odk.collect.android.support.pages.GetBlankFormPage;
 @RunWith(AndroidJUnit4.class)
 public class GetBlankFormsTest {
 
-    public CollectTestRule rule = new CollectTestRule();
+    public CollectTestRule rule = new CollectTestRule(false);
 
     final TestDependencies testDependencies = new TestDependencies();
 
@@ -28,8 +28,7 @@ public class GetBlankFormsTest {
         testDependencies.server.setCredentials("Draymond", "Green");
         testDependencies.server.addForm("One Question", "one-question", "1", "one-question.xml");
 
-        rule.startAtMainMenu()
-                .setServer(testDependencies.server.getURL())
+        rule.withProject(testDependencies.server.getURL())
                 .clickGetBlankFormWithAuthenticationError()
                 .fillUsername("Draymond")
                 .fillPassword("Green")
@@ -41,8 +40,7 @@ public class GetBlankFormsTest {
     public void whenThereIsAnErrorFetchingFormList_showsError() {
         testDependencies.server.alwaysReturnError();
 
-        rule.startAtMainMenu()
-                .setServer(testDependencies.server.getURL())
+        rule.withProject(testDependencies.server.getURL())
                 .clickGetBlankFormWithError()
                 .assertText(R.string.load_remote_form_error)
                 .clickOK(new GetBlankFormPage());
@@ -53,8 +51,7 @@ public class GetBlankFormsTest {
         testDependencies.server.addForm("One Question", "one-question", "1", "one-question.xml");
         testDependencies.server.errorOnFetchingForms();
 
-        rule.startAtMainMenu()
-                .setServer(testDependencies.server.getURL())
+        rule.withProject(testDependencies.server.getURL())
                 .clickGetBlankForm()
                 .clickGetSelected()
                 .assertMessage("1 of 1 downloads failed!")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/GetAndSubmitFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/GetAndSubmitFormTest.java
@@ -15,7 +15,7 @@ import org.odk.collect.android.support.pages.SendFinalizedFormPage;
 @RunWith(AndroidJUnit4.class)
 public class GetAndSubmitFormTest {
 
-    private final CollectTestRule rule = new CollectTestRule();
+    private final CollectTestRule rule = new CollectTestRule(false);
     private final TestDependencies testDependencies = new TestDependencies();
 
     @Rule
@@ -25,9 +25,8 @@ public class GetAndSubmitFormTest {
     public void canGetBlankForm_fillItIn_andSubmit() {
         testDependencies.server.addForm("One Question", "one-question", "1", "one-question.xml");
 
-        rule.startAtMainMenu()
+        rule.withProject(testDependencies.server.getURL())
                 // Fetch form
-                .setServer(testDependencies.server.getURL())
                 .clickGetBlankForm()
                 .clickGetSelected()
                 .assertMessage("All downloads succeeded!")

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -40,6 +40,7 @@ import org.odk.collect.android.activities.viewmodels.FormDownloadListViewModel;
 import org.odk.collect.android.adapters.FormDownloadListAdapter;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.RefreshFormListDialogFragment;
+import org.odk.collect.android.formmanagement.FormDownloadException;
 import org.odk.collect.android.formmanagement.FormDownloader;
 import org.odk.collect.android.formmanagement.FormSourceExceptionMapper;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
@@ -651,7 +652,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
     }
 
     @Override
-    public void formsDownloadingComplete(Map<ServerFormDetails, String> result) {
+    public void formsDownloadingComplete(Map<ServerFormDetails, FormDownloadException> result) {
         if (downloadFormsTask != null) {
             downloadFormsTask.setDownloaderListener(null);
         }
@@ -667,8 +668,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         // Set result to true for forms which were downloaded
         if (viewModel.isDownloadOnlyMode()) {
             for (ServerFormDetails serverFormDetails : result.keySet()) {
-                String successKey = result.get(serverFormDetails);
-                if (getString(R.string.success).equals(successKey)) {
+                if (result.get(serverFormDetails) == null) {
                     if (viewModel.getFormResults().containsKey(serverFormDetails.getFormId())) {
                         viewModel.putFormResult(serverFormDetails.getFormId(), true);
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormUpdateDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormUpdateDownloader.kt
@@ -10,19 +10,19 @@ class FormUpdateDownloader {
         formDownloader: FormDownloader,
         successMessage: String,
         failureMessage: String
-    ): Map<ServerFormDetails, String> {
-        val results = mutableMapOf<ServerFormDetails, String>()
+    ): Map<ServerFormDetails, FormDownloadException?> {
+        val results = mutableMapOf<ServerFormDetails, FormDownloadException?>()
 
         changeLock.withLock { acquiredLock: Boolean ->
             if (acquiredLock) {
                 for (serverFormDetails in updatedForms) {
                     try {
                         formDownloader.downloadForm(serverFormDetails, null, null)
-                        results[serverFormDetails] = successMessage
+                        results[serverFormDetails] = null
                     } catch (e: FormDownloadException.DownloadingInterrupted) {
                         break
                     } catch (e: FormDownloadException) {
-                        results[serverFormDetails] = failureMessage
+                        results[serverFormDetails] = e
                     }
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialog.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
+import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.utilities.FormsDownloadResultInterpreter
@@ -14,7 +15,7 @@ import org.odk.collect.errors.ErrorActivity
 import java.io.Serializable
 
 class FormsDownloadResultDialog : DialogFragment() {
-    private lateinit var result: Map<ServerFormDetails, String>
+    private lateinit var result: Map<ServerFormDetails, FormDownloadException?>
 
     var listener: FormDownloadResultDialogListener? = null
 
@@ -27,7 +28,7 @@ class FormsDownloadResultDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        result = arguments?.getSerializable(ARG_RESULT) as Map<ServerFormDetails, String>
+        result = arguments?.getSerializable(ARG_RESULT) as Map<ServerFormDetails, FormDownloadException?>
 
         val builder = MaterialAlertDialogBuilder(requireContext())
             .setMessage(getMessage())

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/DownloadFormsTaskListener.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/DownloadFormsTaskListener.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.listeners;
 
+import org.odk.collect.android.formmanagement.FormDownloadException;
 import org.odk.collect.android.formmanagement.ServerFormDetails;
 
 import java.util.Map;
@@ -22,7 +23,7 @@ import java.util.Map;
  * @author Carl Hartung (carlhartung@gmail.com)
  */
 public interface DownloadFormsTaskListener {
-    void formsDownloadingComplete(Map<ServerFormDetails, String> result);
+    void formsDownloadingComplete(Map<ServerFormDetails, FormDownloadException> result);
 
     void progressUpdate(String currentFile, int progress, int total);
 

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/NotificationManagerNotifier.kt
@@ -6,6 +6,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import org.odk.collect.android.R
+import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.notifications.builders.FormUpdatesAvailableNotificationBuilder
 import org.odk.collect.android.notifications.builders.FormUpdatesDownloadedNotificationBuilder
@@ -41,7 +42,7 @@ class NotificationManagerNotifier(
         }
     }
 
-    override fun onUpdatesDownloaded(result: Map<ServerFormDetails, String>, projectId: String) {
+    override fun onUpdatesDownloaded(result: Map<ServerFormDetails, FormDownloadException?>, projectId: String) {
         notificationManager.notify(
             FORM_UPDATE_NOTIFICATION_ID,
             FormUpdatesDownloadedNotificationBuilder.build(

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/Notifier.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/Notifier.kt
@@ -1,11 +1,12 @@
 package org.odk.collect.android.notifications
 
+import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.forms.FormSourceException
 
 interface Notifier {
     fun onUpdatesAvailable(updates: List<ServerFormDetails>, projectId: String)
-    fun onUpdatesDownloaded(result: Map<ServerFormDetails, String>, projectId: String)
+    fun onUpdatesDownloaded(result: Map<ServerFormDetails, FormDownloadException?>, projectId: String)
     fun onSync(exception: FormSourceException?, projectId: String)
     fun onSubmission(failure: Boolean, message: String, projectId: String)
 }

--- a/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/notifications/builders/FormUpdatesDownloadedNotificationBuilder.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FillBlankFormActivity
+import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.android.notifications.NotificationManagerNotifier
 import org.odk.collect.android.utilities.ApplicationConstants
@@ -18,7 +19,7 @@ import java.io.Serializable
 
 object FormUpdatesDownloadedNotificationBuilder {
 
-    fun build(application: Application, result: Map<ServerFormDetails, String>, projectName: String): Notification {
+    fun build(application: Application, result: Map<ServerFormDetails, FormDownloadException?>, projectName: String): Notification {
         val allFormsDownloadedSuccessfully = FormsDownloadResultInterpreter.allFormsDownloadedSuccessfully(result, application)
 
         val intent = if (allFormsDownloadedSuccessfully) {

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DownloadFormsTask.java
@@ -14,6 +14,8 @@
 
 package org.odk.collect.android.tasks;
 
+import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
+
 import android.os.AsyncTask;
 
 import org.odk.collect.android.R;
@@ -62,7 +64,7 @@ public class DownloadFormsTask extends
                 publishProgress(serverFormDetails.getFormName(), currentFormNumber, totalForms);
 
                 formDownloader.downloadForm(serverFormDetails, count -> {
-                    String message = Collect.getInstance().getString(R.string.form_download_progress,
+                    String message = getLocalizedString(Collect.getInstance(), R.string.form_download_progress,
                             serverFormDetails.getFormName(),
                             String.valueOf(count),
                             String.valueOf(serverFormDetails.getManifest().getMediaFiles().size())
@@ -71,7 +73,7 @@ public class DownloadFormsTask extends
                     publishProgress(message, currentFormNumber, totalForms);
                 }, this::isCancelled);
 
-                results.put(serverFormDetails, Collect.getInstance().getString(R.string.success));
+                results.put(serverFormDetails, getLocalizedString(Collect.getInstance(), R.string.success));
             } catch (FormDownloadException.DownloadingInterrupted e) {
                 return emptyMap();
             } catch (FormDownloadException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDownloadResultInterpreter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDownloadResultInterpreter.kt
@@ -2,26 +2,28 @@ package org.odk.collect.android.utilities
 
 import android.content.Context
 import org.odk.collect.android.R
+import org.odk.collect.android.formmanagement.FormDownloadException
+import org.odk.collect.android.formmanagement.FormDownloadExceptionMapper
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.errors.ErrorItem
 import org.odk.collect.strings.localization.getLocalizedString
 
 object FormsDownloadResultInterpreter {
-    fun getFailures(result: Map<ServerFormDetails, String>, context: Context) = result.filter {
-        it.value != context.getLocalizedString(R.string.success)
+    fun getFailures(result: Map<ServerFormDetails, FormDownloadException?>, context: Context) = result.filter {
+        it.value != null
     }.map {
         ErrorItem(
             it.key.formName ?: "",
             context.getLocalizedString(R.string.form_details, it.key.formId ?: "", it.key.formVersion ?: ""),
-            it.value
+            FormDownloadExceptionMapper(context).getMessage(it.value)
         )
     }
 
-    fun getNumberOfFailures(result: Map<ServerFormDetails, String>, context: Context) = result.count {
-        it.value != context.getLocalizedString(R.string.success)
+    fun getNumberOfFailures(result: Map<ServerFormDetails, FormDownloadException?>, context: Context) = result.count {
+        it.value != null
     }
 
-    fun allFormsDownloadedSuccessfully(result: Map<ServerFormDetails, String>, context: Context) = result.values.all {
-        it == context.getLocalizedString(R.string.success)
+    fun allFormsDownloadedSuccessfully(result: Map<ServerFormDetails, FormDownloadException?>, context: Context) = result.values.all {
+        it == null
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormUpdateDownloaderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormUpdateDownloaderTest.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.formmanagement
 
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.mockito.Mockito.any
 import org.mockito.Mockito.doAnswer
@@ -66,6 +67,6 @@ class FormUpdateDownloaderTest {
         )
 
         assertThat(results.size, `is`(1))
-        assertThat(results[serverForms[0]], `is`("success"))
+        assertThat(results[serverForms[0]], equalTo(null))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/fragments/dialogs/FormsDownloadResultDialogTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.odk.collect.android.R
 import org.odk.collect.android.application.Collect
+import org.odk.collect.android.formmanagement.FormDownloadException
 import org.odk.collect.android.formmanagement.ServerFormDetails
 import org.odk.collect.fragmentstest.DialogFragmentTest
 import org.odk.collect.testshared.RobolectricHelpers
@@ -30,9 +31,13 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `The dialog should be dismissed after clicking out of it's area or on device back button`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf<ServerFormDetails, String>())
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, FormDownloadException>()
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
             assertThat(it.isCancelable, `is`(true))
         }
@@ -41,20 +46,31 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `The title of the 'POSITIVE BUTTON' should be 'OK'`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf<ServerFormDetails, String>())
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, FormDownloadException>()
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).text, `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.ok)))
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).text,
+                `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.ok))
+            )
         }
     }
 
     @Test
     fun `The dialog should be dismissed after clicking on the 'POSITIVE BUTTON'`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf<ServerFormDetails, String>())
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, FormDownloadException>()
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
             it.listener = listener
             assertThat(it.dialog!!.isShowing, `is`(true))
@@ -67,9 +83,13 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `onCloseDownloadingResult() should be called after clicking on the 'POSITIVE BUTTON'`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf<ServerFormDetails, String>())
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, FormDownloadException>()
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
             it.listener = listener
             (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).performClick()
@@ -79,11 +99,15 @@ class FormsDownloadResultDialogTest {
     }
 
     @Test
-    fun `onCloseDownloadingResult() should be called after clicking on the 'NEGATIVE BUTTON'`() {
+    fun `if there are errors onCloseDownloadingResult() should be called after clicking on the 'NEGATIVE BUTTON'`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf(resultItem to "Exception"))
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf(resultItem to FormDownloadException.InvalidSubmission())
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
             it.listener = listener
             (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).performClick()
@@ -95,7 +119,10 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `If there are no errors an appropriate message should be displayed`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf<ServerFormDetails, String>())
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, String>()
+        )
 
         DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         DialogFragmentTest
@@ -109,23 +136,36 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `If there are no errors 'SHOW DETAILS' button should be hidden`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf<ServerFormDetails, String>())
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, String>()
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).visibility, `is`(View.GONE))
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).visibility,
+                `is`(View.GONE)
+            )
         }
     }
 
     @Test
     fun `If there are errors an appropriate message should be displayed`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf(resultItem to "Exception"))
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf(resultItem to FormDownloadException.InvalidSubmission())
+        )
 
         DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         DialogFragmentTest
             .onViewInDialog(
-                withText(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.some_downloads_failed, "1", "1"))
+                withText(
+                    ApplicationProvider.getApplicationContext<Collect>()
+                        .getString(R.string.some_downloads_failed, "1", "1")
+                )
             ).check(
                 matches(
                     isDisplayed()
@@ -136,21 +176,38 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `If there are errors 'SHOW DETAILS' button should be displayed`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf(resultItem to "Exception"))
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf(resultItem to FormDownloadException.InvalidSubmission())
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).visibility, `is`(View.VISIBLE))
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).text, `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.show_details)))
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).visibility,
+                `is`(View.VISIBLE)
+            )
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).text,
+                `is`(
+                    ApplicationProvider.getApplicationContext<Collect>()
+                        .getString(R.string.show_details)
+                )
+            )
         }
     }
 
     @Test
     fun `The dialog should be dismissed after clicking on the 'NEGATIVE BUTTON'`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf(resultItem to "Exception"))
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf<ServerFormDetails, String>()
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
             it.listener = listener
             assertThat(it.dialog!!.isShowing, `is`(true))
@@ -163,21 +220,43 @@ class FormsDownloadResultDialogTest {
     @Test
     fun `Recreation should not change the state of dialog`() {
         val args = Bundle()
-        args.putSerializable(FormsDownloadResultDialog.ARG_RESULT, hashMapOf(resultItem to "Exception"))
+        args.putSerializable(
+            FormsDownloadResultDialog.ARG_RESULT,
+            hashMapOf(resultItem to FormDownloadException.InvalidSubmission())
+        )
 
-        val scenario = DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
+        val scenario =
+            DialogFragmentTest.launchDialogFragment(FormsDownloadResultDialog::class.java, args)
         scenario.onFragment {
             assertThat(Shadows.shadowOf(it.dialog).title, `is`(""))
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).text, `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.ok)))
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).text, `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.show_details)))
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).text,
+                `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.ok))
+            )
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).text,
+                `is`(
+                    ApplicationProvider.getApplicationContext<Collect>()
+                        .getString(R.string.show_details)
+                )
+            )
         }
 
         scenario.recreate()
 
         scenario.onFragment {
             assertThat(Shadows.shadowOf(it.dialog).title, `is`(""))
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).text, `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.ok)))
-            assertThat((it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).text, `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.show_details)))
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_POSITIVE).text,
+                `is`(ApplicationProvider.getApplicationContext<Collect>().getString(R.string.ok))
+            )
+            assertThat(
+                (it.dialog as AlertDialog).getButton(AlertDialog.BUTTON_NEGATIVE).text,
+                `is`(
+                    ApplicationProvider.getApplicationContext<Collect>()
+                        .getString(R.string.show_details)
+                )
+            )
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/FormsDownloadResultInterpreterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/FormsDownloadResultInterpreterTest.kt
@@ -8,6 +8,8 @@ import org.hamcrest.Matchers.`is`
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
+import org.odk.collect.android.formmanagement.FormDownloadException
+import org.odk.collect.android.formmanagement.FormDownloadExceptionMapper
 import org.odk.collect.android.formmanagement.ServerFormDetails
 
 @RunWith(AndroidJUnit4::class)
@@ -17,14 +19,14 @@ class FormsDownloadResultInterpreterTest {
     private val formDetails1 = ServerFormDetails("Form 1", "", "1", "1", "", false, true, null)
     private val formDetails2 = ServerFormDetails("Form 2", "", "5", "4", "", false, true, null)
 
-    private var resultWithoutErrors = mapOf(
-        formDetails1 to context.getString(R.string.success),
-        formDetails2 to context.getString(R.string.success)
+    private var resultWithoutErrors = mapOf<ServerFormDetails, FormDownloadException?>(
+        formDetails1 to null,
+        formDetails2 to null
     )
 
-    private var resultWithOneError = mapOf(
-        formDetails1 to context.getString(R.string.success),
-        formDetails2 to "Exception"
+    private var resultWithOneError = mapOf<ServerFormDetails, FormDownloadException?>(
+        formDetails1 to null,
+        formDetails2 to FormDownloadException.FormParsingError()
     )
 
     @Test
@@ -37,7 +39,7 @@ class FormsDownloadResultInterpreterTest {
         assertThat(FormsDownloadResultInterpreter.getFailures(resultWithOneError, context).size, `is`(1))
         assertThat(FormsDownloadResultInterpreter.getFailures(resultWithOneError, context)[0].title, `is`("Form 2"))
         assertThat(FormsDownloadResultInterpreter.getFailures(resultWithOneError, context)[0].secondaryText, `is`(context.getString(R.string.form_details, "5", "4")))
-        assertThat(FormsDownloadResultInterpreter.getFailures(resultWithOneError, context)[0].supportingText, `is`("Exception"))
+        assertThat(FormsDownloadResultInterpreter.getFailures(resultWithOneError, context)[0].supportingText, `is`(FormDownloadExceptionMapper(context).getMessage(resultWithOneError[formDetails2])))
     }
 
     @Test


### PR DESCRIPTION
Closes #4931
~~Blocked by #4929~~

This makes the same changes as #4932 but also removes the source of the problem by taking localized strings out of `DownloadFormsTask`.

#### What has been done to verify that this works as intended?

Existing tests checking download flows.

#### Why is this the best possible solution? Were any other approaches considered?

I didn't want to add the risk of a refactor to the original hotfix, but I feel pretty good about this change after making it. Using the localized success/failure message in our logic was a little strange but it also opened us up to bugs like the one we experienced (a translated string getting compared to a non translated one). I think using a nullable exception to track success/failure is much clearer **and** safer.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to just check the issue is fixed!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
