### PR TITLE
Launch select from map with zoom on current location

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -53,7 +53,8 @@ class SelectOneFromMapDialogFragment : MaterialFullScreenDialogFragment(), Fragm
                 SelectionMapFragment(
                     SelectChoicesMapData(resources, scheduler, prompt, selectedIndex),
                     skipSummary = Appearances.hasAppearance(prompt, Appearances.QUICK),
-                    showNewItemButton = false
+                    showNewItemButton = false,
+                    zoomToFeatureBoundingBoxOnLoad = false
                 )
             }
             .build()

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -54,7 +54,7 @@ class SelectOneFromMapDialogFragment : MaterialFullScreenDialogFragment(), Fragm
                     SelectChoicesMapData(resources, scheduler, prompt, selectedIndex),
                     skipSummary = Appearances.hasAppearance(prompt, Appearances.QUICK),
                     showNewItemButton = false,
-                    zoomToFeatureBoundingBoxOnLoad = false
+                    zoomToFitItems = false
                 )
             }
             .build()

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -36,7 +36,7 @@ class SelectionMapFragment(
     val selectionMapData: SelectionMapData,
     val skipSummary: Boolean = false,
     val showNewItemButton: Boolean = true,
-    val zoomToFeatureBoundingBoxOnLoad: Boolean = true
+    val zoomToFitItems: Boolean = true
 ) : Fragment() {
 
     @Inject
@@ -321,7 +321,7 @@ class SelectionMapFragment(
         if (selectedFeatureId != null) {
             onFeatureClicked(selectedFeatureId)
             viewportInitialized = true
-        } else if (zoomToFeatureBoundingBoxOnLoad && !viewportInitialized && points.isNotEmpty()) {
+        } else if (zoomToFitItems && !viewportInitialized && points.isNotEmpty()) {
             map.zoomToBoundingBox(points, 0.8, false)
             viewportInitialized = true
         }

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -35,7 +35,8 @@ import javax.inject.Inject
 class SelectionMapFragment(
     val selectionMapData: SelectionMapData,
     val skipSummary: Boolean = false,
-    val showNewItemButton: Boolean = true
+    val showNewItemButton: Boolean = true,
+    val zoomToFeatureBoundingBoxOnLoad: Boolean = true
 ) : Fragment() {
 
     @Inject
@@ -320,7 +321,7 @@ class SelectionMapFragment(
         if (selectedFeatureId != null) {
             onFeatureClicked(selectedFeatureId)
             viewportInitialized = true
-        } else if (!viewportInitialized && points.isNotEmpty()) {
+        } else if (zoomToFeatureBoundingBoxOnLoad && !viewportInitialized && points.isNotEmpty()) {
             map.zoomToBoundingBox(points, 0.8, false)
             viewportInitialized = true
         }

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -149,7 +149,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `zooms to current location when zoomToFeatureBoundingBoxOnLoad is false`() {
+    fun `zooms to current location when zoomToFitItems is false`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
             Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0)
@@ -160,7 +160,7 @@ class SelectionMapFragmentTest {
             SelectionMapFragment::class.java,
             factory = FragmentFactoryBuilder()
                 .forClass(SelectionMapFragment::class.java) {
-                    SelectionMapFragment(data, zoomToFeatureBoundingBoxOnLoad = false)
+                    SelectionMapFragment(data, zoomToFitItems = false)
                 }.build()
         )
 

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -149,6 +149,28 @@ class SelectionMapFragmentTest {
     }
 
     @Test
+    fun `zooms to current location when zoomToFeatureBoundingBoxOnLoad is false`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
+            Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0)
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableNonNullLiveData(items))
+
+        launcherRule.launchInContainer(
+            SelectionMapFragment::class.java,
+            factory = FragmentFactoryBuilder()
+                .forClass(SelectionMapFragment::class.java) {
+                    SelectionMapFragment(data, zoomToFeatureBoundingBoxOnLoad = false)
+                }.build()
+        )
+
+        assertThat(map.center, equalTo(FakeMapFragment.DEFAULT_CENTER))
+
+        map.setLocation(MapPoint(1.0, 2.0))
+        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+    }
+
+    @Test
     fun `zooms to current location when there are no items`() {
         whenever(data.getMappableItems()).doReturn(MutableNonNullLiveData(emptyList()))
 


### PR DESCRIPTION
Closes #5093

#### What has been done to verify that this works as intended?
Ran with osmdroid, Google Maps, Mapbox. Added test.

#### Why is this the best possible solution? Were any other approaches considered?
We briefly considered changing the behavior for the form instance map as well. That map is intended to be a summary of work done, though, whereas the select from map is more likely to be used for tasking upcoming work. It makes sense that they would start with a different zoom.

I also considered doing some additional work on making the zoom deterministic here. I've decided to do it separately in case it's controversial https://github.com/getodk/collect/pull/5099.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The intentional behavior change is that now all three mapping engines should start the select from map view zoomed in to the device location.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any with select from map (https://forum.getodk.org/t/odk-collect-v2022-2-beta-select-from-map-geojson-datasets/36913/6)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Should be included in https://github.com/getodk/docs/issues/1458

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
