### PR TITLE
Prevent `ConcurrentModificationException` when logging or flushing the `AuditEventLogger`

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -162,9 +162,11 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         isLoading.setValue(true);
 
         scheduler.immediate((Supplier<Boolean>) () -> {
-            return updateAnswersForScreen(answers, evaluateConstraints);
+            return saveScreenAnswersToFormController(answers, evaluateConstraints);
         }, updateSuccess -> {
             isLoading.setValue(false);
+
+            formController.getAuditEventLogger().flush();
 
             if (updateSuccess) {
                 try {
@@ -183,9 +185,11 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         isLoading.setValue(true);
 
         scheduler.immediate((Supplier<Boolean>) () -> {
-            return updateAnswersForScreen(answers);
+            return saveScreenAnswersToFormController(answers, false);
         }, updateSuccess -> {
             isLoading.setValue(false);
+
+            formController.getAuditEventLogger().flush();
 
             if (updateSuccess) {
                 try {
@@ -206,6 +210,13 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
     }
 
     public boolean updateAnswersForScreen(HashMap<FormIndex, IAnswerData> answers, Boolean evaluateConstraints) {
+        boolean success = saveScreenAnswersToFormController(answers, evaluateConstraints);
+        formController.getAuditEventLogger().flush();
+
+        return success;
+    }
+
+    private boolean saveScreenAnswersToFormController(HashMap<FormIndex, IAnswerData> answers, Boolean evaluateConstraints) {
         if (formController == null) {
             return false;
         }
@@ -221,7 +232,6 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
             return false;
         }
 
-        formController.getAuditEventLogger().flush();
         return true;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -2,6 +2,7 @@
 package org.odk.collect.android.formentry.audit;
 
 import android.location.Location;
+import android.os.Looper;
 import android.os.SystemClock;
 
 import org.javarosa.core.model.FormIndex;
@@ -57,6 +58,11 @@ public class AuditEventLogger {
      */
     public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
                          boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
+        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
+            throw new IllegalStateException("Cannot log event from background thread!");
+        }
+
+
         if (!isAuditEnabled() || shouldBeIgnored(eventType)) {
             return;
         }
@@ -101,6 +107,10 @@ public class AuditEventLogger {
      * Finalizes and writes events
      */
     public void flush() {
+        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
+            throw new IllegalStateException("Cannot flush events from background thread!");
+        }
+
         if (isAuditEnabled()) {
             finalizeEvents();
             writeEvents();

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventLogger.java
@@ -1,6 +1,9 @@
 
 package org.odk.collect.android.formentry.audit;
 
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_DISABLED;
+import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_ENABLED;
+
 import android.location.Location;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -14,9 +17,6 @@ import java.util.List;
 
 import io.reactivex.annotations.Nullable;
 import timber.log.Timber;
-
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_DISABLED;
-import static org.odk.collect.android.formentry.audit.AuditEvent.AuditEventType.LOCATION_PROVIDERS_ENABLED;
 
 /**
  * Handle logging of auditEvents (which contain time and might contain location coordinates),
@@ -58,10 +58,7 @@ public class AuditEventLogger {
      */
     public void logEvent(AuditEvent.AuditEventType eventType, FormIndex formIndex,
                          boolean writeImmediatelyToDisk, String questionAnswer, long currentTime, String changeReason) {
-        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
-            throw new IllegalStateException("Cannot log event from background thread!");
-        }
-
+        checkAndroidUIThread();
 
         if (!isAuditEnabled() || shouldBeIgnored(eventType)) {
             return;
@@ -107,13 +104,18 @@ public class AuditEventLogger {
      * Finalizes and writes events
      */
     public void flush() {
-        if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
-            throw new IllegalStateException("Cannot flush events from background thread!");
-        }
+        checkAndroidUIThread();
 
         if (isAuditEnabled()) {
             finalizeEvents();
             writeEvents();
+        }
+    }
+
+    private void checkAndroidUIThread() {
+        Looper mainLooper = Looper.getMainLooper();
+        if (mainLooper != null && mainLooper.getThread() != Thread.currentThread()) {
+            throw new IllegalStateException("Cannot modify audit log from background thread!");
         }
     }
 


### PR DESCRIPTION
Should hopefully resolve [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/eebd7555f890d15034057bc131e622dd?time=last-seven-days&types=crash&sessionEventKey=630465E800C70001216501F62C12F425_1713447215830504361).

#### What has been done to verify that this works as intended?

Added assertions in code to prevent us from logging or flushing with the audit log from background threads.

#### Why is this the best possible solution? Were any other approaches considered?

We could potentially have made `AuditEventLogger` "thread safe" by queuing/locking changes to the log itself, but that felt like a much more involved change. It looks like we introduced the only case of logging/flushing on a background thread in v2022.3.0, so making sure we went back to only calling `AuditEventLogger` from the UI thread made sense to me. When reviewing, it'd be good to verify that I'm right that we don't modify `AuditEventLogger` from a background thread anywhere else.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It'll be good to verify filling and editing forms with auditing both enabled and disabled.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
