### PR TITLE
 Add markers all at once in Mapbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Certain functions in ODK Collect depend on cloud services that require API keys 
     ```
   4. Create a new secret token with the "DOWNLOADS:READ" secret scope and then add it to `secrets.properties` as `MAPBOX_DOWNLOADS_TOKEN`.
 
-*Note: Mapbox will not be available as an option in compiled versions of Collect unless you follow the steps above. Mapbox will also not be available on x86 devices as the native libraries are excluded to reduce the APK size.*
+*Note: Mapbox will not be available as an option in compiled versions of Collect unless you follow the steps above. Mapbox will also not be available on x86 devices as the native libraries are excluded to reduce the APK size. If you need to use an x86 device, you can force the build to include x86 libs by include the `x86Libs` Gradle parameter. For example, to build a debug APK with x86 libs: `./gradlew assembleDebug -Px86Libs`.*
 
 ## Debugging JavaRosa
 

--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -181,12 +181,14 @@ android {
         // abiFilters to exclude any ABIs; but to keep the APK slim, we include
         // the Mapbox native library only for 32-bit and 64-bit ARM devices and
         // omit it for all X86 devices.
-        exclude 'lib/x86/libmapbox-maps.so'
-        exclude 'lib/x86/libmapbox-common.so'
-        exclude 'lib/x86/libc++_shared.so'
-        exclude 'lib/x86_64/libmapbox-maps.so'
-        exclude 'lib/x86_64/libmapbox-common.so'
-        exclude 'lib/x86_64/libc++_shared.so'
+        if (!project.hasProperty("x86Libs")) {
+            exclude 'lib/x86/libmapbox-maps.so'
+            exclude 'lib/x86/libmapbox-common.so'
+            exclude 'lib/x86/libc++_shared.so'
+            exclude 'lib/x86_64/libmapbox-maps.so'
+            exclude 'lib/x86_64/libmapbox-common.so'
+            exclude 'lib/x86_64/libc++_shared.so'
+        }
     }
 
     compileOptions {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/FakeClickableMapFragment.kt
@@ -43,6 +43,12 @@ class FakeClickableMapFragment : Fragment(), MapFragment {
         return id
     }
 
+    override fun addMarkers(markers: List<MapFragment.MarkerDescription>): List<Int> {
+        return markers.map {
+            addMarker(it.point, it.isDraggable, it.iconAnchor, it.iconDrawableId)
+        }
+    }
+
     override fun setMarkerIcon(featureId: Int, drawableId: Int) {}
 
     override fun getMarkerPoint(featureId: Int): MapPoint {

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -271,6 +271,17 @@ public class GoogleMapFragment extends SupportMapFragment implements
         return featureId;
     }
 
+    @Override
+    public List<Integer> addMarkers(List<MarkerDescription> markers) {
+        List<Integer> featureIds = new ArrayList<>();
+        for (MarkerDescription markerDescription : markers) {
+            int featureId = addMarker(markerDescription.getPoint(), markerDescription.isDraggable(), markerDescription.getIconAnchor(), markerDescription.getIconDrawableId());
+            featureIds.add(featureId);
+        }
+
+        return featureIds;
+    }
+
     @Override public void setMarkerIcon(int featureId, int drawableId) {
         MapFeature feature = features.get(featureId);
         if (feature instanceof MarkerFeature) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/NoOpMapFragment.kt
@@ -45,6 +45,10 @@ class NoOpMapFragment : Fragment(), MapFragment {
         TODO("Not yet implemented")
     }
 
+    override fun addMarkers(markers: MutableList<MapFragment.MarkerDescription>?): MutableList<Int> {
+        TODO("Not yet implemented")
+    }
+
     override fun setMarkerIcon(featureId: Int, drawableId: Int) {
     }
 

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -344,11 +344,19 @@ class SelectionMapFragment(
         map.clearFeatures()
         itemsByFeatureId.clear()
 
-        for (item in items) {
-            val point = MapPoint(item.latitude, item.longitude)
-            val featureId = map.addMarker(point, false, MapFragment.BOTTOM, item.smallIcon)
+        val markerDescriptions = items.map {
+            MapFragment.MarkerDescription(
+                MapPoint(it.latitude, it.longitude),
+                false,
+                MapFragment.BOTTOM,
+                it.smallIcon
+            )
+        }
+
+        val featureIds = map.addMarkers(markerDescriptions)
+        items.zip(featureIds).forEach { (item, featureId) ->
             itemsByFeatureId[featureId] = item
-            points.add(point)
+            points.add(MapPoint(item.latitude, item.longitude))
         }
     }
 

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -87,6 +87,12 @@ class FakeMapFragment : Fragment(), MapFragment {
         return markers.size - 1
     }
 
+    override fun addMarkers(markers: List<MapFragment.MarkerDescription>): List<Int> {
+        return markers.map {
+            addMarker(it.point, it.isDraggable, it.iconAnchor, it.iconDrawableId)
+        }
+    }
+
     override fun setMarkerIcon(featureId: Int, drawableId: Int) {
         markerIcons[featureId] = drawableId
     }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapUtils.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapUtils.kt
@@ -31,6 +31,25 @@ object MapUtils {
         )
     }
 
+    fun createPointAnnotations(
+        context: Context,
+        pointAnnotationManager: PointAnnotationManager,
+        markerFeatures: List<MapFragment.MarkerDescription>,
+    ): List<PointAnnotation> {
+        val pointAnnotationOptionsList = markerFeatures.map {
+            PointAnnotationOptions()
+                .withPoint(Point.fromLngLat(it.point.lon, it.point.lat, it.point.alt))
+                .withIconImage(MapsMarkerCache.getMarkerBitmap(it.iconDrawableId, context))
+                .withIconSize(1.0)
+                .withSymbolSortKey(10.0)
+                .withDraggable(it.isDraggable)
+                .withTextOpacity(0.0)
+                .withIconAnchor(getIconAnchorValue(it.iconAnchor))
+        }
+
+        return pointAnnotationManager.create(pointAnnotationOptionsList)
+    }
+
     private fun getIconAnchorValue(@MapFragment.IconAnchor iconAnchor: String): IconAnchor {
         return when (iconAnchor) {
             MapFragment.BOTTOM -> IconAnchor.BOTTOM

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -285,19 +285,33 @@ class MapboxMapFragment :
         iconAnchor: String,
         iconDrawableId: Int,
     ): Int {
-        val featureId = nextFeatureId++
-        features[featureId] = MarkerFeature(
-            requireContext(),
-            pointAnnotationManager,
-            featureId,
-            featureClickListener,
-            featureDragEndListener,
-            point,
-            draggable,
-            iconAnchor,
-            iconDrawableId
-        )
-        return featureId
+        return addMarkers(
+            listOf(MapFragment.MarkerDescription(point, draggable, iconAnchor, iconDrawableId))
+        ).first()
+    }
+
+    override fun addMarkers(markers: List<MapFragment.MarkerDescription>): List<Int> {
+        val pointAnnotations =
+            MapUtils.createPointAnnotations(requireContext(), pointAnnotationManager, markers)
+
+        val featureIds = mutableListOf<Int>()
+        pointAnnotations.forEach {
+            val featureId = nextFeatureId++
+            val markerFeature = MarkerFeature(
+                requireContext(),
+                pointAnnotationManager,
+                it,
+                featureId,
+                featureClickListener,
+                featureDragEndListener,
+                MapPoint(it.point.latitude(), it.point.longitude())
+            )
+
+            featureIds.add(featureId)
+            features[featureId] = markerFeature
+        }
+
+        return featureIds
     }
 
     override fun setMarkerIcon(featureId: Int, drawableId: Int) {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MarkerFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MarkerFeature.kt
@@ -11,26 +11,16 @@ import org.odk.collect.maps.MapsMarkerCache
 
 /** A point annotation that can optionally be dragged by the user. */
 class MarkerFeature(
-    private val context: Context,
+    val context: Context,
     private val pointAnnotationManager: PointAnnotationManager,
-    private val featureId: Int,
+    private val pointAnnotation: PointAnnotation,
+    val featureId: Int,
     private val featureClickListener: MapFragment.FeatureListener?,
     private val featureDragEndListener: MapFragment.FeatureListener?,
-    var point: MapPoint,
-    draggable: Boolean,
-    @MapFragment.IconAnchor iconAnchor: String,
-    iconDrawableId: Int
+    var point: MapPoint
 ) : MapFeature {
     private val clickListener = ClickListener()
     private val dragListener = DragListener()
-    private var pointAnnotation = MapUtils.createPointAnnotation(
-        pointAnnotationManager,
-        point,
-        draggable,
-        iconAnchor,
-        iconDrawableId,
-        context
-    )
 
     init {
         pointAnnotationManager.apply {

--- a/maps/src/main/java/org/odk/collect/maps/MapFragment.java
+++ b/maps/src/main/java/org/odk/collect/maps/MapFragment.java
@@ -102,6 +102,8 @@ public interface MapFragment {
      */
     int addMarker(MapPoint point, boolean draggable, @IconAnchor String iconAnchor, int iconDrawableId);
 
+    List<Integer> addMarkers(List<MarkerDescription> markers);
+
     /** Sets the icon for a marker. */
     void setMarkerIcon(int featureId, int drawableId);
 
@@ -196,5 +198,37 @@ public interface MapFragment {
 
     interface FeatureListener {
         void onFeature(int featureId);
+    }
+
+    class MarkerDescription {
+
+        private final MapPoint point;
+        private final boolean draggable;
+        private final String iconAnchor;
+        private final int iconDrawableId;
+
+        public MarkerDescription(MapPoint point, boolean draggable, @IconAnchor String iconAnchor, int iconDrawableId) {
+            this.point = point;
+            this.draggable = draggable;
+            this.iconAnchor = iconAnchor;
+            this.iconDrawableId = iconDrawableId;
+        }
+
+        public MapPoint getPoint() {
+            return point;
+        }
+
+        public boolean isDraggable() {
+            return draggable;
+        }
+
+        @IconAnchor
+        public String getIconAnchor() {
+            return iconAnchor;
+        }
+
+        public int getIconDrawableId() {
+            return iconDrawableId;
+        }
     }
 }

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -299,6 +299,17 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
     }
 
     @Override
+    public List<Integer> addMarkers(List<MarkerDescription> markers) {
+        List<Integer> featureIds = new ArrayList<>();
+        for (MarkerDescription markerDescription : markers) {
+            int featureId = addMarker(markerDescription.getPoint(), markerDescription.isDraggable(), markerDescription.getIconAnchor(), markerDescription.getIconDrawableId());
+            featureIds.add(featureId);
+        }
+
+        return featureIds;
+    }
+
+    @Override
     public void setMarkerIcon(int featureId, int drawableId) {
         MapFeature feature = features.get(featureId);
         if (feature instanceof MarkerFeature) {


### PR DESCRIPTION
Closes #5177
~~Blocked by #5194~~

We'd talked about making this change before (in #5087) for example, but had decided to hold off until we heard feedback from users around performance. It seems that with the Mapbox v10 upgrade, minimizing and reopening the app can cause an ANR when adding large amounts of markers. I wasn't sure exactly why, but switching to adding markers in one go (against the Mapbox SDK) fixes this problem and **dramatically** speeds up loading for larger sets of items in selection maps (form map or select one from map widget).

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

I did also try an approach of offloading some of the marker generation code to the background, but this didn't help - the ANR could still be reproduced. My theory is that the continual adding of markers (one by one) while the app was minimized caused problems for Mapbox (which seems very plausible).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I've had to make changes to the selection map for all the map engines, so we should do a QA pass on that again. 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
