### PR TITLE
Replace existing form with matching formid and version

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FillBlankFormActivity.kt
@@ -39,6 +39,7 @@ import org.odk.collect.android.preferences.dialogs.ServerAuthDialogFragment
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.tasks.FormSyncTask
 import org.odk.collect.android.utilities.ApplicationConstants
+import org.odk.collect.android.utilities.ChangeLockProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.android.views.ObviousProgressBar
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.dismissDialog
@@ -73,6 +74,9 @@ class FillBlankFormActivity :
 
     @Inject
     lateinit var instancesRepositoryProvider: InstancesRepositoryProvider
+
+    @Inject
+    lateinit var changeLockProvider: ChangeLockProvider
 
     lateinit var menuDelegate: BlankFormListMenuDelegate
 
@@ -143,7 +147,7 @@ class FillBlankFormActivity :
         formSyncTask = lastCustomNonConfigurationInstance as FormSyncTask?
         if (formSyncTask == null) {
             Timber.i("Starting new disk sync task")
-            formSyncTask = FormSyncTask().also {
+            formSyncTask = FormSyncTask(changeLockProvider, currentProjectProvider.getCurrentProject().uuid).also {
                 it.setDiskSyncListener(this)
                 it.execute()
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -20,6 +20,7 @@ import org.odk.collect.shared.strings.Validator;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -52,6 +53,7 @@ public class ServerFormDownloader implements FormDownloader {
     @Override
     public void downloadForm(ServerFormDetails form, @Nullable ProgressReporter progressReporter, @Nullable Supplier<Boolean> isCancelled) throws FormDownloadException {
         Form formOnDevice;
+        List<Form> preExistingFormsWithSameIdAndVersion = new ArrayList<>();
         try {
             formOnDevice = formsRepository.getOneByMd5Hash(validateHash(form.getHash()));
         } catch (IllegalArgumentException e) {
@@ -63,8 +65,8 @@ public class ServerFormDownloader implements FormDownloader {
                 formsRepository.restore(formOnDevice.getDbId());
             }
         } else {
-            List<Form> allSameFormIdVersion = formsRepository.getAllByFormIdAndVersion(form.getFormId(), form.getFormVersion());
-            if (!allSameFormIdVersion.isEmpty() && !form.getDownloadUrl().contains("/draft.xml")) {
+            preExistingFormsWithSameIdAndVersion = formsRepository.getAllByFormIdAndVersion(form.getFormId(), form.getFormVersion());
+            if (!preExistingFormsWithSameIdAndVersion.isEmpty() && !form.getDownloadUrl().contains("/draft.xml")) {
                 analytics.logEventWithParam(DOWNLOAD_SAME_FORMID_VERSION_DIFFERENT_HASH, "form", AnalyticsUtils.getFormHash(form.getFormId(), form.getFormName()));
             }
         }
@@ -80,6 +82,9 @@ public class ServerFormDownloader implements FormDownloader {
         } finally {
             try {
                 deleteDirectory(tempDir);
+                for (Form formToDelete : preExistingFormsWithSameIdAndVersion) {
+                    formsRepository.delete(formToDelete.getDbId());
+                }
             } catch (IOException ignored) {
                 // ignored
             }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
@@ -31,6 +31,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.adapters.FormListAdapter;
 import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.forms.DatabaseFormColumns;
+import org.odk.collect.android.utilities.ChangeLockProvider;
 import org.odk.collect.material.MaterialProgressDialogFragment;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.itemsets.FastExternalItemsetsRepository;
@@ -73,6 +74,9 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
     @Inject
     CurrentProjectProvider currentProjectProvider;
 
+    @Inject
+    ChangeLockProvider changeLockProvider;
+
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
@@ -89,7 +93,7 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
 
         if (backgroundTasks == null) {
             backgroundTasks = new BackgroundTasks();
-            backgroundTasks.formSyncTask = new FormSyncTask();
+            backgroundTasks.formSyncTask = new FormSyncTask(changeLockProvider, currentProjectProvider.getCurrentProject().getUuid());
             backgroundTasks.formSyncTask.setDiskSyncListener(this);
             backgroundTasks.formSyncTask.execute((Void[]) null);
         }


### PR DESCRIPTION
Closes #1693 

#### What has been done to verify that this works as intended?
I've tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
This is what we have discussed. As I said:

> I think the best option (short and safe) is to insert new forms like now even if they are duplicate but collect and then remove pre-existing forms with the same id and version at the end of the process of downloading a form
Thanks to the functionality that copies media files from other forms with the same id we won't need to download them again and at the same time we won't end up with abandoned media files. So it seems like a win-win solution


#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should fix the problem with duplicate forms with the same id and version. We can reproduce it using central drafts. I aslo implemented changes in syncing forms from disc. The issue I solved will be difficult to reproduce:

> I was also able to find one possible scenario when users might end up with duplicate forms.... if forms are being synchronized with the server (match exactly) we first download an xml file and then save a new row in database. If between those two steps we trigger our FormSyncTask (by opening the list of forms), then it might detect that xml file and try to add it to database too.


so please focus on regression testing to make sure that functionality works as expected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
