### PR TITLE
Remove `logFormEvent` and `logServerEvent`

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -520,8 +520,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
     // Precondition: the instance directory must be ready so that the audit file can be created
     private void formControllerAvailable(@NonNull FormController formController) {
-        AnalyticsUtils.setForm(formController);
-
         menuDelegate.formLoaded(formController);
 
         identityPromptViewModel.formLoaded(formController);
@@ -822,7 +820,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         switch (requestCode) {
             case RequestCodes.OSM_CAPTURE:
-                AnalyticsUtils.logFormEvent(OPEN_MAP_KIT_RESPONSE);
+                Analytics.log(OPEN_MAP_KIT_RESPONSE);
                 setWidgetData(intent.getStringExtra("OSM_FILE_NAME"));
                 break;
             case RequestCodes.EX_ARBITRARY_FILE_CHOOSER:

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.java
@@ -2,11 +2,9 @@ package org.odk.collect.android.analytics;
 
 import static org.odk.collect.android.analytics.AnalyticsEvents.INVALID_FORM_HASH;
 import static org.odk.collect.android.analytics.AnalyticsEvents.SET_SERVER;
-import static org.odk.collect.settings.keys.ProjectKeys.KEY_SERVER_URL;
 
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.javarosawrapper.FormController;
-import org.odk.collect.shared.settings.Settings;
 import org.odk.collect.shared.strings.Md5;
 
 import java.io.ByteArrayInputStream;
@@ -16,22 +14,6 @@ public final class AnalyticsUtils {
 
     private AnalyticsUtils() {
 
-    }
-
-    public static void setForm(FormController formController) {
-        Analytics.setParam("form", getFormHash(formController));
-    }
-
-    public static void logFormEvent(String event) {
-        Analytics.log(event, "form");
-    }
-
-    public static void logFormEvent(String event, String formId, String formTitle) {
-        Analytics.log(event, "form", getFormHash(formId, formTitle));
-    }
-
-    public static void logServerEvent(String event, Settings generalSettings) {
-        Analytics.log(event, "server", getServerHash(generalSettings));
     }
 
     public static void logServerConfiguration(Analytics analytics, String url) {
@@ -67,10 +49,6 @@ public final class AnalyticsUtils {
         return host;
     }
 
-    public static String getFormHash(String formId, String formTitle) {
-        return Md5.getMd5Hash(new ByteArrayInputStream((formTitle + " " + formId).getBytes()));
-    }
-
     public static String getFormHash(FormController formController) {
         if (formController != null) {
             String formID = formController.getFormDef().getMainInstance().getRoot().getAttributeValue("", "id");
@@ -80,8 +58,7 @@ public final class AnalyticsUtils {
         }
     }
 
-    private static String getServerHash(Settings generalSettings) {
-        String currentServerUrl = generalSettings.getString(KEY_SERVER_URL);
-        return Md5.getMd5Hash(new ByteArrayInputStream(currentServerUrl.getBytes()));
+    private static String getFormHash(String formId, String formTitle) {
+        return Md5.getMd5Hash(new ByteArrayInputStream((formTitle + " " + formId).getBytes()));
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/AndroidShortcutsActivity.java
@@ -24,9 +24,9 @@ import androidx.lifecycle.ViewModelProvider;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.jetbrains.annotations.NotNull;
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.formmanagement.BlankFormsListViewModel;
 import org.odk.collect.android.formmanagement.BlankFormsListViewModel.BlankForm;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -64,7 +64,7 @@ public class AndroidShortcutsActivity extends AppCompatActivity {
         new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.select_odk_shortcut)
                 .setItems(forms.stream().map(BlankForm::getName).toArray(String[]::new), (dialog, item) -> {
-                    AnalyticsUtils.logServerEvent(AnalyticsEvents.CREATE_SHORTCUT, settingsProvider.getUnprotectedSettings());
+                    Analytics.log(AnalyticsEvents.CREATE_SHORTCUT);
 
                     Intent intent = getShortcutIntent(forms, item);
                     setResult(RESULT_OK, intent);

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormsProvider.java
@@ -44,8 +44,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 
 import org.jetbrains.annotations.NotNull;
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.analytics.AnalyticsEvents;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.forms.DatabaseFormsRepository;
 import org.odk.collect.android.formmanagement.FormDeleter;
@@ -59,7 +59,6 @@ import org.odk.collect.android.utilities.InstancesRepositoryProvider;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.projects.ProjectsRepository;
-import org.odk.collect.settings.SettingsProvider;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -92,9 +91,6 @@ public class FormsProvider extends ContentProvider {
     @Inject
     ProjectsRepository projectsRepository;
 
-    @Inject
-    SettingsProvider settingsProvider;
-
     // Do not call it in onCreate() https://stackoverflow.com/questions/23521083/inject-database-in-a-contentprovider-with-dagger
     private void deferDaggerInit() {
         DaggerUtils.getComponent(getContext()).inject(this);
@@ -113,7 +109,7 @@ public class FormsProvider extends ContentProvider {
 
         // We only want to log external calls to the content provider
         if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) == null) {
-            logServerEvent(projectId, AnalyticsEvents.FORMS_PROVIDER_QUERY);
+            logServerEvent(AnalyticsEvents.FORMS_PROVIDER_QUERY);
         }
 
         Cursor cursor;
@@ -196,7 +192,7 @@ public class FormsProvider extends ContentProvider {
         }
 
         String projectId = getProjectId(uri);
-        logServerEvent(projectId, AnalyticsEvents.FORMS_PROVIDER_INSERT);
+        logServerEvent(AnalyticsEvents.FORMS_PROVIDER_INSERT);
 
         String formsPath = storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, projectId);
         String cachePath = storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE, projectId);
@@ -216,7 +212,7 @@ public class FormsProvider extends ContentProvider {
         int count;
 
         String projectId = getProjectId(uri);
-        logServerEvent(projectId, AnalyticsEvents.FORMS_PROVIDER_DELETE);
+        logServerEvent(AnalyticsEvents.FORMS_PROVIDER_DELETE);
 
         FormDeleter formDeleter = new FormDeleter(getFormsRepository(projectId), instancesRepositoryProvider.get(projectId));
 
@@ -249,7 +245,7 @@ public class FormsProvider extends ContentProvider {
         deferDaggerInit();
 
         String projectId = getProjectId(uri);
-        logServerEvent(projectId, AnalyticsEvents.FORMS_PROVIDER_UPDATE);
+        logServerEvent(AnalyticsEvents.FORMS_PROVIDER_UPDATE);
 
         FormsRepository formsRepository = getFormsRepository(projectId);
         String formsPath = storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS, projectId);
@@ -314,8 +310,8 @@ public class FormsProvider extends ContentProvider {
         return ((DatabaseFormsRepository) getFormsRepository(projectId)).rawQuery(projectionMap, projection, selection, selectionArgs, sortOrder, groupBy);
     }
 
-    private void logServerEvent(String projectId, String event) {
-        AnalyticsUtils.logServerEvent(event, settingsProvider.getUnprotectedSettings(projectId));
+    private void logServerEvent(String event) {
+        Analytics.log(event);
     }
 
     static {

--- a/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/external/InstanceProvider.java
@@ -32,9 +32,9 @@ import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.instances.DatabaseInstancesRepository;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -47,7 +47,6 @@ import org.odk.collect.android.utilities.InstancesRepositoryProvider;
 import org.odk.collect.forms.instances.Instance;
 import org.odk.collect.forms.instances.InstancesRepository;
 import org.odk.collect.projects.ProjectsRepository;
-import org.odk.collect.settings.SettingsProvider;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -75,9 +74,6 @@ public class InstanceProvider extends ContentProvider {
     @Inject
     ProjectsRepository projectsRepository;
 
-    @Inject
-    SettingsProvider settingsProvider;
-
     @Override
     public boolean onCreate() {
         return true;
@@ -92,7 +88,7 @@ public class InstanceProvider extends ContentProvider {
 
         // We only want to log external calls to the content provider
         if (uri.getQueryParameter(CursorLoaderFactory.INTERNAL_QUERY_PARAM) == null) {
-            logServerEvent(projectId, AnalyticsEvents.INSTANCE_PROVIDER_QUERY);
+            logServerEvent(AnalyticsEvents.INSTANCE_PROVIDER_QUERY);
         }
 
         Cursor c;
@@ -138,7 +134,7 @@ public class InstanceProvider extends ContentProvider {
         DaggerUtils.getComponent(getContext()).inject(this);
 
         String projectId = getProjectId(uri);
-        logServerEvent(projectId, AnalyticsEvents.INSTANCE_PROVIDER_INSERT);
+        logServerEvent(AnalyticsEvents.INSTANCE_PROVIDER_INSERT);
 
         // Validate the requested uri
         if (URI_MATCHER.match(uri) != INSTANCES) {
@@ -191,7 +187,7 @@ public class InstanceProvider extends ContentProvider {
         DaggerUtils.getComponent(getContext()).inject(this);
 
         String projectId = getProjectId(uri);
-        logServerEvent(projectId, AnalyticsEvents.INSTANCE_PROVIDER_DELETE);
+        logServerEvent(AnalyticsEvents.INSTANCE_PROVIDER_DELETE);
 
         int count;
 
@@ -241,7 +237,7 @@ public class InstanceProvider extends ContentProvider {
         DaggerUtils.getComponent(getContext()).inject(this);
 
         String projectId = getProjectId(uri);
-        logServerEvent(projectId, AnalyticsEvents.INSTANCE_PROVIDER_UPDATE);
+        logServerEvent(AnalyticsEvents.INSTANCE_PROVIDER_UPDATE);
 
         InstancesRepository instancesRepository = instancesRepositoryProvider.get(projectId);
         String instancesPath = storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES, projectId);
@@ -311,8 +307,8 @@ public class InstanceProvider extends ContentProvider {
         }
     }
 
-    private void logServerEvent(String projectId, String event) {
-        AnalyticsUtils.logServerEvent(event, settingsProvider.getUnprotectedSettings(projectId));
+    private void logServerEvent(String event) {
+        Analytics.log(event);
     }
 
     static {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
@@ -14,12 +14,14 @@
 
 package org.odk.collect.android.instancemanagement;
 
+import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
+
 import android.net.Uri;
 
 import org.apache.commons.io.FileUtils;
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.exception.EncryptionException;
 import org.odk.collect.android.external.InstancesContract;
@@ -50,8 +52,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import timber.log.Timber;
-
-import static org.odk.collect.strings.localization.LocalizedApplicationKt.getLocalizedString;
 
 public class InstanceDiskSynchronizer {
 
@@ -197,11 +197,11 @@ public class InstanceDiskSynchronizer {
     }
 
     private void logImport(Form form) {
-        AnalyticsUtils.logFormEvent(AnalyticsEvents.IMPORT_INSTANCE, form.getFormId(), form.getDisplayName());
+        Analytics.log(AnalyticsEvents.IMPORT_INSTANCE, form.getFormId(), form.getDisplayName());
     }
 
     private void logImportAndEncrypt(Form form) {
-        AnalyticsUtils.logFormEvent(AnalyticsEvents.IMPORT_AND_ENCRYPT_INSTANCE, form.getFormId(), form.getDisplayName());
+        Analytics.log(AnalyticsEvents.IMPORT_AND_ENCRYPT_INSTANCE, form.getFormId(), form.getDisplayName());
     }
 
     private void encryptInstance(Instance instance) throws EncryptionException, IOException {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -23,9 +23,9 @@ import android.view.View;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.analytics.AnalyticsEvents;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.databinding.GeoWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.utilities.Appearances;
@@ -116,9 +116,9 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
         // Only default geopoint supports accuracy threshold
         if (Appearances.getSanitizedAppearanceHint(prompt).isEmpty()) {
             if (prompt.getQuestion().getAdditionalAttribute(null, "accuracyThreshold") != null) {
-                AnalyticsUtils.logFormEvent(AnalyticsEvents.ACCURACY_THRESHOLD);
+                Analytics.log(AnalyticsEvents.ACCURACY_THRESHOLD);
             } else {
-                AnalyticsUtils.logFormEvent(AnalyticsEvents.ACCURACY_THRESHOLD_DEFAULT);
+                Analytics.log(AnalyticsEvents.ACCURACY_THRESHOLD_DEFAULT);
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -32,9 +32,9 @@ import android.widget.Toast;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.StringData;
+import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
 import org.odk.collect.android.activities.CaptureSelfieVideoActivity;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.utilities.Appearances;
@@ -232,9 +232,9 @@ public class VideoWidget extends QuestionWidget implements FileWidget, ButtonCli
         boolean highResolution = settingsProvider.getUnprotectedSettings().getBoolean(ProjectKeys.KEY_HIGH_RESOLUTION);
         if (highResolution) {
             i.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, 1);
-            AnalyticsUtils.logFormEvent(REQUEST_HIGH_RES_VIDEO);
+            Analytics.log(REQUEST_HIGH_RES_VIDEO);
         } else {
-            AnalyticsUtils.logFormEvent(REQUEST_VIDEO_NOT_HIGH_RES);
+            Analytics.log(REQUEST_VIDEO_NOT_HIGH_RES);
         }
         try {
             waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());


### PR DESCRIPTION
These events no longer work as Firebase limits the total number of param values to 200, so we end up only ever seeing a max of 200 forms or 200 servers for each event. Removing this, so we don't accidentally add any more of these in.