### PR TITLE
Use JR 3.4.0 snapshot

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -44,7 +44,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.5.2"
-    const val javarosa = "org.getodk:javarosa:3.3.0"
+    const val javarosa = "org.getodk:javarosa:3.4.0-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:3.6.0" // Upgrading will require minSdkVersion >=24, it uses zxing:core 3.3.2 by default


### PR DESCRIPTION
Update javarosa to include geojson parsing. Verified against https://test.getodk.cloud/#/projects/149/forms/geojson