### PR TITLE
Return instance URI for Form EDIT action

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/FormEditActionTest.kt
@@ -26,7 +26,7 @@ class FormEditActionTest {
         .around(rule)
 
     @Test
-    fun opensFormAndReturnsInstanceURIAfterFormEntry() {
+    fun editForm_andThenFillingForm_returnsNewInstanceURI() {
         rule.startAtMainMenu()
             .copyAndSyncForm("one-question.xml")
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -27,14 +27,17 @@ public class FormEndPage extends Page<FormEndPage> {
         return this;
     }
 
-    public MainMenuPage clickSaveAndExit() {
+    public <D extends Page<D>> D clickSaveAndExit(D destination) {
         onView(withId(R.id.save_exit_button)).perform(click());
-        return new MainMenuPage().assertOnPage();
+        return destination.assertOnPage();
+    }
+
+    public MainMenuPage clickSaveAndExit() {
+        return clickSaveAndExit(new MainMenuPage());
     }
 
     public FormMapPage clickSaveAndExitBackToMap() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return new FormMapPage().assertOnPage();
+        return clickSaveAndExit(new FormMapPage());
     }
 
     public FormEntryPage clickSaveAndExitWithError(String errorText) {
@@ -44,13 +47,11 @@ public class FormEndPage extends Page<FormEndPage> {
     }
 
     public OkDialog clickSaveAndExitWithErrorDialog() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return new OkDialog().assertOnPage();
+        return clickSaveAndExit(new OkDialog());
     }
 
     public ChangesReasonPromptPage clickSaveAndExitWithChangesReasonPrompt() {
-        onView(withId(R.id.save_exit_button)).perform(click());
-        return new ChangesReasonPromptPage(formName).assertOnPage();
+        return clickSaveAndExit(new ChangesReasonPromptPage(formName));
     }
 
     public FormEndPage assertMarkFinishedIsSelected() {

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -288,7 +288,6 @@ the specific language governing permissions and limitations under the License.
         Do not use the activity directly as its name/package might change. -->
         <activity
             android:name=".external.FormUriActivity"
-            android:noHistory="true"
             tools:ignore="AppLinkUrlError">
 
             <intent-filter>

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -42,11 +42,13 @@ class FormUriActivity : Activity() {
             logAnalytics(uriProjectId)
 
             if (projectId == currentProjectProvider.getCurrentProject().uuid) {
-                startActivity(
+                startActivityForResult(
                     Intent(this, FormEntryActivity::class.java).also {
+                        it.action = intent.action
                         it.data = uri
                         intent.extras?.let { sourceExtras -> it.putExtras(sourceExtras) }
-                    }
+                    },
+                    1
                 )
             } else {
                 MaterialAlertDialogBuilder(this)
@@ -58,6 +60,12 @@ class FormUriActivity : Activity() {
                     .show()
             }
         }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        setResult(resultCode, data)
+        finish()
     }
 
     private fun logAnalytics(uriProjectId: String?) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -1,8 +1,9 @@
 package org.odk.collect.android.external
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
@@ -14,13 +15,19 @@ import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.projects.ProjectsRepository
 import javax.inject.Inject
 
-class FormUriActivity : Activity() {
+class FormUriActivity : ComponentActivity() {
 
     @Inject
     lateinit var currentProjectProvider: CurrentProjectProvider
 
     @Inject
     lateinit var projectsRepository: ProjectsRepository
+
+    private val openForm =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            setResult(it.resultCode, it.data)
+            finish()
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,13 +49,12 @@ class FormUriActivity : Activity() {
             logAnalytics(uriProjectId)
 
             if (projectId == currentProjectProvider.getCurrentProject().uuid) {
-                startActivityForResult(
+                openForm.launch(
                     Intent(this, FormEntryActivity::class.java).also {
                         it.action = intent.action
                         it.data = uri
                         intent.extras?.let { sourceExtras -> it.putExtras(sourceExtras) }
                     },
-                    1
                 )
             } else {
                 MaterialAlertDialogBuilder(this)
@@ -60,12 +66,6 @@ class FormUriActivity : Activity() {
                     .show()
             }
         }
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        setResult(resultCode, data)
-        finish()
     }
 
     private fun logAnalytics(uriProjectId: String?) {


### PR DESCRIPTION
Closes #5008

#### What has been done to verify that this works as intended?

Updated test.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the problem. The VIEW/EDIT action for forms is the only thing that's had any changes.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
