### PR TITLE
Improved validating URLs

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/Validator.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/Validator.kt
@@ -15,6 +15,8 @@
  */
 package org.odk.collect.androidshared.utils
 
+import android.util.Patterns
+import android.webkit.URLUtil
 import java.util.regex.Pattern
 
 object Validator {
@@ -35,9 +37,6 @@ object Validator {
 
     @JvmStatic
     fun isUrlValid(url: String): Boolean {
-        return Pattern
-            .compile("^https?://.+$", Pattern.CASE_INSENSITIVE)
-            .matcher(url)
-            .matches()
+        return URLUtil.isValidUrl(url) && Patterns.WEB_URL.matcher(url).matches()
     }
 }

--- a/androidshared/src/main/java/org/odk/collect/androidshared/utils/Validator.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/utils/Validator.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.odk.collect.shared.strings
+package org.odk.collect.androidshared.utils
 
 import java.util.regex.Pattern
 

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/ValidatorTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/ValidatorTest.kt
@@ -98,5 +98,6 @@ class ValidatorTest {
         assertFalse(Validator.isUrlValid("1964thetribute.com"))
         assertFalse(Validator.isUrlValid("http:/www.example.com"))
         assertFalse(Validator.isUrlValid("http:www.example.com"))
+        assertFalse(Validator.isUrlValid("https:///."))
     }
 }

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/ValidatorTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/ValidatorTest.kt
@@ -15,10 +15,13 @@
  */
 package org.odk.collect.androidshared.utils
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class ValidatorTest {
     @Test
     fun emailValidationTestCase() {
@@ -65,7 +68,6 @@ class ValidatorTest {
         assertTrue(Validator.isUrlValid("https://example.com/foo/bar"))
         assertTrue(Validator.isUrlValid("http://example.com/foo/bar"))
         assertTrue(Validator.isUrlValid("http://www.example.com?foo=BaR"))
-        assertTrue(Validator.isUrlValid("http://www.example.com#fooBaR"))
         assertTrue(Validator.isUrlValid("http://www.example.com"))
         assertTrue(Validator.isUrlValid("http://www.example.com:8080"))
         assertTrue(Validator.isUrlValid("http://www.example.com:8080/foo/bar"))
@@ -78,6 +80,7 @@ class ValidatorTest {
         assertTrue(Validator.isUrlValid("https://example.com/foo/bar"))
         assertTrue(Validator.isUrlValid("http://عمان.icom.museum"))
         assertTrue(Validator.isUrlValid("http://www.example.com/foo/bar?a=b&c=d"))
+        assertFalse(Validator.isUrlValid("http://www.example.com#fooBaR"))
         assertFalse(Validator.isUrlValid("http://"))
         assertFalse(Validator.isUrlValid("example.com"))
         assertFalse(Validator.isUrlValid("EXAMPLE.COM"))

--- a/androidshared/src/test/java/org/odk/collect/androidshared/utils/ValidatorTest.kt
+++ b/androidshared/src/test/java/org/odk/collect/androidshared/utils/ValidatorTest.kt
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.odk.collect.shared
+package org.odk.collect.androidshared.utils
 
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Test
-import org.odk.collect.shared.strings.Validator
 
 class ValidatorTest {
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -6,13 +6,13 @@ import static org.odk.collect.android.utilities.FileUtils.interuptablyWriteFile;
 import org.jetbrains.annotations.NotNull;
 import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.FormNameUtils;
+import org.odk.collect.androidshared.utils.Validator;
 import org.odk.collect.async.OngoingWorkListener;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormSource;
 import org.odk.collect.forms.FormSourceException;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.shared.strings.Md5;
-import org.odk.collect.shared.strings.Validator;
 
 import java.io.File;
 import java.io.IOException;

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -19,9 +19,9 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.androidshared.ui.ToastUtils;
+import org.odk.collect.androidshared.utils.Validator;
 import org.odk.collect.permissions.PermissionListener;
 import org.odk.collect.permissions.PermissionsProvider;
-import org.odk.collect.shared.strings.Validator;
 
 import javax.inject.Inject;
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ServerPreferencesFragment.java
@@ -48,11 +48,11 @@ import org.odk.collect.android.preferences.filters.ControlCharacterFilter;
 import org.odk.collect.android.preferences.filters.WhitespaceFilter;
 import org.odk.collect.android.utilities.PlayServicesChecker;
 import org.odk.collect.androidshared.ui.ToastUtils;
+import org.odk.collect.androidshared.utils.Validator;
 import org.odk.collect.permissions.PermissionListener;
 import org.odk.collect.permissions.PermissionsProvider;
 import org.odk.collect.settings.keys.ProjectKeys;
 import org.odk.collect.shared.strings.Md5;
-import org.odk.collect.shared.strings.Validator;
 
 import java.io.ByteArrayInputStream;
 

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -27,12 +27,12 @@ import org.odk.collect.android.utilities.SoftKeyboardController
 import org.odk.collect.androidshared.system.IntentLauncher
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.ToastUtils
+import org.odk.collect.androidshared.utils.Validator
 import org.odk.collect.material.MaterialFullScreenDialogFragment
 import org.odk.collect.permissions.PermissionListener
 import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
-import org.odk.collect.shared.strings.Validator
 import javax.inject.Inject
 
 class ManualProjectCreatorDialog :

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormsDirDiskFormsSynchronizer.java
@@ -7,10 +7,10 @@ import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formmanagement.DiskFormsSynchronizer;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.storage.StorageSubdirectory;
+import org.odk.collect.androidshared.utils.Validator;
 import org.odk.collect.forms.Form;
 import org.odk.collect.forms.FormsRepository;
 import org.odk.collect.shared.strings.Md5;
-import org.odk.collect.shared.strings.Validator;
 
 import java.io.File;
 import java.util.ArrayList;


### PR DESCRIPTION
Closes #4900 

This issue has been partially fixed in https://github.com/getodk/collect/pull/5154 so now on master there is no crash like described in the issue. The improvement here is that wrong URLs like the one from the issue should be not allowed at all.

#### What has been done to verify that this works as intended?
I've verified the fix manually and improved automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
There is not much to discuss here. I've just used better validators as discussed in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This should just fix the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
