### PR TITLE
Stop `typeText` causing issues

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectDisplayPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ProjectDisplayPage.kt
@@ -1,11 +1,8 @@
 package org.odk.collect.android.support.pages
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
-import org.hamcrest.core.StringEndsWith
 import org.odk.collect.android.R
 
 class ProjectDisplayPage : Page<ProjectDisplayPage>() {
@@ -21,10 +18,9 @@ class ProjectDisplayPage : Page<ProjectDisplayPage>() {
         return this
     }
 
-    fun setProjectIcon(projectIcon: String?): ProjectDisplayPage {
+    fun setProjectIcon(projectIcon: String): ProjectDisplayPage {
         clickOnString(R.string.project_icon)
-        onView(ViewMatchers.withClassName(StringEndsWith.endsWith("EditText"))).perform(replaceText(""))
-        onView(ViewMatchers.withClassName(StringEndsWith.endsWith("EditText"))).perform(ViewActions.typeText(projectIcon))
+        inputText(projectIcon)
         clickOKOnDialog()
         return this
     }


### PR DESCRIPTION
It looks like `typeText` can fire early and create problems like in this [Test Lab Failure](https://console.firebase.google.com/u/0/project/api-project-322300403941/testlab/histories/bh.f6f8331e5ae6e371/matrices/6913446554566118302/executions/bs.a516de6f970e6b7d/testcases/6/test-cases) (required login) - the resulting project icon is "Y" instead of "X" after typing "XY". Removing it here so we just `replaceText` instead.