### PR TITLE
Stop crash if `SelectionMapFragment` is destroyed before view is created

### DIFF
--- a/fragmentstest/src/main/java/org/odk/collect/fragmentstest/FragmentScenarioLauncherRule.kt
+++ b/fragmentstest/src/main/java/org/odk/collect/fragmentstest/FragmentScenarioLauncherRule.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StyleRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import androidx.fragment.app.testing.FragmentScenario
+import androidx.lifecycle.Lifecycle
 import org.junit.rules.ExternalResource
 
 /**
@@ -30,20 +31,23 @@ class FragmentScenarioLauncherRule @JvmOverloads constructor(
         fragmentClass: Class<F>,
         args: Bundle? = null,
         @StyleRes themResId: Int? = defaultThemeResId,
-        factory: FragmentFactory? = defaultFactory
+        factory: FragmentFactory? = defaultFactory,
+        initialState: Lifecycle.State = Lifecycle.State.RESUMED
     ): FragmentScenario<F> {
         val scenario = if (themResId != null) {
             FragmentScenario.launchInContainer(
                 fragmentClass,
                 fragmentArgs = args,
                 themeResId = themResId,
-                factory = factory
+                factory = factory,
+                initialState = initialState
             )
         } else {
             FragmentScenario.launchInContainer(
                 fragmentClass,
                 fragmentArgs = args,
-                factory = factory
+                factory = factory,
+                initialState = initialState
             )
         }
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -156,7 +156,10 @@ class SelectionMapFragment(
     }
 
     override fun onDestroy() {
-        summarySheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
+        if (this::summarySheetBehavior.isInitialized) {
+            summarySheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
+        }
+
         super.onDestroy()
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -407,6 +408,16 @@ class SelectionMapFragmentTest {
             loadingLiveData.value = false
             assertThat(getFragmentByClass(it.childFragmentManager, dialogClass), nullValue())
         }
+    }
+
+    @Test
+    fun `onDestroy works if the view was never created`() {
+        val scenario = launcherRule.launchInContainer(
+            SelectionMapFragment::class.java,
+            initialState = Lifecycle.State.CREATED // `onCreateView` is called at `RESUMED`
+        )
+
+        scenario.moveToState(Lifecycle.State.DESTROYED)
     }
 
     private fun MappableSelectItem.toMapPoint(): MapPoint {


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/043c01066a4a5b895b1c81fe75d4e94c?time=last-seven-days&versions=v2022.2.0%20(4418)&types=crash&sessionEventKey=6259276A012B00014A520816A4ABE37A_1665184498893467527).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I played around with switching to using a nullable type for `BottomSheetBehavior` and then also adding some better memory management in `onDestroyView` (nulling it out), but decided that'd be the sort of change I'd like to do as part of the clean-up in #4943.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This seems low risk to me and can probably go in without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
