### PR TITLE
Use content description to click on projects icon

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/MainMenuPage.java
@@ -1,14 +1,5 @@
 package org.odk.collect.android.support.pages;
 
-import android.accounts.AccountManager;
-import android.app.Activity;
-import android.app.Instrumentation;
-import android.content.Intent;
-
-import org.hamcrest.core.StringContains;
-import org.odk.collect.android.R;
-import org.odk.collect.android.support.WaitFor;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
@@ -21,6 +12,15 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.core.AllOf.allOf;
+
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Intent;
+
+import org.hamcrest.core.StringContains;
+import org.odk.collect.android.R;
+import org.odk.collect.android.support.WaitFor;
 
 public class MainMenuPage extends Page<MainMenuPage> {
 
@@ -35,12 +35,8 @@ public class MainMenuPage extends Page<MainMenuPage> {
     public ProjectSettingsDialogPage openProjectSettingsDialog() {
         assertOnPage(); // Make sure we've waited for the application load correctly
 
-        onView(withId(R.id.projects)).perform(click());
-        // It seems there is some lag here sometimes
-        return WaitFor.waitFor(() -> {
-            // It seems there is some lag here sometimes
-            return new ProjectSettingsDialogPage().assertOnPage();
-        });
+        clickOnContentDescription(R.string.projects);
+        return new ProjectSettingsDialogPage().assertOnPage();
     }
 
     public FormEntryPage startBlankForm(String formName) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -238,6 +238,7 @@ public class MainMenuActivity extends CollectAbstractActivity {
         ProjectIconView projectIconView = (ProjectIconView) projectsMenuItem.getActionView();
         projectIconView.setProject(currentProjectViewModel.getCurrentProject().getValue());
         projectIconView.setOnClickListener(v -> onOptionsItemSelected(projectsMenuItem));
+        projectIconView.setContentDescription(getString(R.string.projects));
 
         return super.onPrepareOptionsMenu(menu);
     }

--- a/collect_app/src/main/res/menu/main_menu.xml
+++ b/collect_app/src/main/res/menu/main_menu.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016 Nafundi
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright 2016 Nafundi
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,5 +19,5 @@ limitations under the License.
         android:id="@+id/projects"
         android:title="@string/projects"
         app:actionLayout="@layout/current_project_menu_icon"
-        app:showAsAction="always"/>
+        app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
We've seen some flakiness with this click action, and I'm hoping switching to a matcher that doesn't use ID might help or at least give us better error output (like the view hierarchy). I've run this change a few times on Test Lab and only seen green results.