### PR TITLE
Cache bitmaps used to display markers on maps

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -49,7 +49,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
-import org.odk.collect.android.utilities.IconUtils;
 import org.odk.collect.android.utilities.MapFragmentReferenceLayerUtils;
 import org.odk.collect.android.utilities.ThemeUtils;
 import org.odk.collect.androidshared.ui.ToastUtils;
@@ -180,6 +179,11 @@ public class GoogleMapFragment extends SupportMapFragment implements
     @Override public void onStop() {
         mapProvider.onMapFragmentStop(this);
         super.onStop();
+    }
+
+    @Override public void onDestroy() {
+        MapsMarkerCache.clearCache();
+        super.onDestroy();
     }
 
     @Override public void applyConfig(Bundle config) {
@@ -635,8 +639,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     private BitmapDescriptor getBitmapDescriptor(int drawableId) {
-        return BitmapDescriptorFactory.fromBitmap(
-            IconUtils.getBitmap(getActivity(), drawableId));
+        return BitmapDescriptorFactory.fromBitmap(MapsMarkerCache.getMarkerBitmap(drawableId, getContext()));
     }
 
     private void showGpsDisabledAlert() {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapsMarkerCache.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapsMarkerCache.kt
@@ -1,0 +1,31 @@
+package org.odk.collect.android.geo
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.util.LruCache
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
+
+object MapsMarkerCache {
+    /**
+     * We use different markers in different features but it looks like we will never need to
+     * support more than 10 different types of markers at the same time.
+     */
+    private val cache = LruCache<Int, Bitmap>(10)
+
+    @JvmStatic
+    fun getMarkerBitmap(@DrawableRes drawable: Int, context: Context): Bitmap {
+        if (cache[drawable] == null) {
+            ContextCompat.getDrawable(context, drawable)?.toBitmap().also {
+                cache.put(drawable, it)
+            }
+        }
+        return cache[drawable]
+    }
+
+    @JvmStatic
+    fun clearCache() {
+        cache.evictAll()
+    }
+}


### PR DESCRIPTION
Closes #5007

#### What has been done to verify that this works as intended?
I tested the fix manually to make sure there is no regression in adding markers in maps.

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue which seems to take place on some devices with limited memory when a lot of markers is displayed on a map. Thus I  decided to implement caching to avoid creating for example 100 new bitmaps if we have 100 markers that in fact use the same bitmap.

The solution is based on:
- https://developer.android.com/topic/performance/graphics/cache-bitmap#memory-cache
- https://proandroiddev.com/using-vector-drawables-as-google-map-markers-on-android-1eb69790fc61

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just check if there is no regression in maps (Geotrace / Geoshape widget, FormsMapView) when we display markers (**only with GoogleMaps**).

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
