### PR TITLE
Add more info to `ExternalFilesUtils` crash

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/ExternalFilesUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/ExternalFilesUtils.kt
@@ -14,7 +14,7 @@ object ExternalFilesUtils {
             throw IllegalStateException("External files dir is null!")
         } else {
             try {
-                val testFile = File(externalFilesDir.toString() + File.separator + ".test")
+                val testFile = File(externalFilesDir, ".test")
                 testFile.createNewFile()
                 testFile.delete()
             } catch (e: IOException) {

--- a/androidshared/src/main/java/org/odk/collect/androidshared/system/ExternalFilesUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/system/ExternalFilesUtils.kt
@@ -8,13 +8,27 @@ object ExternalFilesUtils {
 
     @JvmStatic
     fun testExternalFilesAccess(context: Context) {
-        try {
-            val externalFilesDir = context.getExternalFilesDir(null)
-            val testFile = File(externalFilesDir.toString() + File.separator + ".test")
-            testFile.createNewFile()
-            testFile.delete()
-        } catch (e: IOException) {
-            throw IllegalStateException("App can't write to storage!")
+        val externalFilesDir = context.getExternalFilesDir(null)
+
+        if (externalFilesDir == null) {
+            throw IllegalStateException("External files dir is null!")
+        } else {
+            try {
+                val testFile = File(externalFilesDir.toString() + File.separator + ".test")
+                testFile.createNewFile()
+                testFile.delete()
+            } catch (e: IOException) {
+                if (!externalFilesDir.exists()) {
+                    throw IllegalStateException(
+                        "External files dir does not exist: ${externalFilesDir.absolutePath}"
+                    )
+                } else {
+                    throw IllegalStateException(
+                        "App can't write to external files dir: ${externalFilesDir.absolutePath}",
+                        e
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
We've talked about doing this to get more insight into what might be causing this problem.