### PR TITLE
Add WRITE_EXTERNAL_STORAGE permission to fix problems with accessing storage

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -43,6 +43,13 @@ the specific language governing permissions and limitations under the License.
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!--
+        Since we use Scoped Storage, we should not need this permission. However, we discovered that
+        this might be required in some rare cases, probably due to bugs in Android OS.
+        See: https://github.com/getodk/collect/issues/5145
+     -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <!-- Removed in API 23 -->
     <uses-permission
         android:name="android.permission.USE_CREDENTIALS"


### PR DESCRIPTION
Work towards #5145

#### What has been done to verify that this works as intended?
I've verified the fix on the only device I was able to use to reproduce the issue.

#### Why is this the best possible solution? Were any other approaches considered?
We discussed this solution in the issue. It's a weird bug and we can't even be sure that the fix is going to work well in all cases but we want to give it a try.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The QA team does not have other devices that could be used to reproduce the issue so I would only focus on installing the app on different android versions to see if the new permission does not cause any problems.  

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
