### PR TITLE
Fixed scale type used in image widgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -139,7 +139,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
             if (f != null && f.exists()) {
                 imageView = createAnswerImageView(getContext());
                 answerLayout.addView(imageView);
-                imageLoader.loadImage(imageView, f, ImageView.ScaleType.CENTER_INSIDE, new GlideImageLoader.ImageLoaderCallback() {
+                imageLoader.loadImage(imageView, f, ImageView.ScaleType.FIT_CENTER, new GlideImageLoader.ImageLoaderCallback() {
                     @Override
                     public void onLoadFailed() {
                         answerLayout.removeView(imageView);


### PR DESCRIPTION
Closes #5031 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
There is not much to discuss here, I've just fixed the used scale type.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just test image widgets to make sure that images are displayed properly no matter what their size is.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
