### PR TITLE
Close databse connections for given project when it is removed

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConnection.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConnection.kt
@@ -59,6 +59,22 @@ open class DatabaseConnection(
         private val toClose = mutableListOf<SQLiteOpenHelper>()
 
         @JvmStatic
+        fun cleanUp() {
+            val openHelpersToClear = mutableListOf<String>()
+
+            openHelpers.forEach { (databasePath, openHelper) ->
+                if (!File(databasePath).exists()) {
+                    openHelper.close()
+                    openHelpersToClear.add(databasePath)
+                }
+            }
+
+            openHelpersToClear.forEach {
+                openHelpers.remove(it)
+            }
+        }
+
+        @JvmStatic
         fun closeAll() {
             openHelpers.forEach { (_, openHelper) -> openHelper.close() }
             openHelpers.clear()

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectDeleter.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.projects
 
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
 import org.odk.collect.android.backgroundwork.InstanceSubmitScheduler
+import org.odk.collect.android.database.DatabaseConnection
 import org.odk.collect.android.utilities.ChangeLockProvider
 import org.odk.collect.forms.instances.Instance
 import org.odk.collect.forms.instances.InstancesRepository
@@ -59,6 +60,8 @@ class ProjectDeleter(
         projectsRepository.delete(currentProject.uuid)
 
         File(projectDirPath).deleteRecursively()
+
+        DatabaseConnection.cleanUp()
 
         return if (projectsRepository.getAll().isNotEmpty()) {
             val newProject = projectsRepository.getAll()[0]


### PR DESCRIPTION
Closes #4870 

#### What has been done to verify that this works as intended?
I've verified the issue manually.

#### Why is this the best possible solution? Were any other approaches considered?
I think it's the only solution we just need to close database connections before removing them at all.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that the issue does not occur. You can also test deleting other projects (not only demo ones) to make sure ther is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
