### PR TITLE
Use black as default signature color

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/draw/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/draw/DrawActivity.java
@@ -19,6 +19,7 @@ import android.app.Activity;
 import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -111,9 +112,6 @@ public class DrawActivity extends CollectAbstractActivity {
 
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
-
-        PenColorPickerViewModel viewModel = new ViewModelProvider(this, factory).get(PenColorPickerViewModel.class);
-        viewModel.getPenColor().observe(this, penColor -> drawView.setColor(penColor));
 
         fabActions = findViewById(R.id.fab_actions);
         final FloatingActionButton fabSetColor = findViewById(R.id.fab_set_color);
@@ -231,6 +229,15 @@ public class DrawActivity extends CollectAbstractActivity {
 
         drawView = findViewById(R.id.drawView);
         drawView.setupView(OPTION_SIGNATURE.equals(loadOption));
+
+        PenColorPickerViewModel viewModel = new ViewModelProvider(this, factory).get(PenColorPickerViewModel.class);
+        viewModel.getPenColor().observe(this, penColor -> {
+            if (OPTION_SIGNATURE.equals(loadOption) && viewModel.isDefaultValue()) {
+                drawView.setColor(Color.BLACK);
+            } else {
+                drawView.setColor(penColor);
+            }
+        });
     }
 
     private void saveAndClose() {

--- a/collect_app/src/main/java/org/odk/collect/android/draw/PenColorPickerViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/draw/PenColorPickerViewModel.kt
@@ -18,10 +18,14 @@ class PenColorPickerViewModel(private val metaSettings: Settings) : ViewModel() 
             }
         }
 
+    var isDefaultValue = true
+        private set
+
     private val _penColor = MutableNonNullLiveData(lastUsedPenColor)
     val penColor: NonNullLiveData<Int> = _penColor
 
     fun setPenColor(color: Int) {
+        isDefaultValue = false
         metaSettings.save(MetaKeys.LAST_USED_PEN_COLOR, color)
         _penColor.value = color
     }


### PR DESCRIPTION
Closes #5065

#### What has been done to verify that this works as intended?
I tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
This seems to be the easiest way to fix the issue. I didn't have any other ideas worth discussing.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to verify that the issue is fixed and that for other draw widgets (`DrawWidget`, `AnnotateWidget`) pen color is remembered correctly.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
