### PR TITLE
Allow starting apps by package name on newer devices

### DIFF
--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -315,4 +315,10 @@ the specific language governing permissions and limitations under the License.
         </activity>
 
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
Closes #5157 

#### What has been done to verify that this works as intended?
I've verified manually that this works well.

#### Why is this the best possible solution? Were any other approaches considered?
The problem is that:
> When an app targets Android 11 (API level 30) or higher and queries for information about the other apps that are installed on a device, the system filters this information by default. The limited package visibility reduces the number of apps that appear to be installed on a device, from your app's perspective.

see: https://developer.android.com/training/package-visibility

To solve the issue we have a few options:
- [Specific package names](https://developer.android.com/training/package-visibility/declaring#package-name) it is not going to work in our case since we don't know what apps our users want to start
- [QUERY_ALL_PACKAGES](https://developer.android.com/training/package-visibility/declaring) permissions (not recommended) so I don't want to use it. It would even probably require having a special permission from Google Play to publish such an app.
- [Packages that match an intent filter signature](https://developer.android.com/training/package-visibility/declaring#intent-filter-signature) this is what I used to solve the problem and it seems like the best option here

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that the issue is fixed and that will be enough.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
