### PR TITLE
Fixed adding offline layers

### DIFF
--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.dsl.cameraOptions
 import com.mapbox.maps.extension.style.layers.Layer
-import com.mapbox.maps.extension.style.layers.addLayerAt
+import com.mapbox.maps.extension.style.layers.addLayerAbove
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.generated.RasterLayer
 import com.mapbox.maps.extension.style.sources.Source
@@ -95,7 +95,7 @@ class MapboxMapFragment :
     private var tileServer: TileHttpServer? = null
     private var referenceLayerFile: File? = null
     private var clientWantsLocationUpdates = false
-    private var offlineLayerPosition = -1
+    private var topStyleLayerId: String? = null
     private val locationCallback = MapboxLocationCallback(this)
     private var mapFragmentDelegate = MapFragmentDelegate(
         this,
@@ -210,9 +210,9 @@ class MapboxMapFragment :
         val styleUrl = config.getString(KEY_STYLE_URL) ?: Style.MAPBOX_STREETS
         referenceLayerFile = getReferenceLayerFile(config, referenceLayerRepository)
         mapboxMap.loadStyleUri(styleUrl) {
-            if (offlineLayerPosition == -1) {
-                // remember the index of first layer above other already existing layers
-                offlineLayerPosition = it.styleLayers.size - 1
+            if (topStyleLayerId == null) {
+                // remember the id of the top style layer
+                topStyleLayerId = it.styleLayers.last().id
             }
             loadReferenceOverlay()
         }
@@ -599,7 +599,9 @@ class MapboxMapFragment :
     }
 
     private fun addOverlayLayer(layer: Layer) {
-        mapboxMap.getStyle()?.addLayerAt(layer, offlineLayerPosition)
+        topStyleLayerId?.let {
+            mapboxMap.getStyle()?.addLayerAbove(layer, topStyleLayerId)
+        }
     }
 
     private fun addOverlaySource(source: Source) {


### PR DESCRIPTION
Closes #5236 

#### What has been done to verify that this works as intended?
I've verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
Adding offline layers is a bit problematic we have to add them above style layers (such a layer might consist of over 100 layers like streets for example) but below layers that represent points/lines (to keep points and lines visible) etc. The previous solution attempted to remember the index of the top style layer but it was faulty and selected offline layer was added below the last of layers that selected style layer consisted of. The current solution with using ids instead of indexes works well.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify the case described in the issue and generally changing styles and offline layers. There is no need to test other providers than Mapbox.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
