### PR TITLE
Avoid calling permission listeners if Activity is finishing

### DIFF
--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -32,7 +32,7 @@ import timber.log.Timber
  */
 open class PermissionsProvider(
     private val permissionsChecker: PermissionsChecker,
-    private val permissionsApi: PermissionsAPI = DexterPermissionsAPI
+    private val requestPermissionsApi: RequestPermissionsAPI = DexterRequestPermissionsAPI
 ) {
 
     val isCameraPermissionGranted: Boolean
@@ -243,7 +243,7 @@ open class PermissionsProvider(
             }
         }
 
-        permissionsApi.requestPermissions(activity, safePermissionsListener, *permissions)
+        requestPermissionsApi.requestPermissions(activity, safePermissionsListener, *permissions)
     }
 
     protected open fun showAdditionalExplanation(
@@ -305,7 +305,7 @@ open class PermissionsProvider(
     }
 }
 
-interface PermissionsAPI {
+interface RequestPermissionsAPI {
     fun requestPermissions(
         activity: Activity,
         listener: PermissionListener,
@@ -313,7 +313,7 @@ interface PermissionsAPI {
     )
 }
 
-object DexterPermissionsAPI : PermissionsAPI {
+object DexterRequestPermissionsAPI : RequestPermissionsAPI {
 
     override fun requestPermissions(
         activity: Activity,

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -30,10 +30,18 @@ import timber.log.Timber
  * area so that classes don't have to deal with this responsibility; they just receive a callback
  * that tells them if they have been granted the permission they requested.
  */
-open class PermissionsProvider(
+open class PermissionsProvider internal constructor(
     private val permissionsChecker: PermissionsChecker,
-    private val requestPermissionsApi: RequestPermissionsAPI = DexterRequestPermissionsAPI
+    private val requestPermissionsApi: RequestPermissionsAPI
 ) {
+
+    /**
+     * Public facing constructor that doesn't expose [RequestPermissionsAPI]
+     */
+    constructor(permissionsChecker: PermissionsChecker) : this(
+        permissionsChecker,
+        DexterRequestPermissionsAPI
+    )
 
     val isCameraPermissionGranted: Boolean
         get() = permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA)
@@ -305,7 +313,7 @@ open class PermissionsProvider(
     }
 }
 
-interface RequestPermissionsAPI {
+internal interface RequestPermissionsAPI {
     fun requestPermissions(
         activity: Activity,
         listener: PermissionListener,
@@ -313,7 +321,7 @@ interface RequestPermissionsAPI {
     )
 }
 
-object DexterRequestPermissionsAPI : RequestPermissionsAPI {
+internal object DexterRequestPermissionsAPI : RequestPermissionsAPI {
 
     override fun requestPermissions(
         activity: Activity,

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -24,7 +23,7 @@ class PermissionsProviderTest {
     private var uri = mock<Uri>()
     private var contentResolver = mock<ContentResolver>()
     private var permissionListener = mock<PermissionListener>()
-    private val permissionsApi = mock<PermissionsAPI> {
+    private val permissionsApi = mock<RequestPermissionsAPI> {
         on { requestPermissions(any(), any(), any()) } doAnswer {
             (it.getArgument(1) as PermissionListener).granted()
         }
@@ -34,7 +33,7 @@ class PermissionsProviderTest {
 
     @Before
     fun setup() {
-        permissionsProvider = spy(PermissionsProvider(permissionsChecker, permissionsApi))
+        permissionsProvider = PermissionsProvider(permissionsChecker, permissionsApi)
     }
 
     @Test
@@ -46,9 +45,8 @@ class PermissionsProviderTest {
 
     @Test
     fun `When camera permission not granted should isCameraPermissionGranted() return false`() {
-        whenever(permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA)).thenReturn(
-            false
-        )
+        whenever(permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA))
+            .thenReturn(false)
 
         assertThat(permissionsProvider.isCameraPermissionGranted, `is`(false))
     }


### PR DESCRIPTION
Should prevent [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/32bfd02368a071b00cbc8c2e729c0dca?time=last-seven-days&versions=v2022.2.0%20(4418)&types=crash&sessionEventKey=6257F4300038000121BD5B5133923E95_1664850225155885106).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I couldn't reproduce, but I can imagine there is a flow where the permission listener actions (`granted` or `denied`) can be called after the original Activity that kicked off the permission request has finished. This can result in crashes as the listener might try and interact with the Activity in some way that's now impossible (showing a dialog for instance). The simplest solution I could see is just to avoid calling the listener.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Good to check any of the major parts of the app where permissions are requested but since we don't have reproduction steps here, there isn't much to check.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
