### PR TITLE
Improvements to `SelectOneFromMapWidget`

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
@@ -1,0 +1,23 @@
+package org.odk.collect.android.support.rules
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class RetryOnDeviceErrorRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                try {
+                    base.evaluate()
+                } catch (e: Throwable) {
+                    if (e::class.simpleName == "RootViewWithoutFocusException") {
+                        base.evaluate()
+                    } else {
+                        throw e
+                    }
+                }
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -11,7 +11,8 @@ object TestRuleChain {
     @JvmOverloads
     fun chain(testDependencies: TestDependencies = TestDependencies()): RuleChain =
         RuleChain
-            .outerRule(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
+            .outerRule(RetryOnDeviceErrorRule())
+            .around(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
             .around(DisableDeviceAnimationsRule())
             .around(ResetStateRule(testDependencies))
             .around(IdlingResourceRule(testDependencies.idlingResources))

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.kt
@@ -24,11 +24,9 @@ import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
-import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.async.Scheduler
 import org.odk.collect.geo.selection.SelectionMapFragment
-import org.odk.collect.material.MaterialProgressDialogFragment
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.strings.localization.LocalizedActivity
 import javax.inject.Inject
@@ -96,23 +94,6 @@ class FormMapActivity : LocalizedActivity() {
                 formNavigator.newInstance(this, formId)
             }
         }
-
-        viewModel.isLoading().observe(this) {
-            if (it) {
-                DialogFragmentUtils.showIfNotShowing(
-                    MaterialProgressDialogFragment().also { dialog ->
-                        dialog.message = "Loading..."
-                    },
-                    TAG_LOADING_PROGRESS_DIALOG,
-                    supportFragmentManager
-                )
-            } else {
-                DialogFragmentUtils.dismissDialog(
-                    TAG_LOADING_PROGRESS_DIALOG,
-                    supportFragmentManager
-                )
-            }
-        }
     }
 
     override fun onResume() {
@@ -122,6 +103,5 @@ class FormMapActivity : LocalizedActivity() {
 
     companion object {
         const val EXTRA_FORM_ID = "form_id"
-        private const val TAG_LOADING_PROGRESS_DIALOG = "loading_progress_dialog"
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModel.kt
@@ -37,7 +37,7 @@ class FormMapViewModel(
     private var itemCount = MutableLiveData(0)
     private val form = formsRepository.get(formId)!!
 
-    private val isLoading = MutableLiveData(false)
+    private val isLoading = MutableNonNullLiveData(false)
 
     init {
         mapTitle.value = form.displayName
@@ -59,7 +59,7 @@ class FormMapViewModel(
         return mappableItems
     }
 
-    fun isLoading(): LiveData<Boolean> {
+    override fun isLoading(): NonNullLiveData<Boolean> {
         return isLoading
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.MutableLiveData
 import org.javarosa.core.model.FormIndex
 import org.javarosa.core.model.SelectChoice
 import org.javarosa.core.model.data.SelectOneData
-import org.javarosa.core.model.data.helper.Selection
 import org.javarosa.core.model.instance.geojson.GeojsonFeature
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.R
@@ -49,9 +48,10 @@ class SelectOneFromMapDialogFragment : MaterialFullScreenDialogFragment(), Fragm
         childFragmentManager.fragmentFactory = FragmentFactoryBuilder()
             .forClass(SelectionMapFragment::class.java) {
                 val formIndex = requireArguments().getSerializable(ARG_FORM_INDEX) as FormIndex
+                val selectedIndex = requireArguments().getSerializable(ARG_SELECTED_INDEX) as Int?
                 val prompt = formEntryViewModel.getQuestionPrompt(formIndex)
                 SelectionMapFragment(
-                    SelectChoicesMapData(resources, scheduler, prompt),
+                    SelectChoicesMapData(resources, scheduler, prompt, selectedIndex),
                     skipSummary = Appearances.hasAppearance(prompt, Appearances.QUICK),
                     showNewItemButton = false
                 )
@@ -93,13 +93,15 @@ class SelectOneFromMapDialogFragment : MaterialFullScreenDialogFragment(), Fragm
 
     companion object {
         const val ARG_FORM_INDEX = "form_index"
+        const val ARG_SELECTED_INDEX = "selected_index"
     }
 }
 
 internal class SelectChoicesMapData(
     private val resources: Resources,
     scheduler: Scheduler,
-    prompt: FormEntryPrompt
+    prompt: FormEntryPrompt,
+    private val selectedIndex: Int?
 ) :
     SelectionMapData {
 
@@ -144,9 +146,6 @@ internal class SelectChoicesMapData(
                     MappableSelectItem.IconifiedText(null, "${it.first}: ${it.second}")
                 }
 
-                val selected =
-                    selectChoice.index == (prompt.answerValue?.value as? Selection)?.index
-
                 list + MappableSelectItem.WithAction(
                     index.toLong(),
                     latitude,
@@ -159,7 +158,7 @@ internal class SelectChoicesMapData(
                         R.drawable.ic_save,
                         resources.getString(R.string.select_item)
                     ),
-                    selected
+                    selectChoice.index == selectedIndex
                 )
             } else {
                 list

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.MutableLiveData
 import org.javarosa.core.model.FormIndex
 import org.javarosa.core.model.SelectChoice
 import org.javarosa.core.model.data.SelectOneData
+import org.javarosa.core.model.data.helper.Selection
 import org.javarosa.core.model.instance.geojson.GeojsonFeature
 import org.javarosa.form.api.FormEntryPrompt
 import org.odk.collect.android.R
@@ -143,6 +144,9 @@ internal class SelectChoicesMapData(
                     MappableSelectItem.IconifiedText(null, "${it.first}: ${it.second}")
                 }
 
+                val selected =
+                    selectChoice.index == (prompt.answerValue?.value as? Selection)?.index
+
                 list + MappableSelectItem.WithAction(
                     index.toLong(),
                     latitude,
@@ -154,7 +158,8 @@ internal class SelectChoicesMapData(
                     MappableSelectItem.IconifiedText(
                         R.drawable.ic_save,
                         resources.getString(R.string.select_item)
-                    )
+                    ),
+                    selected
                 )
             } else {
                 list

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -132,6 +132,10 @@ internal class SelectChoicesMapData(private val resources: Resources, prompt: Fo
         }
     }
 
+    override fun isLoading(): NonNullLiveData<Boolean> {
+        return MutableNonNullLiveData(false)
+    }
+
     override fun getMapTitle(): LiveData<String> {
         return mapTitle
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
@@ -17,6 +17,7 @@ import org.odk.collect.android.formentry.questions.QuestionDetails
 import org.odk.collect.android.widgets.QuestionWidget
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_FORM_INDEX
+import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_SELECTED_INDEX
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.permissions.PermissionListener
 
@@ -42,7 +43,12 @@ class SelectOneFromMapWidget(context: Context, questionDetails: QuestionDetails)
                     override fun granted() {
                         DialogFragmentUtils.showIfNotShowing(
                             SelectOneFromMapDialogFragment::class.java,
-                            Bundle().also { it.putSerializable(ARG_FORM_INDEX, prompt.index) },
+                            Bundle().also {
+                                it.putSerializable(ARG_FORM_INDEX, prompt.index)
+                                (answer?.value as? Selection)?.index?.let { index ->
+                                    it.putInt(ARG_SELECTED_INDEX, index)
+                                }
+                            },
                             (context as FragmentActivity).supportFragmentManager
                         )
                     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
@@ -70,12 +70,14 @@ class SelectOneFromMapWidget(context: Context, questionDetails: QuestionDetails)
 
     override fun clearAnswer() {
         updateAnswer(null)
+        widgetValueChanged()
     }
 
     override fun setOnLongClickListener(l: OnLongClickListener?) {}
 
     override fun setData(answer: Any?) {
         updateAnswer(answer as SelectOneData)
+        widgetValueChanged()
     }
 
     private fun updateAnswer(answer: SelectOneData?) {

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
@@ -407,8 +407,32 @@ class FormMapViewModelTest {
         )
     }
 
+    @Test
+    fun `is loading is true while forms and instances are being fetched`() {
+        val form = formsRepository.save(
+            FormUtils.buildForm("id", "version", TempFiles.createTempDir().absolutePath)
+                .build()
+        )
+
+        val viewModel = createViewModel(form)
+        assertThat(viewModel.isLoading().value, equalTo(false))
+
+        viewModel.load()
+        assertThat(viewModel.isLoading().value, equalTo(true))
+
+        scheduler.runBackground()
+        assertThat(viewModel.isLoading().value, equalTo(false))
+    }
+
     private fun createAndLoadViewModel(form: Form): FormMapViewModel {
-        val viewModel = FormMapViewModel(
+        val viewModel = createViewModel(form)
+        viewModel.load()
+        scheduler.runBackground()
+        return viewModel
+    }
+
+    private fun createViewModel(form: Form): FormMapViewModel {
+        return FormMapViewModel(
             application.resources,
             form.dbId,
             formsRepository,
@@ -416,8 +440,6 @@ class FormMapViewModelTest {
             settingsProvider,
             scheduler
         )
-        viewModel.load()
-        return viewModel
     }
 
     private fun formatDate(string: Int, date: Long): String {

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/formmap/FormMapViewModelTest.kt
@@ -18,6 +18,7 @@ import org.odk.collect.geo.selection.MappableSelectItem
 import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.keys.ProtectedProjectKeys
 import org.odk.collect.shared.TempFiles
+import org.odk.collect.testshared.FakeScheduler
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -31,6 +32,7 @@ class FormMapViewModelTest {
     }
 
     private val application = ApplicationProvider.getApplicationContext<Application>()
+    private val scheduler = FakeScheduler()
 
     @Test
     fun `returns count based on form instances`() {
@@ -411,7 +413,8 @@ class FormMapViewModelTest {
             form.dbId,
             formsRepository,
             instancesRepository,
-            settingsProvider
+            settingsProvider,
+            scheduler
         )
         viewModel.load()
         return viewModel

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.javarosa.core.model.data.SelectOneData
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -78,6 +79,34 @@ class SelectChoicesMapDataTest {
         val properties = data.getMappableItems().value[0].properties
         assertThat(properties.size, equalTo(1))
         assertThat(properties[0], equalTo(IconifiedText(null, "property: blah")))
+    }
+
+    @Test
+    fun `selected choice has selected set to true`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(children = listOf(treeElement("geometry", "12.0 -1.0 305 0")))
+            ),
+            selectChoice(
+                value = "b",
+                item = treeElement(children = listOf(treeElement("geometry", "12.0 -1.0 305 0")))
+            )
+        )
+
+        val prompt = MockFormEntryPromptBuilder()
+            .withLongText("Which is your favourite place?")
+            .withAnswer(SelectOneData(choices[0].selection()))
+            .withSelectChoices(choices)
+            .withSelectChoiceText(mapOf(choices[0] to "A", choices[1] to "B"))
+            .build()
+
+        val resources = ApplicationProvider.getApplicationContext<Application>().resources
+        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        scheduler.runBackground()
+
+        assertThat(data.getMappableItems().value[0].selected, equalTo(true))
+        assertThat(data.getMappableItems().value[1].selected, equalTo(false))
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -43,7 +43,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt, -1)
+        val data = SelectChoicesMapData(resources, scheduler, prompt, null)
         scheduler.runBackground()
 
         assertThat(data.getItemCount().value, equalTo(2))
@@ -72,7 +72,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt, -1)
+        val data = SelectChoicesMapData(resources, scheduler, prompt, null)
         scheduler.runBackground()
 
         val properties = data.getMappableItems().value[0].properties
@@ -88,7 +88,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt, -1)
+        val data = SelectChoicesMapData(resources, scheduler, prompt, null)
         assertThat(data.isLoading().value, equalTo(true))
 
         scheduler.runBackground()

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -6,7 +6,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.javarosa.core.model.data.SelectOneData
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,7 +43,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        val data = SelectChoicesMapData(resources, scheduler, prompt, -1)
         scheduler.runBackground()
 
         assertThat(data.getItemCount().value, equalTo(2))
@@ -73,40 +72,12 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        val data = SelectChoicesMapData(resources, scheduler, prompt, -1)
         scheduler.runBackground()
 
         val properties = data.getMappableItems().value[0].properties
         assertThat(properties.size, equalTo(1))
         assertThat(properties[0], equalTo(IconifiedText(null, "property: blah")))
-    }
-
-    @Test
-    fun `selected choice has selected set to true`() {
-        val choices = listOf(
-            selectChoice(
-                value = "a",
-                item = treeElement(children = listOf(treeElement("geometry", "12.0 -1.0 305 0")))
-            ),
-            selectChoice(
-                value = "b",
-                item = treeElement(children = listOf(treeElement("geometry", "12.0 -1.0 305 0")))
-            )
-        )
-
-        val prompt = MockFormEntryPromptBuilder()
-            .withLongText("Which is your favourite place?")
-            .withAnswer(SelectOneData(choices[0].selection()))
-            .withSelectChoices(choices)
-            .withSelectChoiceText(mapOf(choices[0] to "A", choices[1] to "B"))
-            .build()
-
-        val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt)
-        scheduler.runBackground()
-
-        assertThat(data.getMappableItems().value[0].selected, equalTo(true))
-        assertThat(data.getMappableItems().value[1].selected, equalTo(false))
     }
 
     @Test
@@ -117,7 +88,7 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        val data = SelectChoicesMapData(resources, scheduler, prompt, -1)
         assertThat(data.isLoading().value, equalTo(true))
 
         scheduler.runBackground()

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -13,9 +13,12 @@ import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.widgets.support.FormFixtures.selectChoice
 import org.odk.collect.android.widgets.support.FormFixtures.treeElement
 import org.odk.collect.geo.selection.MappableSelectItem.IconifiedText
+import org.odk.collect.testshared.FakeScheduler
 
 @RunWith(AndroidJUnit4::class)
 class SelectChoicesMapDataTest {
+
+    private val scheduler = FakeScheduler()
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -40,7 +43,9 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, prompt)
+        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        scheduler.runBackground()
+
         assertThat(data.getItemCount().value, equalTo(2))
         assertThat(data.getMappableItems().value.size, equalTo(1))
         assertThat(data.getMappableItems().value[0].name, equalTo("A"))
@@ -67,10 +72,26 @@ class SelectChoicesMapDataTest {
             .build()
 
         val resources = ApplicationProvider.getApplicationContext<Application>().resources
-        val data = SelectChoicesMapData(resources, prompt)
+        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        scheduler.runBackground()
 
         val properties = data.getMappableItems().value[0].properties
         assertThat(properties.size, equalTo(1))
         assertThat(properties[0], equalTo(IconifiedText(null, "property: blah")))
+    }
+
+    @Test
+    fun `isLoading is true when items are being loaded from choices`() {
+        val prompt = MockFormEntryPromptBuilder()
+            .withSelectChoices(emptyList())
+            .withSelectChoiceText(emptyMap())
+            .build()
+
+        val resources = ApplicationProvider.getApplicationContext<Application>().resources
+        val data = SelectChoicesMapData(resources, scheduler, prompt)
+        assertThat(data.isLoading().value, equalTo(true))
+
+        scheduler.runBackground()
+        assertThat(data.isLoading().value, equalTo(false))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
@@ -30,6 +30,7 @@ import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.utilities.Appearances
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_FORM_INDEX
+import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_SELECTED_INDEX
 import org.odk.collect.android.widgets.support.FormFixtures.selectChoice
 import org.odk.collect.android.widgets.support.FormFixtures.treeElement
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
@@ -160,6 +161,26 @@ class SelectOneFromMapDialogFragmentTest {
                     )
                 )
             )
+        }
+    }
+
+    @Test
+    fun `contains SelectionMapFragment with correct data with selected index`() {
+        launcherRule.launchDialogFragment(
+            SelectOneFromMapDialogFragment::class.java,
+            Bundle().also {
+                it.putSerializable(ARG_FORM_INDEX, prompt.index)
+                it.putSerializable(ARG_SELECTED_INDEX, selectChoices[1].index)
+            }
+        ).onFragment {
+            val binding = SelectOneFromMapDialogLayoutBinding.bind(it.view!!)
+            val fragment = binding.selectionMap.getFragment<SelectionMapFragment>()
+            assertThat(fragment, notNullValue())
+            assertThat(fragment.skipSummary, equalTo(false))
+            assertThat(fragment.showNewItemButton, equalTo(false))
+
+            val data = fragment.selectionMapData
+            assertThat(data.getMappableItems().value[1].selected, equalTo(true))
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
@@ -228,4 +228,36 @@ class SelectOneFromMapWidgetTest {
         widget.setData(SelectOneData(choices[1].selection()))
         assertThat(widget.binding.answer.text, equalTo("B"))
     }
+
+    @Test
+    fun `setData answer is passed to SelectOneFromMapDialogFragment`() {
+        val choices = listOf(
+            selectChoice("a"),
+            selectChoice("b")
+        )
+        val prompt = MockFormEntryPromptBuilder()
+            .withSelectChoices(choices)
+            .withSelectChoiceText(
+                mapOf(choices[0] to "A", choices[1] to "B")
+            )
+            .build()
+
+        val widget =
+            SelectOneFromMapWidget(activityController.setup().get(), QuestionDetails(prompt))
+        widget.setData(SelectOneData(choices[1].selection()))
+
+        whenever(formEntryViewModel.getQuestionPrompt(prompt.index)).doReturn(prompt)
+        widget.binding.button.performClick()
+
+        val fragment = getFragmentByClass(
+            activityController.get().supportFragmentManager,
+            SelectOneFromMapDialogFragment::class.java
+        )
+        assertThat(fragment, notNullValue())
+        assertThat(
+            fragment?.requireArguments()
+                ?.getSerializable(SelectOneFromMapDialogFragment.ARG_SELECTED_INDEX),
+            equalTo(choices[1].index)
+        )
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.fakes.FakePermissionsProvider
@@ -25,6 +26,7 @@ import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.support.WidgetTestActivity
 import org.odk.collect.android.widgets.support.FormFixtures.selectChoice
+import org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener
 import org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAnswer
 import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
@@ -123,15 +125,10 @@ class SelectOneFromMapWidgetTest {
 
     @Test
     fun `shows answer`() {
-        val choices = listOf(
-            selectChoice("a"),
-            selectChoice("b")
-        )
+        val choices = listOf(selectChoice("a"), selectChoice("b"))
         val prompt = MockFormEntryPromptBuilder()
             .withSelectChoices(choices)
-            .withSelectChoiceText(
-                mapOf(choices[0] to "A", choices[1] to "B")
-            )
+            .withSelectChoiceText(mapOf(choices[0] to "A", choices[1] to "B"))
             .withAnswer(SelectOneData(choices[0].selection()))
             .build()
 
@@ -155,7 +152,7 @@ class SelectOneFromMapWidgetTest {
 
     @Test
     fun `prompt answer is returned from getAnswer`() {
-        val selectChoice = selectChoice(value = "a", index = 101)
+        val selectChoice = selectChoice(value = "a")
         val answer = SelectOneData(selectChoice.selection())
 
         val widget = SelectOneFromMapWidget(
@@ -167,7 +164,7 @@ class SelectOneFromMapWidgetTest {
 
     @Test
     fun `clearAnswer removes answer`() {
-        val selectChoice = selectChoice(value = "a", index = 101)
+        val selectChoice = selectChoice(value = "a")
         val answer = SelectOneData(selectChoice.selection())
 
         val widget = SelectOneFromMapWidget(
@@ -179,16 +176,26 @@ class SelectOneFromMapWidgetTest {
     }
 
     @Test
-    fun `clearAnswer updates shown answer`() {
-        val choices = listOf(
-            selectChoice("a"),
-            selectChoice("b")
+    fun `clearAnswer calls value changed listener`() {
+        val selectChoice = selectChoice(value = "a")
+        val answer = SelectOneData(selectChoice.selection())
+
+        val widget = SelectOneFromMapWidget(
+            activityController.get(),
+            QuestionDetails(promptWithAnswer(answer))
         )
+
+        val mockValueChangedListener = mockValueChangedListener(widget)
+        widget.clearAnswer()
+        verify(mockValueChangedListener).widgetValueChanged(widget)
+    }
+
+    @Test
+    fun `clearAnswer updates shown answer`() {
+        val choices = listOf(selectChoice("a"), selectChoice("b"))
         val prompt = MockFormEntryPromptBuilder()
             .withSelectChoices(choices)
-            .withSelectChoiceText(
-                mapOf(choices[0] to "A", choices[1] to "B")
-            )
+            .withSelectChoiceText(mapOf(choices[0] to "A", choices[1] to "B"))
             .withAnswer(SelectOneData(choices[0].selection()))
             .build()
 
@@ -213,10 +220,7 @@ class SelectOneFromMapWidgetTest {
 
     @Test
     fun `setData updates shown answer`() {
-        val choices = listOf(
-            selectChoice("a"),
-            selectChoice("b")
-        )
+        val choices = listOf(selectChoice("a"), selectChoice("b"))
         val prompt = MockFormEntryPromptBuilder()
             .withSelectChoices(choices)
             .withSelectChoiceText(
@@ -230,16 +234,26 @@ class SelectOneFromMapWidgetTest {
     }
 
     @Test
-    fun `setData answer is passed to SelectOneFromMapDialogFragment`() {
-        val choices = listOf(
-            selectChoice("a"),
-            selectChoice("b")
-        )
+    fun `setData calls value change listener`() {
+        val choices = listOf(selectChoice("a"))
         val prompt = MockFormEntryPromptBuilder()
             .withSelectChoices(choices)
-            .withSelectChoiceText(
-                mapOf(choices[0] to "A", choices[1] to "B")
-            )
+            .withSelectChoiceText(mapOf(choices[0] to "A"))
+            .build()
+
+        val widget = SelectOneFromMapWidget(activityController.get(), QuestionDetails(prompt))
+
+        val mockValueChangedListener = mockValueChangedListener(widget)
+        widget.setData(SelectOneData(choices[0].selection()))
+        verify(mockValueChangedListener).widgetValueChanged(widget)
+    }
+
+    @Test
+    fun `setData answer is passed to SelectOneFromMapDialogFragment`() {
+        val choices = listOf(selectChoice("a"), selectChoice("b"))
+        val prompt = MockFormEntryPromptBuilder()
+            .withSelectChoices(choices)
+            .withSelectChoiceText(mapOf(choices[0] to "A", choices[1] to "B"))
             .build()
 
         val widget =

--- a/geo/build.gradle
+++ b/geo/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation project(path: ':analytics')
     implementation project(path: ':permissions')
     implementation project(path: ':maps')
+    implementation project(path: ':material')
 
     debugImplementation project(path: ':fragmentstest')
     testImplementation project(path: ':androidtest')

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.ViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import org.odk.collect.androidshared.livedata.NonNullLiveData
-import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.geo.GeoDependencyComponentProvider
 import org.odk.collect.geo.R
@@ -88,22 +87,13 @@ class SelectionMapFragment(
             requireActivity().finish()
         }
 
-        selectionMapData.isLoading().observe(this) {
-            if (it) {
-                val dialog = MaterialProgressDialogFragment().also { dialog ->
-                    dialog.message = getString(R.string.loading)
-                }
-
-                DialogFragmentUtils.showIfNotShowing(
-                    dialog,
-                    MaterialProgressDialogFragment::class.java,
-                    childFragmentManager
-                )
-            } else {
-                DialogFragmentUtils.dismissDialog(
-                    MaterialProgressDialogFragment::class.java,
-                    childFragmentManager
-                )
+        MaterialProgressDialogFragment.showOn(
+            this,
+            selectionMapData.isLoading(),
+            childFragmentManager
+        ) {
+            MaterialProgressDialogFragment().also { dialog ->
+                dialog.message = getString(R.string.loading)
             }
         }
     }

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.ViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
 import org.odk.collect.androidshared.livedata.NonNullLiveData
+import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.ToastUtils
 import org.odk.collect.geo.GeoDependencyComponentProvider
 import org.odk.collect.geo.R
@@ -24,6 +25,7 @@ import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragment.ReadyListener
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.material.MaterialProgressDialogFragment
 import org.odk.collect.permissions.PermissionsChecker
 import javax.inject.Inject
 
@@ -84,6 +86,25 @@ class SelectionMapFragment(
         ) {
             ToastUtils.showLongToast(requireContext(), R.string.not_granted_permission)
             requireActivity().finish()
+        }
+
+        selectionMapData.isLoading().observe(this) {
+            if (it) {
+                val dialog = MaterialProgressDialogFragment().also { dialog ->
+                    dialog.message = "Loading..."
+                }
+
+                DialogFragmentUtils.showIfNotShowing(
+                    dialog,
+                    MaterialProgressDialogFragment::class.java,
+                    childFragmentManager
+                )
+            } else {
+                DialogFragmentUtils.dismissDialog(
+                    MaterialProgressDialogFragment::class.java,
+                    childFragmentManager
+                )
+            }
         }
     }
 
@@ -370,6 +391,7 @@ internal class SelectedFeatureViewModel : ViewModel() {
 }
 
 interface SelectionMapData {
+    fun isLoading(): NonNullLiveData<Boolean>
     fun getMapTitle(): LiveData<String>
     fun getItemType(): String
     fun getItemCount(): LiveData<Int>

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -315,7 +315,12 @@ class SelectionMapFragment(
 
         updateFeatures(items)
 
-        if (!viewportInitialized && points.isNotEmpty()) {
+        val selectedFeatureId =
+            itemsByFeatureId.filter { it.value.selected }.map { it.key }.firstOrNull()
+        if (selectedFeatureId != null) {
+            onFeatureClicked(selectedFeatureId)
+            viewportInitialized = true
+        } else if (!viewportInitialized && points.isNotEmpty()) {
             map.zoomToBoundingBox(points, 0.8, false)
             viewportInitialized = true
         }
@@ -397,6 +402,7 @@ sealed interface MappableSelectItem {
     val largeIcon: Int
     val name: String
     val properties: List<IconifiedText>
+    val selected: Boolean
 
     data class WithInfo(
         override val id: Long,
@@ -407,6 +413,7 @@ sealed interface MappableSelectItem {
         override val name: String,
         override val properties: List<IconifiedText>,
         val info: String,
+        override val selected: Boolean = false,
     ) : MappableSelectItem
 
     data class WithAction(
@@ -417,7 +424,8 @@ sealed interface MappableSelectItem {
         override val largeIcon: Int,
         override val name: String,
         override val properties: List<IconifiedText>,
-        val action: IconifiedText
+        val action: IconifiedText,
+        override val selected: Boolean = false
     ) : MappableSelectItem
 
     data class IconifiedText(val icon: Int?, val text: String)

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -91,7 +91,7 @@ class SelectionMapFragment(
         selectionMapData.isLoading().observe(this) {
             if (it) {
                 val dialog = MaterialProgressDialogFragment().also { dialog ->
-                    dialog.message = "Loading..."
+                    dialog.message = getString(R.string.loading)
                 }
 
                 DialogFragmentUtils.showIfNotShowing(

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -19,6 +19,8 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -40,7 +42,9 @@ import org.odk.collect.geo.support.RobolectricApplication
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.maps.MapPoint
+import org.odk.collect.material.MaterialProgressDialogFragment
 import org.odk.collect.permissions.PermissionsChecker
+import org.odk.collect.testshared.RobolectricHelpers.getFragmentByClass
 
 @RunWith(AndroidJUnit4::class)
 class SelectionMapFragmentTest {
@@ -50,6 +54,7 @@ class SelectionMapFragmentTest {
     private val map = FakeMapFragment()
     private val referenceLayerSettingsNavigator: ReferenceLayerSettingsNavigator = mock()
     private val data = mock<SelectionMapData> {
+        on { isLoading() } doReturn MutableNonNullLiveData(false)
         on { getMapTitle() } doReturn MutableLiveData("")
         on { getItemType() } doReturn "Things"
         on { getItemCount() } doReturn MutableLiveData(0)
@@ -350,6 +355,23 @@ class SelectionMapFragmentTest {
         assertThat(map.getZoomBoundingBox(), equalTo(null))
         assertThat(map.center, equalTo(MapPoint(55.0, 66.0)))
         assertThat(map.zoom, equalTo(7.0))
+    }
+
+    @Test
+    fun `shows progress dialog when loading`() {
+        val loadingLiveData = MutableNonNullLiveData(false)
+        whenever(data.isLoading()).thenReturn(loadingLiveData)
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java).onFragment {
+            val dialogClass = MaterialProgressDialogFragment::class.java
+            assertThat(getFragmentByClass(it.childFragmentManager, dialogClass), nullValue())
+
+            loadingLiveData.value = true
+            assertThat(getFragmentByClass(it.childFragmentManager, dialogClass), notNullValue())
+
+            loadingLiveData.value = false
+            assertThat(getFragmentByClass(it.childFragmentManager, dialogClass), nullValue())
+        }
     }
 
     private fun MappableSelectItem.toMapPoint(): MapPoint {

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -326,6 +326,19 @@ class SelectionMapFragmentTest {
     }
 
     @Test
+    fun `centers on already selected item and does not move when location changes`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
+            Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0, selected = true)
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableNonNullLiveData(items))
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java)
+        map.setLocation(MapPoint(1.0, 2.0))
+        assertThat(map.center, equalTo(items[1].toMapPoint()))
+    }
+
+    @Test
     fun `hides new item button when showNewItemButton is false`() {
         launcherRule.launchInContainer(
             SelectionMapFragment::class.java,

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -114,6 +114,10 @@ class FakeMapFragment : MapFragment {
     override fun runOnGpsLocationReady(listener: ReadyListener) {}
     override fun setGpsLocationListener(listener: PointListener?) {
         gpsLocationListener = listener
+
+        gpsLocation?.let {
+            listener?.onPoint(it)
+        }
     }
 
     override fun setRetainMockAccuracy(retainMockAccuracy: Boolean) {

--- a/material/build.gradle
+++ b/material/build.gradle
@@ -23,6 +23,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -35,6 +36,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring Dependencies.desugar
+
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.android_material
     implementation Dependencies.androidx_fragment

--- a/material/src/main/java/org/odk/collect/material/MaterialProgressDialogFragment.java
+++ b/material/src/main/java/org/odk/collect/material/MaterialProgressDialogFragment.java
@@ -1,5 +1,7 @@
 package org.odk.collect.material;
 
+import static android.content.DialogInterface.BUTTON_NEGATIVE;
+
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -9,12 +11,16 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
-
-import static android.content.DialogInterface.BUTTON_NEGATIVE;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.LifecycleOwner;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.odk.collect.androidshared.livedata.NonNullLiveData;
+import org.odk.collect.androidshared.ui.DialogFragmentUtils;
+
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 /**
  * Provides a reusable progress dialog implemented with {@link MaterialAlertDialogBuilder}. Progress
@@ -133,5 +139,16 @@ public class MaterialProgressDialogFragment extends DialogFragment {
 
     public View getDialogView() {
         return dialogView;
+    }
+
+    public static void showOn(LifecycleOwner lifecycleOwner, NonNullLiveData<Boolean> liveData, FragmentManager fragmentManager, Supplier<MaterialProgressDialogFragment> supplier) {
+        liveData.observe(lifecycleOwner, isLoading -> {
+            if (isLoading) {
+                MaterialProgressDialogFragment dialog = supplier.get();
+                DialogFragmentUtils.showIfNotShowing(dialog, MaterialProgressDialogFragment.class.getName(), fragmentManager);
+            } else {
+                DialogFragmentUtils.dismissDialog(MaterialProgressDialogFragment.class.getName(), fragmentManager);
+            }
+        });
     }
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1071,6 +1071,8 @@
     <string name="select_odk_shortcut">Select ODK Shortcut</string>
     <string name="background_audio_help">This form records the audio from your device\'s microphone.\n\nYou can use the volume indicator to make sure the microphone is close enough to the sound you need to record.\n\nTo stop the recording please exit this form.\n\nFor more information please contact the person who asked you to collect data.</string>
 
+    <string name="loading">Loading…</string>
+
     <!--
      ##############################################
      # Projects


### PR DESCRIPTION
This adds a few things:

* A progress indicator is now shown when loading choices on the map (and also on the form map when loading instances)
* If a choice has been selected, clicking "Select Place" opens the map with that choice centered (and with its details showing)
* The widget now works properly with field list recomputations

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It would be good to test all the above changes (including a quick look at the form map).

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
