### PR TITLE
Show error when mysterious reload crash would happen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -467,7 +467,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 .get(FormEntryViewModel.class);
 
         formEntryViewModel.getCurrentIndex().observe(this, index -> {
-            formIndexAnimationHandler.handle(index);
+            if (index != null && Collect.getInstance().getFormController() == null) {
+                // https://github.com/getodk/collect/issues/5241
+                createErrorDialog("getFormController() is null, please email support@getodk.org with a description of what you were doing when this happened.", true);
+            } else {
+                formIndexAnimationHandler.handle(index);
+            }
         });
 
         formEntryViewModel.isLoading().observe(this, isLoading -> {


### PR DESCRIPTION
Closes #5241

We decided on this approach in a separate conversation due to not having any other theories around a potential fix (or reproduction steps).

#### What has been done to verify that this works as intended?

Verified manually with modified code to simulate crash.

#### Why is this the best possible solution? Were any other approaches considered?

This doesn't solve the problem - a user can still get into the scenario that causes the crash (however that happens), but know we exit form entry gracefully, and encourage them to get in touch. This will hopefully mean that we will get more info from folks if they're experiencing this repeatedly.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should be fairly low risk as I've only added code that will run in a state we can't reproduce. Can skip QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
