### PR TITLE
Prevent crashes when clicking Save Geopoint early

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/GeoPointActivity.java
@@ -53,7 +53,7 @@ import java.util.TimerTask;
 import timber.log.Timber;
 
 public class GeoPointActivity extends LocalizedActivity implements LocationListener,
-        LocationClient.LocationClientListener, GpsStatus.Listener {
+        LocationClient.LocationClientListener, GpsStatus.Listener, DialogInterface.OnClickListener {
 
     public static final String EXTRA_ACCURACY_THRESHOLD = "accuracyThreshold";
 
@@ -202,28 +202,32 @@ public class GeoPointActivity extends LocalizedActivity implements LocationListe
                 .create();
 
         dialogMessage = getString(R.string.please_wait_long);
-
-        DialogInterface.OnClickListener geoPointButtonListener =
-                (dialog, which) -> {
-                    switch (which) {
-                        case DialogInterface.BUTTON_POSITIVE:
-                            logSavePointManual();
-                            returnLocation();
-                            break;
-                        case DialogInterface.BUTTON_NEGATIVE:
-                            location = null;
-                            finish();
-                            break;
-                    }
-                };
         locationDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string.save_point),
-                geoPointButtonListener);
+                this);
         locationDialog.setButton(DialogInterface.BUTTON_NEGATIVE,
                 getString(R.string.cancel_location),
-                geoPointButtonListener);
+                this);
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        switch (which) {
+            case DialogInterface.BUTTON_POSITIVE:
+                logSavePointManual();
+                returnLocation();
+                break;
+            case DialogInterface.BUTTON_NEGATIVE:
+                location = null;
+                finish();
+                break;
+        }
     }
 
     private void logSavePointManual() {
+        if (location == null) {
+            return;
+        }
+
         String event;
         if (System.currentTimeMillis() - startTime < 2000) {
             event = AnalyticsEvents.SAVE_POINT_IMMEDIATE;

--- a/geo/src/test/java/org/odk/collect/geo/GeoPointActivityTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/GeoPointActivityTest.java
@@ -4,6 +4,7 @@ import static android.app.Activity.RESULT_OK;
 import static android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -14,6 +15,7 @@ import static org.odk.collect.geo.Constants.EXTRA_RETAIN_MOCK_ACCURACY;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.location.Location;
 
@@ -169,5 +171,14 @@ public class GeoPointActivityTest {
         intent.putExtra(EXTRA_RETAIN_MOCK_ACCURACY, false);
         ActivityScenario.launch(intent);
         verify(locationClient).setRetainMockAccuracy(false);
+    }
+
+    @Test
+    public void clickingSaveGeoPoint_beforeLocationFound_finishesActivity() {
+        ActivityScenario<GeoPointActivity> scenario = ActivityScenario.launch(GeoPointActivity.class);
+        scenario.onActivity(activity -> {
+            activity.onClick(null, DialogInterface.BUTTON_POSITIVE);
+            assertThat(activity.isFinishing(), equalTo(true));
+        });
     }
 }


### PR DESCRIPTION
Fixes the crash reported in [Firebase](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/0c4681222cfeb34c2e29805ae831dc55?time=last-seven-days&type=crash&versions=v2021.3.3%20(4332)&sessionEventKey=61BC7099023000016A8366CC23160BDB_1621074324837477558).

We won't need a `master` version of this change as we are reimplanting the `GeoPointActivity` (in #4718). I'll add a note to that issue to block saving the geopoint early.

#### What has been done to verify that this works as intended?

New test to catch the case we missed in review and checked manually.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should hopefully just fix the crash. I think it'd be a good idea to run QA over this quickly (just the default geopoint widget).

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
