### PR TITLE
Fix class reference

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
-import org.odk.collect.android.RecordedIntentsRule
 import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.preferences.source.SettingsProvider
@@ -38,6 +37,7 @@ import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.shared.strings.UUIDGenerator
+import org.odk.collect.testshared.RecordedIntentsRule
 
 @RunWith(AndroidJUnit4::class)
 class FormUriActivityTest {


### PR DESCRIPTION
Just fixes a reference to a class that was breaking test code compilation. No need for QA checks.