### PR TITLE
Avoid crashes in FormEntryActivity when webview is absent

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -383,7 +383,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             try {
                 new WebView(this);
             } catch (Exception | Error e) {
-                // ignored
+                // Don't crash if WebView not available
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -380,7 +380,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         // Workaround for https://issuetracker.google.com/issues/37124582. Some widgets trigger
         // this issue by including WebViews
         if (Build.VERSION.SDK_INT >= 24) {
-            new WebView(this);
+            try {
+                new WebView(this);
+            } catch (Exception | Error e) {
+                // ignored
+            }
         }
 
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
Closes #4965 

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
In `FormEntryActivity` we create `WebView` to handle the issue described in:
- https://github.com/getodk/collect/compare/master...grzesiek2010:COLLECT-4965?expand=1#diff-150be8209a860d77a445a11267821bfba08a71b0b8c581bbb115641f42dc7919R380
- https://github.com/getodk/collect/pull/4803#issuecomment-906168621

some devices might not have  `WebView` (or have it disabled) and then the app would crash. The fix which might cause the crash handles a small bug:
- it occurs only in forms that use selects with `image-map` appearance
- even if the bug is not handled it occurs only if we open a form for the first time after [cold start](https://developer.android.com/topic/performance/vitals/launch-time) 

so it's a small bug but the crash it causes on devices without  `WebView` occurs every time no matter if a from contains that particular widget and no matter if we open a form for the first time or not.
So the issue should be handled. There is not much we can do we we can just catch the exception.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
