### PR TITLE
Improved handling errors during importing new projects

### DIFF
--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.settings
 
-import org.json.JSONException
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.importing.ProjectDetailsCreatorImpl
@@ -29,10 +28,6 @@ class ODKAppSettingsImporter(
     )
 
     fun fromJSON(json: String, project: Project.Saved): Boolean {
-        return try {
-            settingsImporter.fromJSON(json, project)
-        } catch (e: JSONException) {
-            false
-        }
+        return settingsImporter.fromJSON(json, project)
     }
 }

--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.settings
 
+import org.json.JSONException
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.importing.ProjectDetailsCreatorImpl
@@ -30,7 +31,7 @@ class ODKAppSettingsImporter(
     fun fromJSON(json: String, project: Project.Saved): Boolean {
         return try {
             settingsImporter.fromJSON(json, project)
-        } catch (e: Throwable) {
+        } catch (e: JSONException) {
             false
         }
     }

--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
@@ -28,6 +28,10 @@ class ODKAppSettingsImporter(
     )
 
     fun fromJSON(json: String, project: Project.Saved): Boolean {
-        return settingsImporter.fromJSON(json, project)
+        return try {
+            settingsImporter.fromJSON(json, project)
+        } catch (e: Throwable) {
+            false
+        }
     }
 }

--- a/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
@@ -20,6 +20,7 @@ internal class SettingsImporter(
     private val projectDetailsCreator: ProjectDetailsCreator
 ) {
 
+    @Throws(JSONException::class)
     fun fromJSON(json: String, project: Project.Saved): Boolean {
         if (!settingsValidator.isValid(json)) {
             return false
@@ -31,38 +32,34 @@ internal class SettingsImporter(
         generalSettings.clear()
         adminSettings.clear()
 
-        try {
-            val jsonObject = JSONObject(json)
+        val jsonObject = JSONObject(json)
 
-            // Import unprotected settings
-            val general = jsonObject.getJSONObject(AppConfigurationKeys.GENERAL)
-            importToPrefs(general, generalSettings)
+        // Import unprotected settings
+        val general = jsonObject.getJSONObject(AppConfigurationKeys.GENERAL)
+        importToPrefs(general, generalSettings)
 
-            // Import protected settings
-            val admin = jsonObject.getJSONObject(AppConfigurationKeys.ADMIN)
-            importToPrefs(admin, adminSettings)
+        // Import protected settings
+        val admin = jsonObject.getJSONObject(AppConfigurationKeys.ADMIN)
+        importToPrefs(admin, adminSettings)
 
-            // Import project details
-            val projectDetails = if (jsonObject.has(AppConfigurationKeys.PROJECT)) {
-                jsonObject.getJSONObject(AppConfigurationKeys.PROJECT)
-            } else {
-                JSONObject()
-            }
-
-            val connectionIdentifier = if (generalSettings.getString(ProjectKeys.KEY_PROTOCOL).equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {
-                generalSettings.getString(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT) ?: ""
-            } else {
-                generalSettings.getString(ProjectKeys.KEY_SERVER_URL) ?: ""
-            }
-
-            importProjectDetails(
-                project,
-                projectDetails,
-                connectionIdentifier
-            )
-        } catch (ignored: JSONException) {
-            // Ignored
+        // Import project details
+        val projectDetails = if (jsonObject.has(AppConfigurationKeys.PROJECT)) {
+            jsonObject.getJSONObject(AppConfigurationKeys.PROJECT)
+        } else {
+            JSONObject()
         }
+
+        val connectionIdentifier = if (generalSettings.getString(ProjectKeys.KEY_PROTOCOL).equals(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {
+            generalSettings.getString(ProjectKeys.KEY_SELECTED_GOOGLE_ACCOUNT) ?: ""
+        } else {
+            generalSettings.getString(ProjectKeys.KEY_SERVER_URL) ?: ""
+        }
+
+        importProjectDetails(
+            project,
+            projectDetails,
+            connectionIdentifier
+        )
 
         settingsMigrator.migrate(generalSettings, adminSettings)
 

--- a/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.settings.importing
 
-import org.json.JSONException
 import org.json.JSONObject
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
@@ -20,7 +19,6 @@ internal class SettingsImporter(
     private val projectDetailsCreator: ProjectDetailsCreator
 ) {
 
-    @Throws(JSONException::class)
     fun fromJSON(json: String, project: Project.Saved): Boolean {
         if (!settingsValidator.isValid(json)) {
             return false

--- a/settings/src/main/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidator.kt
+++ b/settings/src/main/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidator.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.settings.validation
 
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
@@ -10,11 +11,15 @@ internal class JsonSchemaSettingsValidator(private val schemaProvider: () -> Inp
     SettingsValidator {
 
     override fun isValid(json: String): Boolean {
-        return schemaProvider().use { schemaStream ->
-            val schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)
-            val schema = schemaFactory.getSchema(schemaStream)
-            val errors = schema.validate(ObjectMapper().readTree(json))
-            errors.isEmpty()
+        return try {
+            schemaProvider().use { schemaStream ->
+                val schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)
+                val schema = schemaFactory.getSchema(schemaStream)
+                val errors = schema.validate(ObjectMapper().readTree(json))
+                errors.isEmpty()
+            }
+        } catch (e: JsonParseException) {
+            false
         }
     }
 }

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
@@ -28,7 +28,7 @@ class ODKAppSettingsImporterTest {
         )
         assertThat(result, equalTo(false))
         assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
-        assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
+        assertSettingsEmpty(settingsProvider.getProtectedSettings())
     }
 
     @Test
@@ -39,7 +39,7 @@ class ODKAppSettingsImporterTest {
         )
         assertThat(result, equalTo(false))
         assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
-        assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
+        assertSettingsEmpty(settingsProvider.getProtectedSettings())
     }
 
     @Test

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
@@ -41,4 +41,15 @@ class ODKAppSettingsImporterTest {
         assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
         assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
     }
+
+    @Test
+    fun `rejects invalid JSON`() {
+        val result = settingsImporter.fromJSON(
+            "{\"general\":{*},\"admin\":{}}",
+            projectsRepository.save(Project.New("Flat", "AS", "#ff0000"))
+        )
+        assertThat(result, equalTo(false))
+        assertSettingsEmpty(settingsProvider.getUnprotectedSettings())
+        assertSettingsEmpty(settingsProvider.getProtectedSettings())
+    }
 }

--- a/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
@@ -4,27 +4,13 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 
-private const val SCHEMA = """
-            {
-                "${'$'}schema": "https://json-schema.org/draft/2019-09/schema",
-                "${'$'}id": "https://example.com/example.schema.json",
-                "title": "Schema",
-                "type": "object",
-                "properties": {
-                    "foo": {
-                        "type": "boolean"
-                    }
-                }
-            }
-            """
-
 class JsonSchemaSettingsValidatorTest {
-    private val validator = JsonSchemaSettingsValidator {
-        SCHEMA.byteInputStream()
-    }
-
     @Test
     fun `returns true when json is valid based on schema`() {
+        val validator = JsonSchemaSettingsValidator {
+            SCHEMA.byteInputStream()
+        }
+
         assertThat(
             validator.isValid(
                 """
@@ -39,6 +25,10 @@ class JsonSchemaSettingsValidatorTest {
 
     @Test
     fun `returns false when json is invalid based on schema`() {
+        val validator = JsonSchemaSettingsValidator {
+            SCHEMA.byteInputStream()
+        }
+
         assertThat(
             validator.isValid(
                 """
@@ -53,9 +43,27 @@ class JsonSchemaSettingsValidatorTest {
 
     @Test
     fun `returns false when json is invalid`() {
+        val validator = JsonSchemaSettingsValidator {
+            SCHEMA.byteInputStream()
+        }
+
         assertThat(
             validator.isValid("*"),
             equalTo(false)
         )
     }
 }
+
+private const val SCHEMA = """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2019-09/schema",
+                "${'$'}id": "https://example.com/example.schema.json",
+                "title": "Schema",
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "boolean"
+                    }
+                }
+            }
+            """

--- a/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
@@ -19,13 +19,12 @@ private const val SCHEMA = """
             """
 
 class JsonSchemaSettingsValidatorTest {
+    private val validator = JsonSchemaSettingsValidator {
+        SCHEMA.byteInputStream()
+    }
 
     @Test
     fun `returns true when json is valid based on schema`() {
-        val validator = JsonSchemaSettingsValidator {
-            SCHEMA.byteInputStream()
-        }
-
         assertThat(
             validator.isValid(
                 """
@@ -40,10 +39,6 @@ class JsonSchemaSettingsValidatorTest {
 
     @Test
     fun `returns false when json is invalid based on schema`() {
-        val validator = JsonSchemaSettingsValidator {
-            SCHEMA.byteInputStream()
-        }
-
         assertThat(
             validator.isValid(
                 """
@@ -58,10 +53,6 @@ class JsonSchemaSettingsValidatorTest {
 
     @Test
     fun `returns false when json is invalid`() {
-        val validator = JsonSchemaSettingsValidator {
-            SCHEMA.byteInputStream()
-        }
-
         assertThat(
             validator.isValid("*"),
             equalTo(false)

--- a/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
@@ -65,4 +65,28 @@ class JsonSchemaSettingsValidatorTest {
             equalTo(false)
         )
     }
+
+    @Test
+    fun `returns false when json is invalid`() {
+        val validator = JsonSchemaSettingsValidator {
+            """
+            {
+                "${'$'}schema": "https://json-schema.org/draft/2019-09/schema",
+                "${'$'}id": "https://example.com/example.schema.json",
+                "title": "Schema",
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "boolean"
+                    }
+                }
+            }
+            """.byteInputStream()
+        }
+
+        assertThat(
+            validator.isValid("*"),
+            equalTo(false)
+        )
+    }
 }

--- a/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
@@ -4,12 +4,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 
-class JsonSchemaSettingsValidatorTest {
-
-    @Test
-    fun `returns true when json is valid based on schema`() {
-        val validator = JsonSchemaSettingsValidator {
-            """
+private const val SCHEMA = """
             {
                 "${'$'}schema": "https://json-schema.org/draft/2019-09/schema",
                 "${'$'}id": "https://example.com/example.schema.json",
@@ -21,7 +16,14 @@ class JsonSchemaSettingsValidatorTest {
                     }
                 }
             }
-            """.byteInputStream()
+            """
+
+class JsonSchemaSettingsValidatorTest {
+
+    @Test
+    fun `returns true when json is valid based on schema`() {
+        val validator = JsonSchemaSettingsValidator {
+            SCHEMA.byteInputStream()
         }
 
         assertThat(
@@ -39,19 +41,7 @@ class JsonSchemaSettingsValidatorTest {
     @Test
     fun `returns false when json is invalid based on schema`() {
         val validator = JsonSchemaSettingsValidator {
-            """
-            {
-                "${'$'}schema": "https://json-schema.org/draft/2019-09/schema",
-                "${'$'}id": "https://example.com/example.schema.json",
-                "title": "Schema",
-                "type": "object",
-                "properties": {
-                    "foo": {
-                        "type": "boolean"
-                    }
-                }
-            }
-            """.byteInputStream()
+            SCHEMA.byteInputStream()
         }
 
         assertThat(
@@ -69,19 +59,7 @@ class JsonSchemaSettingsValidatorTest {
     @Test
     fun `returns false when json is invalid`() {
         val validator = JsonSchemaSettingsValidator {
-            """
-            {
-                "${'$'}schema": "https://json-schema.org/draft/2019-09/schema",
-                "${'$'}id": "https://example.com/example.schema.json",
-                "title": "Schema",
-                "type": "object",
-                "properties": {
-                    "foo": {
-                        "type": "boolean"
-                    }
-                }
-            }
-            """.byteInputStream()
+            SCHEMA.byteInputStream()
         }
 
         assertThat(


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
I think the most common issues that might happen in real life could be caused by `JSONException` which we used to catch in `SettingsImporter#fromJSON` but ignore. I decided to remove that try/catch so that the exception will be propagated and caught in `ODKAppSettingsImporter` where we catch not only `JSONException` but all possible exceptions and errors because no matter what goes wrong a new project should not be added.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think testing scaaning qr codes to make sure there is no regression would be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
