### PR TITLE
Allow notification actions to be clicked when notification is minimized

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/NotificationDrawer.kt
@@ -53,7 +53,13 @@ class NotificationDrawer {
         destination: D
     ): D {
         val device = waitForNotification(appName)
-        val actionElement = device.findObject(By.text(actionText)) ?: device.findObject(By.text(actionText.uppercase()))
+
+        var actionElement = device.findObject(By.text(actionText)) ?: device.findObject(By.text(actionText.uppercase()))
+        if (actionElement == null) {
+            device.findObject(By.text(appName)).click() // Expand notification to show actions
+            actionElement = device.findObject(By.text(actionText)) ?: device.findObject(By.text(actionText.uppercase()))
+        }
+
         actionElement.click()
         isOpen = false
 


### PR DESCRIPTION
Fixes issue with notifications being collapsed automatically during test runs.