### PR TITLE
Upgrade JavaRosa

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -45,7 +45,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.6"
-    const val javarosa = "org.getodk:javarosa:3.4.1"
+    const val javarosa = "org.getodk:javarosa:3.5.0-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:3.6.0" // Upgrading will require minSdkVersion >=24, it uses zxing:core 3.3.2 by default


### PR DESCRIPTION
Closes #4554

This upgrades JavaRosa so that instance files are now encoded as UTF-8 (rather than ASCII with escaped characters). Unicode will now be unescaped in instance XML and there is an `encoding` attribute added to the XML doc itself.

#### What has been done to verify that this works as intended?

Ran existing tests and verified that forms now included unicode manually (there are tests on the JavaRosa side for this).

#### Why is this the best possible solution? Were any other approaches considered?

Discussion at https://github.com/getodk/javarosa/pull/685.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It would be good to do a general pass on saving/submitting forms with emoji or other unicode.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
