### PR TITLE
Fix test heap for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,10 @@ jobs:
           command: |
             cat .circleci/collect_app_test_classes.txt | circleci tests split > .circleci/fork_test_classes.txt && \
             echo "Tests for this fork:" && \
-            cat .circleci/fork_test_classes.txt
+            cat .circleci/fork_test_classes.txt && \
+            echo "" && \
+            echo "Will run command:" && \
+            echo "./gradlew collect_app:testDebug $(cat .circleci/fork_test_classes.txt | awk '{for (i=1; i<=NF; i++) printf "--tests %s ",$i}')"
 
       - run:
           name: Run app unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
   test_app:
     <<: *android_config
-    parallelism: 4
+    parallelism: 6
     steps:
       - attach_workspace:
           at: ~/work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
   test_app:
     <<: *android_config
-    parallelism: 6
+    parallelism: 4
     steps:
       - attach_workspace:
           at: ~/work

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx5g -Dkotlin.compiler.execution.strategy="in-process"
+org.gradle.jvmargs=-Xmx4g -Dkotlin.compiler.execution.strategy="in-process"
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=3

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,5 +1,6 @@
-org.gradle.jvmargs=-Xmx5120M -XX:+UseParallelGC -Dkotlin.daemon.jvm.options\="-Xmx5120M"
+org.gradle.jvmargs=-Xmx5g -Dkotlin.daemon.jvm.options\="-Xmx5g"
 org.gradle.workers.max=3
 org.gradle.daemon=false
 org.gradle.parallel=true
 kotlin.compiler.execution.strategy=in-process
+test.heap.max=1g

--- a/.circleci/gradle.properties
+++ b/.circleci/gradle.properties
@@ -1,6 +1,5 @@
-org.gradle.jvmargs=-Xmx5g -Dkotlin.daemon.jvm.options\="-Xmx5g"
-org.gradle.workers.max=3
+org.gradle.jvmargs=-Xmx5g -Dkotlin.compiler.execution.strategy="in-process"
 org.gradle.daemon=false
 org.gradle.parallel=true
-kotlin.compiler.execution.strategy=in-process
+org.gradle.workers.max=3
 test.heap.max=1g

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If you have finished testing a pull request, please use a template from [Testing
 You can customize the heap size that is used for compiling and running tests. Increasing these will most likely speed up compilation and tests on your local machine. The default values are specified in the project's `gradle.properties` and this can be overriden by your user level `gradle.properties` (found in your `GRADLE_USER_HOME` directory). An example `gradle.properties` that would give you a heap size of 4GB (rather than the default 1GB) would look like:
 
 ```
-org.gradle.jvmargs=-Xmx4096 -Dkotlin.daemon.jvm.options\="-Xmx4096"
+org.gradle.jvmargs=-Xmx4096
 ```
 
 ## Testing a form without a server

--- a/androidshared/src/test/resources/robolectric.properties
+++ b/androidshared/src/test/resources/robolectric.properties
@@ -1,0 +1,1 @@
+instrumentedPackages=androidx.loader.content

--- a/androidshared/src/test/resources/robolectric.properties
+++ b/androidshared/src/test/resources/robolectric.properties
@@ -1,1 +1,2 @@
+# Workaround for https://github.com/robolectric/robolectric/issues/6593
 instrumentedPackages=androidx.loader.content

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,13 @@ configurations.all {
     transitive = true
 }
 
+subprojects {
+    tasks.withType(Test) {
+       minHeapSize = '512m'
+       maxHeapSize = project.properties['test.heap.max']
+    }
+}
+
 task checkAll(type: GradleBuild) {
     tasks = ['checkCode', 'checkTests']
 }

--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -91,7 +91,7 @@ object Dependencies {
     const val okhttp3_mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.okhttp3}"
     const val kotlinx_coroutines_test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2"
     const val hamcrest = "org.hamcrest:hamcrest:2.2"
-    const val robolectric = "org.robolectric:robolectric:4.5.1"
-    const val robolectric_shadows_multidex = "org.robolectric:shadows-multidex:4.5.1"
+    const val robolectric = "org.robolectric:robolectric:4.7.3"
+    const val robolectric_shadows_multidex = "org.robolectric:shadows-multidex:4.7.3"
     const val uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 }

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -198,10 +198,6 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
         }
-
-        unitTests.all {
-            maxHeapSize = '1g'
-        }
     }
 
     lintOptions {

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -198,6 +198,10 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
         }
+
+        unitTests.all {
+            maxHeapSize = '1g'
+        }
     }
 
     lintOptions {

--- a/collect_app/src/test/resources/robolectric.properties
+++ b/collect_app/src/test/resources/robolectric.properties
@@ -1,1 +1,3 @@
 application=org.odk.collect.android.application.RobolectricApplication
+instrumentedPackages=androidx.loader.content
+

--- a/download-robolectric-deps.sh
+++ b/download-robolectric-deps.sh
@@ -1,8 +1,9 @@
 set -e
 
-wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all/6.0.1_r3-robolectric-r1/android-all-6.0.1_r3-robolectric-r1.jar -P robolectric-deps
-wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all/7.0.0_r1-robolectric-r1/android-all-7.0.0_r1-robolectric-r1.jar -P robolectric-deps
-wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all/11-robolectric-6757853/android-all-11-robolectric-6757853.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/6.0.1_r3-robolectric-r1-i3/android-all-instrumented-6.0.1_r3-robolectric-r1-i3.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/7.0.0_r1-robolectric-r1-i3/android-all-instrumented-7.0.0_r1-robolectric-r1-i3.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/11-robolectric-6757853-i3/android-all-instrumented-11-robolectric-6757853-i3.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/12-robolectric-7732740-i3/android-all-instrumented-12-robolectric-7732740-i3.jar -P robolectric-deps
 
 mkdir -p collect_app/src/test/resources && cp robolectric-deps.properties "$_"
 mkdir -p audiorecorder/src/test/resources && cp robolectric-deps.properties "$_"
@@ -10,3 +11,4 @@ mkdir -p projects/src/test/resources && cp robolectric-deps.properties "$_"
 mkdir -p location/src/test/resources && cp robolectric-deps.properties "$_"
 mkdir -p androidshared/src/test/resources && cp robolectric-deps.properties "$_"
 mkdir -p geo/src/test/resources && cp robolectric-deps.properties "$_"
+mkdir -p permissions/src/test/resources && cp robolectric-deps.properties "$_"

--- a/geo/src/test/resources/robolectric.properties
+++ b/geo/src/test/resources/robolectric.properties
@@ -1,1 +1,4 @@
 application=org.odk.collect.geo.RobolectricApplication
+
+# Workaround for https://github.com/robolectric/robolectric/issues/6593
+instrumentedPackages=androidx.loader.content

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #You can override this in ~/.gradle/gradle.properties
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M"
+org.gradle.jvmargs=-Xmx1g
 test.heap.max=1g

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M"
+test.heap.max=1g

--- a/permissions/src/test/resources/robolectric.properties
+++ b/permissions/src/test/resources/robolectric.properties
@@ -1,0 +1,1 @@
+instrumentedPackages=androidx.loader.content

--- a/permissions/src/test/resources/robolectric.properties
+++ b/permissions/src/test/resources/robolectric.properties
@@ -1,1 +1,2 @@
+# Workaround for https://github.com/robolectric/robolectric/issues/6593
 instrumentedPackages=androidx.loader.content

--- a/robolectric-deps.properties
+++ b/robolectric-deps.properties
@@ -1,5 +1,4 @@
-org.robolectric\:android-all\:6.0.1_r3-robolectric-r1=../../../../../../robolectric-deps/android-all-6.0.1_r3-robolectric-r1.jar
-org.robolectric\:android-all\:7.0.0_r1-robolectric-r1=../../../../../../robolectric-deps/android-all-7.0.0_r1-robolectric-r1.jar
-org.robolectric\:android-all\:9-robolectric-4913185-2=../../../../../../robolectric-deps/android-all-9-robolectric-4913185-2.jar
-org.robolectric\:android-all\:10-robolectric-5803371=../../../../../../robolectric-deps/android-all-10-robolectric-5803371.jar
-org.robolectric\:android-all\:11-robolectric-6757853=../../../../../../robolectric-deps/android-all-11-robolectric-6757853.jar
+org.robolectric\:android-all-instrumented\:6.0.1_r3-robolectric-r1-i3=../../../../../../robolectric-deps/android-all-instrumented-6.0.1_r3-robolectric-r1-i3.jar
+org.robolectric\:android-all-instrumented\:7.0.0_r1-robolectric-r1-i3=../../../../../../robolectric-deps/android-all-instrumented-7.0.0_r1-robolectric-r1-i3.jar
+org.robolectric\:android-all-instrumented\:11-robolectric-6757853-i3=../../../../../../robolectric-deps/android-all-instrumented-11-robolectric-6757853-i3.jar
+org.robolectric\:android-all-instrumented\:12-robolectric-7732740-i3=../../../../../../robolectric-deps/android-all-instrumented-12-robolectric-7732740-i3.jar


### PR DESCRIPTION
This fixes the test memory heap configuration so that we don't end up seeing OOMs on CI (or locally for bigger runs).