### PR TITLE
Fix recording points stopping on rotate for geotrace/geoshape

### DIFF
--- a/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
+++ b/location/src/main/java/org/odk/collect/location/tracker/ForegroundServiceLocationTracker.kt
@@ -42,7 +42,7 @@ class ForegroundServiceLocationTracker(private val application: Application) : L
     }
 }
 
-class LocationTrackerService : Service() {
+class LocationTrackerService : Service(), LocationClient.LocationClientListener {
 
     private val locationClient: LocationClient by lazy {
         LocationClientProvider.getClient(application)
@@ -74,25 +74,7 @@ class LocationTrackerService : Service() {
             )
         }
 
-        locationClient.setListener(object : LocationClient.LocationClientListener {
-            override fun onClientStart() {
-                locationClient.requestLocationUpdates {
-                    application.getState().set(
-                        LOCATION_KEY,
-                        Location(it.latitude, it.longitude, it.altitude, it.accuracy)
-                    )
-                }
-            }
-
-            override fun onClientStartFailure() {
-                // Ignored
-            }
-
-            override fun onClientStop() {
-                // Ignored
-            }
-        })
-
+        locationClient.setListener(this)
         locationClient.start()
         return START_NOT_STICKY
     }
@@ -100,6 +82,23 @@ class LocationTrackerService : Service() {
     override fun onDestroy() {
         locationClient.stop()
         application.getState().clear(LOCATION_KEY)
+    }
+
+    override fun onClientStart() {
+        locationClient.requestLocationUpdates {
+            application.getState().set(
+                LOCATION_KEY,
+                Location(it.latitude, it.longitude, it.altitude, it.accuracy)
+            )
+        }
+    }
+
+    override fun onClientStartFailure() {
+        // Ignored
+    }
+
+    override fun onClientStop() {
+        // Ignored
     }
 
     private fun createNotification(): Notification {


### PR DESCRIPTION
Closes #5173
~~Blocked by #5206~~

This switches out an anonymous class instance being used as a listener for a reference to the current object. This prevents the listener from being garbage collected before the "observer" object.

#### What has been done to verify that this works as intended?

Verified manually. This bug relies on garbage collection, so it's as good as impossible to write a test for.

#### Why is this the best possible solution? Were any other approaches considered?

I think a better solution would actually be to remove the use of `WeakReference` in `BaseLocationClient` to store listeners. I've [created an issue](https://github.com/getodk/collect/issues/5208) to handle that later. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This makes changes to the core code used when recording locations for geotrace, geoshape and geopoint. It would be good to carry out some checks involving those question types.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
