### PR TITLE
Fix problems with permissions in tests

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/AudioRecordingTest.java
@@ -2,11 +2,9 @@ package org.odk.collect.android.feature.formentry;
 
 import static org.odk.collect.android.support.FileUtils.copyFileFromAssets;
 
-import android.Manifest;
 import android.app.Application;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,7 +51,6 @@ public class AudioRecordingTest {
 
     @Rule
     public final RuleChain chain = TestRuleChain.chain(testDependencies)
-            .around(GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO))
             .around(rule);
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -14,7 +14,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -89,7 +88,6 @@ public class BackgroundAudioRecordingTest {
 
     @Rule
     public final RuleChain chain = TestRuleChain.chain(testDependencies)
-            .around(GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO))
             .around(rule);
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalAudioRecordingTest.java
@@ -4,7 +4,6 @@ import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
 import static org.odk.collect.android.support.FileUtils.copyFileFromAssets;
 
-import android.Manifest;
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Intent;
@@ -12,7 +11,6 @@ import android.net.Uri;
 import android.provider.MediaStore;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,7 +33,6 @@ public class ExternalAudioRecordingTest {
 
     @Rule
     public final RuleChain chain = TestRuleChain.chain()
-            .around(GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO))
             .around(new RecordedIntentsRule())
             .around(new RunnableRule(() -> {
                 // Return audio file when RECORD_SOUND_ACTION intent is sent

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/IntentGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/IntentGroupTest.java
@@ -37,7 +37,6 @@ import static org.odk.collect.android.support.matchers.CustomMatchers.withIndex;
 import static org.odk.collect.android.support.FileUtils.copyFileFromAssets;
 import static org.odk.collect.androidtest.NestedScrollToAction.nestedScrollTo;
 
-import android.Manifest;
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.ClipData;
@@ -48,7 +47,6 @@ import android.os.Environment;
 
 import androidx.core.content.FileProvider;
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -74,7 +72,6 @@ public class IntentGroupTest {
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()
             .around(new RecordedIntentsRule())
-            .around(GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)) // Needed to write temp file
             .around(rule);
 
     // Verifies that a value given to the label text with form buttonText is used as the button text.

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/LikertTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/LikertTest.java
@@ -14,16 +14,13 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.odk.collect.android.support.matchers.CustomMatchers.withIndex;
 
-import android.Manifest;
-
-import androidx.test.rule.GrantPermissionRule;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.rules.FormActivityTestRule;
 import org.odk.collect.android.support.rules.ResetStateRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 
 import java.util.Collections;
 
@@ -33,8 +30,7 @@ public class LikertTest {
     public FormActivityTestRule activityTestRule = new FormActivityTestRule(LIKERT_TEST_FORM, "All widgets likert icon", Collections.singletonList("famous.jpg"));
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
-            .outerRule(GrantPermissionRule.grant(Manifest.permission.CAMERA))
+    public RuleChain copyFormChain = TestRuleChain.chain()
             .around(new ResetStateRule())
             .around(activityTestRule);
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/LocationAuditTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/LocationAuditTest.java
@@ -5,10 +5,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import android.Manifest;
-
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,6 +13,7 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.support.rules.FormActivityTestRule;
 import org.odk.collect.android.support.rules.ResetStateRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 
 public class LocationAuditTest {
     private static final String LOCATION_AUDIT_FORM = "location-audit.xml";
@@ -23,8 +21,7 @@ public class LocationAuditTest {
     public FormActivityTestRule rule = new FormActivityTestRule(LOCATION_AUDIT_FORM, "Audit with Location");
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
-            .outerRule(GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION))
+    public RuleChain copyFormChain = TestRuleChain.chain()
             .around(new ResetStateRule())
             .around(rule);
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/SetGeopointActionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/SetGeopointActionTest.java
@@ -5,10 +5,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import android.Manifest;
-
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,7 +21,6 @@ public class SetGeopointActionTest {
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()
-            .around(GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION))
             .around(rule);
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/PreviouslyDownloadedOnlyTest.kt
@@ -1,10 +1,8 @@
 package org.odk.collect.android.feature.formmanagement
 
-import android.Manifest
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.rule.GrantPermissionRule
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.empty
@@ -30,7 +28,6 @@ class PreviouslyDownloadedOnlyTest {
 
     @get:Rule
     var ruleChain: RuleChain = TestRuleChain.chain(testDependencies)
-        .around(GrantPermissionRule.grant(Manifest.permission.GET_ACCOUNTS))
         .around(notificationDrawerRule)
         .around(rule)
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/SendFinalizedFormTest.java
@@ -1,9 +1,6 @@
 package org.odk.collect.android.feature.instancemanagement;
 
-import android.Manifest;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +24,6 @@ public class SendFinalizedFormTest {
 
     @Rule
     public RuleChain chain = TestRuleChain.chain(testDependencies)
-            .around(GrantPermissionRule.grant(Manifest.permission.GET_ACCOUNTS))
             .around(new RecordedIntentsRule())
             .around(rule);
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/maps/FormMapTest.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.feature.maps
 
-import android.Manifest
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Context
@@ -9,7 +8,6 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -43,7 +41,6 @@ class FormMapTest {
 
     @get:Rule
     var copyFormChain: RuleChain = TestRuleChain.chain(testDependencies)
-        .around(GrantPermissionRule.grant(Manifest.permission.ACCESS_COARSE_LOCATION))
         .around(RecordedIntentsRule())
         .around(rule)
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ConfigureWithQRCodeTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/ConfigureWithQRCodeTest.java
@@ -1,12 +1,10 @@
 package org.odk.collect.android.feature.settings;
 
-import android.Manifest;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 import androidx.work.WorkManager;
 
 import org.junit.After;
@@ -19,16 +17,14 @@ import org.odk.collect.android.configure.qr.AppConfigurationGenerator;
 import org.odk.collect.android.configure.qr.QRCodeGenerator;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.support.rules.CollectTestRule;
-import org.odk.collect.android.support.CountingTaskExecutorIdlingResource;
-import org.odk.collect.android.support.rules.IdlingResourceRule;
 import org.odk.collect.android.support.rules.ResetStateRule;
 import org.odk.collect.android.support.rules.RunnableRule;
-import org.odk.collect.android.support.SchedulerIdlingResource;
 import org.odk.collect.android.support.StubBarcodeViewDecoder;
 import org.odk.collect.android.support.TestScheduler;
 import org.odk.collect.android.support.pages.ProjectSettingsPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.QRCodePage;
+import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.views.BarcodeViewDecoder;
 import org.odk.collect.async.Scheduler;
 
@@ -45,14 +41,9 @@ public class ConfigureWithQRCodeTest {
     private final StubQRCodeGenerator stubQRCodeGenerator = new StubQRCodeGenerator();
     private final StubBarcodeViewDecoder stubBarcodeViewDecoder = new StubBarcodeViewDecoder();
     private final TestScheduler testScheduler = new TestScheduler();
-    private final CountingTaskExecutorIdlingResource countingTaskExecutorIdlingResource = new CountingTaskExecutorIdlingResource();
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
-            .outerRule(GrantPermissionRule.grant(
-                    Manifest.permission.READ_PHONE_STATE,
-                    Manifest.permission.CAMERA
-            ))
+    public RuleChain copyFormChain = TestRuleChain.chain()
             .around(new ResetStateRule(new AppDependencyModule() {
 
                 @Override
@@ -70,9 +61,6 @@ public class ConfigureWithQRCodeTest {
                     return testScheduler;
                 }
             }))
-            .around(countingTaskExecutorIdlingResource)
-            .around(new IdlingResourceRule(new SchedulerIdlingResource(testScheduler)))
-            .around(new IdlingResourceRule(countingTaskExecutorIdlingResource))
             .around(new RunnableRule(stubQRCodeGenerator::setup))
             .around(rule);
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormManagementSettingsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/settings/FormManagementSettingsTest.kt
@@ -1,8 +1,6 @@
 package org.odk.collect.android.feature.settings
 
-import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.empty
@@ -24,7 +22,6 @@ class FormManagementSettingsTest {
 
     @get:Rule
     var ruleChain: RuleChain = TestRuleChain.chain(testDependencies)
-        .around(GrantPermissionRule.grant(Manifest.permission.GET_ACCOUNTS))
         .around(RecordedIntentsRule())
         .around(rule)
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/CustomSQLiteQueryExecutionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/CustomSQLiteQueryExecutionTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.support.rules.RunnableRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.utilities.CustomSQLiteQueryExecutor;
 
 import java.io.File;
@@ -45,8 +46,8 @@ public class CustomSQLiteQueryExecutionTest {
     private SQLiteDatabase sqLiteDatabase;
 
     @Rule
-    public RuleChain copyFormChain = RuleChain
-            .outerRule(new RunnableRule(() -> {
+    public RuleChain copyFormChain = TestRuleChain.chain()
+            .around(new RunnableRule(() -> {
                 try {
                     File dbPath = File.createTempFile("test", ".db");
                     dbPath.deleteOnExit();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/AboutPageTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/AboutPageTest.java
@@ -1,9 +1,6 @@
 package org.odk.collect.android.regression;
 
-import android.Manifest;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.rule.GrantPermissionRule;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +25,6 @@ public class AboutPageTest {
 
     @Rule
     public RuleChain ruleChain = TestRuleChain.chain()
-            .around(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
             .around(rule);
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -17,7 +17,17 @@ object TestRuleChain {
 
         return RuleChain
             .outerRule(RetryOnDeviceErrorRule())
-            .around(GrantPermissionRule.grant(Manifest.permission.READ_PHONE_STATE))
+            .around(
+                GrantPermissionRule.grant(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.CAMERA,
+                    Manifest.permission.READ_PHONE_STATE,
+                    Manifest.permission.RECORD_AUDIO,
+                    Manifest.permission.GET_ACCOUNTS
+                )
+            )
             .around(DisableDeviceAnimationsRule())
             .around(ResetStateRule(testDependencies))
             .around(countingTaskExecutorIdlingResource)


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've run tests on firebase to make sure everything is fine.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that many of our tests didn't have permissions they needed so depending on the order of running them they could pass or fail.
Initially I thought about revoking permissions at the begging of every test and granting only those we really need. To do that I investigated two options:
- executeShellCommand to revoke permissions - this can't be used in tests because revoking a permission will restart the entire app process and end the test with failure 
- [Android Test Orchestrator](https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator) which should clear permissions for every test - this worked well locally but not on firebase

Since revoking permissions in tests is problematic I decided that maybe the easiest solution (granting all permissions for all tests) will be the best one. We do not test granting/denying permissions either way (if we need to do things like that we use mocked permissions providers) so I think it doesn't make sense to deal with a proper granting/revoking permissions for all tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
