### PR TITLE
Increase CI resource size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ references:
     working_directory: ~/work
     docker:
       - image: circleci/android:api-30
+    resource_class: medium+
 
 jobs:
   compile:

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,5 +1,5 @@
-org.gradle.jvmargs=-Xmx3072M -XX:+UseParallelGC -Dkotlin.daemon.jvm.options\="-Xmx3072M"
-org.gradle.workers.max=2
+org.gradle.jvmargs=-Xmx5120M -XX:+UseParallelGC -Dkotlin.daemon.jvm.options\="-Xmx5120M"
+org.gradle.workers.max=3
 org.gradle.daemon=false
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
We've been seeing a lot of "Gradle build daemon disappeared unexpectedly" errors in CI. These seem to have replaced the "out of memory" errors we were seeing before - I think we've traded exceeding our memory allowance for not having enough memory to dependably compile our code.

#### What has been done to verify that this works as intended?

Ran CI on this branch several times.

#### Why is this the best possible solution? Were any other approaches considered?

After looking at a bunch of support posts (including [this one](https://discuss.circleci.com/t/gradle-build-daemon-disappeared-unexpectedly-react-native/31003)), it seems like the best thing to do is up the size of our CI machine so that we can increase the heap size we allow the JVM to have. It will cost 1.5x credits but avoiding reruns might actually drop our overall costs.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just changes CI config. No need for CI.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
