### PR TITLE
Set up click listeners for OSM properly

### DIFF
--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -682,7 +682,22 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
 
     private void addAttributionAndMapEventsOverlays() {
         map.getOverlays().add(new AttributionOverlay(getContext()));
-        map.getOverlays().add(new MapEventsOverlay(new MapEventsReceiver(clickListener, longPressListener)));
+        map.getOverlays().add(
+                new MapEventsOverlay(
+                        new MapEventsReceiver(
+                                point -> {
+                                    if (clickListener != null) {
+                                        clickListener.onPoint(point);
+                                    }
+                                },
+                                point -> {
+                                    if (longPressListener != null) {
+                                        longPressListener.onPoint(point);
+                                    }
+                                }
+                        )
+                )
+        );
     }
 
     private void onConfigChanged(Bundle config) {


### PR DESCRIPTION
Closes #5168

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

We could switch out the event overlay on `setClickListener` and `setLongPressListener`, but that seemed a lot more complex as we'd have to keep track of the event overlay and add/remove it at the right time. Just using proxy listeners that reference the fields in `OSMDroidFragment` felt simpler.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

We should anywhere that OSM is used as I've made changes to the code OSM code.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
