### PR TITLE
Make sure the value used in range widget is between rangeStart and rangeEnd 

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtils.java
@@ -111,6 +111,10 @@ public class RangeWidgetUtils {
         BigDecimal actualValue = null;
         if (prompt.getAnswerValue() != null) {
             actualValue = new BigDecimal(prompt.getAnswerValue().getValue().toString());
+
+            if (actualValue.compareTo(rangeStart) < 0 || actualValue.compareTo(rangeEnd) > 0) {
+                actualValue = null;
+            }
         }
 
         if (isRangeSliderWidgetValid(rangeQuestion, slider)) {

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/RangeWidgetUtilsTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithQuestionDefAndAnswer;
@@ -18,7 +19,9 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.core.model.RangeQuestion;
+import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.core.model.data.StringData;
+import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,6 +88,30 @@ public class RangeWidgetUtilsTest {
         RangeWidgetUtils.setUpRangePickerWidget(widgetTestActivity(), binding, promptWithQuestionDefAndAnswer(
                 rangeQuestion, new StringData("4")));
         assertThat(binding.widgetAnswerText.getText(), equalTo("4"));
+    }
+
+    @Test
+    public void whenPromptHasAnswerThatIsOutOfRange_sliderValueShouldNotBeSet() {
+        slider.setValue(5);
+
+        // Value bigger than rangeEnd
+        FormEntryPrompt prompt = mock(FormEntryPrompt.class);
+        IntegerData biggerAnswerValue = new IntegerData(rangeQuestion.getRangeEnd().intValue() + 1);
+        when(prompt.getAnswerValue()).thenReturn(biggerAnswerValue);
+        when(prompt.getQuestion()).thenReturn(rangeQuestion);
+
+        BigDecimal value = RangeWidgetUtils.setUpSlider(prompt, slider, true);
+        assertNull(value);
+        assertThat(slider.getValue(), equalTo(5f));
+
+        // Value smaller than rangeStart
+        IntegerData smallerAnswerValue = new IntegerData(rangeQuestion.getRangeStart().intValue() - 1);
+        when(prompt.getAnswerValue()).thenReturn(smallerAnswerValue);
+        when(prompt.getQuestion()).thenReturn(rangeQuestion);
+
+        value = RangeWidgetUtils.setUpSlider(prompt, slider, true);
+        assertNull(value);
+        assertThat(slider.getValue(), equalTo(5f));
     }
 
     @Test


### PR DESCRIPTION
Closes #5234 

#### What has been done to verify that this works as intended?
I've added tests and verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a fix for the case we missed before. Not much to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just test the steps described in the issue.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached in the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
