### PR TITLE
Fixed calling methods from PermissionListener after granting/denying permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,12 @@ allprojects {
           url "${rootDir}/jcenter-local-m2"
         }
     }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            freeCompilerArgs = ['-Xjvm-default=all']
+        }
+    }
 }
 
 configurations.all {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/BackgroundAudioRecordingTest.java
@@ -176,7 +176,7 @@ public class BackgroundAudioRecordingTest {
                 .assertText(R.string.background_audio_permission_explanation)
                 .clickOK(new FormEntryPage("One Question"));
 
-        permissionsProvider.deny();
+        permissionsProvider.additionalExplanationClosed();
         new MainMenuPage().assertOnPage();
     }
 
@@ -224,12 +224,8 @@ public class BackgroundAudioRecordingTest {
             controllable = true;
         }
 
-        public void grant() {
-            InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> action.granted());
-        }
-
-        public void deny() {
-            InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> action.denied());
+        public void additionalExplanationClosed() {
+            InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> action.additionalExplanationClosed());
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -884,20 +884,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
     }
 
     private void loadFile(Uri uri) {
-        permissionsProvider.requestReadUriPermission(this, uri, getContentResolver(), new PermissionListener() {
-            @Override
-            public void granted() {
-                MaterialProgressDialogFragment progressDialog = new MaterialProgressDialogFragment();
-                progressDialog.setMessage(getString(R.string.please_wait));
-                DialogFragmentUtils.showIfNotShowing(progressDialog, TAG_PROGRESS_DIALOG_MEDIA_LOADING, getSupportFragmentManager());
+        permissionsProvider.requestReadUriPermission(this, uri, getContentResolver(), () -> {
+            MaterialProgressDialogFragment progressDialog = new MaterialProgressDialogFragment();
+            progressDialog.setMessage(getString(R.string.please_wait));
+            DialogFragmentUtils.showIfNotShowing(progressDialog, TAG_PROGRESS_DIALOG_MEDIA_LOADING, getSupportFragmentManager());
 
-                mediaLoadingFragment.beginMediaLoadingTask(uri);
-            }
-
-            @Override
-            public void denied() {
-
-            }
+            mediaLoadingFragment.beginMediaLoadingTask(uri);
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2080,7 +2080,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
 
         if (formController != null) {
             if (propertyManager.isPhoneStateRequired()) {
-                permissionsProvider.requestReadPhoneStatePermission(this, true, new PermissionListener() {
+                permissionsProvider.requestReadPhoneStatePermission(this, new PermissionListener() {
                     @Override
                     public void granted() {
                         loadForm();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -2087,7 +2087,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                     }
 
                     @Override
-                    public void denied() {
+                    public void additionalExplanationClosed() {
                         finish();
                     }
                 });

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeTabsActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeTabsActivity.kt
@@ -86,9 +86,6 @@ class QRCodeTabsActivity : LocalizedActivity() {
                     setupViewPager()
                 }
 
-                override fun denied() {
-                }
-
                 override fun additionalExplanationDialogClosed() {
                     finish()
                 }

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeTabsActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeTabsActivity.kt
@@ -87,6 +87,9 @@ class QRCodeTabsActivity : LocalizedActivity() {
                 }
 
                 override fun denied() {
+                }
+
+                override fun additionalExplanationDialogClosed() {
                     finish()
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeTabsActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/configure/qr/QRCodeTabsActivity.kt
@@ -86,7 +86,7 @@ class QRCodeTabsActivity : LocalizedActivity() {
                     setupViewPager()
                 }
 
-                override fun additionalExplanationDialogClosed() {
+                override fun additionalExplanationClosed() {
                     finish()
                 }
             }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/BackgroundAudioPermissionDialogFragment.java
@@ -71,7 +71,7 @@ public class BackgroundAudioPermissionDialogFragment extends DialogFragment {
             }
 
             @Override
-            public void denied() {
+            public void additionalExplanationClosed() {
                 activity.finish();
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/ODKView.java
@@ -542,11 +542,6 @@ public class ODKView extends SwipeHandler.View implements OnLongClickListener, W
 
                                             questionWidget.showAnswerContainer();
                                         }
-
-                                        @Override
-                                        public void denied() {
-
-                                        }
                                     });
                                 } catch (Exception | Error e) {
                                     Timber.w(e);

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
@@ -100,8 +100,6 @@ class BlankFormListActivity : LocalizedActivity(), OnFormItemClickListener {
                         }
                     )
                 }
-
-                override fun denied() = Unit
             }
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleDriveActivity.java
@@ -273,7 +273,7 @@ public class GoogleDriveActivity extends FormListActivity implements View.OnClic
             }
 
             @Override
-            public void denied() {
+            public void additionalExplanationClosed() {
                 finish();
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
@@ -179,7 +179,7 @@ public class GoogleSheetsUploaderActivity extends CollectAbstractActivity implem
             }
 
             @Override
-            public void denied() {
+            public void additionalExplanationClosed() {
                 finish();
             }
         });

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -20,7 +20,6 @@ import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.androidshared.utils.Validator;
-import org.odk.collect.permissions.PermissionListener;
 import org.odk.collect.permissions.PermissionsProvider;
 
 import javax.inject.Inject;
@@ -62,16 +61,7 @@ public class FormMetadataPreferencesFragment extends BaseProjectPreferencesFragm
         if (permissionsProvider.isReadPhoneStatePermissionGranted()) {
             phonePreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_PHONE_NUMBER));
         } else if (savedInstanceState == null) {
-            permissionsProvider.requestReadPhoneStatePermission(getActivity(), true, new PermissionListener() {
-                @Override
-                public void granted() {
-                    phonePreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_PHONE_NUMBER));
-                }
-
-                @Override
-                public void denied() {
-                }
-            });
+            permissionsProvider.requestReadPhoneStatePermission(getActivity(), true, () -> phonePreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_PHONE_NUMBER)));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragment.java
@@ -61,7 +61,7 @@ public class FormMetadataPreferencesFragment extends BaseProjectPreferencesFragm
         if (permissionsProvider.isReadPhoneStatePermissionGranted()) {
             phonePreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_PHONE_NUMBER));
         } else if (savedInstanceState == null) {
-            permissionsProvider.requestReadPhoneStatePermission(getActivity(), true, () -> phonePreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_PHONE_NUMBER)));
+            permissionsProvider.requestReadPhoneStatePermission(getActivity(), () -> phonePreference.setSummaryProvider(new PropertyManagerPropertySummaryProvider(propertyManager, PROPMGR_PHONE_NUMBER)));
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ManualProjectCreatorDialog.kt
@@ -198,10 +198,6 @@ class ManualProjectCreatorDialog :
                         )
                     }
                 }
-
-                override fun denied() {
-                    // nothing
-                }
             }
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialog.kt
@@ -111,8 +111,6 @@ class QrCodeProjectCreatorDialog :
                                 }
                             }
                         }
-
-                        override fun denied() {}
                     }
                 )
             }
@@ -152,9 +150,6 @@ class QrCodeProjectCreatorDialog :
                     if (isAdded) {
                         startScanning(savedInstanceState)
                     }
-                }
-
-                override fun denied() {
                 }
             }
         )

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/AnnotateWidget.java
@@ -35,7 +35,6 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
-import org.odk.collect.permissions.PermissionListener;
 
 import java.io.File;
 import java.util.Locale;
@@ -131,16 +130,7 @@ public class AnnotateWidget extends BaseImageWidget implements ButtonClickListen
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                getPermissionsProvider().requestCameraPermission((Activity) getContext(), new PermissionListener() {
-                    @Override
-                    public void granted() {
-                        captureImage();
-                    }
-
-                    @Override
-                    public void denied() {
-                    }
-                });
+                getPermissionsProvider().requestCameraPermission((Activity) getContext(), this::captureImage);
                 break;
             case R.id.choose_image:
                 imageCaptureHandler.chooseImage(R.string.annotate_image);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BarcodeWidget.java
@@ -36,7 +36,6 @@ import org.odk.collect.android.utilities.CameraUtils;
 import org.odk.collect.androidshared.ui.ToastUtils;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
-import org.odk.collect.permissions.PermissionListener;
 
 /**
  * Widget that allows user to scan barcodes and add them to the form.
@@ -117,21 +116,14 @@ public class BarcodeWidget extends QuestionWidget implements WidgetDataReceiver 
     }
 
     private void onButtonClick() {
-        getPermissionsProvider().requestCameraPermission((Activity) getContext(), new PermissionListener() {
-            @Override
-            public void granted() {
-                waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
+        getPermissionsProvider().requestCameraPermission((Activity) getContext(), () -> {
+            waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
 
-                IntentIntegrator intent = new IntentIntegrator((Activity) getContext())
-                        .setCaptureActivity(ScannerWithFlashlightActivity.class);
+            IntentIntegrator intent = new IntentIntegrator((Activity) getContext())
+                    .setCaptureActivity(ScannerWithFlashlightActivity.class);
 
-                setCameraIdIfNeeded(getFormEntryPrompt(), intent);
-                intent.initiateScan();
-            }
-
-            @Override
-            public void denied() {
-            }
+            setCameraIdIfNeeded(getFormEntryPrompt(), intent);
+            intent.initiateScan();
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/ImageWidget.java
@@ -34,7 +34,6 @@ import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.QuestionMediaManager;
 import org.odk.collect.android.widgets.interfaces.ButtonClickListener;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
-import org.odk.collect.permissions.PermissionListener;
 
 import java.io.File;
 import java.util.Locale;
@@ -130,16 +129,7 @@ public class ImageWidget extends BaseImageWidget implements ButtonClickListener 
     public void onButtonClick(int buttonId) {
         switch (buttonId) {
             case R.id.capture_image:
-                getPermissionsProvider().requestCameraPermission((Activity) getContext(), new PermissionListener() {
-                    @Override
-                    public void granted() {
-                        captureImage();
-                    }
-
-                    @Override
-                    public void denied() {
-                    }
-                });
+                getPermissionsProvider().requestCameraPermission((Activity) getContext(), this::captureImage);
                 break;
             case R.id.choose_image:
                 imageCaptureHandler.chooseImage(R.string.choose_image);

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/VideoWidget.java
@@ -45,7 +45,6 @@ import org.odk.collect.android.widgets.interfaces.FileWidget;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.WaitingForDataRegistry;
 import org.odk.collect.androidshared.ui.ToastUtils;
-import org.odk.collect.permissions.PermissionListener;
 import org.odk.collect.settings.keys.ProjectKeys;
 
 import java.io.File;
@@ -188,27 +187,9 @@ public class VideoWidget extends QuestionWidget implements FileWidget, ButtonCli
         switch (id) {
             case R.id.capture_video:
                 if (selfie) {
-                    getPermissionsProvider().requestCameraAndRecordAudioPermissions((Activity) getContext(), new PermissionListener() {
-                        @Override
-                        public void granted() {
-                            captureVideo();
-                        }
-
-                        @Override
-                        public void denied() {
-                        }
-                    });
+                    getPermissionsProvider().requestCameraAndRecordAudioPermissions((Activity) getContext(), this::captureVideo);
                 } else {
-                    getPermissionsProvider().requestCameraPermission((Activity) getContext(), new PermissionListener() {
-                        @Override
-                        public void granted() {
-                            captureVideo();
-                        }
-
-                        @Override
-                        public void denied() {
-                        }
-                    });
+                    getPermissionsProvider().requestCameraPermission((Activity) getContext(), this::captureVideo);
                 }
                 break;
             case R.id.choose_video:

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidget.kt
@@ -52,8 +52,6 @@ class SelectOneFromMapWidget(context: Context, questionDetails: QuestionDetails)
                             (context as FragmentActivity).supportFragmentManager
                         )
                     }
-
-                    override fun denied() = Unit
                 }
             )
         }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
@@ -78,8 +78,6 @@ class ActivityGeoDataRequester(
                         ApplicationConstants.RequestCodes.LOCATION_CAPTURE,
                     )
                 }
-
-                override fun denied() {}
             },
         )
     }
@@ -110,8 +108,6 @@ class ActivityGeoDataRequester(
                         ApplicationConstants.RequestCodes.GEOSHAPE_CAPTURE,
                     )
                 }
-
-                override fun denied() {}
             },
         )
     }
@@ -142,8 +138,6 @@ class ActivityGeoDataRequester(
                         ApplicationConstants.RequestCodes.GEOTRACE_CAPTURE,
                     )
                 }
-
-                override fun denied() {}
             },
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ExternalAppRecordingRequester.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ExternalAppRecordingRequester.kt
@@ -45,8 +45,6 @@ class ExternalAppRecordingRequester(
                         waitingForDataRegistry.cancelWaitingForData()
                     }
                 }
-
-                override fun denied() {}
             }
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequester.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/InternalRecordingRequester.java
@@ -6,7 +6,6 @@ import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
 import org.odk.collect.audiorecorder.recorder.Output;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
-import org.odk.collect.permissions.PermissionListener;
 import org.odk.collect.permissions.PermissionsProvider;
 
 public class InternalRecordingRequester implements RecordingRequester {
@@ -23,22 +22,14 @@ public class InternalRecordingRequester implements RecordingRequester {
 
     @Override
     public void requestRecording(FormEntryPrompt prompt) {
-        permissionsProvider.requestRecordAudioPermission(activity, new PermissionListener() {
-            @Override
-            public void granted() {
-                String quality = FormEntryPromptUtils.getBindAttribute(prompt, "quality");
-                if (quality != null && quality.equals("voice-only")) {
-                    audioRecorder.start(prompt.getIndex(), Output.AMR);
-                } else if (quality != null && quality.equals("low")) {
-                    audioRecorder.start(prompt.getIndex(), Output.AAC_LOW);
-                } else {
-                    audioRecorder.start(prompt.getIndex(), Output.AAC);
-                }
-            }
-
-            @Override
-            public void denied() {
-
+        permissionsProvider.requestRecordAudioPermission(activity, () -> {
+            String quality = FormEntryPromptUtils.getBindAttribute(prompt, "quality");
+            if (quality != null && quality.equals("voice-only")) {
+                audioRecorder.start(prompt.getIndex(), Output.AMR);
+            } else if (quality != null && quality.equals("low")) {
+                audioRecorder.start(prompt.getIndex(), Output.AAC_LOW);
+            } else {
+                audioRecorder.start(prompt.getIndex(), Output.AAC);
             }
         });
     }

--- a/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionsProvider.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionsProvider.kt
@@ -28,16 +28,6 @@ class FakePermissionsProvider :
         }
     }
 
-    override fun showAdditionalExplanation(
-        activity: Activity,
-        title: Int,
-        message: Int,
-        drawable: Int,
-        action: PermissionListener
-    ) {
-        action.denied()
-    }
-
     fun setPermissionGranted(permissionGranted: Boolean) {
         isPermissionGranted = permissionGranted
     }

--- a/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/preferences/screens/FormMetadataPreferencesFragmentTest.java
@@ -114,7 +114,7 @@ public class FormMetadataPreferencesFragmentTest {
         }
 
         @Override
-        public void requestReadPhoneStatePermission(Activity activity, boolean displayPermissionDeniedDialog, @NonNull PermissionListener action) {
+        public void requestReadPhoneStatePermission(Activity activity, @NonNull PermissionListener action) {
             timesRequested++;
             this.lastAction = action;
         }

--- a/permissions/build.gradle
+++ b/permissions/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation project(':androidtest')
     testImplementation project(':testshared')
     testImplementation project(':fragmentstest')
+    testImplementation project(':strings')
 
     testImplementation Dependencies.androidx_test_ext_junit
     testImplementation Dependencies.androidx_test_espresso_core

--- a/permissions/build.gradle
+++ b/permissions/build.gradle
@@ -60,4 +60,6 @@ dependencies {
     testImplementation Dependencies.androidx_test_espresso_core
     testImplementation Dependencies.androidx_test_espresso_intents
     testImplementation Dependencies.mockito_kotlin
+    testImplementation Dependencies.robolectric
+    testImplementation Dependencies.robolectric_shadows_multidex
 }

--- a/permissions/build.gradle
+++ b/permissions/build.gradle
@@ -61,5 +61,4 @@ dependencies {
     testImplementation Dependencies.androidx_test_espresso_intents
     testImplementation Dependencies.mockito_kotlin
     testImplementation Dependencies.robolectric
-    testImplementation Dependencies.robolectric_shadows_multidex
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/LocationAccessibilityChecker.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/LocationAccessibilityChecker.kt
@@ -1,0 +1,17 @@
+package org.odk.collect.permissions
+
+import android.app.Activity
+import android.content.Context
+import android.location.LocationManager
+import androidx.core.location.LocationManagerCompat
+
+internal interface LocationAccessibilityChecker {
+    fun isLocationEnabled(activity: Activity): Boolean
+}
+
+internal object LocationAccessibilityCheckerImpl : LocationAccessibilityChecker {
+    override fun isLocationEnabled(activity: Activity): Boolean {
+        val locationManager = activity.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return LocationManagerCompat.isLocationEnabled(locationManager)
+    }
+}

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionListener.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionListener.kt
@@ -10,5 +10,5 @@ package org.odk.collect.permissions
 interface PermissionListener {
     fun granted()
     fun denied() = Unit
-    fun additionalExplanationDialogClosed() = Unit
+    fun additionalExplanationClosed() = Unit
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionListener.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionListener.kt
@@ -9,6 +9,6 @@ package org.odk.collect.permissions
  */
 interface PermissionListener {
     fun granted()
-    fun denied()
+    fun denied() = Unit
     fun additionalExplanationDialogClosed() = Unit
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionListener.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionListener.kt
@@ -10,4 +10,5 @@ package org.odk.collect.permissions
 interface PermissionListener {
     fun granted()
     fun denied()
+    fun additionalExplanationDialogClosed() = Unit
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsDialogCreator.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsDialogCreator.kt
@@ -26,7 +26,6 @@ internal object PermissionsDialogCreatorImpl : PermissionsDialogCreator {
     override fun showEnableGPSDialog(
         activity: Activity,
         action: PermissionListener
-
     ) {
         MaterialAlertDialogBuilder(activity)
             .setMessage(activity.getString(R.string.gps_enable_message))
@@ -55,8 +54,6 @@ internal object PermissionsDialogCreatorImpl : PermissionsDialogCreator {
         drawable: Int,
         action: PermissionListener
     ) {
-        action.denied()
-
         MaterialAlertDialogBuilder(activity)
             .setIcon(drawable)
             .setTitle(title)

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsDialogCreator.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsDialogCreator.kt
@@ -1,0 +1,77 @@
+package org.odk.collect.permissions
+
+import android.app.Activity
+import android.content.DialogInterface
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+internal interface PermissionsDialogCreator {
+    fun showEnableGPSDialog(
+        activity: Activity,
+        action: PermissionListener
+    )
+
+    fun showAdditionalExplanation(
+        activity: Activity,
+        title: Int,
+        message: Int,
+        drawable: Int,
+        action: PermissionListener
+    )
+}
+
+internal object PermissionsDialogCreatorImpl : PermissionsDialogCreator {
+    override fun showEnableGPSDialog(
+        activity: Activity,
+        action: PermissionListener
+
+    ) {
+        MaterialAlertDialogBuilder(activity)
+            .setMessage(activity.getString(R.string.gps_enable_message))
+            .setCancelable(false)
+            .setPositiveButton(
+                activity.getString(R.string.enable_gps)
+            ) { _: DialogInterface?, _: Int ->
+                activity.startActivityForResult(
+                    Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS), 0
+                )
+            }
+            .setNegativeButton(
+                activity.getString(R.string.cancel)
+            ) { dialog: DialogInterface, _: Int ->
+                action.denied()
+                dialog.cancel()
+            }
+            .create()
+            .show()
+    }
+
+    override fun showAdditionalExplanation(
+        activity: Activity,
+        title: Int,
+        message: Int,
+        drawable: Int,
+        action: PermissionListener
+    ) {
+        action.denied()
+
+        MaterialAlertDialogBuilder(activity)
+            .setIcon(drawable)
+            .setTitle(title)
+            .setMessage(message)
+            .setCancelable(false)
+            .setPositiveButton(R.string.ok) { _, _ ->
+                action.additionalExplanationClosed()
+            }
+            .setNeutralButton(R.string.open_settings) { _, _ ->
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", activity.packageName, null)
+                    activity.startActivity(this)
+                }
+            }
+            .create()
+            .show()
+    }
+}

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -11,16 +11,6 @@ import android.net.Uri
 import android.provider.Settings
 import androidx.core.location.LocationManagerCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.karumi.dexter.Dexter
-import com.karumi.dexter.DexterBuilder
-import com.karumi.dexter.MultiplePermissionsReport
-import com.karumi.dexter.PermissionToken
-import com.karumi.dexter.listener.DexterError
-import com.karumi.dexter.listener.PermissionDeniedResponse
-import com.karumi.dexter.listener.PermissionGrantedResponse
-import com.karumi.dexter.listener.PermissionRequest
-import com.karumi.dexter.listener.multi.MultiplePermissionsListener
-import timber.log.Timber
 
 /**
  * PermissionsProvider allows all permission related messages and checks to be encapsulated in one
@@ -315,80 +305,5 @@ open class PermissionsProvider internal constructor(
     private fun isLocationEnabled(activity: Activity): Boolean {
         val locationManager = activity.getSystemService(Context.LOCATION_SERVICE) as LocationManager
         return LocationManagerCompat.isLocationEnabled(locationManager)
-    }
-}
-
-internal interface RequestPermissionsAPI {
-    fun requestPermissions(
-        activity: Activity,
-        listener: PermissionListener,
-        vararg permissions: String
-    )
-}
-
-internal object DexterRequestPermissionsAPI : RequestPermissionsAPI {
-
-    override fun requestPermissions(
-        activity: Activity,
-        listener: PermissionListener,
-        vararg permissions: String
-    ) {
-        var builder: DexterBuilder? = null
-        if (permissions.size == 1) {
-            builder = createSinglePermissionRequest(activity, permissions[0], listener)
-        } else if (permissions.size > 1) {
-            builder = createMultiplePermissionsRequest(activity, listener, *permissions)
-        }
-        builder?.withErrorListener { error: DexterError -> Timber.i(error.name) }?.check()
-    }
-
-    private fun createSinglePermissionRequest(
-        activity: Activity,
-        permission: String,
-        listener: PermissionListener
-    ): DexterBuilder {
-        return Dexter.withContext(activity)
-            .withPermission(permission)
-            .withListener(object : com.karumi.dexter.listener.single.PermissionListener {
-                override fun onPermissionGranted(response: PermissionGrantedResponse) {
-                    listener.granted()
-                }
-
-                override fun onPermissionDenied(response: PermissionDeniedResponse) {
-                    listener.denied()
-                }
-
-                override fun onPermissionRationaleShouldBeShown(
-                    permission: PermissionRequest,
-                    token: PermissionToken
-                ) {
-                    token.continuePermissionRequest()
-                }
-            })
-    }
-
-    private fun createMultiplePermissionsRequest(
-        activity: Activity,
-        listener: PermissionListener,
-        vararg permissions: String
-    ): DexterBuilder {
-        return Dexter.withContext(activity)
-            .withPermissions(*permissions)
-            .withListener(object : MultiplePermissionsListener {
-                override fun onPermissionsChecked(report: MultiplePermissionsReport) {
-                    if (report.areAllPermissionsGranted()) {
-                        listener.granted()
-                    } else {
-                        listener.denied()
-                    }
-                }
-
-                override fun onPermissionRationaleShouldBeShown(
-                    permissions: List<PermissionRequest>,
-                    token: PermissionToken
-                ) {
-                    token.continuePermissionRequest()
-                }
-            })
     }
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -59,6 +59,8 @@ open class PermissionsProvider internal constructor(
                 }
 
                 override fun denied() {
+                    action.denied()
+
                     permissionsDialogCreator.showAdditionalExplanation(
                         activity,
                         R.string.camera_runtime_permission_denied_title,
@@ -90,6 +92,8 @@ open class PermissionsProvider internal constructor(
                 }
 
                 override fun denied() {
+                    action.denied()
+
                     permissionsDialogCreator.showAdditionalExplanation(
                         activity,
                         R.string.location_runtime_permissions_denied_title,
@@ -112,6 +116,8 @@ open class PermissionsProvider internal constructor(
                 }
 
                 override fun denied() {
+                    action.denied()
+
                     permissionsDialogCreator.showAdditionalExplanation(
                         activity,
                         R.string.record_audio_runtime_permission_denied_title,
@@ -134,6 +140,8 @@ open class PermissionsProvider internal constructor(
                 }
 
                 override fun denied() {
+                    action.denied()
+
                     permissionsDialogCreator.showAdditionalExplanation(
                         activity,
                         R.string.camera_runtime_permission_denied_title,
@@ -156,6 +164,8 @@ open class PermissionsProvider internal constructor(
                 }
 
                 override fun denied() {
+                    action.denied()
+
                     permissionsDialogCreator.showAdditionalExplanation(
                         activity,
                         R.string.get_accounts_runtime_permission_denied_title,
@@ -171,7 +181,6 @@ open class PermissionsProvider internal constructor(
 
     open fun requestReadPhoneStatePermission(
         activity: Activity,
-        displayPermissionDeniedDialog: Boolean,
         action: PermissionListener
     ) {
         requestPermissions(
@@ -182,17 +191,15 @@ open class PermissionsProvider internal constructor(
                 }
 
                 override fun denied() {
-                    if (displayPermissionDeniedDialog) {
-                        permissionsDialogCreator.showAdditionalExplanation(
-                            activity,
-                            R.string.read_phone_state_runtime_permission_denied_title,
-                            R.string.read_phone_state_runtime_permission_denied_desc,
-                            R.drawable.ic_phone,
-                            action
-                        )
-                    } else {
-                        action.denied()
-                    }
+                    action.denied()
+
+                    permissionsDialogCreator.showAdditionalExplanation(
+                        activity,
+                        R.string.read_phone_state_runtime_permission_denied_title,
+                        R.string.read_phone_state_runtime_permission_denied_desc,
+                        R.drawable.ic_phone,
+                        action
+                    )
                 }
             },
             Manifest.permission.READ_PHONE_STATE

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -3,10 +3,7 @@ package org.odk.collect.permissions
 import android.Manifest
 import android.app.Activity
 import android.content.ContentResolver
-import android.content.Context
-import android.location.LocationManager
 import android.net.Uri
-import androidx.core.location.LocationManagerCompat
 
 /**
  * PermissionsProvider allows all permission related messages and checks to be encapsulated in one
@@ -16,7 +13,8 @@ import androidx.core.location.LocationManagerCompat
 open class PermissionsProvider internal constructor(
     private val permissionsChecker: PermissionsChecker,
     private val requestPermissionsApi: RequestPermissionsAPI,
-    private val permissionsDialogCreator: PermissionsDialogCreator
+    private val permissionsDialogCreator: PermissionsDialogCreator,
+    private val locationAccessibilityChecker: LocationAccessibilityChecker
 ) {
 
     /**
@@ -25,7 +23,8 @@ open class PermissionsProvider internal constructor(
     constructor(permissionsChecker: PermissionsChecker) : this(
         permissionsChecker,
         DexterRequestPermissionsAPI,
-        PermissionsDialogCreatorImpl
+        PermissionsDialogCreatorImpl,
+        LocationAccessibilityCheckerImpl
     )
 
     val isCameraPermissionGranted: Boolean
@@ -83,7 +82,7 @@ open class PermissionsProvider internal constructor(
             activity,
             object : PermissionListener {
                 override fun granted() {
-                    if (isLocationEnabled(activity)) {
+                    if (locationAccessibilityChecker.isLocationEnabled(activity)) {
                         action.granted()
                     } else {
                         permissionsDialogCreator.showEnableGPSDialog(activity, action)
@@ -254,10 +253,5 @@ open class PermissionsProvider internal constructor(
         } catch (e: Error) {
             listener.denied()
         }
-    }
-
-    private fun isLocationEnabled(activity: Activity): Boolean {
-        val locationManager = activity.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-        return LocationManagerCompat.isLocationEnabled(locationManager)
     }
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -266,7 +266,7 @@ open class PermissionsProvider internal constructor(
             .setMessage(message)
             .setCancelable(false)
             .setPositiveButton(R.string.ok) { _, _ ->
-                action.additionalExplanationDialogClosed()
+                action.additionalExplanationClosed()
             }
             .setNeutralButton(R.string.open_settings) { _, _ ->
                 Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -258,13 +258,15 @@ open class PermissionsProvider internal constructor(
         drawable: Int,
         action: PermissionListener
     ) {
+        action.denied()
+
         MaterialAlertDialogBuilder(activity)
             .setIcon(drawable)
             .setTitle(title)
             .setMessage(message)
             .setCancelable(false)
             .setPositiveButton(R.string.ok) { _, _ ->
-                action.denied()
+                action.additionalExplanationDialogClosed()
             }
             .setNeutralButton(R.string.open_settings) { _, _ ->
                 Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {

--- a/permissions/src/main/java/org/odk/collect/permissions/RequestPermissionsAPI.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/RequestPermissionsAPI.kt
@@ -1,0 +1,88 @@
+package org.odk.collect.permissions
+
+import android.app.Activity
+import com.karumi.dexter.Dexter
+import com.karumi.dexter.DexterBuilder
+import com.karumi.dexter.MultiplePermissionsReport
+import com.karumi.dexter.PermissionToken
+import com.karumi.dexter.listener.DexterError
+import com.karumi.dexter.listener.PermissionDeniedResponse
+import com.karumi.dexter.listener.PermissionGrantedResponse
+import com.karumi.dexter.listener.PermissionRequest
+import com.karumi.dexter.listener.multi.MultiplePermissionsListener
+import timber.log.Timber
+
+internal interface RequestPermissionsAPI {
+    fun requestPermissions(
+        activity: Activity,
+        listener: PermissionListener,
+        vararg permissions: String
+    )
+}
+
+internal object DexterRequestPermissionsAPI : RequestPermissionsAPI {
+
+    override fun requestPermissions(
+        activity: Activity,
+        listener: PermissionListener,
+        vararg permissions: String
+    ) {
+        var builder: DexterBuilder? = null
+        if (permissions.size == 1) {
+            builder = createSinglePermissionRequest(activity, permissions[0], listener)
+        } else if (permissions.size > 1) {
+            builder = createMultiplePermissionsRequest(activity, listener, *permissions)
+        }
+        builder?.withErrorListener { error: DexterError -> Timber.i(error.name) }?.check()
+    }
+
+    private fun createSinglePermissionRequest(
+        activity: Activity,
+        permission: String,
+        listener: PermissionListener
+    ): DexterBuilder {
+        return Dexter.withContext(activity)
+            .withPermission(permission)
+            .withListener(object : com.karumi.dexter.listener.single.PermissionListener {
+                override fun onPermissionGranted(response: PermissionGrantedResponse) {
+                    listener.granted()
+                }
+
+                override fun onPermissionDenied(response: PermissionDeniedResponse) {
+                    listener.denied()
+                }
+
+                override fun onPermissionRationaleShouldBeShown(
+                    permission: PermissionRequest,
+                    token: PermissionToken
+                ) {
+                    token.continuePermissionRequest()
+                }
+            })
+    }
+
+    private fun createMultiplePermissionsRequest(
+        activity: Activity,
+        listener: PermissionListener,
+        vararg permissions: String
+    ): DexterBuilder {
+        return Dexter.withContext(activity)
+            .withPermissions(*permissions)
+            .withListener(object : MultiplePermissionsListener {
+                override fun onPermissionsChecked(report: MultiplePermissionsReport) {
+                    if (report.areAllPermissionsGranted()) {
+                        listener.granted()
+                    } else {
+                        listener.denied()
+                    }
+                }
+
+                override fun onPermissionRationaleShouldBeShown(
+                    permissions: List<PermissionRequest>,
+                    token: PermissionToken
+                ) {
+                    token.continuePermissionRequest()
+                }
+            })
+    }
+}

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsDialogCreatorTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsDialogCreatorTest.kt
@@ -1,0 +1,142 @@
+package org.odk.collect.permissions
+
+import android.app.Activity
+import android.content.DialogInterface
+import android.net.Uri
+import android.provider.Settings
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.FragmentActivity
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.odk.collect.androidtest.RecordedIntentsRule
+import org.odk.collect.testshared.RobolectricHelpers
+import org.odk.collect.testshared.RobolectricHelpers.createThemedActivity
+import org.robolectric.shadows.ShadowDialog
+
+@RunWith(AndroidJUnit4::class)
+class PermissionsDialogCreatorTest {
+    private lateinit var activity: Activity
+    private val permissionListener = mock<PermissionListener>()
+
+    @get:Rule
+    val recordedIntentsRule = RecordedIntentsRule()
+
+    @Before
+    fun setup() {
+        activity = createThemedActivity(FragmentActivity::class.java, R.style.Theme_MaterialComponents)
+    }
+
+    @Test
+    fun `PermissionListener should not be called immediatelly after displaying enable gps dialog`() {
+        PermissionsDialogCreatorImpl.showEnableGPSDialog(
+            activity,
+            permissionListener
+        )
+
+        verifyNoInteractions(permissionListener)
+    }
+
+    @Test
+    fun `Settings should be open after clicking on the positive button in enable gps dialog`() {
+        PermissionsDialogCreatorImpl.showEnableGPSDialog(
+            activity,
+            permissionListener
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick()
+        RobolectricHelpers.runLooper()
+
+        Intents.intended(IntentMatchers.hasAction(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
+    }
+
+    @Test
+    fun `PermissionListener#denied should be called after clicking on the negative button in enable gps dialog`() {
+        PermissionsDialogCreatorImpl.showEnableGPSDialog(
+            activity,
+            permissionListener
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick()
+        RobolectricHelpers.runLooper()
+
+        verify(permissionListener).denied()
+        verifyNoMoreInteractions(permissionListener)
+    }
+
+    @Test
+    fun `PermissionListener should not be called immediatelly after displaying explanation dialog`() {
+        PermissionsDialogCreatorImpl.showAdditionalExplanation(
+            activity,
+            R.string.camera_runtime_permission_denied_title,
+            R.string.camera_runtime_permission_denied_desc,
+            R.drawable.ic_photo_camera,
+            permissionListener
+        )
+
+        verifyNoInteractions(permissionListener)
+    }
+
+    @Test
+    fun `PermissionListener#additionalExplanationClosed should be called after clicking on the positive button in explanation dialog`() {
+        PermissionsDialogCreatorImpl.showAdditionalExplanation(
+            activity,
+            R.string.camera_runtime_permission_denied_title,
+            R.string.camera_runtime_permission_denied_desc,
+            R.drawable.ic_photo_camera,
+            permissionListener
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick()
+        RobolectricHelpers.runLooper()
+
+        verify(permissionListener).additionalExplanationClosed()
+        verifyNoMoreInteractions(permissionListener)
+    }
+
+    @Test
+    fun `PermissionListener#additionalExplanationClosed should not be called after clicking on the neutral button in explanation dialog`() {
+        PermissionsDialogCreatorImpl.showAdditionalExplanation(
+            activity,
+            R.string.camera_runtime_permission_denied_title,
+            R.string.camera_runtime_permission_denied_desc,
+            R.drawable.ic_photo_camera,
+            permissionListener
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
+        RobolectricHelpers.runLooper()
+
+        verifyNoInteractions(permissionListener)
+    }
+
+    @Test
+    fun `Settings should be open after clicking on the neutral button in explanation dialog`() {
+        PermissionsDialogCreatorImpl.showAdditionalExplanation(
+            activity,
+            R.string.camera_runtime_permission_denied_title,
+            R.string.camera_runtime_permission_denied_desc,
+            R.drawable.ic_photo_camera,
+            permissionListener
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
+        RobolectricHelpers.runLooper()
+
+        Intents.intended(IntentMatchers.hasAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS))
+        Intents.intended(IntentMatchers.hasData(Uri.fromParts("package", activity.packageName, null)))
+    }
+}

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsDialogCreatorTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsDialogCreatorTest.kt
@@ -106,23 +106,6 @@ class PermissionsDialogCreatorTest {
     }
 
     @Test
-    fun `PermissionListener#additionalExplanationClosed should not be called after clicking on the neutral button in explanation dialog`() {
-        PermissionsDialogCreatorImpl.showAdditionalExplanation(
-            activity,
-            R.string.camera_runtime_permission_denied_title,
-            R.string.camera_runtime_permission_denied_desc,
-            R.drawable.ic_photo_camera,
-            permissionListener
-        )
-
-        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
-        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
-        RobolectricHelpers.runLooper()
-
-        verifyNoInteractions(permissionListener)
-    }
-
-    @Test
     fun `Settings should be open after clicking on the neutral button in explanation dialog`() {
         PermissionsDialogCreatorImpl.showAdditionalExplanation(
             activity,
@@ -138,5 +121,7 @@ class PermissionsDialogCreatorTest {
 
         Intents.intended(IntentMatchers.hasAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS))
         Intents.intended(IntentMatchers.hasData(Uri.fromParts("package", activity.packageName, null)))
+
+        verifyNoInteractions(permissionListener)
     }
 }

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
@@ -34,21 +34,21 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When camera permission granted should isCameraPermissionGranted return true`() {
+    fun `isCameraPermissionGranted() when camera permission is granted returns true`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA)).thenReturn(true)
 
         assertThat(permissionsProvider.isCameraPermissionGranted, `is`(true))
     }
 
     @Test
-    fun `When camera permission is not granted should isCameraPermissionGranted return false`() {
+    fun `isCameraPermissionGranted() when camera permission is not granted returns false`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA)).thenReturn(false)
 
         assertThat(permissionsProvider.isCameraPermissionGranted, `is`(false))
     }
 
     @Test
-    fun `When camera permission is granted should requestCameraPermission call PermissionListener#granted`() {
+    fun `requestCameraPermission when camera permission is granted calls PermissionListener#granted`() {
         permissionsApi.setGrantedPermission(Manifest.permission.CAMERA)
 
         permissionsProvider.requestCameraPermission(activity, permissionListener)
@@ -59,7 +59,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When camera permission is not granted should requestCameraPermission call PermissionListener#denied`() {
+    fun `requestCameraPermission() when camera permission is not granted calls PermissionListener#denied`() {
         permissionsProvider.requestCameraPermission(activity, permissionListener)
 
         verify(permissionListener).denied()
@@ -67,7 +67,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When camera permission is not granted should requestCameraPermission call PermissionsDialogCreator#showAdditionalExplanation`() {
+    fun `requestCameraPermission() when camera permission is not granted calls PermissionsDialogCreator#showAdditionalExplanation`() {
         permissionsProvider.requestCameraPermission(activity, permissionListener)
 
         verify(permissionsDialogCreator).showAdditionalExplanation(
@@ -81,21 +81,21 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When location permission granted should areLocationPermissionsGranted return true`() {
+    fun `areLocationPermissionsGranted() when location permission is granted returns true`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)).thenReturn(true)
 
         assertThat(permissionsProvider.areLocationPermissionsGranted(), `is`(true))
     }
 
     @Test
-    fun `When location permission is not granted should areLocationPermissionsGranted return false`() {
+    fun `areLocationPermissionsGranted() when location permission is not granted returns false`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)).thenReturn(false)
 
         assertThat(permissionsProvider.areLocationPermissionsGranted(), `is`(false))
     }
 
     @Test
-    fun `When location permission is granted and location is enabled in settings should requestEnabledLocationPermissions call PermissionListener#granted`() {
+    fun `requestEnabledLocationPermissions() when location permission is granted and location is enabled in settings calls PermissionListener#granted`() {
         whenever(locationAccessibilityChecker.isLocationEnabled(activity)).thenReturn(true)
         permissionsApi.setGrantedPermission(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
 
@@ -107,7 +107,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When location permission is granted and location is disabled in settings should requestEnabledLocationPermissions call PermissionsDialogCreator#showEnableGPSDialog`() {
+    fun `requestEnabledLocationPermissions() when location permission is granted and location is disabled in settings calls PermissionsDialogCreator#showEnableGPSDialog`() {
         whenever(locationAccessibilityChecker.isLocationEnabled(activity)).thenReturn(false)
         permissionsApi.setGrantedPermission(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
 
@@ -118,7 +118,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When location permission is not granted should requestEnabledLocationPermissions call PermissionListener#denied`() {
+    fun `requestEnabledLocationPermissions() wen location permission is not granted calls PermissionListener#denied`() {
         permissionsProvider.requestEnabledLocationPermissions(activity, permissionListener)
 
         verify(permissionListener).denied()
@@ -126,7 +126,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When location permission is not granted should requestEnabledLocationPermissions call PermissionsDialogCreator#showAdditionalExplanation`() {
+    fun `requestEnabledLocationPermissions() when location permission is not granted calls PermissionsDialogCreator#showAdditionalExplanation`() {
         permissionsProvider.requestEnabledLocationPermissions(activity, permissionListener)
 
         verify(permissionsDialogCreator).showAdditionalExplanation(
@@ -141,7 +141,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When audio permission is granted should requestRecordAudioPermission call PermissionListener#granted`() {
+    fun `requestRecordAudioPermission() when audio permission is granted calls PermissionListener#granted`() {
         permissionsApi.setGrantedPermission(Manifest.permission.RECORD_AUDIO)
 
         permissionsProvider.requestRecordAudioPermission(activity, permissionListener)
@@ -152,7 +152,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When audio permission is not granted should requestRecordAudioPermission call PermissionListener#denied`() {
+    fun `requestRecordAudioPermission() when audio permission is not granted calls PermissionListener#denied`() {
         permissionsProvider.requestRecordAudioPermission(activity, permissionListener)
 
         verify(permissionListener).denied()
@@ -160,7 +160,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When audio permission is not granted should requestRecordAudioPermission call PermissionsDialogCreator#showAdditionalExplanation`() {
+    fun `requestRecordAudioPermission() when audio permission is not granted calls PermissionsDialogCreator#showAdditionalExplanation`() {
         permissionsProvider.requestRecordAudioPermission(activity, permissionListener)
 
         verify(permissionsDialogCreator).showAdditionalExplanation(
@@ -175,21 +175,21 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When camera and audio permission is granted should areCameraAndRecordAudioPermissionsGranted() return true`() {
+    fun `areCameraAndRecordAudioPermissionsGranted() when camera and audio permission is granted returns true`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)).thenReturn(true)
 
         assertThat(permissionsProvider.areCameraAndRecordAudioPermissionsGranted(), `is`(true))
     }
 
     @Test
-    fun `When camera and audio permission is not granted should areCameraAndRecordAudioPermissionsGranted() return false`() {
+    fun `areCameraAndRecordAudioPermissionsGranted() when camera and audio permission is not granted returns false`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)).thenReturn(false)
 
         assertThat(permissionsProvider.areCameraAndRecordAudioPermissionsGranted(), `is`(false))
     }
 
     @Test
-    fun `When camera and audio permission is granted should requestCameraAndRecordAudioPermissions call PermissionListener#granted`() {
+    fun `requestCameraAndRecordAudioPermissions() when camera and audio permission is granted calls PermissionListener#granted`() {
         permissionsApi.setGrantedPermission(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
 
         permissionsProvider.requestCameraAndRecordAudioPermissions(activity, permissionListener)
@@ -200,7 +200,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When camera and audio permission is not granted should requestCameraAndRecordAudioPermissions call PermissionListener#denied`() {
+    fun `requestCameraAndRecordAudioPermissions() when camera and audio permission is not granted calls PermissionListener#denied`() {
         permissionsProvider.requestCameraAndRecordAudioPermissions(activity, permissionListener)
 
         verify(permissionListener).denied()
@@ -208,7 +208,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When camera and audio permission is not granted should requestCameraAndRecordAudioPermissions call PermissionsDialogCreator#showAdditionalExplanation`() {
+    fun `requestCameraAndRecordAudioPermissions() when camera and audio permission is not granted calls PermissionsDialogCreator#showAdditionalExplanation`() {
         permissionsProvider.requestCameraAndRecordAudioPermissions(activity, permissionListener)
 
         verify(permissionsDialogCreator).showAdditionalExplanation(
@@ -222,21 +222,21 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When get accounts permission is granted should isGetAccountsPermissionGranted() return true`() {
+    fun `isGetAccountsPermissionGranted() when get accounts permission is granted returns true`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.GET_ACCOUNTS)).thenReturn(true)
 
         assertThat(permissionsProvider.isGetAccountsPermissionGranted, `is`(true))
     }
 
     @Test
-    fun `When get accounts permission is not granted should isGetAccountsPermissionGranted() return false`() {
+    fun `isGetAccountsPermissionGranted() when get accounts permission is not granted returns false`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.GET_ACCOUNTS)).thenReturn(false)
 
         assertThat(permissionsProvider.isGetAccountsPermissionGranted, `is`(false))
     }
 
     @Test
-    fun `When get accounts permission is granted should requestGetAccountsPermission call PermissionListener#granted`() {
+    fun `requestGetAccountsPermission() when get accounts permission is granted calls PermissionListener#granted`() {
         permissionsApi.setGrantedPermission(Manifest.permission.GET_ACCOUNTS)
 
         permissionsProvider.requestGetAccountsPermission(activity, permissionListener)
@@ -247,7 +247,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When get accounts permission is denied should requestGetAccountsPermission call PermissionListener#denied`() {
+    fun `requestGetAccountsPermission() when get accounts permission is denied calls PermissionListener#denied`() {
         permissionsProvider.requestGetAccountsPermission(activity, permissionListener)
 
         verify(permissionListener).denied()
@@ -255,7 +255,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When get accounts permission is denied should requestGetAccountsPermission call PermissionsDialogCreator#showAdditionalExplanation`() {
+    fun `requestGetAccountsPermission() when get accounts permission is denied calls PermissionsDialogCreator#showAdditionalExplanation`() {
         permissionsProvider.requestGetAccountsPermission(activity, permissionListener)
 
         verify(permissionsDialogCreator).showAdditionalExplanation(
@@ -269,21 +269,21 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When read phone state permission is granted should isReadPhoneStatePermissionGranted() return true`() {
+    fun `isReadPhoneStatePermissionGranted() when read phone state permission is granted returns true`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_STATE)).thenReturn(true)
 
         assertThat(permissionsProvider.isReadPhoneStatePermissionGranted, `is`(true))
     }
 
     @Test
-    fun `When read phone state permission is not granted should isReadPhoneStatePermissionGranted() return false`() {
+    fun `isReadPhoneStatePermissionGranted() when read phone state permission is not granted returns false`() {
         whenever(permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_STATE)).thenReturn(false)
 
         assertThat(permissionsProvider.isReadPhoneStatePermissionGranted, `is`(false))
     }
 
     @Test
-    fun `When read phone state permission is granted should requestReadPhoneStatePermission call PermissionListener#granted`() {
+    fun `requestReadPhoneStatePermission() when read phone state permission is granted calls PermissionListener#granted`() {
         permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_STATE)
 
         permissionsProvider.requestReadPhoneStatePermission(activity, permissionListener)
@@ -294,7 +294,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When read phone state permission is not granted should requestReadPhoneStatePermission call PermissionListener#denied`() {
+    fun `requestReadPhoneStatePermission() when read phone state permission is not granted calls PermissionListener#denied`() {
         permissionsProvider.requestReadPhoneStatePermission(activity, permissionListener)
 
         verify(permissionListener).denied()
@@ -302,7 +302,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When read phone state permission is not granted should requestReadPhoneStatePermission call PermissionsDialogCreator#showAdditionalExplanation`() {
+    fun `requestReadPhoneStatePermission() when read phone state permission is not granted calls PermissionsDialogCreator#showAdditionalExplanation`() {
         permissionsProvider.requestReadPhoneStatePermission(activity, permissionListener)
 
         verify(permissionsDialogCreator).showAdditionalExplanation(
@@ -316,7 +316,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When request read uri permission granted should granted be called`() {
+    fun `requestReadUriPermission() when request read uri permission granted calls PermissionListener#granted`() {
         permissionsProvider.requestReadUriPermission(
             activity,
             uri,
@@ -327,7 +327,7 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `When request read uri permission throws any exception should denied be called`() {
+    fun `requestReadUriPermission() when throws any exception calls PermissionListener#granted#denied`() {
         whenever(contentResolver.query(uri, null, null, null, null)).thenThrow(
             RuntimeException::class.java
         )

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
@@ -29,12 +29,13 @@ class PermissionsProviderTest {
         }
     }
     private val permissionsDialogCreator = mock<PermissionsDialogCreator>()
+    private val locationAccessibilityChecker = mock<LocationAccessibilityChecker>()
 
     private lateinit var permissionsProvider: PermissionsProvider
 
     @Before
     fun setup() {
-        permissionsProvider = PermissionsProvider(permissionsChecker, permissionsApi, permissionsDialogCreator)
+        permissionsProvider = PermissionsProvider(permissionsChecker, permissionsApi, permissionsDialogCreator, locationAccessibilityChecker)
     }
 
     @Test

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
@@ -28,12 +28,13 @@ class PermissionsProviderTest {
             (it.getArgument(1) as PermissionListener).granted()
         }
     }
+    private val permissionsDialogCreator = mock<PermissionsDialogCreator>()
 
     private lateinit var permissionsProvider: PermissionsProvider
 
     @Before
     fun setup() {
-        permissionsProvider = PermissionsProvider(permissionsChecker, permissionsApi)
+        permissionsProvider = PermissionsProvider(permissionsChecker, permissionsApi, permissionsDialogCreator)
     }
 
     @Test


### PR DESCRIPTION
Closes #5257 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that sometimes we wanted to do something just after denying a permission and in other cases only after closing the dialog with additional explanation. We didn't have a separate method to distinguish those two cases so we kept moving the place where we call `action.denied()` https://github.com/getodk/collect/pull/5270/files#diff-45ef03d6d1becbf74e066bd7ced0cdb45c80fd850e279799f77adc4bf25d859aL267 based on what we needed in a given pr what then caused problems with other features like in this case. Now I have added a separate method for that second case and the problem is solved.

Additionally I have enabled using default interface methods to avoid overriding those two methods from `PermissionListener` which we not always need to use (`deny`/`additionalExplanationClosed`).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please of course verify that the issue no longer occurs. Then please make sure that this issue https://github.com/getodk/collect/issues/5027 does not occur too (since it was related). Last but not least please play with different permissions granting/denying them to check for regressions.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
