### PR TITLE
Cache BitmapDescriptor

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/BitmapDescriptorCache.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/BitmapDescriptorCache.kt
@@ -26,6 +26,7 @@ object BitmapDescriptorCache {
 
     @JvmStatic
     fun clearCache() {
+        MapsMarkerCache.clearCache()
         cache.evictAll()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/BitmapDescriptorCache.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/BitmapDescriptorCache.kt
@@ -1,0 +1,31 @@
+package org.odk.collect.android.geo
+
+import android.content.Context
+import android.util.LruCache
+import androidx.annotation.DrawableRes
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import org.odk.collect.maps.MapsMarkerCache
+
+object BitmapDescriptorCache {
+    /**
+     * We use different markers in different features but it looks like we will never need to
+     * support more than 10 different types of markers at the same time.
+     */
+    private val cache = LruCache<Int, BitmapDescriptor>(10)
+
+    @JvmStatic
+    fun getBitmapDescriptor(@DrawableRes drawable: Int, context: Context): BitmapDescriptor {
+        if (cache[drawable] == null) {
+            BitmapDescriptorFactory.fromBitmap(MapsMarkerCache.getMarkerBitmap(drawable, context)).also {
+                cache.put(drawable, it)
+            }
+        }
+        return cache[drawable]
+    }
+
+    @JvmStatic
+    fun clearCache() {
+        cache.evictAll()
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -33,7 +33,6 @@ import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
-import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.Circle;
 import com.google.android.gms.maps.model.CircleOptions;
 import com.google.android.gms.maps.model.LatLng;
@@ -57,7 +56,6 @@ import org.odk.collect.maps.MapConfigurator;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapFragmentDelegate;
 import org.odk.collect.maps.MapPoint;
-import org.odk.collect.maps.MapsMarkerCache;
 import org.odk.collect.maps.layers.MapFragmentReferenceLayerUtils;
 import org.odk.collect.maps.layers.ReferenceLayerRepository;
 import org.odk.collect.settings.SettingsProvider;
@@ -194,7 +192,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     @Override public void onDestroy() {
-        MapsMarkerCache.clearCache();
+        BitmapDescriptorCache.clearCache();
         super.onDestroy();
     }
 
@@ -661,7 +659,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
     }
 
     private BitmapDescriptor getBitmapDescriptor(int drawableId) {
-        return BitmapDescriptorFactory.fromBitmap(MapsMarkerCache.getMarkerBitmap(drawableId, getContext()));
+        return BitmapDescriptorCache.getBitmapDescriptor(drawableId, getContext());
     }
 
     private void showGpsDisabledAlert() {


### PR DESCRIPTION
Closes #5007 

#### What has been done to verify that this works as intended?
I've just reviewed implemented changes and played with google maps to make sure there is no regression.

#### Why is this the best possible solution? Were any other approaches considered?
I can't reproduce the issue but it seems to be too common to ignore it so I decided to at least try to fix it. To do that I implemented a similar solution we have added some time ago for caching bitmaps https://github.com/getodk/collect/pull/5010. Markers in google maps use `BitmapDescriptor` not just `Bitmap` like in mapbox or osm so my gut says we might need to cache that whole `BitmapDescriptor` in this case. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that displaying markers (map of forms + geo widgets) works well with Google maps.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
