### PR TITLE
Fixed setting formController objects in view models

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -543,9 +543,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         menuDelegate.formLoaded(formController);
 
         identityPromptViewModel.formLoaded(formController);
-        formEntryViewModel.formLoaded(formController);
         formSaveViewModel.formLoaded(formController);
         backgroundAudioViewModel.formLoaded(formController);
+        formEntryViewModel.formLoaded(formController);
     }
 
     private void setupFields(Bundle savedInstanceState) {


### PR DESCRIPTION
Closes #5193 

#### What has been done to verify that this works as intended?
I've confirmed that the issue does not occur anymore.

#### Why is this the best possible solution? Were any other approaches considered?
I just needed to fix the order of setting `formController` objects in view models so that when index is updated in `formEntryViewModel` other view models already have that object set.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just verify that the issue does not occur anymore.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
