### PR TITLE
Use Material 3 Filled Button for selection summary action

### DIFF
--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -46,6 +46,11 @@
         </item>
         <!--/Material theme attributes-->
 
+        <!-- Material3 attributes (needed for Material3 styles/components because theme is
+        Theme.MaterialComponents). These can be added on-demand for components that need them. -->
+        <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
+        <!--/Material3 attributes-->
+
         <!-- Needed to customize the status bar color -->
         <item name="android:statusBarColor">?colorSurface</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">@bool/lightStatusBar</item>

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -26,7 +26,7 @@ and update this document as the code evolves.
 * App mostly stores data in flat files indexed in SQLite
 * Access to data in SQLite happens through repository objects which deal in data/domain objects (`FormsRepository` and `Form` for example)
 * Settings UIs for the app use Android's Preferences abstraction
-* App uses [Material Theming](https://material.io/develop/android/theming/theming-overview) so [Material components](https://material.io/components?platform=android) are preferred over custom or platform ones.
+* App uses [Material 2 Theming](https://material.io/develop/android/theming/theming-overview) so [Material components](https://material.io/components?platform=android) (and [Material 3 components](https://m3.material.io/) where appropriate)are preferred over custom or platform ones.
 * Dagger2 is used to inject "black box" objects such as Activity and just uses a very basic setup
 * Http is handled using OkHttp3 and https client abstractions are generally wrapped in Android's AsyncTask (and some Rx)
 * Geo activities use three engines (Mapbox, osmdroid, Google Maps) depending on the selected basemap even though Mapbox could do everything osmdroid does

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionSummarySheet.kt
@@ -72,7 +72,7 @@ internal class SelectionSummarySheet(context: Context, attrs: AttributeSet?) :
                 binding.action.text = item.action.text
 
                 if (item.action.icon != null) {
-                    binding.action.chipIcon = ContextCompat.getDrawable(context, item.action.icon)
+                    binding.action.icon = ContextCompat.getDrawable(context, item.action.icon)
                 }
 
                 binding.action.visibility = View.VISIBLE

--- a/geo/src/main/res/layout/selection_summary_sheet_layout.xml
+++ b/geo/src/main/res/layout/selection_summary_sheet_layout.xml
@@ -51,20 +51,15 @@
             app:layout_constraintTop_toBottomOf="@id/name"
             tools:text="Info" />
 
-        <com.google.android.material.chip.Chip
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/action"
+            style="@style/Widget.Material3.Button.Icon"
             android:layout_width="wrap_content"
-            android:layout_height="54dp"
+            android:layout_height="wrap_content"
             android:textColor="?colorOnPrimary"
-            app:chipBackgroundColor="?colorSecondary"
-            app:chipEndPadding="@dimen/margin_large"
-            app:chipIconSize="20dp"
-            app:chipIconTint="?colorOnPrimary"
-            app:iconStartPadding="@dimen/margin_standard"
             app:layout_constraintStart_toEndOf="@id/guideline_start"
             app:layout_constraintTop_toBottomOf="@id/info"
-            app:textStartPadding="@dimen/margin_small"
-            tools:chipIcon="@drawable/ic_delete"
+            tools:icon="@drawable/ic_delete"
             tools:text="Action"
             tools:visibility="visible" />
 

--- a/geo/src/main/res/layout/selection_summary_sheet_layout.xml
+++ b/geo/src/main/res/layout/selection_summary_sheet_layout.xml
@@ -56,6 +56,7 @@
             style="@style/Widget.Material3.Button.Icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_small"
             android:textColor="?colorOnPrimary"
             app:layout_constraintStart_toEndOf="@id/guideline_start"
             app:layout_constraintTop_toBottomOf="@id/info"

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionSummarySheetTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionSummarySheetTest.kt
@@ -146,7 +146,7 @@ class SelectionSummarySheetTest {
         assertThat(selectionSummarySheet.binding.info.visibility, equalTo(View.GONE))
 
         assertThat(selectionSummarySheet.binding.action.text, equalTo("Come on in"))
-        val iconDrawable = selectionSummarySheet.binding.action.chipIcon
+        val iconDrawable = selectionSummarySheet.binding.action.icon
         assertThat(
             getCreatedFromResId(iconDrawable!!),
             equalTo(android.R.drawable.ic_btn_speak_now)


### PR DESCRIPTION
We realized that our heavily customized Material Chip button looked exactly like [Material 3's Filled Button](https://m3.material.io/components/buttons/guideline). Before moving on, I wanted to investigate using that component and... success! It looks like we can use Material 3 components just fine with our `MaterialComponents` theme as long as we define the theme attributes that a component requires (an exhaustive list is [here](https://m3.material.io/libraries/mdc-android/getting-started)).

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Using Material 3 cuts down on a lot of customization here. We should think about adopting Material 3 components for other new UIs in the app from now on.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be very low risk but worth playing around with the selection summary sheet seeing as this is our first Material 3 component.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
