### PR TITLE
Fix `FormHierarchyPage` usage in tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
@@ -34,7 +34,7 @@ class InstancePickActionTest {
         val intent = Intent(Intent.ACTION_PICK)
         intent.type = InstancesContract.CONTENT_TYPE
         val result = rule.launchForResult(intent, EditSavedFormPage()) {
-            it.clickOnForm("One Question")
+            it.clickOnFormClosingApp("One Question")
         }
 
         val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/EditSavedFormPage.java
@@ -56,7 +56,7 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
     }
 
     public OkDialog clickOnFormWithDialog(String instanceName) {
-        clickOnForm(instanceName);
+        scrollToAndClickOnForm(instanceName);
         return new OkDialog().assertOnPage();
     }
 
@@ -67,12 +67,17 @@ public class EditSavedFormPage extends Page<EditSavedFormPage> {
 
     public FormHierarchyPage clickOnForm(String formName, String instanceName) {
         scrollToAndClickOnForm(instanceName);
-        return new FormHierarchyPage(formName);
+        return new FormHierarchyPage(formName).assertOnPage();
     }
 
     public FormHierarchyPage clickOnForm(String formName) {
         scrollToAndClickOnForm(formName);
-        return new FormHierarchyPage(formName);
+        return new FormHierarchyPage(formName).assertOnPage();
+    }
+
+    public AppClosedPage clickOnFormClosingApp(String formName) {
+        scrollToAndClickOnForm(formName);
+        return new AppClosedPage().assertOnPage();
     }
 
     private void scrollToAndClickOnForm(String formName) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormHierarchyPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormHierarchyPage.java
@@ -4,12 +4,15 @@ import androidx.annotation.NonNull;
 import androidx.test.espresso.contrib.RecyclerViewActions;
 
 import org.odk.collect.android.R;
+import org.odk.collect.android.support.WaitFor;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import java.util.concurrent.Callable;
 
 public class FormHierarchyPage extends Page<FormHierarchyPage> {
 
@@ -22,6 +25,12 @@ public class FormHierarchyPage extends Page<FormHierarchyPage> {
     @NonNull
     @Override
     public FormHierarchyPage assertOnPage() {
+        // Make sure we wait for loading to finish
+        WaitFor.waitFor((Callable<Void>) () -> {
+            assertTextDoesNotExist(R.string.loading_form);
+            return null;
+        });
+
         assertToolbarTitle(formName);
         assertText(R.string.jump_to_beginning);
         assertText(R.string.jump_to_end);

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/CollectTestRule.kt
@@ -1,12 +1,16 @@
 package org.odk.collect.android.support.rules
 
 import android.app.Activity
+import android.app.Application
 import android.app.Instrumentation
 import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.NoMatchingViewException
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.odk.collect.android.activities.SplashScreenActivity
 import org.odk.collect.android.external.AndroidShortcutsActivity
+import org.odk.collect.android.injection.DaggerUtils.getComponent
 import org.odk.collect.android.support.pages.FirstLaunchPage
 import org.odk.collect.android.support.pages.MainMenuPage
 import org.odk.collect.android.support.pages.Page
@@ -23,7 +27,25 @@ class CollectTestRule @JvmOverloads constructor(
             override fun evaluate() {
                 launch(SplashScreenActivity::class.java)
 
-                val firstLaunchPage = FirstLaunchPage().assertOnPage()
+                val firstLaunchPage = FirstLaunchPage()
+
+                /**
+                 * We've seen some failures here that look like they could be to do with our
+                 * state not being reset properly. Here we catch a view assertion and throw
+                 * a specific exception if that looks like it's the case to help debugging.
+                 */
+                try {
+                    firstLaunchPage.assertOnPage()
+                } catch (e: NoMatchingViewException) {
+                    val application = ApplicationProvider.getApplicationContext<Application>()
+                    val projectsRepository = getComponent(application).projectsRepository()
+
+                    if (projectsRepository.getAll().isNotEmpty()) {
+                        throw IllegalStateException("Projects not reset properly!")
+                    } else {
+                        throw e
+                    }
+                }
 
                 if (useDemoProject) {
                     firstLaunchPage.clickTryCollect()


### PR DESCRIPTION
This adds missing `assertOnPage` calls to some actions that return `FormHierarchyPage` and updates tests that were incorrectly using those actions but getting away with it.

#### What has been done to verify that this works as intended?

Ran Test Lab a few times.

#### Why is this the best possible solution? Were any other approaches considered?

Nothing much to discuss here. We need `assertOnPage` calls to check we're in the right place before doing anything else in a test.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just test changes. This can be merged without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
