### PR TITLE
Only trigger InstanceAutoSender if autosend is enabled in settings or the form requests autosending

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.kt
@@ -17,6 +17,8 @@ import android.content.Context
 import android.os.Environment
 import androidx.work.BackoffPolicy
 import androidx.work.WorkerParameters
+import org.odk.collect.android.backgroundwork.autosend.FormLevelAutoSendChecker
+import org.odk.collect.android.backgroundwork.autosend.GeneralAutoSendChecker
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.instancemanagement.InstanceAutoSender
 import org.odk.collect.android.network.NetworkStateProvider
@@ -26,8 +28,6 @@ import org.odk.collect.async.WorkerAdapter
 import org.odk.collect.settings.SettingsProvider
 import java.util.function.Supplier
 import javax.inject.Inject
-import org.odk.collect.android.backgroundwork.autosend.FormLevelAutoSendChecker
-import org.odk.collect.android.backgroundwork.autosend.GeneralAutoSendChecker
 
 class AutoSendTaskSpec : TaskSpec {
     @Inject

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.kt
@@ -14,7 +14,6 @@
 package org.odk.collect.android.backgroundwork
 
 import android.content.Context
-import android.os.Environment
 import androidx.work.BackoffPolicy
 import androidx.work.WorkerParameters
 import org.odk.collect.android.backgroundwork.autosend.FormLevelAutoSendChecker
@@ -71,9 +70,7 @@ class AutoSendTaskSpec : TaskSpec {
         return Supplier {
             val projectId = inputData[TaskData.DATA_PROJECT_ID]
             if (projectId != null) {
-                if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED &&
-                    (generalAutoSendChecker.isAutoSendEnabled(projectId) || formLevelAutoSendChecker.isAutoSendEnabled(projectId))
-                ) {
+                if (generalAutoSendChecker.isAutoSendEnabled(projectId) || formLevelAutoSendChecker.isAutoSendEnabled(projectId)) {
                     return@Supplier instanceAutoSender.autoSendInstances(projectId)
                 }
                 false

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpec.kt
@@ -68,12 +68,12 @@ class AutoSendTaskSpec : TaskSpec {
             val projectId = inputData[TaskData.DATA_PROJECT_ID]
             if (projectId != null) {
                 val currentNetworkInfo = connectivityProvider.networkInfo
-                if (Environment.getExternalStorageState() != Environment.MEDIA_MOUNTED ||
-                    !(networkTypeMatchesAutoSendSetting(currentNetworkInfo, projectId) || atLeastOneFormSpecifiesAutoSend(projectId))
+                if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED &&
+                    (networkTypeMatchesAutoSendSetting(currentNetworkInfo, projectId) || atLeastOneFormSpecifiesAutoSend(projectId))
                 ) {
-                    networkTypeMatchesAutoSendSetting(currentNetworkInfo, projectId)
+                    return@Supplier instanceAutoSender.autoSendInstances(projectId)
                 }
-                instanceAutoSender.autoSendInstances(projectId)
+                false
             } else {
                 throw IllegalArgumentException("No project ID provided!")
             }

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/autosend/FormLevelAutoSendChecker.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/autosend/FormLevelAutoSendChecker.kt
@@ -1,0 +1,17 @@
+package org.odk.collect.android.backgroundwork.autosend
+
+import org.odk.collect.android.utilities.FormsRepositoryProvider
+import org.odk.collect.forms.Form
+
+class FormLevelAutoSendChecker(private val formsRepositoryProvider: FormsRepositoryProvider) {
+
+    /**
+     * Returns true if at least one form currently on the device specifies that all of its filled
+     * forms should auto-send no matter the connection type.
+     */
+    fun isAutoSendEnabled(projectId: String): Boolean {
+        return formsRepositoryProvider.get(projectId).all.any { form: Form ->
+            form.autoSend.toBoolean()
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/backgroundwork/autosend/GeneralAutoSendChecker.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/backgroundwork/autosend/GeneralAutoSendChecker.kt
@@ -1,0 +1,34 @@
+package org.odk.collect.android.backgroundwork.autosend
+
+import android.net.ConnectivityManager
+import org.odk.collect.android.network.NetworkStateProvider
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.ProjectKeys
+
+class GeneralAutoSendChecker(
+    private val networkStateProvider: NetworkStateProvider,
+    private val settingsProvider: SettingsProvider
+) {
+
+    /**
+     * Returns whether the currently-available connection type is included in the app-level auto-send
+     * settings.
+     *
+     * @return true if a connection is available and settings specify it should trigger auto-send,
+     * false otherwise.
+     */
+    fun isAutoSendEnabled(projectId: String): Boolean {
+        val networkInfo = networkStateProvider.networkInfo ?: return false
+
+        val autosend = settingsProvider.getUnprotectedSettings(projectId).getString(ProjectKeys.KEY_AUTOSEND)
+        var sendwifi = autosend == "wifi_only"
+        var sendnetwork = autosend == "cellular_only"
+
+        if (autosend == "wifi_and_cellular") {
+            sendwifi = true
+            sendnetwork = true
+        }
+        return networkInfo.type == ConnectivityManager.TYPE_WIFI &&
+            sendwifi || networkInfo.type == ConnectivityManager.TYPE_MOBILE && sendnetwork
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -40,6 +40,8 @@ import org.odk.collect.android.application.initialization.upgrade.UpgradeInitial
 import org.odk.collect.android.backgroundwork.FormUpdateAndInstanceSubmitScheduler;
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler;
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler;
+import org.odk.collect.android.backgroundwork.autosend.FormLevelAutoSendChecker;
+import org.odk.collect.android.backgroundwork.autosend.GeneralAutoSendChecker;
 import org.odk.collect.android.configure.qr.AppConfigurationGenerator;
 import org.odk.collect.android.configure.qr.CachingQRCodeGenerator;
 import org.odk.collect.android.configure.qr.QRCodeDecoder;
@@ -631,5 +633,17 @@ public class AppDependencyModule {
     @Provides
     public ImageLoader providesImageLoader() {
         return new GlideImageLoader();
+    }
+
+    @Provides
+    @Singleton
+    public GeneralAutoSendChecker providesGeneralAutoSendChecker(NetworkStateProvider networkStateProvider, SettingsProvider settingsProvider) {
+        return new GeneralAutoSendChecker(networkStateProvider, settingsProvider);
+    }
+
+    @Provides
+    @Singleton
+    public FormLevelAutoSendChecker providesFormLevelAutoSendChecker(FormsRepositoryProvider formsRepositoryProvider) {
+        return new FormLevelAutoSendChecker(formsRepositoryProvider);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpecTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/AutoSendTaskSpecTest.kt
@@ -6,18 +6,25 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.TestSettingsProvider
+import org.odk.collect.android.backgroundwork.autosend.FormLevelAutoSendChecker
+import org.odk.collect.android.backgroundwork.autosend.GeneralAutoSendChecker
 import org.odk.collect.android.formmanagement.InstancesAppState
 import org.odk.collect.android.gdrive.GoogleAccountsManager
 import org.odk.collect.android.gdrive.GoogleApiProvider
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.instancemanagement.InstanceAutoSender
+import org.odk.collect.android.network.NetworkStateProvider
 import org.odk.collect.android.notifications.Notifier
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.utilities.ChangeLockProvider
@@ -34,6 +41,8 @@ class AutoSendTaskSpecTest {
     private val instanceAutoSender = mock<InstanceAutoSender>()
 
     private lateinit var projectId: String
+    private val generalAutoSendChecker: GeneralAutoSendChecker = mock()
+    private val formLevelAutoSendChecker: FormLevelAutoSendChecker = mock()
 
     @Before
     fun setup() {
@@ -53,6 +62,17 @@ class AutoSendTaskSpecTest {
             ): InstanceAutoSender {
                 return instanceAutoSender
             }
+
+            override fun providesGeneralAutoSendChecker(
+                networkStateProvider: NetworkStateProvider,
+                settingsProvider: SettingsProvider
+            ): GeneralAutoSendChecker {
+                return generalAutoSendChecker
+            }
+
+            override fun providesFormLevelAutoSendChecker(formsRepositoryProvider: FormsRepositoryProvider): FormLevelAutoSendChecker {
+                return formLevelAutoSendChecker
+            }
         })
 
         RobolectricHelpers.mountExternalStorage()
@@ -62,14 +82,72 @@ class AutoSendTaskSpecTest {
     }
 
     @Test
-    fun `passes project id`() {
-        val inputData = mapOf(TaskData.DATA_PROJECT_ID to projectId)
-        AutoSendTaskSpec().getTask(ApplicationProvider.getApplicationContext(), inputData, true).get()
+    fun `maxRetries should not be limited`() {
+        assertThat(AutoSendTaskSpec().maxRetries, `is`(nullValue()))
+    }
+
+    @Test
+    fun `if autosend is disabled in settings and there are no forms with autosend enabled on a form level, autosender should not be triggered`() {
+        whenever(generalAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(false)
+        whenever(formLevelAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(false)
+
+        triggerAutoSendTask()
+
+        verifyNoInteractions(instanceAutoSender)
+    }
+
+    @Test
+    fun `if autosend is enabled in settings and there are no forms with autosend enabled on a form level, autosender should be triggered`() {
+        whenever(generalAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(true)
+        whenever(formLevelAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(false)
+
+        triggerAutoSendTask()
+
         verify(instanceAutoSender).autoSendInstances(projectId)
     }
 
     @Test
-    fun `maxRetries should not be limited`() {
-        assertThat(AutoSendTaskSpec().maxRetries, `is`(nullValue()))
+    fun `if autosend is disabled in settings but there are forms with autosend enabled on a form level, autosender should be triggered`() {
+        whenever(generalAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(false)
+        whenever(formLevelAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(true)
+
+        triggerAutoSendTask()
+
+        verify(instanceAutoSender).autoSendInstances(projectId)
+    }
+
+    @Test
+    fun `if autosend is enabled in settings and there are forms with autosend enabled on a form level, autosender should be triggered`() {
+        whenever(generalAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(true)
+        whenever(formLevelAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(true)
+
+        triggerAutoSendTask()
+
+        verify(instanceAutoSender).autoSendInstances(projectId)
+    }
+
+    @Test
+    fun `if autosend is disabled in settings and there are no forms with autosend enabled on a form level, task should return false`() {
+        whenever(generalAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(false)
+        whenever(formLevelAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(false)
+
+        assertFalse(triggerAutoSendTask())
+    }
+
+    @Test
+    fun `if autosender is triggered, task should return result from autosender`() {
+        whenever(generalAutoSendChecker.isAutoSendEnabled(projectId)).thenReturn(true)
+        whenever(instanceAutoSender.autoSendInstances(projectId)).thenReturn(true)
+
+        assertTrue(triggerAutoSendTask())
+
+        whenever(instanceAutoSender.autoSendInstances(projectId)).thenReturn(false)
+
+        assertFalse(triggerAutoSendTask())
+    }
+
+    private fun triggerAutoSendTask(): Boolean {
+        val inputData = mapOf(TaskData.DATA_PROJECT_ID to projectId)
+        return AutoSendTaskSpec().getTask(ApplicationProvider.getApplicationContext(), inputData, true).get()
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/autosend/FormLevelAutoSendCheckerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/autosend/FormLevelAutoSendCheckerTest.kt
@@ -1,0 +1,68 @@
+package org.odk.collect.android.backgroundwork.autosend
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.android.utilities.FormsRepositoryProvider
+import org.odk.collect.forms.Form
+import org.odk.collect.forms.FormsRepository
+import org.odk.collect.formstest.FormUtils
+import org.odk.collect.formstest.InMemFormsRepository
+
+class FormLevelAutoSendCheckerTest {
+    private val projectID = "projectID"
+    private lateinit var formsRepositoryProvider: FormsRepositoryProvider
+    private lateinit var formsRepository: FormsRepository
+    private lateinit var formLevelAutoSendChecker: FormLevelAutoSendChecker
+
+    @Before
+    fun setup() {
+        formsRepository = InMemFormsRepository()
+        formsRepositoryProvider = mock<FormsRepositoryProvider>().also {
+            whenever(it.get(projectID)).thenReturn(formsRepository)
+        }
+        formLevelAutoSendChecker = FormLevelAutoSendChecker(formsRepositoryProvider)
+    }
+
+    @Test
+    fun `if there are no forms with autosend enabled return false`() {
+        formsRepository.save(
+            Form.Builder()
+                .formId("form-1")
+                .formFilePath(FormUtils.createXFormFile("1", "1").absolutePath)
+                .build()
+        )
+
+        formsRepository.save(
+            Form.Builder()
+                .formId("form-2")
+                .formFilePath(FormUtils.createXFormFile("2", "1").absolutePath)
+                .build()
+        )
+
+        assertFalse(formLevelAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if there is at least one form with autosend enabled return true`() {
+        formsRepository.save(
+            Form.Builder()
+                .formId("form-1")
+                .formFilePath(FormUtils.createXFormFile("1", "1").absolutePath)
+                .build()
+        )
+
+        formsRepository.save(
+            Form.Builder()
+                .formId("form-2")
+                .formFilePath(FormUtils.createXFormFile("2", "1").absolutePath)
+                .autoSend("true")
+                .build()
+        )
+
+        assertTrue(formLevelAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/backgroundwork/autosend/GeneralAutoSendCheckerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/backgroundwork/autosend/GeneralAutoSendCheckerTest.kt
@@ -1,0 +1,102 @@
+package org.odk.collect.android.backgroundwork.autosend
+
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.android.network.NetworkStateProvider
+import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.ProjectKeys
+
+class GeneralAutoSendCheckerTest {
+    private val projectID = "projectID"
+    private lateinit var networkInfo: NetworkInfo
+    private lateinit var networkStateProvider: NetworkStateProvider
+    private lateinit var settingsProvider: SettingsProvider
+    private lateinit var generalAutoSendChecker: GeneralAutoSendChecker
+
+    @Before
+    fun setup() {
+        networkInfo = mock()
+        networkStateProvider = mock<NetworkStateProvider>().also {
+            whenever(it.networkInfo).thenReturn(networkInfo)
+        }
+        settingsProvider = InMemSettingsProvider()
+        generalAutoSendChecker = GeneralAutoSendChecker(networkStateProvider, settingsProvider)
+    }
+
+    @Test
+    fun `if networkInfo is null return false`() {
+        whenever(networkStateProvider.networkInfo).thenReturn(null)
+
+        assertFalse(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend disabled return false`() {
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "off")
+
+        assertFalse(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for wifi only but wifi is disabled return false`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_DUMMY)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "wifi_only")
+
+        assertFalse(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for wifi only and wifi is enabled return true`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_WIFI)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "wifi_only")
+
+        assertTrue(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for cellular only but cellular is disabled return false`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_DUMMY)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "cellular_only")
+
+        assertFalse(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for cellular only and cellular is enabled return true`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_MOBILE)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "cellular_only")
+
+        assertTrue(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for wifi and cellular but both are disabled return false`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_DUMMY)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "wifi_and_cellular")
+
+        assertFalse(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for wifi and cellular and wifi is enabled return true`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_WIFI)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "wifi_and_cellular")
+
+        assertTrue(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+
+    @Test
+    fun `if autosend enabled for wifi and cellular and cellular is enabled return true`() {
+        whenever(networkInfo.type).thenReturn(ConnectivityManager.TYPE_MOBILE)
+        settingsProvider.getUnprotectedSettings(projectID).save(ProjectKeys.KEY_AUTOSEND, "wifi_and_cellular")
+
+        assertTrue(generalAutoSendChecker.isAutoSendEnabled(projectID))
+    }
+}


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
In https://github.com/getodk/collect/pull/5024/files#diff-988ec72f11211c5e52159ad89b1a182ee276edd0482b79d4eb8e027b7b51e742 I made a mistake refactoring `AutoSendTaskSpec`. The problem is that `InstanceAutoSender` is always called even it it shouldn't when `autosend` is disabled in settings and there are no forms with `autosend` used on a forma level: https://github.com/getodk/collect/pull/5024/files#diff-988ec72f11211c5e52159ad89b1a182ee276edd0482b79d4eb8e027b7b51e742R76
It hasn't been spotted because:
- we didn't have tests for it
- the fact that we trigger that task doesn't mean anything will be sent, we have another check point which verifies if it should happen: https://github.com/getodk/collect/blob/master/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceAutoSender.java#L91

So it looks like the bug is not severe but it's definitely a bug we should fix ASAP.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
