### PR TITLE
Exclude newer version of commons-io used in javarosa

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -314,6 +314,7 @@ dependencies {
         exclude group: 'commons-logging'
     }
     implementation(Dependencies.javarosa) {
+        exclude group: 'commons-io'
         exclude group: 'joda-time'
         exclude group: 'org.slf4j'
         exclude group: 'org.hamcrest', module: 'hamcrest-all'


### PR DESCRIPTION
Closes #5178 

The problem was that in Javarosa we merged https://github.com/getodk/javarosa/pull/688 which added a new dependency `commons-io:commons-io:2.11.0`. This dependency became automatically available in Collect and caused conflicts since the version we use is 2.5 and we can't use a newer one, see: https://github.com/getodk/collect/pull/4158

#### What has been done to verify that this works as intended?
I've verified that the crash does not occur anymore on Android 5.

#### Why is this the best possible solution? Were any other approaches considered?
I could also downgrade `commons-io` used in Javarosa to the version used in Collect and then maybe even remove it from Collect but I think those two project should have separate dependencies.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue on Android 5 and have no side effects.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
