### PR TITLE
Add dialog click helper to manual mode switch

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QrCodeProjectCreatorDialogPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/QrCodeProjectCreatorDialogPage.kt
@@ -14,8 +14,7 @@ class QrCodeProjectCreatorDialogPage : Page<QrCodeProjectCreatorDialogPage>() {
     }
 
     fun switchToManualMode(): ManualProjectCreatorDialogPage {
-        clickOnString(R.string.configure_manually)
-        return ManualProjectCreatorDialogPage().assertOnPage()
+        return clickOnButtonInDialog(R.string.configure_manually, ManualProjectCreatorDialogPage())
     }
 
     fun assertDuplicateDialogShown(): QrCodeProjectCreatorDialogPage {


### PR DESCRIPTION
Just adds the dialog click helper to prevent problems when click on the manual mode button in the QR project creator dialog.