### PR TITLE
Stop early swipes causes crashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/listeners/SwipeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/SwipeHandler.java
@@ -89,6 +89,10 @@ public class SwipeHandler {
 
         @Override
         public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+            if (view == null) {
+                return false;
+            }
+
             FlingRegister.flingDetected();
 
             if (e1 != null && e2 != null


### PR DESCRIPTION
Closes #4896

#### What has been done to verify that this works as intended?

Verified manually (with modified code to create a window of time when you can swipe before the form has loaded).

#### Why is this the best possible solution? Were any other approaches considered?

The issue lays out a nice (if I do say so myself), but more time intensive route to solving this. We made some good progress on cleaning up the swipe code in the last release however, and I think we should see how further loading states (like we're adding in #5229) force us to keep making progress there.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should have no effect although changing form entry swipe code is always a little scary. Good to put form entry and swiping/using next and back buttons through its paces.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
