### PR TITLE
Zoom to default level with previous selection on selection map

### DIFF
--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -180,7 +180,7 @@ class SelectionMapFragmentTest {
 
         map.setLocation(MapPoint(1.0, 2.0))
         assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
-        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_ZOOM))
+        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
     }
 
     @Test
@@ -205,7 +205,7 @@ class SelectionMapFragmentTest {
         onView(withId(R.id.zoom_to_location)).perform(click())
 
         assertThat(map.center, equalTo(MapPoint(40.181389, 44.514444)))
-        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_ZOOM))
+        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
     }
 
     @Test
@@ -347,7 +347,20 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `centers on already selected item and does not move when location changes`() {
+    fun `centers on already selected item`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
+            Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0, selected = true)
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableNonNullLiveData(items))
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java)
+        assertThat(map.center, equalTo(items[1].toMapPoint()))
+        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_POINT_ZOOM))
+    }
+
+    @Test
+    fun `does not move when location changes when centered on already selected item`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, latitude = 40.0),
             Fixtures.actionMappableSelectItem().copy(id = 1, latitude = 41.0, selected = true)

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -180,6 +180,7 @@ class SelectionMapFragmentTest {
 
         map.setLocation(MapPoint(1.0, 2.0))
         assertThat(map.center, equalTo(MapPoint(1.0, 2.0)))
+        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_ZOOM))
     }
 
     @Test
@@ -204,6 +205,7 @@ class SelectionMapFragmentTest {
         onView(withId(R.id.zoom_to_location)).perform(click())
 
         assertThat(map.center, equalTo(MapPoint(40.181389, 44.514444)))
+        assertThat(map.zoom, equalTo(FakeMapFragment.DEFAULT_ZOOM))
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -46,7 +46,9 @@ class FakeMapFragment : MapFragment {
     }
 
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {
+        zoomBoundingBox = null
         this.center = center
+        this.zoom = DEFAULT_ZOOM
     }
 
     override fun zoomToPoint(center: MapPoint?, zoom: Double, animate: Boolean) {
@@ -162,5 +164,10 @@ class FakeMapFragment : MapFragment {
          * [setCenter]
          */
         val DEFAULT_CENTER = MapPoint(-1.0, -1.0)
+
+        /**
+         * The value used to zoom when [zoomToPoint] is called without a zoom level
+         */
+        const val DEFAULT_ZOOM = -1.0
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -48,7 +48,7 @@ class FakeMapFragment : MapFragment {
     override fun zoomToPoint(center: MapPoint?, animate: Boolean) {
         zoomBoundingBox = null
         this.center = center
-        this.zoom = DEFAULT_ZOOM
+        this.zoom = DEFAULT_POINT_ZOOM
     }
 
     override fun zoomToPoint(center: MapPoint?, zoom: Double, animate: Boolean) {
@@ -67,7 +67,12 @@ class FakeMapFragment : MapFragment {
         zoomBoundingBox = Pair(points, scaleFactor)
     }
 
-    override fun addMarker(point: MapPoint, draggable: Boolean, iconAnchor: String, iconDrawableId: Int): Int {
+    override fun addMarker(
+        point: MapPoint,
+        draggable: Boolean,
+        iconAnchor: String,
+        iconDrawableId: Int
+    ): Int {
         markers.add(point)
         markerIcons.add(null)
         markerIcons[markers.size - 1] = iconDrawableId
@@ -168,6 +173,6 @@ class FakeMapFragment : MapFragment {
         /**
          * The value used to zoom when [zoomToPoint] is called without a zoom level
          */
-        const val DEFAULT_ZOOM = -1.0
+        const val DEFAULT_POINT_ZOOM = -1.0
     }
 }


### PR DESCRIPTION
Closes #5131

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. I think zooming and current selection is a little messy in `SelectionMapFragment` but we've got some issues to come back to there and this is part of our next hotfix so wanted to avoid anything other than absolutely needed changes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just improve the zoom experience as described in the issue!

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
