### PR TITLE
Always handle disabled Location when checking location permissions

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.kt
@@ -195,7 +195,7 @@ class FillBlankFormActivity :
     }
 
     private fun onMapButtonClick(id: Long) {
-        permissionsProvider.requestLocationPermissions(
+        permissionsProvider.requestEnabledLocationPermissions(
             this,
             object : PermissionListener {
                 override fun granted() {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2475,7 +2475,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         displayUIFor(backgroundLocationViewModel.activityDisplayed());
 
         if (backgroundLocationViewModel.isBackgroundLocationPermissionsCheckNeeded()) {
-            permissionsProvider.requestLocationPermissions(this, new PermissionListener() {
+            permissionsProvider.requestEnabledLocationPermissions(this, new PermissionListener() {
                 @Override
                 public void granted() {
                     displayUIFor(backgroundLocationViewModel.locationPermissionsGranted());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
@@ -89,7 +89,7 @@ class ActivityGeoDataRequester(
         answerText: String?,
         waitingForDataRegistry: WaitingForDataRegistry
     ) {
-        permissionsProvider.requestLocationPermissions(
+        permissionsProvider.requestEnabledLocationPermissions(
             activity,
             object : PermissionListener {
                 override fun granted() {
@@ -121,7 +121,7 @@ class ActivityGeoDataRequester(
         answerText: String?,
         waitingForDataRegistry: WaitingForDataRegistry
     ) {
-        permissionsProvider.requestLocationPermissions(
+        permissionsProvider.requestEnabledLocationPermissions(
             activity,
             object : PermissionListener {
                 override fun granted() {

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -95,35 +95,13 @@ open class PermissionsProvider(private val permissionsChecker: PermissionsChecke
         )
     }
 
-    fun requestLocationPermissions(activity: Activity, action: PermissionListener) {
-        requestPermissions(
-            activity,
-            object : PermissionListener {
-                override fun granted() {
-                    action.granted()
-                }
-
-                override fun denied() {
-                    showAdditionalExplanation(
-                        activity,
-                        R.string.location_runtime_permissions_denied_title,
-                        R.string.location_runtime_permissions_denied_desc,
-                        R.drawable.ic_room_black_24dp,
-                        action
-                    )
-                }
-            },
-            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
-        )
-    }
-
     /**
      * Request location permissions and make sure Location is enabled at a system level. If the
      * latter is not true, show a dialog prompting the user to do so rather than
      * [PermissionListener.granted].
      */
     fun requestEnabledLocationPermissions(activity: Activity, action: PermissionListener) {
-        requestLocationPermissions(
+        requestPermissions(
             activity,
             object : PermissionListener {
                 override fun granted() {
@@ -149,9 +127,16 @@ open class PermissionsProvider(private val permissionsChecker: PermissionsChecke
                 }
 
                 override fun denied() {
-                    action.denied()
+                    showAdditionalExplanation(
+                        activity,
+                        R.string.location_runtime_permissions_denied_title,
+                        R.string.location_runtime_permissions_denied_desc,
+                        R.drawable.ic_room_black_24dp,
+                        action
+                    )
                 }
-            }
+            },
+            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION
         )
     }
 

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -101,7 +101,10 @@ open class PermissionsProvider(private val permissionsChecker: PermissionsChecke
                             }
                             .setNegativeButton(
                                 activity.getString(R.string.cancel)
-                            ) { dialog: DialogInterface, _: Int -> dialog.cancel() }
+                            ) { dialog: DialogInterface, _: Int ->
+                                action.denied()
+                                dialog.cancel()
+                            }
                             .create()
                             .show()
                     }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -54,25 +54,6 @@ open class PermissionsProvider(private val permissionsChecker: PermissionsChecke
     open val isReadPhoneStatePermissionGranted: Boolean
         get() = permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_STATE)
 
-    open fun requestReadStoragePermission(activity: Activity, action: PermissionListener) {
-        requestPermissions(
-            activity,
-            object : PermissionListener {
-                override fun granted() {
-                    action.granted()
-                }
-
-                override fun denied() {
-                    showAdditionalExplanation(
-                        activity, R.string.storage_runtime_permission_denied_title,
-                        R.string.storage_runtime_permission_denied_desc, R.drawable.sd, action
-                    )
-                }
-            },
-            Manifest.permission.READ_EXTERNAL_STORAGE
-        )
-    }
-
     fun requestCameraPermission(activity: Activity, action: PermissionListener) {
         requestPermissions(
             activity,
@@ -329,7 +310,7 @@ open class PermissionsProvider(private val permissionsChecker: PermissionsChecke
             contentResolver.query(uri, null, null, null, null)
                 .use { listener.granted() }
         } catch (e: SecurityException) {
-            requestReadStoragePermission(
+            requestPermissions(
                 activity,
                 object : PermissionListener {
                     override fun granted() {
@@ -337,9 +318,14 @@ open class PermissionsProvider(private val permissionsChecker: PermissionsChecke
                     }
 
                     override fun denied() {
-                        listener.denied()
+                        showAdditionalExplanation(
+                            activity, R.string.storage_runtime_permission_denied_title,
+                            R.string.storage_runtime_permission_denied_desc, R.drawable.sd,
+                            listener
+                        )
                     }
-                }
+                },
+                Manifest.permission.READ_EXTERNAL_STORAGE
             )
         } catch (e: Exception) {
             listener.denied()

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
@@ -8,8 +8,6 @@ import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
@@ -137,22 +135,6 @@ class PermissionsProviderTest {
             permissionListener
         )
         verify(permissionListener).granted()
-    }
-
-    @Test
-    fun `When request read uri permission not granted should user be asked to grant read storage permission`() {
-        whenever(contentResolver.query(uri, null, null, null, null)).thenThrow(
-            SecurityException::class.java
-        )
-        doNothing().whenever(permissionsProvider).requestReadStoragePermission(any(), any())
-
-        permissionsProvider.requestReadUriPermission(
-            activity,
-            uri,
-            contentResolver,
-            permissionListener
-        )
-        verify(permissionsProvider).requestReadStoragePermission(any(), any())
     }
 
     @Test


### PR DESCRIPTION
Closes #4996 

#### What has been done to verify that this works as intended?
I reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
There is not much to discuss here we just should always check if location is enabled as a part of location requests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Recently we have added checking if location is enabled for location permission requests (see: https://github.com/getodk/collect/pull/4990) it was used only before starting a geopoint widget. However there are other places when we request location permissions:
- when a user tries to open the map of forms from the list of forms
- when a user uses geo widgets (geotrace and geoshape)
- when a user uses a form with background location

so we need to verify that always when we check location permissions we also check if location is enabled at all.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
