### PR TITLE
Ignore errors when settings QR code includes values not in schema enums

### DIFF
--- a/settings/src/main/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidator.kt
+++ b/settings/src/main/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidator.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SpecVersion
+import com.networknt.schema.ValidatorTypeCode
 import org.odk.collect.settings.importing.SettingsValidator
 import java.io.InputStream
 
@@ -16,7 +17,7 @@ internal class JsonSchemaSettingsValidator(private val schemaProvider: () -> Inp
                 val schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)
                 val schema = schemaFactory.getSchema(schemaStream)
                 val errors = schema.validate(ObjectMapper().readTree(json))
-                errors.isEmpty()
+                errors.none { it.type != ValidatorTypeCode.ENUM.value }
             }
         } catch (e: JsonParseException) {
             false

--- a/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidatorTest.kt
@@ -15,7 +15,7 @@ class JsonSchemaSettingsValidatorTest {
             validator.isValid(
                 """
                 {
-                    "foo": false
+                    "foo": "option1"
                 }
                 """
             ),
@@ -33,7 +33,7 @@ class JsonSchemaSettingsValidatorTest {
             validator.isValid(
                 """
                 {
-                    "foo": "bar"
+                    "foo": false
                 }
                 """
             ),
@@ -52,6 +52,24 @@ class JsonSchemaSettingsValidatorTest {
             equalTo(false)
         )
     }
+
+    @Test
+    fun `returns true when json contains values different than those specified in a corresponding enum`() {
+        val validator = JsonSchemaSettingsValidator {
+            SCHEMA.byteInputStream()
+        }
+
+        assertThat(
+            validator.isValid(
+                """
+                {
+                    "foo": "option3"
+                }
+                """
+            ),
+            equalTo(true)
+        )
+    }
 }
 
 private const val SCHEMA = """
@@ -62,7 +80,11 @@ private const val SCHEMA = """
                 "type": "object",
                 "properties": {
                     "foo": {
-                        "type": "boolean"
+                        "type": "string",
+                        "enum": [
+                            "option1",
+                            "option2"
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
Closes #5089 

#### What has been done to verify that this works as intended?
I've tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
As we discussed in the issue this seems to be a good first step to avoid blocking users with old qr codes. Later we should add improvements to make sure default values are used if there are ones that we do not support.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the bug so no other areas should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
