### PR TITLE
Make it easier to determine how many users have multiple projects

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/UserPropertiesInitializer.kt
@@ -18,7 +18,7 @@ class UserPropertiesInitializer(
     fun initialize() {
         val projects = projectsRepository.getAll()
 
-        analytics.setUserProperty("ProjectsCount", projects.size.toString())
+        analytics.setUserProperty("UsingMultipleProjects", (projects.size > 1).toString())
 
         analytics.setUserProperty(
             "UsingLegacyFormUpdate",


### PR DESCRIPTION
The current user property (`ProjectsCount`) makes it a little awkward to answer the question "how many devices have multiple (> 1) projects configured on them?". While we see projects being adopted, this is the question I've been asking in my head more than "how many projects do people typically have configured?".

#### What has been done to verify that this works as intended?

Nothing.

#### Why is this the best possible solution? Were any other approaches considered?

We could keep both properties in, but we can just add `ProjectsCount` back in if we feel like we need it later.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

No changes to user visible features here. Can skip QA on this.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
