### PR TITLE
Do not log it as error if uri can not be accessed on Huawei devices

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/ContentUriProvider.java
@@ -47,8 +47,8 @@ public final class ContentUriProvider {
                         Timber.i("%s: %s", ContentUriProvider.class.getSimpleName(), "Completed Android N+ Huawei file copy. Attempting to return the cached file");
                         return FileProvider.getUriForFile(context, authority, cacheLocation);
                     } catch (IOException e1) {
-                        Timber.e(e1, "%s: %s", ContentUriProvider.class.getSimpleName(), "Failed to copy the Huawei file. Re-throwing exception");
-                        throw new IllegalArgumentException("Huawei devices are unsupported for Android N", e1);
+                        Timber.i(e1, "%s: %s", ContentUriProvider.class.getSimpleName(), "Failed to copy the Huawei file. Re-throwing exception");
+                        return null;
                     } finally {
                         IOUtils.closeQuietly(in);
                         IOUtils.closeQuietly(out);

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
@@ -56,7 +56,7 @@ class MediaUtils(private val intentLauncher: IntentLauncher, private val content
 
         if (contentUri == null) {
             ToastUtils.showLongToast(context, "Can't' open file!")
-            return;
+            return
         }
 
         val intent = Intent().apply {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
@@ -54,6 +54,11 @@ class MediaUtils(private val intentLauncher: IntentLauncher, private val content
             file
         )
 
+        if (contentUri == null) {
+            ToastUtils.showLongToast(context, "Can't' open file!")
+            return;
+        }
+
         val intent = Intent().apply {
             action = Intent.ACTION_VIEW
             setDataAndType(contentUri, getMimeType(file, expectedMimeType))

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/MediaUtils.kt
@@ -55,7 +55,7 @@ class MediaUtils(private val intentLauncher: IntentLauncher, private val content
         )
 
         if (contentUri == null) {
-            ToastUtils.showLongToast(context, "Can't' open file!")
+            ToastUtils.showLongToast(context, "Can't open file. If you are on a Huawei device, this is expected and will not be fixed.")
             return
         }
 

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/MediaUtilsTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/MediaUtilsTest.kt
@@ -53,7 +53,7 @@ class MediaUtilsTest {
 
         mediaUtils.openFile(context, file, "image/*")
 
-        assertThat(ShadowToast.getTextOfLatestToast(), `is`("Can't' open file!"))
+        assertThat(ShadowToast.getTextOfLatestToast(), `is`("Can't open file. If you are on a Huawei device, this is expected and will not be fixed."))
         assertThat(ShadowToast.getLatestToast().duration, `is`(Toast.LENGTH_LONG))
         verify(intentLauncher, never()).launch(any(), any(), any())
     }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/MediaUtilsTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/MediaUtilsTest.kt
@@ -10,8 +10,10 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.BuildConfig
@@ -35,6 +37,25 @@ class MediaUtilsTest {
 
         assertThat(ShadowToast.getTextOfLatestToast(), `is`("File: file:/image.png is missing."))
         assertThat(ShadowToast.getLatestToast().duration, `is`(Toast.LENGTH_LONG))
+        verify(intentLauncher, never()).launch(any(), any(), any())
+    }
+
+    @Test
+    fun `When URI for file we try to open is null a toast should be displayed`() {
+        val file = File.createTempFile("image", ".png")
+        whenever(
+            contentUriProvider.getUriForFile(
+                context,
+                BuildConfig.APPLICATION_ID + ".provider",
+                file
+            )
+        ).thenReturn(null)
+
+        mediaUtils.openFile(context, file, "image/*")
+
+        assertThat(ShadowToast.getTextOfLatestToast(), `is`("Can't' open file!"))
+        assertThat(ShadowToast.getLatestToast().duration, `is`(Toast.LENGTH_LONG))
+        verify(intentLauncher, never()).launch(any(), any(), any())
     }
 
     @Test


### PR DESCRIPTION
Closes #5012

#### What has been done to verify that this works as intended?
I've improved test and reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
It looks like we can't fix that problem with some Huawei devices so I decided to at least improve the code a bit and stop lgging it as error plus display a toast instead of just throwing en exception.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
