### PR TITLE
Selection summary redesign

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -274,11 +274,12 @@ class SelectionMapFragment(
                 }
                 map.setMarkerIcon(featureId, item.largeIcon)
                 summarySheet.setItem(item)
+
+                summarySheetBehavior.state = STATE_COLLAPSED
                 summarySheet.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
                     override fun onGlobalLayout() {
                         summarySheet.viewTreeObserver.removeOnGlobalLayoutListener(this)
                         summarySheetBehavior.peekHeight = summarySheet.peekHeight
-                        summarySheetBehavior.state = STATE_COLLAPSED
                     }
                 })
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -7,13 +7,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
-import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
@@ -212,7 +213,6 @@ class SelectionMapFragment(
     private fun setUpSummarySheet(binding: SelectionMapLayoutBinding) {
         summarySheet = binding.summarySheet
         summarySheetBehavior = BottomSheetBehavior.from(summarySheet)
-        summarySheetBehavior.fitToContents = false
         summarySheetBehavior.state = STATE_HIDDEN
 
         val onBackPressedCallback = object : OnBackPressedCallback(false) {
@@ -274,9 +274,15 @@ class SelectionMapFragment(
                 }
                 map.setMarkerIcon(featureId, item.largeIcon)
                 summarySheet.setItem(item)
-                selectedFeatureViewModel.setSelectedFeatureId(featureId)
+                summarySheet.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+                    override fun onGlobalLayout() {
+                        summarySheet.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                        summarySheetBehavior.peekHeight = summarySheet.peekHeight
+                        summarySheetBehavior.state = STATE_COLLAPSED
+                    }
+                })
 
-                summarySheetBehavior.state = STATE_HALF_EXPANDED
+                selectedFeatureViewModel.setSelectedFeatureId(featureId)
             } else {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_SELECT_ITEM,

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
-import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
@@ -212,6 +212,7 @@ class SelectionMapFragment(
     private fun setUpSummarySheet(binding: SelectionMapLayoutBinding) {
         summarySheet = binding.summarySheet
         summarySheetBehavior = BottomSheetBehavior.from(summarySheet)
+        summarySheetBehavior.fitToContents = false
         summarySheetBehavior.state = STATE_HIDDEN
 
         val onBackPressedCallback = object : OnBackPressedCallback(false) {
@@ -275,7 +276,7 @@ class SelectionMapFragment(
                 summarySheet.setItem(item)
                 selectedFeatureViewModel.setSelectedFeatureId(featureId)
 
-                summarySheetBehavior.state = STATE_EXPANDED
+                summarySheetBehavior.state = STATE_HALF_EXPANDED
             } else {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_SELECT_ITEM,

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
@@ -6,6 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.content.ContextCompat
+import androidx.core.view.get
+import androidx.core.view.size
 import org.odk.collect.geo.R
 import org.odk.collect.geo.databinding.PropertyBinding
 import org.odk.collect.geo.databinding.SelectionSummarySheetLayoutBinding
@@ -19,6 +21,20 @@ internal class SelectionSummarySheet(context: Context, attrs: AttributeSet?) :
         SelectionSummarySheetLayoutBinding.inflate(LayoutInflater.from(context), this, true)
 
     var listener: Listener? = null
+
+    val peekHeight: Int
+        get() {
+            return when (binding.properties.size) {
+                0 -> binding.properties.top
+                1 -> binding.properties.top + binding.properties[0].bottom
+                else -> {
+                    val bottomOfFirstProp = binding.properties.top + binding.properties[0].bottom
+                    val secondPropHeight = binding.properties[1].bottom - binding.properties[1].top
+                    val enoughOfSecondPropToImplyMoreProps = (secondPropHeight / 12) * 7
+                    bottomOfFirstProp + enoughOfSecondPropToImplyMoreProps
+                }
+            }
+        }
 
     private var itemId: Long? = null
 

--- a/geo/src/main/res/drawable/property_divider.xml
+++ b/geo/src/main/res/drawable/property_divider.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Material Design reference: https://material.io/design/components/dividers.html#specs -->
+
+    <item>
+        <shape android:shape="rectangle">
+            <size android:height="1dp" />
+            <solid android:color="@color/color_on_surface_low_emphasis"/>
+        </shape>
+    </item>
+
+</layer-list>

--- a/geo/src/main/res/layout/property.xml
+++ b/geo/src/main/res/layout/property.xml
@@ -11,9 +11,11 @@
         android:id="@+id/icon"
         android:layout_width="30dp"
         android:layout_height="30dp"
+        android:layout_marginStart="@dimen/margin_standard"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?colorPrimary" />
 
     <TextView
         android:id="@+id/text"

--- a/geo/src/main/res/layout/property.xml
+++ b/geo/src/main/res/layout/property.xml
@@ -27,7 +27,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/icon"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginStart="0dp"
+        app:layout_goneMarginStart="@dimen/margin_standard"
         tools:text="Status" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/geo/src/main/res/layout/selection_map_layout.xml
+++ b/geo/src/main/res/layout/selection_map_layout.xml
@@ -29,11 +29,11 @@
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/map_container"
+            android:name="org.odk.collect.maps.MapFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_above="@id/geometry_status"
-            android:layout_below="@id/title"
-            android:name="org.odk.collect.maps.MapFragment"/>
+            android:layout_below="@id/title" />
 
         <org.odk.collect.androidshared.ui.multiclicksafe.MultiClickSafeImageButton
             android:id="@+id/new_item"
@@ -95,7 +95,8 @@
     <org.odk.collect.geo.selection.SelectionSummarySheet
         android:id="@+id/summary_sheet"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:background="?colorSurface"
         app:behavior_hideable="true"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
 

--- a/geo/src/main/res/layout/selection_summary_sheet_layout.xml
+++ b/geo/src/main/res/layout/selection_summary_sheet_layout.xml
@@ -37,56 +37,52 @@
         app:layout_constraintTop_toBottomOf="@id/guideline_top"
         tools:text="Name" />
 
-    <FrameLayout
-        android:id="@id/action_container"
+    <TextView
+        android:id="@+id/info"
+        style="?textAppearanceBody2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:textColor="@color/color_on_surface_medium_emphasis"
         app:layout_constraintStart_toEndOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/name">
+        app:layout_constraintTop_toBottomOf="@id/name"
+        tools:text="Info" />
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/action"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="?colorOnPrimary"
-            app:chipBackgroundColor="?colorSecondary"
-            app:chipEndPadding="@dimen/margin_small"
-            app:chipIconTint="?colorOnPrimary"
-            app:iconStartPadding="@dimen/margin_small"
-            tools:text="Action"
-            tools:visibility="visible" />
-
-        <TextView
-            android:id="@+id/info"
-            style="?textAppearanceBody2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginVertical="@dimen/margin_small"
-            android:textColor="?colorOnSurface"
-            tools:text="Info"
-            tools:visibility="gone" />
-
-    </FrameLayout>
+    <com.google.android.material.chip.Chip
+        android:id="@+id/action"
+        android:layout_width="wrap_content"
+        android:layout_height="54dp"
+        android:textColor="?colorOnPrimary"
+        app:chipBackgroundColor="?colorSecondary"
+        app:chipEndPadding="@dimen/margin_large"
+        app:chipIconSize="20dp"
+        app:chipIconTint="?colorOnPrimary"
+        app:iconStartPadding="@dimen/margin_standard"
+        app:layout_constraintStart_toEndOf="@id/guideline_start"
+        app:layout_constraintTop_toBottomOf="@id/info"
+        app:textStartPadding="@dimen/margin_small"
+        tools:chipIcon="@drawable/ic_delete"
+        tools:text="Action"
+        tools:visibility="visible" />
 
     <View
         android:id="@+id/divider"
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:layout_marginTop="@dimen/margin_small"
-        android:background="?colorPrimary"
-        app:layout_constraintEnd_toStartOf="@id/guideline_end"
-        app:layout_constraintStart_toEndOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/action_container" />
+        android:alpha="0.12"
+        android:background="?colorOnSurface"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/action" />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:id="@+id/properties"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_standard"
         android:orientation="vertical"
-        app:layout_constraintEnd_toStartOf="@id/guideline_end"
-        app:layout_constraintStart_toEndOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/action_container" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/geo/src/main/res/layout/selection_summary_sheet_layout.xml
+++ b/geo/src/main/res/layout/selection_summary_sheet_layout.xml
@@ -1,88 +1,96 @@
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?colorSurface"
-    android:paddingBottom="@dimen/margin_standard">
+    android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_top"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="@dimen/margin_standard" />
+        android:background="?colorSurface"
+        android:paddingBottom="@dimen/margin_standard">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_start"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_begin="@dimen/margin_standard" />
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_top"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_begin="@dimen/margin_standard" />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_end"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="@dimen/margin_standard" />
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_start"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_begin="@dimen/margin_standard" />
 
-    <TextView
-        android:id="@+id/name"
-        style="?textAppearanceHeadline6"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="?colorOnSurface"
-        app:layout_constraintStart_toEndOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/guideline_top"
-        tools:text="Name" />
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline_end"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_end="@dimen/margin_standard" />
 
-    <TextView
-        android:id="@+id/info"
-        style="?textAppearanceBody2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:textColor="@color/color_on_surface_medium_emphasis"
-        app:layout_constraintStart_toEndOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/name"
-        tools:text="Info" />
+        <TextView
+            android:id="@+id/name"
+            style="?textAppearanceHeadline6"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?colorOnSurface"
+            app:layout_constraintStart_toEndOf="@id/guideline_start"
+            app:layout_constraintTop_toBottomOf="@id/guideline_top"
+            tools:text="Name" />
 
-    <com.google.android.material.chip.Chip
-        android:id="@+id/action"
-        android:layout_width="wrap_content"
-        android:layout_height="54dp"
-        android:textColor="?colorOnPrimary"
-        app:chipBackgroundColor="?colorSecondary"
-        app:chipEndPadding="@dimen/margin_large"
-        app:chipIconSize="20dp"
-        app:chipIconTint="?colorOnPrimary"
-        app:iconStartPadding="@dimen/margin_standard"
-        app:layout_constraintStart_toEndOf="@id/guideline_start"
-        app:layout_constraintTop_toBottomOf="@id/info"
-        app:textStartPadding="@dimen/margin_small"
-        tools:chipIcon="@drawable/ic_delete"
-        tools:text="Action"
-        tools:visibility="visible" />
+        <TextView
+            android:id="@+id/info"
+            style="?textAppearanceBody2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:textColor="@color/color_on_surface_medium_emphasis"
+            app:layout_constraintStart_toEndOf="@id/guideline_start"
+            app:layout_constraintTop_toBottomOf="@id/name"
+            tools:text="Info" />
 
-    <View
-        android:id="@+id/divider"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:layout_marginTop="@dimen/margin_small"
-        android:alpha="0.12"
-        android:background="?colorOnSurface"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/action" />
+        <com.google.android.material.chip.Chip
+            android:id="@+id/action"
+            android:layout_width="wrap_content"
+            android:layout_height="54dp"
+            android:textColor="?colorOnPrimary"
+            app:chipBackgroundColor="?colorSecondary"
+            app:chipEndPadding="@dimen/margin_large"
+            app:chipIconSize="20dp"
+            app:chipIconTint="?colorOnPrimary"
+            app:iconStartPadding="@dimen/margin_standard"
+            app:layout_constraintStart_toEndOf="@id/guideline_start"
+            app:layout_constraintTop_toBottomOf="@id/info"
+            app:textStartPadding="@dimen/margin_small"
+            tools:chipIcon="@drawable/ic_delete"
+            tools:text="Action"
+            tools:visibility="visible" />
 
-    <androidx.appcompat.widget.LinearLayoutCompat
-        android:id="@+id/properties"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider" />
+        <View
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="@dimen/margin_small"
+            android:background="@drawable/property_divider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/action" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:id="@+id/properties"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:divider="@drawable/property_divider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider"
+            app:showDividers="middle" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</androidx.core.widget.NestedScrollView>

--- a/geo/src/main/res/layout/selection_summary_sheet_layout.xml
+++ b/geo/src/main/res/layout/selection_summary_sheet_layout.xml
@@ -7,7 +7,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?colorSurface"
         android:paddingBottom="@dimen/margin_standard">
 
         <androidx.constraintlayout.widget.Guideline

--- a/material/src/main/java/org/odk/collect/material/BottomSheetBehavior.kt
+++ b/material/src/main/java/org/odk/collect/material/BottomSheetBehavior.kt
@@ -14,6 +14,22 @@ class BottomSheetBehavior<V : View> private constructor(private val view: V) {
 
     private val callbacks = mutableListOf<BottomSheetCallback>()
 
+    var fitToContents: Boolean = actual.isFitToContents
+        set(value) {
+            if (DRAGGING_ENABLED) {
+                actual.isFitToContents = value
+            }
+
+            field = value
+        }
+        get() {
+            return if (DRAGGING_ENABLED) {
+                actual.isFitToContents
+            } else {
+                field
+            }
+        }
+
     var state: Int = actual.state
         set(value) {
             if (DRAGGING_ENABLED) {

--- a/material/src/main/java/org/odk/collect/material/BottomSheetBehavior.kt
+++ b/material/src/main/java/org/odk/collect/material/BottomSheetBehavior.kt
@@ -14,17 +14,17 @@ class BottomSheetBehavior<V : View> private constructor(private val view: V) {
 
     private val callbacks = mutableListOf<BottomSheetCallback>()
 
-    var fitToContents: Boolean = actual.isFitToContents
+    var peekHeight: Int = actual.peekHeight
         set(value) {
             if (DRAGGING_ENABLED) {
-                actual.isFitToContents = value
+                actual.peekHeight = value
             }
 
             field = value
         }
         get() {
             return if (DRAGGING_ENABLED) {
-                actual.isFitToContents
+                actual.peekHeight
             } else {
                 field
             }


### PR DESCRIPTION
Closes #5136 

The selection summary now has an updated design based on what's specified in the issue. The one difference is that the title does not have the primary color (blue) background as it felt like that gave the sheet an older style (of Material Design) look.

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. Will leave comments on anything work highlighting.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This should be fairly low risk. It'd be good to check the select one from map and form map (shouldn't need to use different mapping engines).

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
