### PR TITLE
Fixed logging errors

### DIFF
--- a/androidtest/src/main/java/org/odk/collect/androidtest/ActivityScenarioLauncherRule.kt
+++ b/androidtest/src/main/java/org/odk/collect/androidtest/ActivityScenarioLauncherRule.kt
@@ -32,7 +32,7 @@ open class ActivityScenarioLauncherRule : ExternalResource() {
             try {
                 it.close()
             } catch (e: Throwable) {
-                Timber.e("Error closing ActivityScenario: $e")
+                Timber.e(Error("Error closing ActivityScenario: $e"))
             }
         }
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
@@ -14,10 +14,10 @@ class RetryOnDeviceErrorRule : TestRule {
                     base.evaluate()
                 } catch (e: Exception) {
                     if (e is PerformException) {
-                        Timber.e("RetryOnDeviceErrorRule: Retrying due to PerformException!")
+                        Timber.e(Error("RetryOnDeviceErrorRule: Retrying due to PerformException!"))
                         base.evaluate()
                     } else if (e::class.simpleName == "RootViewWithoutFocusException") {
-                        Timber.e("RetryOnDeviceErrorRule: Retrying due to RootViewWithoutFocusException!")
+                        Timber.e(Error("RetryOnDeviceErrorRule: Retrying due to RootViewWithoutFocusException!"))
                         base.evaluate()
                     } else {
                         throw e

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/RetryOnDeviceErrorRule.kt
@@ -14,10 +14,10 @@ class RetryOnDeviceErrorRule : TestRule {
                     base.evaluate()
                 } catch (e: Exception) {
                     if (e is PerformException) {
-                        Timber.e(Error("RetryOnDeviceErrorRule: Retrying due to PerformException!"))
+                        Timber.w("RetryOnDeviceErrorRule: Retrying due to PerformException!")
                         base.evaluate()
                     } else if (e::class.simpleName == "RootViewWithoutFocusException") {
-                        Timber.e(Error("RetryOnDeviceErrorRule: Retrying due to RootViewWithoutFocusException!"))
+                        Timber.w("RetryOnDeviceErrorRule: Retrying due to RootViewWithoutFocusException!")
                         base.evaluate()
                     } else {
                         throw e

--- a/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/AppListActivity.java
@@ -157,7 +157,7 @@ abstract class AppListActivity extends CollectAbstractActivity {
             outState.putBoolean(IS_SEARCH_BOX_SHOWN, !searchView.isIconified());
             outState.putString(SEARCH_TEXT, String.valueOf(searchView.getQuery()));
         } else {
-            Timber.e("Unexpected null search view (issue #1412)");
+            Timber.e(new Error("Unexpected null search view (issue #1412)"));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormDownloadListActivity.java
@@ -462,7 +462,7 @@ public class FormDownloadListActivity extends FormListActivity implements FormLi
 
     public boolean isLocalFormSuperseded(String formId) {
         if (formId == null) {
-            Timber.e("isLocalFormSuperseded: server is not OpenRosa-compliant. <formID> is null!");
+            Timber.e(new Error("isLocalFormSuperseded: server is not OpenRosa-compliant. <formID> is null!"));
             return true;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -471,7 +471,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         formEntryViewModel.getCurrentIndex().observe(this, index -> {
             if (index != null && Collect.getInstance().getFormController() == null) {
                 // https://github.com/getodk/collect/issues/5241
-                Timber.e("getCurrentIndex() firing with null getFormController(). The one stored in formEntryViewModel is %s", (formEntryViewModel.isFormControllerSet() ? "not null" : "null"));
+                Timber.e(new Error("getCurrentIndex() firing with null getFormController(). The one stored in formEntryViewModel is " + (formEntryViewModel.isFormControllerSet() ? "not null" : "null")));
                 createErrorDialog("getFormController() is null, please email support@getodk.org with a description of what you were doing when this happened.", true);
             } else {
                 formIndexAnimationHandler.handle(index);
@@ -741,7 +741,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
 
         } else {
-            Timber.e("Couldn't access cache directory when looking for save points!");
+            Timber.e(new Error("Couldn't access cache directory when looking for save points!"));
         }
 
         return null;
@@ -772,7 +772,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
             }
         } catch (Exception e) {
-            Timber.e("Could not schedule SavePointTask. Perhaps a lot of swiping is taking place?");
+            Timber.e(new Error("Could not schedule SavePointTask. Perhaps a lot of swiping is taking place?"));
         }
     }
 
@@ -821,7 +821,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     && formLoaderTask.getStatus() != AsyncTask.Status.FINISHED) {
                 formLoaderTask.setActivityResult(requestCode, resultCode, intent);
             } else {
-                Timber.e("Got an activityResult without any pending form loader");
+                Timber.e(new Error("Got an activityResult without any pending form loader"));
             }
             return;
         }
@@ -935,7 +935,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
             }
         } else {
-            Timber.e("currentView returned null.");
+            Timber.e(new Error("currentView returned null."));
         }
         return null;
     }
@@ -976,7 +976,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
 
             if (!set) {
-                Timber.e("Attempting to return data to a widget or set of widgets not looking for data");
+                Timber.e(new Error("Attempting to return data to a widget or set of widgets not looking for data"));
             }
         }
     }
@@ -1183,7 +1183,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 return new EmptyView(this);
 
             default:
-                Timber.e("Attempted to create a view that does not exist.");
+                Timber.e(new Error("Attempted to create a view that does not exist."));
                 // this is badness to avoid a crash.
                 try {
                     event = formController.stepToNextScreenEvent();
@@ -1946,7 +1946,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         FormController formController = getFormController();
 
         if (formController != null && !formEntryViewModel.isFormControllerSet()) {
-            Timber.e("FormController set in App but not ViewModel");
+            Timber.e(new Error("FormController set in App but not ViewModel"));
         }
 
         if (formLoaderTask != null) {
@@ -2071,7 +2071,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         } else if (outAnimation == animation) {
             animationCompletionSet |= 2;
         } else {
-            Timber.e("Unexpected animation");
+            Timber.e(new Error("Unexpected animation"));
         }
 
         if (animationCompletionSet == 3) {
@@ -2254,7 +2254,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 }
             }
         } else {
-            Timber.e("FormController is null");
+            Timber.e(new Error("FormController is null"));
             showLongToast(this, R.string.loading_form_failed);
             finish();
         }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -153,7 +153,7 @@ public class InstanceUploaderActivity extends CollectAbstractActivity implements
         instancesToSend = ArrayUtils.toObject(selectedInstanceIDs);
 
         if (instancesToSend.length == 0) {
-            Timber.e("onCreate: No instances to upload!");
+            Timber.e(new Error("onCreate: No instances to upload!"));
             // drop through -- everything will process through OK
         } else {
             Timber.i("onCreate: Beginning upload of %d instances!", instancesToSend.length);

--- a/collect_app/src/main/java/org/odk/collect/android/application/initialization/CrashReportingTree.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/initialization/CrashReportingTree.kt
@@ -10,7 +10,7 @@ internal class CrashReportingTree(private val analytics: Analytics) : Timber.Tre
         when (priority) {
             Log.WARN -> analytics.logMessage("W/$tag: $message")
 
-            Log.ERROR -> analytics.logNonFatal(t ?: Throwable("E/$tag: $message"))
+            Log.ERROR -> analytics.logNonFatal(t ?: Error("E/$tag: $message"))
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/CachingQRCodeGenerator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/CachingQRCodeGenerator.java
@@ -36,7 +36,7 @@ public class CachingQRCodeGenerator implements QRCodeGenerator {
         File writeDir = new File(new StoragePathProvider().getOdkDirPath(StorageSubdirectory.SETTINGS));
         if (!writeDir.exists()) {
             if (!writeDir.mkdirs()) {
-                Timber.e("Error creating directory %s", writeDir.getAbsolutePath());
+                Timber.e(new Error("Error creating directory " + writeDir.getAbsolutePath()));
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/draw/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/draw/DrawActivity.java
@@ -255,7 +255,7 @@ public class DrawActivity extends CollectAbstractActivity {
             // apparently on 4.x, the orientation change notification can occur
             // sometime before the view is rendered. In that case, the view
             // dimensions will not be known.
-            Timber.e("View has zero width or zero height");
+            Timber.e(new Error("View has zero width or zero height"));
         } else {
             FileOutputStream fos;
             fos = new FileOutputStream(f);

--- a/collect_app/src/main/java/org/odk/collect/android/externaldata/ExternalDataManagerImpl.java
+++ b/collect_app/src/main/java/org/odk/collect/android/externaldata/ExternalDataManagerImpl.java
@@ -51,7 +51,7 @@ public class ExternalDataManagerImpl implements ExternalDataManager {
         if (sqLiteOpenHelper == null) {
             if (mediaFolder == null) {
                 String msg = getLocalizedString(Collect.getInstance(), R.string.ext_not_initialized_error);
-                Timber.e(msg);
+                Timber.e(new Error(msg));
                 if (required) {
                     throw new ExternalDataException(msg);
                 } else {

--- a/collect_app/src/main/java/org/odk/collect/android/externaldata/ExternalDataReaderImpl.java
+++ b/collect_app/src/main/java/org/odk/collect/android/externaldata/ExternalDataReaderImpl.java
@@ -64,8 +64,7 @@ public class ExternalDataReaderImpl implements ExternalDataReader {
             if (ExternalSQLiteOpenHelper.shouldUpdateDBforDataSet(dbFile, dataSetFile)) {
                 boolean deleted = dbFile.delete();
                 if (!deleted) {
-                    Timber.e("%s has changed but we could not delete the previous DB at %s",
-                            dataSetFile.getName(), dbFile.getAbsolutePath());
+                    Timber.e(new Error(dataSetFile.getName() + " has changed but we could not delete the previous DB at " + dbFile.getAbsolutePath()));
                     return true;
                 }
             } else {

--- a/collect_app/src/main/java/org/odk/collect/android/externaldata/ExternalSQLiteOpenHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/externaldata/ExternalSQLiteOpenHelper.java
@@ -91,7 +91,7 @@ public class ExternalSQLiteOpenHelper extends SQLiteOpenHelper {
             // this means that the function handler needed the database through calling
             // getReadableDatabase() --> getWritableDatabase(),
             // but this is not allowed, so just return;
-            Timber.e("The function handler triggered this external data population. This is not good.");
+            Timber.e(new Error("The function handler triggered this external data population. This is not good."));
             return;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/externaldata/handler/ExternalDataHandlerPull.java
+++ b/collect_app/src/main/java/org/odk/collect/android/externaldata/handler/ExternalDataHandlerPull.java
@@ -70,7 +70,7 @@ public class ExternalDataHandlerPull extends ExternalDataHandlerBase {
     public Object eval(Object[] args, EvaluationContext ec) {
 
         if (args.length != 4) {
-            Timber.e("4 arguments are needed to evaluate the %s function", HANDLER_NAME);
+            Timber.e(new Error("4 arguments are needed to evaluate the " + HANDLER_NAME + " function"));
             return "";
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/externaldata/handler/ExternalDataHandlerSearch.java
+++ b/collect_app/src/main/java/org/odk/collect/android/externaldata/handler/ExternalDataHandlerSearch.java
@@ -184,7 +184,7 @@ public class ExternalDataHandlerSearch extends ExternalDataHandlerBase {
                 c = db.query(ExternalDataUtil.EXTERNAL_DATA_TABLE_NAME, sqlColumns, selection,
                         selectionArgs, null, null, ExternalDataUtil.SORT_COLUMN_NAME);
             } catch (Exception e) {
-                Timber.e(getLocalizedString(Collect.getInstance(), R.string.ext_import_csv_missing_error, dataSetName, dataSetName));
+                Timber.e(new Error(getLocalizedString(Collect.getInstance(), R.string.ext_import_csv_missing_error, dataSetName, dataSetName)));
                 c = db.query(ExternalDataUtil.EXTERNAL_DATA_TABLE_NAME, sqlColumns, selection,
                         selectionArgs, null, null, null);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventSaveTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/audit/AuditEventSaveTask.java
@@ -66,7 +66,7 @@ public class AuditEventSaveTask extends AsyncTask<AuditEvent, Void, Void> {
                 if (fw != null) {
                     fw.close();
                 } else {
-                    Timber.e("Attempt to close null FileWriter for AuditEventLogger.");
+                    Timber.e(new Error("Attempt to close null FileWriter for AuditEventLogger."));
                 }
             } catch (Exception e) {
                 Timber.e(e);
@@ -99,12 +99,12 @@ public class AuditEventSaveTask extends AsyncTask<AuditEvent, Void, Void> {
                 if (tfw != null) {
                     tfw.close();
                 } else {
-                    Timber.e("Attempt to close null FileWriter for AuditEventLogger.");
+                    Timber.e(new Error("Attempt to close null FileWriter for AuditEventLogger."));
                 }
                 if (br != null) {
                     br.close();
                 } else {
-                    Timber.e("Attempt to close null BufferedReader for AuditEventLogger.");
+                    Timber.e(new Error("Attempt to close null BufferedReader for AuditEventLogger."));
                 }
             } catch (Exception e) {
                 Timber.e(e);

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/loading/FormInstanceFileCreator.java
@@ -33,7 +33,7 @@ public class FormInstanceFileCreator {
         if (FileUtils.createFolder(instanceDir)) {
             return new File(instanceDir + File.separator + formFileName + "_" + timestamp + ".xml");
         } else {
-            Timber.e("Error creating form instance file");
+            Timber.e(new Error("Error creating form instance file"));
             return null;
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/AppListFragment.java
@@ -193,7 +193,7 @@ public abstract class AppListFragment extends ListFragment {
     private void setupBottomSheet() {
         CollectAbstractActivity activity = (CollectAbstractActivity) getActivity();
         if (activity == null) {
-            Timber.e("Activity is null");
+            Timber.e(new Error("Activity is null"));
             return;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/BlankFormListFragment.java
@@ -242,7 +242,7 @@ public class BlankFormListFragment extends FormListFragment implements DiskSyncL
             ToastUtils.showShortToast(requireContext(), getString(R.string.file_deleted_ok, String.valueOf(deletedForms)));
         } else {
             // had some failures
-            Timber.e("Failed to delete %d forms", toDeleteCount - deletedForms);
+            Timber.e(new Error("Failed to delete " + (toDeleteCount - deletedForms) + " forms"));
             ToastUtils.showLongToast(requireContext(), getString(R.string.file_deleted_error, String.valueOf(getCheckedCount()
                     - deletedForms), String.valueOf(getCheckedCount())));
         }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/Camera2VideoFragment.java
@@ -226,7 +226,7 @@ public class Camera2VideoFragment extends Fragment
                 return size;
             }
         }
-        Timber.e("Couldn't find any suitable video size");
+        Timber.e(new Error("Couldn't find any suitable video size"));
         return choices[choices.length - 1];
     }
 
@@ -257,7 +257,7 @@ public class Camera2VideoFragment extends Fragment
         if (!bigEnough.isEmpty()) {
             return Collections.min(bigEnough, new Camera2Fragment.CompareSizesByArea());
         } else {
-            Timber.e("Couldn't find any suitable preview size");
+            Timber.e(new Error("Couldn't find any suitable preview size"));
             return choices[0];
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/SavedFormListFragment.java
@@ -208,7 +208,7 @@ public class SavedFormListFragment extends InstanceListFragment implements Delet
             ToastUtils.showShortToast(requireContext(), getString(R.string.file_deleted_ok, String.valueOf(deletedInstances)));
         } else {
             // had some failures
-            Timber.e("Failed to delete %d instances", toDeleteCount - deletedInstances);
+            Timber.e(new Error("Failed to delete " + (toDeleteCount - deletedInstances) + " instances"));
             ToastUtils.showLongToast(requireContext(), getString(R.string.file_deleted_error,
                     String.valueOf(toDeleteCount - deletedInstances),
                     String.valueOf(toDeleteCount)));

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomTimePickerDialog.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/dialogs/CustomTimePickerDialog.java
@@ -102,7 +102,7 @@ public class CustomTimePickerDialog extends DialogFragment {
                 if (mode == modeSpinner) {
                     Field field = findField(TimePickerDialog.class, TimePicker.class, "mTimePicker");
                     if (field == null) {
-                        Timber.e("Reflection failed: Couldn't find field 'mTimePicker'");
+                        Timber.e(new Error("Reflection failed: Couldn't find field 'mTimePicker'"));
                         return;
                     }
 
@@ -111,7 +111,7 @@ public class CustomTimePickerDialog extends DialogFragment {
                     Field delegateField = findField(TimePicker.class, delegateClass, "mDelegate");
 
                     if (delegateField == null) {
-                        Timber.e("Reflection failed: Couldn't find field 'mDelegate'");
+                        Timber.e(new Error("Reflection failed: Couldn't find field 'mDelegate'"));
                         return;
                     }
                     Object delegate = delegateField.get(timePicker);

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
@@ -660,7 +660,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
                 }
                 if (rootId == null) {
                     if (!isCancelled()) {
-                        Timber.e("Unable to fetch drive contents");
+                        Timber.e(new Error("Unable to fetch drive contents"));
                     }
                     return null;
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
@@ -123,7 +123,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
 
         // at this point, we don't expect this to be empty...
         if (instancesToSend.length == 0) {
-            Timber.e("onCreate: No instances to upload!");
+            Timber.e(new Error("onCreate: No instances to upload!"));
             // drop through --
             // everything will process through OK
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceDiskSynchronizer.java
@@ -227,7 +227,7 @@ public class InstanceDiskSynchronizer {
 
                 SaveFormToDisk.manageFilesAfterSavingEncryptedForm(instanceXml, submissionXml);
                 if (!EncryptionUtils.deletePlaintextFiles(instanceXml, null)) {
-                    Timber.e("Error deleting plaintext files for %s", instanceXml.getAbsolutePath());
+                    Timber.e(new Error("Error deleting plaintext files for " + instanceXml.getAbsolutePath()));
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/javarosawrapper/FormController.java
@@ -219,7 +219,7 @@ public class FormController {
             case "endOfForm":
                 return FormIndex.createEndOfFormIndex();
             case "unexpected":
-                Timber.e("Unexpected string from XPath");
+                Timber.e(new Error("Unexpected string from XPath"));
                 return null;
             default:
                 FormIndex returned = null;

--- a/collect_app/src/main/java/org/odk/collect/android/listeners/SwipeHandler.java
+++ b/collect_app/src/main/java/org/odk/collect/android/listeners/SwipeHandler.java
@@ -123,14 +123,14 @@ public class SwipeHandler {
                     beenSwiped = true;
                     if (velocityX > 0) {
                         if (e1.getX() > e2.getX()) {
-                            Timber.e("showNextView VelocityX is bogus! %f > %f", e1.getX(), e2.getX());
+                            Timber.e(new Error("showNextView VelocityX is bogus! " + e1.getX() + " > " + e2.getX()));
                             onSwipe.onSwipeForward();
                         } else {
                             onSwipe.onSwipeBackward();
                         }
                     } else {
                         if (e1.getX() < e2.getX()) {
-                            Timber.e("showPreviousView VelocityX is bogus! %f < %f", e1.getX(), e2.getX());
+                            Timber.e("showPreviousView VelocityX is bogus! " + e1.getX() + " < " + e2.getX());
                             onSwipe.onSwipeBackward();
                         } else {
                             onSwipe.onSwipeForward();

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaXmlFetcher.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaXmlFetcher.java
@@ -56,7 +56,7 @@ class OpenRosaXmlFetcher {
             if (inputStreamResult.getStatusCode() != HttpURLConnection.HTTP_OK) {
                 String error = "getXML failed while accessing "
                         + urlString + " with status code: " + inputStreamResult.getStatusCode();
-                Timber.e(error);
+                Timber.e(new Error(error));
                 return new DocumentFetchResult(error, inputStreamResult.getStatusCode());
             }
 
@@ -98,7 +98,7 @@ class OpenRosaXmlFetcher {
         }
 
         if (uri.getHost() == null) {
-            Timber.e("Invalid server URL (no hostname): %s", downloadUrl);
+            Timber.e(new Error("Invalid server URL (no hostname): " + downloadUrl));
             throw new Exception("Invalid server URL (no hostname): " + downloadUrl);
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectDisplayPreferencesFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/ProjectDisplayPreferencesFragment.kt
@@ -145,8 +145,10 @@ class ProjectDisplayPreferencesFragment :
                     File(storagePathProvider.getProjectRootDirPath() + File.separator + sanitizedOldProjectName).delete()
                 } catch (e: Exception) {
                     Timber.e(
-                        FileUtils.getFilenameError(
-                            name
+                        Error(
+                            FileUtils.getFilenameError(
+                                name
+                            )
                         )
                     )
                 }
@@ -156,8 +158,10 @@ class ProjectDisplayPreferencesFragment :
                     File(storagePathProvider.getProjectRootDirPath() + File.separator + sanitizedNewProjectName).createNewFile()
                 } catch (e: Exception) {
                     Timber.e(
-                        FileUtils.getFilenameError(
-                            newValue as String
+                        Error(
+                            FileUtils.getFilenameError(
+                                newValue as String
+                            )
                         )
                     )
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/storage/StoragePathProvider.kt
@@ -28,8 +28,10 @@ class StoragePathProvider(
                 File(path + File.separator + sanitizedProjectName).createNewFile()
             } catch (e: Exception) {
                 Timber.e(
-                    FileUtils.getFilenameError(
-                        projectsRepository.get(uuid)!!.name
+                    Error(
+                        FileUtils.getFilenameError(
+                            projectsRepository.get(uuid)!!.name
+                        )
                     )
                 )
             }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteFormsTask.java
@@ -66,7 +66,7 @@ public class DeleteFormsTask extends AsyncTask<Long, Integer, Integer> {
                 successCount++;
                 publishProgress(successCount, toDeleteCount);
             } catch (Exception ex) {
-                Timber.e("Exception during delete of: %s exception: %s", param.toString(), ex.toString());
+                Timber.e(new Error("Exception during delete of: " + param.toString() + " exception: " + ex));
             }
         }
         successCount = deleted;

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/DeleteInstancesTask.java
@@ -68,7 +68,7 @@ public class DeleteInstancesTask extends AsyncTask<Long, Integer, Integer> {
                 publishProgress(successCount, toDeleteCount);
 
             } catch (Exception ex) {
-                Timber.e("Exception during delete of: %s exception: %s", param.toString(), ex.toString());
+                Timber.e(new Error("Exception during delete of: " + param.toString() + " exception: " + ex));
             }
         }
         successCount = deleted;

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -126,7 +126,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
 
         final String formPath = path[0];
         if (formPath == null) {
-            Timber.e("formPath is null");
+            Timber.e(new Error("formPath is null"));
             errorMsg = "formPath is null, please email support@getodk.org with a description of what you were doing when this happened.";
             return null;
         }
@@ -418,7 +418,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
 
         // weak check for matching forms
         if (!savedRoot.getName().equals(templateRoot.getName()) || savedRoot.getMult() != 0) {
-            Timber.e("Saved form instance does not match template form definition");
+            Timber.e(new Error("Saved form instance does not match template form definition"));
             return;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveFormToDisk.java
@@ -439,7 +439,7 @@ public class SaveFormToDisk {
                 values.put(DatabaseInstanceColumns.GEOMETRY_TYPE, (String) null);
 
                 if (!EncryptionUtils.deletePlaintextFiles(instanceXml, new File(lastSavedPath))) {
-                    Timber.e("Error deleting plaintext files for %s", instanceXml.getAbsolutePath());
+                    Timber.e(new Error("Error deleting plaintext files for " + instanceXml.getAbsolutePath()));
                 }
             }
         }
@@ -472,7 +472,7 @@ public class SaveFormToDisk {
         if (!instanceXml.delete()) {
             String msg = "Error deleting " + instanceXml.getAbsolutePath()
                     + " prior to renaming submission.xml";
-            Timber.e(msg);
+            Timber.e(new Error(msg));
             throw new IOException(msg);
         }
 
@@ -480,7 +480,7 @@ public class SaveFormToDisk {
         if (!submissionXml.renameTo(instanceXml)) {
             String msg =
                     "Error renaming submission.xml to " + instanceXml.getAbsolutePath();
-            Timber.e(msg);
+            Timber.e(new Error(msg));
             throw new IOException(msg);
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/Appearances.java
@@ -139,10 +139,10 @@ public final class Appearances {
                         }
                     }
                 } catch (Exception e) {
-                    Timber.e(EXCEPTION_PARSING_COLUMNS);
+                    Timber.e(new Error(EXCEPTION_PARSING_COLUMNS));
                 }
             } catch (Exception e) {
-                Timber.e(EXCEPTION_PARSING_COLUMNS);
+                Timber.e(new Error(EXCEPTION_PARSING_COLUMNS));
             }
         } else if (appearance.contains(COLUMNS)) {
             switch (screenUtils.getScreenSizeConfiguration()) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/EncryptionUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/EncryptionUtils.java
@@ -271,7 +271,7 @@ public class EncryptionUtils {
             Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
             if (instance == null) {
                 String msg = getLocalizedString(Collect.getInstance(), R.string.not_exactly_one_record_for_this_instance);
-                Timber.e(msg);
+                Timber.e(new Error(msg));
                 throw new EncryptionException(msg, null);
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -116,8 +116,7 @@ public final class FileUtils {
             if (errorMessage != null) {
                 try {
                     Thread.sleep(500);
-                    Timber.e("Retrying to copy the file after 500ms: %s",
-                            sourceFile.getAbsolutePath());
+                    Timber.e(new Error("Retrying to copy the file after 500ms: " + sourceFile.getAbsolutePath()));
                     errorMessage = actualCopy(sourceFile, destFile);
                 } catch (InterruptedException e) {
                     Timber.i(e);
@@ -126,7 +125,7 @@ public final class FileUtils {
             return errorMessage;
         } else {
             String msg = "Source file does not exist: " + sourceFile.getAbsolutePath();
-            Timber.e(msg);
+            Timber.e(new Error(msg));
             return msg;
         }
     }
@@ -349,7 +348,7 @@ public final class FileUtils {
      */
     public static void checkMediaPath(File mediaDir) {
         if (mediaDir.exists() && mediaDir.isFile()) {
-            Timber.e("The media folder is already there and it is a FILE!! We will need to delete it and create a folder instead");
+            Timber.e(new Error("The media folder is already there and it is a FILE!! We will need to delete it and create a folder instead"));
             boolean deleted = mediaDir.delete();
             if (!deleted) {
                 throw new RuntimeException(
@@ -508,7 +507,7 @@ public final class FileUtils {
                 success = true;
 
             } catch (Exception e) {
-                Timber.e(e.toString());
+                Timber.e(e);
                 // silently retry unless this is the last attempt,
                 // in which case we rethrow the exception.
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormDefCache.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormDefCache.java
@@ -54,7 +54,7 @@ public final class FormDefCache {
             Timber.i("Deleting no-longer-wanted temp cache file %s for form %s",
                     tempCacheFile.getName(), formDef.getTitle());
             if (!tempCacheFile.delete()) {
-                Timber.e("Unable to delete %s", tempCacheFile.getName());
+                Timber.e(new Error("Unable to delete " + tempCacheFile.getName()));
             }
         } else {
             if (tempCacheFile.renameTo(cachedFormDefFile)) {
@@ -63,8 +63,7 @@ public final class FormDefCache {
                 Timber.i("Caching %s took %.3f seconds.", formDef.getTitle(),
                         (System.currentTimeMillis() - formSaveStart) / 1000F);
             } else {
-                Timber.e("Unable to rename temporary file %s to cache file %s",
-                        tempCacheFile.toString(), cachedFormDefFile.toString());
+                Timber.e(new Error("Unable to rename temporary file " + tempCacheFile + " to cache file " + cachedFormDefFile));
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AudioWidget.java
@@ -153,10 +153,10 @@ public class AudioWidget extends QuestionWidget implements FileWidget, WidgetDat
                 updatePlayerMedia();
                 widgetValueChanged();
             } else {
-                Timber.e("NO AUDIO EXISTS at: %s", newAudio.getAbsolutePath());
+                Timber.e(new Error("NO AUDIO EXISTS at: " + newAudio.getAbsolutePath()));
             }
         } else {
-            Timber.e("AudioWidget's setBinaryData must receive a File object.");
+            Timber.e(new Error("AudioWidget's setBinaryData must receive a File object."));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseArbitraryFileWidget.java
@@ -53,10 +53,10 @@ public abstract class BaseArbitraryFileWidget extends QuestionWidget implements 
                 widgetValueChanged();
             } else {
                 answerFile = null;
-                Timber.e("Inserting Arbitrary file FAILED");
+                Timber.e(new Error("Inserting Arbitrary file FAILED"));
             }
         } else if (object != null) {
-            Timber.e("FileWidget's setBinaryData must receive a File but received: %s", object.getClass());
+            Timber.e(new Error("FileWidget's setBinaryData must receive a File but received: " + object.getClass()));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -109,10 +109,10 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
                 addCurrentImageToLayout();
                 widgetValueChanged();
             } else {
-                Timber.e("NO IMAGE EXISTS at: %s", newImage.getAbsolutePath());
+                Timber.e(new Error("NO IMAGE EXISTS at: " + newImage.getAbsolutePath()));
             }
         } else {
-            Timber.e("ImageWidget's setBinaryData must receive a File object.");
+            Timber.e(new Error("ImageWidget's setBinaryData must receive a File object."));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExAudioWidget.java
@@ -100,15 +100,15 @@ public class ExAudioWidget extends QuestionWidget implements FileWidget, WidgetD
                 updatePlayerMedia();
                 widgetValueChanged();
             } else {
-                Timber.e("Inserting Audio file FAILED");
+                Timber.e(new Error("Inserting Audio file FAILED"));
             }
         } else if (object != null) {
             if (object instanceof File) {
                 ToastUtils.showLongToast(getContext(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
-                Timber.e("ExAudioWidget's setBinaryData must receive a audio file but received: %s", FileUtils.getMimeType((File) object));
+                Timber.e(new Error("ExAudioWidget's setBinaryData must receive a audio file but received: " + FileUtils.getMimeType((File) object)));
             } else {
-                Timber.e("ExAudioWidget's setBinaryData must receive a audio file but received: %s", object.getClass());
+                Timber.e(new Error("ExAudioWidget's setBinaryData must receive a audio file but received: " + object.getClass()));
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExImageWidget.java
@@ -95,15 +95,15 @@ public class ExImageWidget extends QuestionWidget implements FileWidget, WidgetD
                 displayImage();
                 widgetValueChanged();
             } else {
-                Timber.e("Inserting Image file FAILED");
+                Timber.e(new Error("Inserting Image file FAILED"));
             }
         } else if (object != null) {
             if (object instanceof File) {
                 ToastUtils.showLongToast(getContext(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
-                Timber.e("ExImageWidget's setBinaryData must receive an image file but received: %s", FileUtils.getMimeType((File) object));
+                Timber.e(new Error("ExImageWidget's setBinaryData must receive an image file but received: " + FileUtils.getMimeType((File) object)));
             } else {
-                Timber.e("ExImageWidget's setBinaryData must receive an image file but received: %s", object.getClass());
+                Timber.e(new Error("ExImageWidget's setBinaryData must receive an image file but received: " + object.getClass()));
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ExVideoWidget.java
@@ -91,15 +91,15 @@ public class ExVideoWidget extends QuestionWidget implements FileWidget, WidgetD
                 binding.playVideoButton.setEnabled(true);
                 widgetValueChanged();
             } else {
-                Timber.e("Inserting Video file FAILED");
+                Timber.e(new Error("Inserting Video file FAILED"));
             }
         } else if (object != null) {
             if (object instanceof File) {
                 ToastUtils.showLongToast(getContext(), R.string.invalid_file_type);
                 mediaUtils.deleteMediaFile(((File) object).getAbsolutePath());
-                Timber.e("ExVideoWidget's setBinaryData must receive a video file but received: %s", FileUtils.getMimeType((File) object));
+                Timber.e(new Error("ExVideoWidget's setBinaryData must receive a video file but received: " + FileUtils.getMimeType((File) object)));
             } else {
-                Timber.e("ExVideoWidget's setBinaryData must receive a video file but received: %s", object.getClass());
+                Timber.e(new Error("ExVideoWidget's setBinaryData must receive a video file but received: " + object.getClass()));
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -304,7 +304,7 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
     @Deprecated
     protected void addQuestionLabel(View v) {
         if (v == null) {
-            Timber.e("cannot add a null view as questionMediaLayout");
+            Timber.e(new Error("cannot add a null view as questionMediaLayout"));
             return;
         }
         // default for questionmedialayout

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/StringWidget.java
@@ -184,7 +184,7 @@ public class StringWidget extends QuestionWidget {
                     answerEditText.setMinLines(rows);
                     answerEditText.setGravity(Gravity.TOP); // to write test starting at the top of the edit area
                 } catch (Exception e) {
-                    Timber.e("Unable to process the rows setting for the answerText field: %s", e.toString());
+                    Timber.e(new Error("Unable to process the rows setting for the answerText field: " + e));
                 }
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -154,10 +154,10 @@ public class VideoWidget extends QuestionWidget implements FileWidget, ButtonCli
                 widgetValueChanged();
                 playButton.setEnabled(binaryName != null);
             } else {
-                Timber.e("Inserting Video file FAILED");
+                Timber.e(new Error("Inserting Video file FAILED"));
             }
         } else {
-            Timber.e("VideoWidget's setBinaryData must receive a File or Uri object.");
+            Timber.e(new Error("VideoWidget's setBinaryData must receive a File or Uri object."));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/LabelWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/LabelWidget.java
@@ -126,7 +126,7 @@ public class LabelWidget extends QuestionWidget {
 
                         if (errorMsg != null) {
                             // errorMsg is only set when an error has occured
-                            Timber.e(errorMsg);
+                            Timber.e(new Error(errorMsg));
                             missingImage = new TextView(getContext());
                             missingImage.setText(errorMsg);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/LikertWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/LikertWidget.java
@@ -263,7 +263,7 @@ public class LikertWidget extends QuestionWidget {
                 errorMsg = getContext().getString(R.string.file_missing, imageFile);
             }
             if (errorMsg != null) {
-                Timber.e(errorMsg);
+                Timber.e(new Error(errorMsg));
             }
         } catch (InvalidReferenceException e) {
             Timber.d(e, "Invalid image reference due to %s ", e.getMessage());

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/ListMultiWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/ListMultiWidget.java
@@ -177,7 +177,7 @@ public class ListMultiWidget extends QuestionWidget implements MultiChoiceWidget
 
                         if (errorMsg != null) {
                             // errorMsg is only set when an error has occured
-                            Timber.e(errorMsg);
+                            Timber.e(new Error(errorMsg));
                             missingImage = new TextView(getContext());
                             missingImage.setText(errorMsg);
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/ListWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/ListWidget.java
@@ -166,7 +166,7 @@ public class ListWidget extends QuestionWidget implements MultiChoiceWidget, OnC
 
                         if (errorMsg != null) {
                             // errorMsg is only set when an error has occured
-                            Timber.e(errorMsg);
+                            Timber.e(new Error(errorMsg));
                             missingImage = new TextView(getContext());
                             missingImage.setText(errorMsg);
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/TileHttpServer.java
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/TileHttpServer.java
@@ -81,7 +81,7 @@ class TileHttpServer {
                 continue;  // this port is in use; try another one
             }
         }
-        Timber.e("No ports available from %d to %d", portMin, portMax);
+        Timber.e(new Error("No ports available from " + portMin + " to " + portMax));
         return null;
     }
 

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmMBTileSource.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmMBTileSource.java
@@ -112,7 +112,7 @@ class OsmMBTileSource extends BitmapTileSourceBase {
         if (cursor.getCount() != 0) {
             cursor.moveToFirst();
             value = cursor.getInt(0);
-            Timber.e("Found a minimum zoomlevel of %d", value);
+            Timber.e(new Error("Found a minimum zoomlevel of " + value));
         }
 
         cursor.close();


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've reviewed implemented changes.

#### Why is this the best possible solution? Were any other approaches considered?
After merging https://github.com/getodk/collect/pull/5252 we ended up with many different errors logged in one category https://console.firebase.google.com/u/1/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/f940b5ab1c52a2583207fb130644f9ce?time=last-seven-days&versions=v2022.3.3%20(4490)&sessionEventKey=6304C495037400011B4C6EF52F2D7CBE_1713485720918396517

The problem was that if we log `Tiber.e` with just a message we need to create `throwable` because it's required in `crashlytics.recordException` (such a `throwable` is created in [CrashReportingTree](https://github.com/getodk/collect/pull/5252/files#diff-02662bcce6ec95546375a46512665a81ad590bebe3889f99c281098797ff2e16R13) for all types of messages) and we end up with one category of nonfatals.

To solve the issue I updated all `Timber.e` wrapping messages with `Error`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
