### PR TITLE
Ignore errors closing ActivityScenario

### DIFF
--- a/androidtest/build.gradle
+++ b/androidtest/build.gradle
@@ -39,5 +39,6 @@ dependencies {
     implementation Dependencies.androidx_test_espresso_core
     implementation Dependencies.androidx_appcompat
     implementation Dependencies.androidx_test_espresso_intents
+    implementation Dependencies.timber
 }
 

--- a/androidtest/src/main/java/org/odk/collect/androidtest/ActivityScenarioLauncherRule.kt
+++ b/androidtest/src/main/java/org/odk/collect/androidtest/ActivityScenarioLauncherRule.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import org.junit.rules.ExternalResource
+import timber.log.Timber
 
 /**
  * Alternative to [ActivityScenario] that allows tests to do work before launching the [Activity]
@@ -27,6 +28,12 @@ open class ActivityScenarioLauncherRule : ExternalResource() {
     }
 
     override fun after() {
-        scenarios.forEach(ActivityScenario<*>::close)
+        scenarios.forEach {
+            try {
+                it.close()
+            } catch (e: Throwable) {
+                Timber.e("Error closing ActivityScenario: $e")
+            }
+        }
     }
 }


### PR DESCRIPTION
We've seen crashes during UI tests due to exceptions being thrown as we tidy up `ActivityScenario` instances. I've made it so these are ignored (but still logged so we can see if later fails/crashes are related).