### PR TITLE
Make json schema identifiers more specific

### DIFF
--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
@@ -19,7 +19,7 @@ class ODKAppSettingsImporter(
     private val settingsImporter = SettingsImporter(
         settingsProvider,
         ODKAppSettingsMigrator(settingsProvider.getMetaSettings()),
-        JsonSchemaSettingsValidator { javaClass.getResourceAsStream("/settings_schema.json")!! },
+        JsonSchemaSettingsValidator { javaClass.getResourceAsStream("/client-settings.schema.json")!! },
         generalDefaults,
         adminDefaults,
         settingsChangedHandler,

--- a/settings/src/main/resources/client-settings.schema.json
+++ b/settings/src/main/resources/client-settings.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://getodk.com/client-settings.schema.json",
+  "$id": "https://getodk.org/client-settings.schema.json",
   "title": "ODK Client Settings",
   "type": "object",
   "properties": {

--- a/settings/src/main/resources/settings_schema.json
+++ b/settings/src/main/resources/settings_schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://getodk.com/settings.schema.json",
-  "title": "Settings",
+  "$id": "https://getodk.com/client-settings.schema.json",
+  "title": "ODK Client Settings",
   "type": "object",
   "properties": {
     "project": {


### PR DESCRIPTION
I talked to @grzesiek2010 and @seadowg briefly about this and figured I'd make the change instead of filing an issue. Happy to entertain alternatives, though. The `title` is intended to stand more on its own. The idea with changing the URI is to have a story in case we have other kinds of settings we want to specify. None of this has been released yet so the change should have no impact.