### PR TITLE
Removed old style info icons from dialogs

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/BearingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/BearingActivity.java
@@ -98,7 +98,6 @@ public class BearingActivity extends CollectAbstractActivity implements SensorEv
         // back button doesn't cancel
         bearingDialog.setCancelable(false);
         bearingDialog.setIndeterminate(true);
-        bearingDialog.setIcon(android.R.drawable.ic_dialog_info);
         bearingDialog.setTitle(getString(R.string.getting_bearing));
         bearingDialog.setMessage(getString(R.string.please_wait_long));
         bearingDialog.setButton(DialogInterface.BUTTON_POSITIVE,

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -608,7 +608,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         };
         alertDialog.setCancelable(false);
         alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.ok), quitListener);
-        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         viewModel.setAlertDialogMsg(message);
         viewModel.setAlertTitle(title);
         viewModel.setAlertShowing(true);
@@ -631,7 +630,6 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
         cancelDialog = new DayNightProgressDialog(this);
         cancelDialog.setTitle(getString(R.string.canceling));
         cancelDialog.setMessage(getString(R.string.please_wait));
-        cancelDialog.setIcon(android.R.drawable.ic_dialog_info);
         cancelDialog.setIndeterminate(true);
         cancelDialog.setCancelable(false);
         viewModel.setCancelDialogShowing(true);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -785,7 +785,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
     protected void createErrorDialog(String errorMsg) {
         AlertDialog alertDialog = new MaterialAlertDialogBuilder(this).create();
 
-        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertDialog.setTitle(getString(R.string.error_occured));
         alertDialog.setMessage(errorMsg);
         DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -190,7 +190,6 @@ public class InstanceChooserList extends InstanceListActivity implements Adapter
 
     private void createErrorDialog(String errorMsg, final boolean shouldExit) {
         AlertDialog alertDialog = new MaterialAlertDialogBuilder(this).create();
-        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertDialog.setMessage(errorMsg);
         DialogInterface.OnClickListener errorListener = new DialogInterface.OnClickListener() {
             @Override

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -350,7 +350,6 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
                 getString(R.string.show_sent_and_unsent_forms)};
 
         AlertDialog alertDialog = new MaterialAlertDialogBuilder(this)
-                .setIcon(android.R.drawable.ic_dialog_info)
                 .setTitle(getString(R.string.change_view))
                 .setNeutralButton(getString(R.string.cancel), (dialog, id) -> {
                     dialog.cancel();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/RefreshFormListDialogFragment.java
@@ -1,10 +1,8 @@
 package org.odk.collect.android.formentry;
 
-import android.app.Dialog;
 import android.content.Context;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
 import org.odk.collect.android.R;
 import org.odk.collect.material.MaterialProgressDialogFragment;
@@ -23,11 +21,6 @@ public class RefreshFormListDialogFragment extends MaterialProgressDialogFragmen
         setTitle(getString(R.string.downloading_data));
         setMessage(getString(R.string.please_wait));
         setCancelable(false);
-    }
-
-    @Override
-    public void setupDialog(@NonNull Dialog dialog, int style) {
-        ((AlertDialog) dialog).setIcon(android.R.drawable.ic_dialog_info);
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ResetSettingsResultDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/ResetSettingsResultDialog.java
@@ -62,7 +62,6 @@ public class ResetSettingsResultDialog extends DialogFragment {
 
         return new MaterialAlertDialogBuilder(getActivity())
                 .setTitle(R.string.reset_app_state_result)
-                .setIcon(android.R.drawable.ic_dialog_info)
                 .setMessage(message)
                 .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleAccountNotSetDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleAccountNotSetDialog.java
@@ -18,7 +18,6 @@ public final class GoogleAccountNotSetDialog {
 
     public static void show(Activity activity) {
         AlertDialog alertDialog = new MaterialAlertDialogBuilder(activity)
-                .setIcon(android.R.drawable.ic_dialog_info)
                 .setTitle(R.string.missing_google_account_dialog_title)
                 .setMessage(R.string.missing_google_account_dialog_desc)
                 .setOnCancelListener(dialog -> {

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
@@ -413,7 +413,6 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
         };
         alertDialog.setCancelable(false);
         alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.ok), quitListener);
-        alertDialog.setIcon(android.R.drawable.ic_dialog_info);
         alertShowing = true;
         alertMsg = message;
         DialogUtils.showDialog(alertDialog, this);

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -279,7 +279,6 @@ public class ServerPreferencesFragment extends BaseProjectPreferencesFragment im
         if (TextUtils.isEmpty(account) && protocol.equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {
 
             AlertDialog alertDialog = new MaterialAlertDialogBuilder(getActivity())
-                    .setIcon(android.R.drawable.ic_dialog_info)
                     .setTitle(R.string.missing_google_account_dialog_title)
                     .setMessage(R.string.missing_google_account_dialog_desc)
                     .setPositiveButton(getString(R.string.ok), (dialog, which) -> dialog.dismiss())


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've just reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
In https://github.com/getodk/collect/pull/4993 we agreed that those old style icons should be removed. That pull request has been closed and it might take us some time to get back to it. However I think it would be good to remove those icons so I created this pull request.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
