### PR TITLE
Fixed the 'Reset app' dialog

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ResetDialogPreferenceFragmentCompat.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ResetDialogPreferenceFragmentCompat.java
@@ -1,6 +1,5 @@
 package org.odk.collect.android.preferences.dialogs;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
@@ -19,6 +18,7 @@ import org.odk.collect.android.activities.CollectAbstractActivity;
 import org.odk.collect.android.fragments.dialogs.ResetSettingsResultDialog;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.utilities.ProjectResetter;
+import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +35,6 @@ public class ResetDialogPreferenceFragmentCompat extends PreferenceDialogFragmen
     @Inject
     ProjectResetter projectResetter;
 
-    private ProgressDialog progressDialog;
     private AppCompatCheckBox preferences;
     private AppCompatCheckBox instances;
     private AppCompatCheckBox forms;
@@ -125,7 +124,7 @@ public class ResetDialogPreferenceFragmentCompat extends PreferenceDialogFragmen
             new AsyncTask<Void, Void, List<Integer>>() {
                 @Override
                 protected void onPreExecute() {
-                    showProgressDialog();
+                    DialogFragmentUtils.showIfNotShowing(ResetProgressDialog.class, ((CollectAbstractActivity) context).getSupportFragmentManager());
                 }
 
                 @Override
@@ -135,22 +134,11 @@ public class ResetDialogPreferenceFragmentCompat extends PreferenceDialogFragmen
 
                 @Override
                 protected void onPostExecute(List<Integer> failedResetActions) {
+                    DialogFragmentUtils.dismissDialog(ResetProgressDialog.class, ((CollectAbstractActivity) context).getSupportFragmentManager());
                     handleResult(resetActions, failedResetActions);
-                    hideProgressDialog();
                 }
             }.execute();
         }
-    }
-
-    private void showProgressDialog() {
-        progressDialog = ProgressDialog.show(context,
-                        context.getString(R.string.please_wait),
-                        context.getString(R.string.reset_in_progress),
-                        true);
-    }
-
-    private void hideProgressDialog() {
-        progressDialog.dismiss();
     }
 
     private void handleResult(final List<Integer> resetActions, List<Integer> failedResetActions) {

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ResetProgressDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/dialogs/ResetProgressDialog.kt
@@ -1,0 +1,16 @@
+package org.odk.collect.android.preferences.dialogs
+
+import android.content.Context
+import org.odk.collect.android.R
+import org.odk.collect.android.fragments.dialogs.ProgressDialogFragment
+import org.odk.collect.strings.localization.getLocalizedString
+
+class ResetProgressDialog : ProgressDialogFragment() {
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        setTitle(context.getLocalizedString(R.string.please_wait))
+        setMessage(context.getLocalizedString(R.string.reset_in_progress))
+        isCancelable = false
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/dialogs/ResetProgressDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/dialogs/ResetProgressDialogTest.kt
@@ -1,0 +1,50 @@
+package org.odk.collect.android.preferences.dialogs
+
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.fragmentstest.DialogFragmentTest
+import org.odk.collect.permissions.R
+import org.odk.collect.strings.localization.getLocalizedString
+
+@RunWith(AndroidJUnit4::class)
+class ResetProgressDialogTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `The dialog should not be dismissed after clicking out of its area or on device back button`() {
+        val scenario = DialogFragmentTest.launchDialogFragment(ResetProgressDialog::class.java)
+        scenario.onFragment {
+            assertThat(it.isCancelable, `is`(false))
+        }
+    }
+
+    @Test
+    fun `The dialog should display proper content`() {
+        val scenario = DialogFragmentTest.launchDialogFragment(ResetProgressDialog::class.java)
+        scenario.onFragment {
+            // Button positive
+            assertThat((it.dialog!! as AlertDialog).getButton((AlertDialog.BUTTON_POSITIVE)).visibility, `is`(View.GONE))
+
+            // Button neutral
+            assertThat((it.dialog!! as AlertDialog).getButton((AlertDialog.BUTTON_NEUTRAL)).visibility, `is`(View.GONE))
+
+            // Button negative
+            assertThat((it.dialog!! as AlertDialog).getButton((AlertDialog.BUTTON_NEGATIVE)).visibility, `is`(View.GONE))
+
+            // Title
+            val titleId: Int = context.resources.getIdentifier("alertTitle", "id", context.packageName)
+            assertThat((it.dialog!!.findViewById(titleId) as TextView).text, `is`(context.getLocalizedString(R.string.please_wait)))
+
+            // Message
+            assertThat((it.dialog!!.findViewById(R.id.message) as TextView).text, `is`(context.getLocalizedString(R.string.reset_in_progress)))
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/dialogs/ResetProgressDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/dialogs/ResetProgressDialogTest.kt
@@ -1,9 +1,6 @@
 package org.odk.collect.android.preferences.dialogs
 
 import android.content.Context
-import android.view.View
-import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.`is`
@@ -13,6 +10,8 @@ import org.junit.runner.RunWith
 import org.odk.collect.fragmentstest.DialogFragmentTest
 import org.odk.collect.permissions.R
 import org.odk.collect.strings.localization.getLocalizedString
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowView
 
 @RunWith(AndroidJUnit4::class)
 class ResetProgressDialogTest {
@@ -30,21 +29,11 @@ class ResetProgressDialogTest {
     fun `The dialog should display proper content`() {
         val scenario = DialogFragmentTest.launchDialogFragment(ResetProgressDialog::class.java)
         scenario.onFragment {
-            // Button positive
-            assertThat((it.dialog!! as AlertDialog).getButton((AlertDialog.BUTTON_POSITIVE)).visibility, `is`(View.GONE))
-
-            // Button neutral
-            assertThat((it.dialog!! as AlertDialog).getButton((AlertDialog.BUTTON_NEUTRAL)).visibility, `is`(View.GONE))
-
-            // Button negative
-            assertThat((it.dialog!! as AlertDialog).getButton((AlertDialog.BUTTON_NEGATIVE)).visibility, `is`(View.GONE))
-
             // Title
-            val titleId: Int = context.resources.getIdentifier("alertTitle", "id", context.packageName)
-            assertThat((it.dialog!!.findViewById(titleId) as TextView).text, `is`(context.getLocalizedString(R.string.please_wait)))
+            assertThat(Shadows.shadowOf(it.dialog).title, `is`(context.getLocalizedString(R.string.please_wait)))
 
             // Message
-            assertThat((it.dialog!!.findViewById(R.id.message) as TextView).text, `is`(context.getLocalizedString(R.string.reset_in_progress)))
+            assertThat(ShadowView.innerText(it.dialogView), `is`(context.getLocalizedString(R.string.reset_in_progress)))
         }
     }
 }


### PR DESCRIPTION
Closes #4979

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
I replaced android progress dialog with our ProgressDialogFragment which works well with themes and is used in many other places.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the issue and has no side effects.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
