### PR TITLE
Avoid adding duplicate points in polylines/polyshapes

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -409,8 +409,7 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
 
     private void onClick(MapPoint point) {
         if (inputActive && !recordingEnabled) {
-            map.appendPointToPoly(featureId, point);
-            updateUi();
+            appendPointIfNew(point);
         }
     }
 
@@ -431,6 +430,13 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
 
     private void recordPoint(MapPoint point) {
         if (point != null && isLocationAcceptable(point)) {
+            appendPointIfNew(point);
+        }
+    }
+
+    private void appendPointIfNew(MapPoint point) {
+        List<MapPoint> points = map.getPolyPoints(featureId);
+        if (points.isEmpty() || !point.equals(points.get(points.size() - 1))) {
             map.appendPointToPoly(featureId, point);
             updateUi();
         }

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
@@ -14,15 +14,19 @@
 
 package org.odk.collect.geo.geopoly;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
 import android.content.Intent;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
@@ -99,48 +103,51 @@ public class GeoPolyActivityTest {
 
     @Test
     public void recordButton_should_beHiddenForAutomaticMode() {
-        ActivityScenario<GeoPolyActivity> scenario = launcherRule.launch(GeoPolyActivity.class);
+        launcherRule.launch(GeoPolyActivity.class);
         mapFragment.ready();
 
-        scenario.onActivity((activity -> {
-            activity.updateRecordingMode(R.id.automatic_mode);
-            activity.startInput();
-            assertThat(activity.findViewById(R.id.record_button).getVisibility(), is(View.GONE));
-        }));
+        onView(withId(R.id.play)).perform(click());
+        onView(withId(R.id.automatic_mode)).inRoot(isDialog()).perform(click());
+        onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
+        onView(withId(R.id.record_button)).check(matches(not(isDisplayed())));
     }
 
     @Test
     public void recordButton_should_beVisibleForManualMode() {
-        ActivityScenario<GeoPolyActivity> scenario = launcherRule.launch(GeoPolyActivity.class);
+        launcherRule.launch(GeoPolyActivity.class);
         mapFragment.ready();
 
-        scenario.onActivity((activity -> {
-            activity.updateRecordingMode(R.id.manual_mode);
-            activity.startInput();
-            assertThat(activity.findViewById(R.id.record_button).getVisibility(), is(View.VISIBLE));
-        }));
+        onView(withId(R.id.play)).perform(click());
+        onView(withId(R.id.manual_mode)).inRoot(isDialog()).perform(click());
+        onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
+        onView(withId(R.id.record_button)).check(matches(isDisplayed()));
     }
 
     @Test
-    public void startingInput_usingAutomaticMode_usesRetainMockAccuracyToStartLocationTracker() {
+    public void startingInput_usingAutomaticMode_usesRetainMockAccuracyTrueToStartLocationTracker() {
         Intent intent = new Intent(ApplicationProvider.getApplicationContext(), GeoPolyActivity.class);
 
         intent.putExtra(Constants.EXTRA_RETAIN_MOCK_ACCURACY, true);
-        launcherRule.<GeoPolyActivity>launch(intent).onActivity(activity -> {
-            mapFragment.ready();
-            activity.updateRecordingMode(R.id.automatic_mode);
-            activity.startInput();
-            verify(locationTracker).start(true);
-        });
+        launcherRule.<GeoPolyActivity>launch(intent);
 
-        Mockito.reset(locationTracker); // Ignore previous calls
+        mapFragment.ready();
+        onView(withId(R.id.play)).perform(click());
+        onView(withId(R.id.automatic_mode)).inRoot(isDialog()).perform(click());
+        onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
+        verify(locationTracker).start(true);
+    }
+
+    @Test
+    public void startingInput_usingAutomaticMode_usesRetainMockAccuracyFalseToStartLocationTracker() {
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), GeoPolyActivity.class);
 
         intent.putExtra(Constants.EXTRA_RETAIN_MOCK_ACCURACY, false);
-        launcherRule.<GeoPolyActivity>launch(intent).onActivity(activity -> {
-            mapFragment.ready();
-            activity.updateRecordingMode(R.id.automatic_mode);
-            activity.startInput();
-            verify(locationTracker).start(false);
-        });
+        launcherRule.<GeoPolyActivity>launch(intent);
+
+        mapFragment.ready();
+        onView(withId(R.id.play)).perform(click());
+        onView(withId(R.id.automatic_mode)).inRoot(isDialog()).perform(click());
+        onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click());
+        verify(locationTracker).start(false);
     }
 }

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -24,6 +24,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     private val markers: MutableList<MapPoint> = ArrayList()
     private val markerIcons: MutableList<MarkerIconDescription?> = ArrayList()
     private var hasCenter = false
+    private val polyPoints = mutableMapOf<Int, MutableList<MapPoint>>()
 
     override fun init(
         readyListener: ReadyListener?,
@@ -101,10 +102,16 @@ class FakeMapFragment : Fragment(), MapFragment {
         return 0
     }
 
-    override fun appendPointToPoly(featureId: Int, point: MapPoint) {}
-    override fun removePolyLastPoint(featureId: Int) {}
+    override fun appendPointToPoly(featureId: Int, point: MapPoint) {
+        polyPoints.getOrPut(featureId) { mutableListOf() }.add(point)
+    }
+
+    override fun removePolyLastPoint(featureId: Int) {
+        polyPoints.getOrPut(featureId) { mutableListOf() }.removeLast()
+    }
+
     override fun getPolyPoints(featureId: Int): List<MapPoint> {
-        return emptyList()
+        return polyPoints.getOrPut(featureId) { mutableListOf() }
     }
 
     override fun clearFeatures() {


### PR DESCRIPTION
Closes #5186 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
We discussed possible options in the issue. I think blocking duplicate points is the best one it not only fixes the issue but also improves the flow by reducing the number of points in polylines/polyshapes.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Adding duplicate points (manually or automatically) should be not possible so if the last point equals the one we try to add it's ignored. I can't see any risk here but please test this change carefully.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
