### PR TITLE
Fall back to first project when no current project set

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/projects/CurrentProjectProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/CurrentProjectProvider.kt
@@ -22,7 +22,13 @@ class CurrentProjectProvider(
                 throw IllegalStateException("Current project does not exist!")
             }
         } else {
-            throw IllegalStateException("No current project!")
+            val projects = projectsRepository.getAll()
+
+            if (projects.isNotEmpty()) {
+                return projects[0]
+            } else {
+                throw IllegalStateException("No current project!")
+            }
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/projects/CurrentProjectProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/CurrentProjectProviderTest.kt
@@ -2,79 +2,50 @@ package org.odk.collect.android.projects
 
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import org.hamcrest.Matchers.`is`
-import org.junit.Before
+import org.hamcrest.Matchers.equalTo
 import org.junit.Test
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.odk.collect.android.preferences.source.SharedPreferencesSettings
+import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
-import org.odk.collect.projects.ProjectsRepository
-import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.InMemSettingsProvider
 import org.odk.collect.settings.keys.MetaKeys
 
 class CurrentProjectProviderTest {
 
-    private lateinit var projectsRepository: ProjectsRepository
-    private lateinit var metaSettings: SharedPreferencesSettings
-    private lateinit var settingsProvider: SettingsProvider
-    private lateinit var currentProjectProvider: CurrentProjectProvider
-
-    @Before
-    fun setup() {
-        metaSettings = mock(SharedPreferencesSettings::class.java)
-        settingsProvider = mock(SettingsProvider::class.java)
-        projectsRepository = mock(ProjectsRepository::class.java)
-        currentProjectProvider = CurrentProjectProvider(settingsProvider, projectsRepository)
-    }
+    private val projectsRepository = InMemProjectsRepository()
+    private val settingsProvider = InMemSettingsProvider()
+    private val metaSettings = settingsProvider.getMetaSettings()
+    private val currentProjectProvider =
+        CurrentProjectProvider(settingsProvider, projectsRepository)
 
     @Test
     fun `A project should be returned after calling getCurrentProject() if there is a project for given id`() {
-        `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)
-        `when`(metaSettings.getString(MetaKeys.CURRENT_PROJECT_ID)).thenReturn("123e4567")
-        val project = Project.Saved("123e4567", "ProjectX", "X", "#00FF00")
-        `when`(projectsRepository.get("123e4567")).thenReturn(project)
+        val project = projectsRepository.save(Project.New("ProjectX", "X", "#00FF00"))
+        metaSettings.save(MetaKeys.CURRENT_PROJECT_ID, project.uuid)
 
         assertThat(currentProjectProvider.getCurrentProject(), `is`(project))
     }
 
     @Test
     fun `save() on meta settings should be called after current project is set`() {
-        `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)
-
         currentProjectProvider.setCurrentProject("123e4567")
-        verify(metaSettings).save(MetaKeys.CURRENT_PROJECT_ID, "123e4567")
+        assertThat(metaSettings.getString(MetaKeys.CURRENT_PROJECT_ID), equalTo("123e4567"))
     }
 
     @Test(expected = IllegalStateException::class)
     fun `getCurrentProject throws IllegalStateException when there is no current project`() {
-        `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)
-        `when`(metaSettings.getString(MetaKeys.CURRENT_PROJECT_ID)).thenReturn(null)
-
         currentProjectProvider.getCurrentProject()
     }
 
     @Test
     fun `getCurrentProject returns first project when there is no current project but there are projects`() {
-        `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)
-        `when`(metaSettings.getString(MetaKeys.CURRENT_PROJECT_ID)).thenReturn(null)
-
-        val firstProject = Project.Saved("firstProject", "ProjectX", "X", "#00FF00")
-        `when`(projectsRepository.get("firstProject")).thenReturn(firstProject)
-
-        val secondProject = Project.Saved("secondProject", "ProjectY", "Y", "#00FF00")
-        `when`(projectsRepository.get("secondProject")).thenReturn(secondProject)
-
-        `when`(projectsRepository.getAll()).thenReturn(listOf(firstProject, secondProject))
+        val firstProject = projectsRepository.save(Project.New("ProjectX", "X", "#00FF00"))
+        projectsRepository.save(Project.New("ProjectY", "Y", "#00FF00"))
         assertThat(currentProjectProvider.getCurrentProject(), `is`(firstProject))
     }
 
     @Test(expected = IllegalStateException::class)
     fun `getCurrentProject throws IllegalStateException when current project does not exist`() {
-        `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)
-        `when`(metaSettings.getString(MetaKeys.CURRENT_PROJECT_ID)).thenReturn("123e4567")
-        `when`(projectsRepository.get("123e4567")).thenReturn(null)
-
+        currentProjectProvider.setCurrentProject("123e4567")
         currentProjectProvider.getCurrentProject()
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/projects/CurrentProjectProviderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/CurrentProjectProviderTest.kt
@@ -54,6 +54,21 @@ class CurrentProjectProviderTest {
         currentProjectProvider.getCurrentProject()
     }
 
+    @Test
+    fun `getCurrentProject returns first project when there is no current project but there are projects`() {
+        `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)
+        `when`(metaSettings.getString(MetaKeys.CURRENT_PROJECT_ID)).thenReturn(null)
+
+        val firstProject = Project.Saved("firstProject", "ProjectX", "X", "#00FF00")
+        `when`(projectsRepository.get("firstProject")).thenReturn(firstProject)
+
+        val secondProject = Project.Saved("secondProject", "ProjectY", "Y", "#00FF00")
+        `when`(projectsRepository.get("secondProject")).thenReturn(secondProject)
+
+        `when`(projectsRepository.getAll()).thenReturn(listOf(firstProject, secondProject))
+        assertThat(currentProjectProvider.getCurrentProject(), `is`(firstProject))
+    }
+
     @Test(expected = IllegalStateException::class)
     fun `getCurrentProject throws IllegalStateException when current project does not exist`() {
         `when`(settingsProvider.getMetaSettings()).thenReturn(metaSettings)


### PR DESCRIPTION
Should fix [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/8d842445557fcf3942b4e99ba2f89aec?time=last-seven-days&versions=v2022.3.0%20(4477)&types=crash&sessionEventKey=62EA01B7036F00010B09D6BBA9492EE2_1705956889396036664).

We most likely removed the ability for the user to get into the bad state that causes the crash, but didn't provide a fix for people that are already in that state. This PR attempts that

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

One question is: why didn't we have `CurrentProjectProvider` behave like this before? Potentially, we didn't want to add overprotectiveness in that might allow us to make mistakes elsewhere. An alternative we could switch to if people would prefer we stay away from adding the fallback into `CurrentProjectProvider` would be to add in a new `Upgrade` (or app startup item) that fixes the problem by setting a current project if there isn't one, but there are projects.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This feels relatively safe, but I can't get past the feeling there may have been some reason we didn't want this behaviour in the first place. It'd be good to play around with setting up projects in the app, switching between them, app upgrades etc.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
