### PR TITLE
Fix constructors for SelectChoice after JavaRosa snapshot changes

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -21,7 +21,6 @@ class SelectChoicesMapDataTest {
         val choices = listOf(
             SelectChoice(
                 null,
-                "A",
                 "a",
                 false,
                 TreeElement("").also { item ->
@@ -30,9 +29,10 @@ class SelectChoicesMapDataTest {
                             it.value = StringData("12.0 -1.0 305 0")
                         }
                     )
-                }
+                },
+                ""
             ),
-            SelectChoice(null, "B", "b", false, TreeElement(""))
+            SelectChoice(null, "b", false, TreeElement(""), "")
         )
 
         val prompt = MockFormEntryPromptBuilder()

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
@@ -42,7 +42,6 @@ class SelectOneFromMapDialogFragmentTest {
     private val selectChoices = listOf(
         SelectChoice(
             null,
-            null,
             "a",
             false,
             TreeElement("").also { item ->
@@ -51,10 +50,10 @@ class SelectOneFromMapDialogFragmentTest {
                         it.value = StringData("12.0 -1.0 305 0")
                     }
                 )
-            }
+            },
+            ""
         ),
         SelectChoice(
-            null,
             null,
             "b",
             false,
@@ -64,7 +63,8 @@ class SelectOneFromMapDialogFragmentTest {
                         it.value = StringData("13.0 -1.0 305 0")
                     }
                 )
-            }
+            },
+            ""
         )
     )
 


### PR DESCRIPTION
The last PR merge (#5073) had out of date constructors for `SelectChoice`. This usually wouldn't be possible as we pin our dependency versions but we're currently iterating on and using a snapshot of JavaRosa.