### PR TITLE
Fix checking supported abis

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/application/MapboxClassInstanceCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/MapboxClassInstanceCreator.kt
@@ -14,7 +14,7 @@ object MapboxClassInstanceCreator {
             "armeabi-v7a"
         )
 
-        return createMapboxMapFragment() != null && Build.SUPPORTED_ABIS.any(mapboxAbis::contains)
+        return createMapboxMapFragment() != null && mapboxAbis.contains(Build.SUPPORTED_ABIS.first())
     }
 
     fun createMapboxMapFragment(): MapFragment? {

--- a/collect_app/src/main/java/org/odk/collect/android/application/MapboxClassInstanceCreator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/MapboxClassInstanceCreator.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.application
 
-import android.os.Build
 import androidx.fragment.app.Fragment
 import org.odk.collect.maps.MapConfigurator
 import org.odk.collect.maps.MapFragment
@@ -9,12 +8,12 @@ object MapboxClassInstanceCreator {
 
     @JvmStatic
     fun isMapboxAvailable(): Boolean {
-        val mapboxAbis = listOf(
-            "arm64-v8a",
-            "armeabi-v7a"
-        )
-
-        return createMapboxMapFragment() != null && mapboxAbis.contains(Build.SUPPORTED_ABIS.first())
+        return createMapboxMapFragment() != null && try {
+            System.loadLibrary("mapbox-common")
+            true
+        } catch (e: Throwable) {
+            false
+        }
     }
 
     fun createMapboxMapFragment(): MapFragment? {


### PR DESCRIPTION
Closes #5192 

#### What has been done to verify that this works as intended?
I've run tests on firebase (where I was able to reproduce the issue).

#### Why is this the best possible solution? Were any other approaches considered?
As I said in the issue - `The most preferred ABI is the first element in the list` so we need to compare the first abi with the supported ones instead of comparing the whole list.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that mapbox is still available on the devices you have.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
