### PR TITLE
Make sure BottomSheetCallback is not called after onDestroy

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -54,6 +54,7 @@ class SelectionMapFragment(
 
     private lateinit var summarySheetBehavior: BottomSheetBehavior<*>
     private lateinit var summarySheet: SelectionSummarySheet
+    private lateinit var bottomSheetCallback: BottomSheetCallback
 
     private val itemsByFeatureId: MutableMap<Int, MappableSelectItem> = mutableMapOf()
 
@@ -153,6 +154,11 @@ class SelectionMapFragment(
         outState.putDouble(MAP_ZOOM_KEY, map.zoom)
     }
 
+    override fun onDestroy() {
+        summarySheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
+        super.onDestroy()
+    }
+
     @SuppressLint("MissingPermission") // Permission handled in Constructor
     private fun initMap(newMapFragment: MapFragment, binding: SelectionMapLayoutBinding) {
         map = newMapFragment
@@ -235,7 +241,7 @@ class SelectionMapFragment(
             onBackPressedCallback
         )
 
-        summarySheetBehavior.addBottomSheetCallback(object : BottomSheetCallback() {
+        bottomSheetCallback = object : BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {
                 val selectedFeatureId = selectedFeatureViewModel.getSelectedFeatureId()
                 if (newState == BottomSheetBehavior.STATE_HIDDEN && selectedFeatureId != null) {
@@ -251,7 +257,8 @@ class SelectionMapFragment(
             }
 
             override fun onSlide(bottomSheet: View, slideOffset: Float) {}
-        })
+        }
+        summarySheetBehavior.addBottomSheetCallback(bottomSheetCallback)
 
         summarySheet.listener = object : SelectionSummarySheet.Listener {
             override fun selectionAction(id: Long) {


### PR DESCRIPTION
Closes #5084

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that `BottomSheetCallback` was called after `onDestroy()`. The flow is:
1. When we confirm selecting an item by clicking the `Save` button then we also close the bottoms sheet: https://github.com/getodk/collect/blob/master/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt#L258
2. That triggers `BottomSheetCallback` which updates marker icon
3. If it happens after `onDestroy()` we have that crash

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
it should just fix the issue and have no side effects.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
