### PR TITLE
Downgraded ExifInterface to fix problem with saving attributes after scaling down images

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -17,7 +17,7 @@ object Dependencies {
     const val androidx_appcompat = "androidx.appcompat:appcompat:1.4.1"
     const val androidx_work_runtime = "androidx.work:work-runtime:2.7.1"
     const val androidx_cardview = "androidx.cardview:cardview:1.0.0"
-    const val androidx_exinterface = "androidx.exifinterface:exifinterface:1.3.2" // Check if https://github.com/getodk/collect/issues/4819 no longer takes place before upgrading
+    const val androidx_exinterface = "androidx.exifinterface:exifinterface:1.3.1" // Check if https://github.com/getodk/collect/issues/4819 and https://github.com/getodk/collect/issues/5033 no longer takes place before upgrading
     const val androidx_multidex = "androidx.multidex:multidex:2.0.1"
     const val androidx_preference_ktx = "androidx.preference:preference-ktx:1.1.1"
     const val androidx_fragment_ktx = "androidx.fragment:fragment-ktx:${Versions.androidx_fragment}"


### PR DESCRIPTION
Closes #5033 

#### What has been done to verify that this works as intended?
I was able to reproduce the issue and I also verified that this change fixes it.

#### Why is this the best possible solution? Were any other approaches considered?
I don't know if this is a bug in exifinteface or maybe do something wrong. I reported it as a bug https://issuetracker.google.com/u/1/issues/221097888 and for now the best option is downgrade exif interface to version which seems to work well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue and that's it. There is no risk for other features/components.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with image widget with specified max-pixels: https://docs.getodk.org/form-question-types/#scaling-down-images (the value should be low like 100px maybe)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
