### PR TITLE
Make launch viewport for selection map deterministic

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragment.kt
@@ -53,7 +53,8 @@ class SelectOneFromMapDialogFragment : MaterialFullScreenDialogFragment(), Fragm
                 SelectionMapFragment(
                     SelectChoicesMapData(resources, scheduler, prompt, selectedIndex),
                     skipSummary = Appearances.hasAppearance(prompt, Appearances.QUICK),
-                    showNewItemButton = false
+                    showNewItemButton = false,
+                    zoomToFeatureBoundingBoxOnLoad = false
                 )
             }
             .build()

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -35,7 +35,8 @@ import javax.inject.Inject
 class SelectionMapFragment(
     val selectionMapData: SelectionMapData,
     val skipSummary: Boolean = false,
-    val showNewItemButton: Boolean = true
+    val showNewItemButton: Boolean = true,
+    val zoomToFeatureBoundingBoxOnLoad: Boolean = true
 ) : Fragment() {
 
     @Inject
@@ -320,7 +321,7 @@ class SelectionMapFragment(
         if (selectedFeatureId != null) {
             onFeatureClicked(selectedFeatureId)
             viewportInitialized = true
-        } else if (!viewportInitialized && points.isNotEmpty()) {
+        } else if (zoomToFeatureBoundingBoxOnLoad && !viewportInitialized && points.isNotEmpty()) {
             map.zoomToBoundingBox(points, 0.8, false)
             viewportInitialized = true
         }

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -149,6 +149,23 @@ class SelectionMapFragmentTest {
     }
 
     @Test
+    fun `zooms to fit all items when device location is previously set`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
+            Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0)
+        )
+
+        whenever(data.getMappableItems()).thenReturn(MutableNonNullLiveData(items))
+
+        map.setLocation(MapPoint(1.0, 2.0))
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java)
+
+        val points = items.map { it.toMapPoint() }
+        assertThat(map.getZoomBoundingBox(), equalTo(Pair(points, 0.8)))
+    }
+
+    @Test
     fun `zooms to current location when zoomToFeatureBoundingBoxOnLoad is false`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -149,6 +149,28 @@ class SelectionMapFragmentTest {
     }
 
     @Test
+    fun `zooms to current location when zoomToFeatureBoundingBoxOnLoad is false`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
+            Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0)
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableNonNullLiveData(items))
+
+        launcherRule.launchInContainer(
+            SelectionMapFragment::class.java,
+            factory = FragmentFactoryBuilder()
+                .forClass(SelectionMapFragment::class.java) {
+                    SelectionMapFragment(data, zoomToFeatureBoundingBoxOnLoad = false)
+                }.build()
+        )
+
+        assertThat(map.center, equalTo(FakeMapFragment.DEFAULT_CENTER))
+
+        map.setLocation(MapPoint(1.0, 2.0))
+        assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+    }
+
+    @Test
     fun `zooms to current location when there are no items`() {
         whenever(data.getMappableItems()).doReturn(MutableNonNullLiveData(emptyList()))
 


### PR DESCRIPTION
And addresses non-determinism described at https://github.com/getodk/collect/issues/5093#issuecomment-1095284696

This is going to conflict with https://github.com/getodk/collect/pull/5095! Those changes are more important. I do think it would be best to also fix the non-determinism if possible. Maybe take inspiration from here and do another PR once #5095 is merged?

#### What has been done to verify that this works as intended?
Tried on device with all three mapping engines. Added a test.

#### Why is this the best possible solution? Were any other approaches considered?
Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I think the regression risk is low. There aren't tests for all the possible combinations of start state (and I don't think there should be). There could be an inadvertent change to one of the combinations.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any with a select one from map.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
