### PR TITLE
Bump heap size for compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #You can override this in ~/.gradle/gradle.properties
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx1g
+org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true
 test.heap.max=1g


### PR DESCRIPTION
We've seen that 1 GB isn't enough for a fresh compile any longer but 1.5 GB seems to work fine.