### PR TITLE
Copy media files from old version rather than redownloading

### DIFF
--- a/async/src/main/java/org/odk/collect/async/OngoingWorkListener.kt
+++ b/async/src/main/java/org/odk/collect/async/OngoingWorkListener.kt
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.odk.collect.async
 
-package org.odk.collect.android.listeners;
-
-public interface FormDownloaderListener {
-
-    void progressUpdate(String currentFile, String progress, String total);
-
-    boolean isTaskCancelled();
+/**
+ * Allows a client of some ongoing work to receive updates on progress and to provide a signal
+ * that the work should be cancelled.
+ */
+interface OngoingWorkListener {
+    fun progressUpdate(progress: Int)
+    val isCancelled: Boolean
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.formmanagement
 
-import org.odk.collect.android.utilities.FileUtils.constructMediaPath
 import org.odk.collect.android.utilities.FileUtils.copyFile
 import org.odk.collect.android.utilities.FileUtils.interuptablyWriteFile
 import org.odk.collect.async.OngoingWorkListener
@@ -10,80 +9,51 @@ import org.odk.collect.forms.FormSourceException
 import org.odk.collect.forms.FormsRepository
 import org.odk.collect.forms.MediaFile
 import org.odk.collect.shared.strings.Md5.getMd5Hash
-import timber.log.Timber
 import java.io.File
 import java.io.IOException
 
-class FormMediaDownloader constructor(
-    private val formsDirPath: String,
+class FormMediaDownloader(
     private val formsRepository: FormsRepository,
     private val formSource: FormSource
 ) {
 
     @Throws(IOException::class, FormSourceException::class, InterruptedException::class)
     fun download(
-        tempMediaPath: String,
-        stateListener: OngoingWorkListener?,
+        formToDownload: ServerFormDetails,
         files: List<MediaFile>,
+        tempMediaPath: String,
         tempDir: File,
-        formFileName: String,
-        fd: ServerFormDetails
+        stateListener: OngoingWorkListener?
     ) {
         val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
 
         for (i in files.indices) {
             stateListener?.progressUpdate(i + 1)
 
-            val (filename, hash, downloadUrl) = files[i]
-            val tempMediaFile = File(tempMediaDir, filename)
-            val finalMediaPath = constructMediaPath(
-                formsDirPath + File.separator + formFileName
-            )
-            val finalMediaFile = File(finalMediaPath, filename)
+            val mediaFile = files[i]
+            val tempMediaFile = File(tempMediaDir, mediaFile.filename)
 
-            if (!finalMediaFile.exists()) {
-                val allFormVersions = formsRepository.getAllByFormId(fd.formId)
-                val existingFileInOtherVersion = allFormVersions.map { form: Form ->
-                    File(
-                        form.formMediaPath,
-                        filename
-                    )
-                }.firstOrNull { file: File ->
-                    val currentFileHash = getMd5Hash(file)
-                    val downloadFileHash = validateHash(hash)
-                    file.exists() && currentFileHash.contentEquals(downloadFileHash)
-                }
-
-                if (existingFileInOtherVersion != null) {
-                    copyFile(existingFileInOtherVersion, tempMediaFile)
-                } else {
-                    val mediaFile = formSource.fetchMediaFile(downloadUrl)
-                    interuptablyWriteFile(mediaFile, tempMediaFile, tempDir, stateListener)
-                }
+            val existingFile = searchForExistingMediaFile(formToDownload, mediaFile)
+            if (existingFile != null) {
+                copyFile(existingFile, tempMediaFile)
             } else {
-                val currentFileHash = getMd5Hash(finalMediaFile)
-                val downloadFileHash = validateHash(hash)
-                if (currentFileHash != null && downloadFileHash != null && !currentFileHash.contentEquals(
-                        downloadFileHash
-                    )
-                ) {
-                    // if the hashes match, it's the same file otherwise replace it with the new one
-                    val mediaFile = formSource.fetchMediaFile(downloadUrl)
-                    interuptablyWriteFile(
-                        mediaFile,
-                        tempMediaFile,
-                        tempDir,
-                        stateListener
-                    )
-                } else {
-                    // exists, and the hash is the same
-                    // no need to download it again
-                    Timber.i(
-                        "Skipping media file fetch -- file hashes identical: %s",
-                        finalMediaFile.absolutePath
-                    )
-                }
+                val mediaFile = formSource.fetchMediaFile(mediaFile.downloadUrl)
+                interuptablyWriteFile(mediaFile, tempMediaFile, tempDir, stateListener)
             }
+        }
+    }
+
+    private fun searchForExistingMediaFile(
+        formToDownload: ServerFormDetails,
+        mediaFile: MediaFile
+    ): File? {
+        val allFormVersions = formsRepository.getAllByFormId(formToDownload.formId)
+        return allFormVersions.map { form: Form ->
+            File(form.formMediaPath, mediaFile.filename)
+        }.firstOrNull { file: File ->
+            val currentFileHash = getMd5Hash(file)
+            val downloadFileHash = validateHash(mediaFile.hash)
+            file.exists() && currentFileHash.contentEquals(downloadFileHash)
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -52,12 +52,8 @@ class FormMediaDownloader(
             File(form.formMediaPath, mediaFile.filename)
         }.firstOrNull { file: File ->
             val currentFileHash = getMd5Hash(file)
-            val downloadFileHash = validateHash(mediaFile.hash)
+            val downloadFileHash = mediaFile.hash
             file.exists() && currentFileHash.contentEquals(downloadFileHash)
         }
-    }
-
-    private fun validateHash(hash: String): String? {
-        return hash.ifEmpty { null }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -1,0 +1,93 @@
+package org.odk.collect.android.formmanagement
+
+import org.odk.collect.android.utilities.FileUtils.constructMediaPath
+import org.odk.collect.android.utilities.FileUtils.copyFile
+import org.odk.collect.android.utilities.FileUtils.interuptablyWriteFile
+import org.odk.collect.async.OngoingWorkListener
+import org.odk.collect.forms.Form
+import org.odk.collect.forms.FormSource
+import org.odk.collect.forms.FormSourceException
+import org.odk.collect.forms.FormsRepository
+import org.odk.collect.forms.MediaFile
+import org.odk.collect.shared.strings.Md5.getMd5Hash
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
+
+class FormMediaDownloader constructor(
+    private val formsDirPath: String,
+    private val formsRepository: FormsRepository,
+    private val formSource: FormSource
+) {
+
+    @Throws(IOException::class, FormSourceException::class, InterruptedException::class)
+    fun download(
+        tempMediaPath: String,
+        stateListener: OngoingWorkListener?,
+        files: List<MediaFile>,
+        tempDir: File,
+        formFileName: String,
+        fd: ServerFormDetails
+    ) {
+        val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
+
+        for (i in files.indices) {
+            stateListener?.progressUpdate(i + 1)
+
+            val (filename, hash, downloadUrl) = files[i]
+            val tempMediaFile = File(tempMediaDir, filename)
+            val finalMediaPath = constructMediaPath(
+                formsDirPath + File.separator + formFileName
+            )
+            val finalMediaFile = File(finalMediaPath, filename)
+
+            if (!finalMediaFile.exists()) {
+                val allFormVersions = formsRepository.getAllByFormId(fd.formId)
+                val existingFileInOtherVersion = allFormVersions.map { form: Form ->
+                    File(
+                        form.formMediaPath,
+                        filename
+                    )
+                }.firstOrNull { file: File ->
+                    val currentFileHash = getMd5Hash(file)
+                    val downloadFileHash = validateHash(hash)
+                    file.exists() && currentFileHash.contentEquals(downloadFileHash)
+                }
+
+                if (existingFileInOtherVersion != null) {
+                    copyFile(existingFileInOtherVersion, tempMediaFile)
+                } else {
+                    val mediaFile = formSource.fetchMediaFile(downloadUrl)
+                    interuptablyWriteFile(mediaFile, tempMediaFile, tempDir, stateListener)
+                }
+            } else {
+                val currentFileHash = getMd5Hash(finalMediaFile)
+                val downloadFileHash = validateHash(hash)
+                if (currentFileHash != null && downloadFileHash != null && !currentFileHash.contentEquals(
+                        downloadFileHash
+                    )
+                ) {
+                    // if the hashes match, it's the same file otherwise replace it with the new one
+                    val mediaFile = formSource.fetchMediaFile(downloadUrl)
+                    interuptablyWriteFile(
+                        mediaFile,
+                        tempMediaFile,
+                        tempDir,
+                        stateListener
+                    )
+                } else {
+                    // exists, and the hash is the same
+                    // no need to download it again
+                    Timber.i(
+                        "Skipping media file fetch -- file hashes identical: %s",
+                        finalMediaFile.absolutePath
+                    )
+                }
+            }
+        }
+    }
+
+    private fun validateHash(hash: String?): String? {
+        return if (hash == null || hash.isEmpty()) null else hash
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -23,22 +23,22 @@ class FormMediaDownloader(
         files: List<MediaFile>,
         tempMediaPath: String,
         tempDir: File,
-        stateListener: OngoingWorkListener?
+        stateListener: OngoingWorkListener
     ) {
         val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
 
-        for (i in files.indices) {
-            stateListener?.progressUpdate(i + 1)
+        files.forEachIndexed { i, mediaFile ->
+            stateListener.progressUpdate(i + 1)
 
-            val mediaFile = files[i]
             val tempMediaFile = File(tempMediaDir, mediaFile.filename)
 
-            val existingFile = searchForExistingMediaFile(formToDownload, mediaFile)
-            if (existingFile != null) {
-                copyFile(existingFile, tempMediaFile)
-            } else {
-                val mediaFile = formSource.fetchMediaFile(mediaFile.downloadUrl)
-                interuptablyWriteFile(mediaFile, tempMediaFile, tempDir, stateListener)
+            searchForExistingMediaFile(formToDownload, mediaFile).let {
+                if (it != null) {
+                    copyFile(it, tempMediaFile)
+                } else {
+                    val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
+                    interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
+                }
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -57,7 +57,7 @@ class FormMediaDownloader(
         }
     }
 
-    private fun validateHash(hash: String?): String? {
-        return if (hash == null || hash.isEmpty()) null else hash
+    private fun validateHash(hash: String): String? {
+        return hash.ifEmpty { null }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -2,15 +2,14 @@ package org.odk.collect.android.formmanagement;
 
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.odk.collect.android.analytics.AnalyticsEvents.DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH;
+import static org.odk.collect.android.utilities.FileUtils.interuptablyWriteFile;
 
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.analytics.Analytics;
-import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsUtils;
-import org.odk.collect.android.application.Collect;
-import org.odk.collect.async.OngoingWorkListener;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormNameUtils;
+import org.odk.collect.async.OngoingWorkListener;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormSource;
 import org.odk.collect.forms.FormSourceException;
@@ -20,10 +19,8 @@ import org.odk.collect.shared.strings.Md5;
 import org.odk.collect.shared.strings.Validator;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -105,7 +102,7 @@ public class ServerFormDownloader implements FormDownloader {
             if (fd.getManifest() != null && !fd.getManifest().getMediaFiles().isEmpty()) {
                 downloadMediaFiles(tempMediaPath, stateListener, fd.getManifest().getMediaFiles(), tempDir, fileResult.file.getName(), fd);
             }
-        } catch (FormDownloadException.DownloadingInterrupted e) {
+        } catch (FormDownloadException.DownloadingInterrupted | InterruptedException e) {
             Timber.i(e);
             cleanUp(fileResult, tempMediaPath);
             throw new FormDownloadException.DownloadingInterrupted();
@@ -240,12 +237,12 @@ public class ServerFormDownloader implements FormDownloader {
      * Takes the formName and the URL and attempts to download the specified file. Returns a file
      * object representing the downloaded file.
      */
-    private FileResult downloadXform(String formName, String url, OngoingWorkListener stateListener, File tempDir, String formsDirPath) throws FormSourceException, IOException, FormDownloadException.DownloadingInterrupted {
+    private FileResult downloadXform(String formName, String url, OngoingWorkListener stateListener, File tempDir, String formsDirPath) throws FormSourceException, IOException, FormDownloadException.DownloadingInterrupted, InterruptedException {
         InputStream xform = formSource.fetchForm(url);
 
         String fileName = getFormFileName(formName, formsDirPath);
         File tempFormFile = new File(tempDir + File.separator + fileName);
-        writeFile(xform, tempFormFile, tempDir, stateListener);
+        interuptablyWriteFile(xform, tempFormFile, tempDir, stateListener);
 
         // we've downloaded the file, and we may have renamed it
         // make sure it's not the same as a file we already have
@@ -261,104 +258,7 @@ public class ServerFormDownloader implements FormDownloader {
         }
     }
 
-    /**
-     * Common routine to take a downloaded document save the contents in the file
-     * 'file'. Shared by media file download and form file download.
-     * <p>
-     * SurveyCTO: The file is saved into a temp folder and is moved to the final place if everything
-     * is okay, so that garbage is not left over on cancel.
-     */
-    private void writeFile(InputStream inputStream, File destinationFile, File tempDir, OngoingWorkListener stateListener)
-            throws IOException, FormDownloadException.DownloadingInterrupted {
-
-        File tempFile = File.createTempFile(
-                destinationFile.getName(),
-                ".tempDownload",
-                tempDir
-        );
-
-        // WiFi network connections can be renegotiated during a large form download sequence.
-        // This will cause intermittent download failures.  Silently retry once after each
-        // failure.  Only if there are two consecutive failures do we abort.
-        boolean success = false;
-        int attemptCount = 0;
-        final int maxAttemptCount = 2;
-        while (!success && ++attemptCount <= maxAttemptCount) {
-            // write connection to file
-            InputStream is = null;
-            OutputStream os = null;
-
-            try {
-                is = inputStream;
-                os = new FileOutputStream(tempFile);
-
-                byte[] buf = new byte[4096];
-                int len;
-                while ((len = is.read(buf)) > 0 && (stateListener == null || !stateListener.isCancelled())) {
-                    os.write(buf, 0, len);
-                }
-                os.flush();
-                success = true;
-
-            } catch (Exception e) {
-                Timber.e(e.toString());
-                // silently retry unless this is the last attempt,
-                // in which case we rethrow the exception.
-
-                FileUtils.deleteAndReport(tempFile);
-
-                if (attemptCount == maxAttemptCount) {
-                    throw e;
-                }
-            } finally {
-                if (os != null) {
-                    try {
-                        os.close();
-                    } catch (Exception e) {
-                        Timber.e(e);
-                    }
-                }
-                if (is != null) {
-                    try {
-                        // ensure stream is consumed...
-                        final long count = 1024L;
-                        while (is.skip(count) == count) {
-                            // skipping to the end of the http entity
-                        }
-                    } catch (Exception e) {
-                        // no-op
-                    }
-                    try {
-                        is.close();
-                    } catch (Exception e) {
-                        Timber.w(e);
-                    }
-                }
-            }
-
-            if (stateListener != null && stateListener.isCancelled()) {
-                FileUtils.deleteAndReport(tempFile);
-                throw new FormDownloadException.DownloadingInterrupted();
-            }
-        }
-
-        Timber.d("Completed downloading of %s. It will be moved to the proper path...", tempFile.getAbsolutePath());
-
-        FileUtils.deleteAndReport(destinationFile);
-
-        String errorMessage = FileUtils.copyFile(tempFile, destinationFile);
-
-        if (destinationFile.exists()) {
-            Timber.d("Copied %s over %s", tempFile.getAbsolutePath(), destinationFile.getAbsolutePath());
-            FileUtils.deleteAndReport(tempFile);
-        } else {
-            String msg = Collect.getInstance().getString(R.string.fs_file_copy_error,
-                    tempFile.getAbsolutePath(), destinationFile.getAbsolutePath(), errorMessage);
-            throw new RuntimeException(msg);
-        }
-    }
-
-    private void downloadMediaFiles(String tempMediaPath, OngoingWorkListener stateListener, List<MediaFile> files, File tempDir, String formFileName, ServerFormDetails fd) throws IOException, FormDownloadException.DownloadingInterrupted, FormSourceException {
+    private void downloadMediaFiles(String tempMediaPath, OngoingWorkListener stateListener, List<MediaFile> files, File tempDir, String formFileName, ServerFormDetails fd) throws IOException, FormDownloadException.DownloadingInterrupted, FormSourceException, InterruptedException {
         File tempMediaDir = new File(tempMediaPath);
         tempMediaDir.mkdir();
 
@@ -387,7 +287,7 @@ public class ServerFormDownloader implements FormDownloader {
                     FileUtils.copyFile(existingFileInOtherVersion.get(), tempMediaFile);
                 } else {
                     InputStream mediaFile = formSource.fetchMediaFile(toDownload.getDownloadUrl());
-                    writeFile(mediaFile, tempMediaFile, tempDir, stateListener);
+                    interuptablyWriteFile(mediaFile, tempMediaFile, tempDir, stateListener);
                 }
             } else {
                 String currentFileHash = Md5.getMd5Hash(finalMediaFile);
@@ -396,7 +296,7 @@ public class ServerFormDownloader implements FormDownloader {
                 if (currentFileHash != null && downloadFileHash != null && !currentFileHash.contentEquals(downloadFileHash)) {
                     // if the hashes match, it's the same file otherwise replace it with the new one
                     InputStream mediaFile = formSource.fetchMediaFile(toDownload.getDownloadUrl());
-                    writeFile(mediaFile, tempMediaFile, tempDir, stateListener);
+                    interuptablyWriteFile(mediaFile, tempMediaFile, tempDir, stateListener);
                 } else {
                     // exists, and the hash is the same
                     // no need to download it again

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -14,7 +14,6 @@ import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormSource;
 import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.forms.FormsRepository;
-import org.odk.collect.forms.MediaFile;
 import org.odk.collect.shared.strings.Md5;
 import org.odk.collect.shared.strings.Validator;
 
@@ -23,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -100,8 +98,8 @@ public class ServerFormDownloader implements FormDownloader {
 
             // download media files if there are any
             if (fd.getManifest() != null && !fd.getManifest().getMediaFiles().isEmpty()) {
-                FormMediaDownloader mediaDownloader = new FormMediaDownloader(formsDirPath, formsRepository, formSource);
-                mediaDownloader.download(tempMediaPath, stateListener, fd.getManifest().getMediaFiles(), tempDir, fileResult.file.getName(), fd);
+                FormMediaDownloader mediaDownloader = new FormMediaDownloader(formsRepository, formSource);
+                mediaDownloader.download(fd, fd.getManifest().getMediaFiles(), tempMediaPath, tempDir, stateListener);
             }
         } catch (FormDownloadException.DownloadingInterrupted | InterruptedException e) {
             Timber.i(e);

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -1,5 +1,25 @@
 package org.odk.collect.android.formmanagement;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.odk.collect.android.analytics.AnalyticsEvents.DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH;
+import static org.odk.collect.android.utilities.FileUtils.read;
+import static org.odk.collect.formstest.FormUtils.buildForm;
+import static org.odk.collect.formstest.FormUtils.createXFormBody;
+import static org.odk.collect.shared.PathUtils.getAbsoluteFilePath;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
 import com.google.common.io.Files;
 
 import org.junit.Test;
@@ -22,25 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-
-import static java.util.Arrays.asList;
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-import static org.odk.collect.android.analytics.AnalyticsEvents.DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH;
-import static org.odk.collect.android.utilities.FileUtils.read;
-import static org.odk.collect.formstest.FormUtils.buildForm;
-import static org.odk.collect.formstest.FormUtils.createXFormBody;
-import static org.odk.collect.shared.PathUtils.getAbsoluteFilePath;
 
 @SuppressWarnings("PMD.DoubleBraceInitialization")
 public class ServerFormDownloaderTest {
@@ -225,6 +226,51 @@ public class ServerFormDownloaderTest {
         File mediaFile2 = new File(form.getFormMediaPath() + "/file2");
         assertThat(mediaFile2.exists(), is(true));
         assertThat(new String(read(mediaFile2)), is("contents2"));
+    }
+
+    @Test
+    public void whenFormHasMediaFiles_andIsFormToDownloadIsUpdate_doesNotRedownloadMediaFiles() throws Exception {
+        String xform = createXFormBody("id", "version");
+        ServerFormDetails serverFormDetails = new ServerFormDetails(
+                "Form",
+                "http://downloadUrl",
+                "id",
+                "version",
+                Md5.getMd5Hash(new ByteArrayInputStream(xform.getBytes())),
+                true,
+                false,
+                new ManifestFile("", asList(
+                        new MediaFile("file1", Md5.getMd5Hash("contents1"), "http://file1"),
+                        new MediaFile("file2", Md5.getMd5Hash("contents2"), "http://file2")
+                )));
+
+        FormSource formSource = mock(FormSource.class);
+        when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
+        when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
+        when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents2".getBytes()));
+
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), mock(Analytics.class));
+        downloader.downloadForm(serverFormDetails, null, null);
+
+        String xformUpdate = createXFormBody("id", "updated");
+        ServerFormDetails serverFormDetailsUpdated = new ServerFormDetails(
+                "Form",
+                "http://downloadUpdatedUrl",
+                "id",
+                "updated",
+                Md5.getMd5Hash(new ByteArrayInputStream(xformUpdate.getBytes())),
+                false,
+                true,
+                new ManifestFile("", asList(
+                        new MediaFile("file1", Md5.getMd5Hash("contents1"), "http://file1"),
+                        new MediaFile("file2", Md5.getMd5Hash("contents2"), "http://file2")
+                )));
+
+        when(formSource.fetchForm("http://downloadUpdatedUrl")).thenReturn(new ByteArrayInputStream(xformUpdate.getBytes()));
+        downloader.downloadForm(serverFormDetailsUpdated, null, null);
+
+        verify(formSource, times(1)).fetchMediaFile("http://file1");
+        verify(formSource, times(1)).fetchMediaFile("http://file2");
     }
 
     /**

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
@@ -36,4 +36,28 @@ class OpenRosaResponseParserImplTest {
         val formList = OpenRosaResponseParserImpl().parseFormList(doc)
         assertThat(formList!![0].hash, equalTo(null))
     }
+
+    @Test
+    fun `when media file hash is empty, parseManifest returns null`() {
+        val response = StringBuilder()
+            .appendLine("<?xml version='1.0' encoding='UTF-8' ?>")
+            .appendLine("<manifest xmlns=\"http://openrosa.org/xforms/xformsManifest\">")
+            .appendLine("<mediaFile>")
+            .appendLine("<filename>badger.png</filename>")
+            .appendLine("<hash></hash>")
+            .appendLine("<downloadUrl>http://funk.appspot.com/binaryData?blobKey=%3A477e3</downloadUrl>")
+            .appendLine("</mediaFile>")
+            .appendLine("</manifest>")
+            .toString()
+
+        val doc = StringReader(response).use { reader ->
+            val parser = KXmlParser()
+            parser.setInput(reader)
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
+            Document().also { it.parse(parser) }
+        }
+
+        val mediaFiles = OpenRosaResponseParserImpl().parseManifest(doc)
+        assertThat(mediaFiles, equalTo(null))
+    }
 }


### PR DESCRIPTION
We recently discovered that media files are redownloaded for new form versions even if they exist in the media directory for an older version. This optimizes that process so that existing media files (files with the same name and contents hash) are copied from old versions rather than performing a download.

#### What has been done to verify that this works as intended?

New tests and existing tests.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Hopefully just saves people a bunch of bandwidth. That said, making changes in this part of the code is always dangerous as there are a lot of edge cases, bad-yet-supported behaviour and bugs that have become features which we haven't discovered yet and as such, don't have tests. We'll want to QA form downloading and updating with and without media files and with our usual roster of different servers.

It's also important for reviewers to think of edge cases that we might have missed in tests or in the code itself.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
