### PR TITLE
Fixed styling required questions

### DIFF
--- a/collect_app/src/androidTest/assets/forms/form_styling.xml
+++ b/collect_app/src/androidTest/assets/forms/form_styling.xml
@@ -5,7 +5,7 @@
         <model odk:xforms-version="1.0.0">
             <itext>
                 <translation default="true()" lang="default">
-                    <text id="/data/q1:hint">
+                    <text id="/data/q0:hint">
                         <value>&lt;span style="color:blue"&gt;Hint text&lt;/span&gt;</value>
                         <value form="guidance">&lt;span style="color:blue"&gt;Guidance text&lt;/span&gt;</value>
                     </text>
@@ -13,6 +13,7 @@
             </itext>
             <instance>
                 <data id="form_styling">
+                    <q0 />
                     <q1 />
                     <selectOneQuestions>
                         <q2 />
@@ -35,7 +36,8 @@
                     </meta>
                 </data>
             </instance>
-            <bind nodeset="/data/q1" readonly="true()" type="string" />
+            <bind nodeset="/data/q0" readonly="true()" type="string" />
+            <bind nodeset="/data/q1" type="string" required="true()"/>
             <bind nodeset="/data/selectOneQuestions/q2" type="string" />
             <bind nodeset="/data/selectOneQuestions/q3" type="string" />
             <bind nodeset="/data/selectOneQuestions/q4" type="string" />
@@ -52,9 +54,12 @@
         </model>
     </h:head>
     <h:body>
-        <input ref="/data/q1">
+        <input ref="/data/q0">
             <label>&lt;span style="color:blue"&gt;Note text&lt;/span&gt;</label>
-            <hint ref="jr:itext('/data/q1:hint')" />
+            <hint ref="jr:itext('/data/q0:hint')" />
+        </input>
+        <input ref="/data/q1">
+            <label>#### &lt;span style="color:blue"&gt;Required text question with header style&lt;/span&gt;</label>
         </input>
         <group ref="/data/selectOneQuestions">
             <label>&lt;span style="color:blue"&gt;selectOneQuestions&lt;/span&gt;</label>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormStylingTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormStylingTest.kt
@@ -212,6 +212,7 @@ class FormStylingTest {
             .startBlankForm(FORM_NAME)
             .clickGoToArrow()
             .assertHierarchyItem(0, "Note text", null)
+            .assertHierarchyItem(1, "* Required text question with header style", null)
             .assertHierarchyItem(4, "Rank widget", "1. One")
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormStylingTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormStylingTest.kt
@@ -29,6 +29,14 @@ class FormStylingTest {
     }
 
     @Test
+    fun requiredQuestionLabelWithHeaderStyleTest() {
+        rule.startAtMainMenu()
+            .copyForm(FORM_FILE_NAME)
+            .startBlankForm(FORM_NAME)
+            .swipeToNextQuestion("Required text question with header style", true)
+    }
+
+    @Test
     fun questionHintTest() {
         rule.startAtMainMenu()
             .copyForm(FORM_FILE_NAME)
@@ -204,7 +212,7 @@ class FormStylingTest {
             .startBlankForm(FORM_NAME)
             .clickGoToArrow()
             .assertHierarchyItem(0, "Note text", null)
-            .assertHierarchyItem(3, "Rank widget", "1. One")
+            .assertHierarchyItem(4, "Rank widget", "1. One")
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -52,6 +52,7 @@ import org.odk.collect.android.formentry.repeats.DeleteRepeatDialogFragment;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.logic.HierarchyElement;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
+import org.odk.collect.android.utilities.HtmlUtils;
 import org.odk.collect.androidshared.ui.DialogFragmentUtils;
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard;
 
@@ -560,7 +561,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
                         String label = fp.getShortText();
                         String answerDisplay = FormEntryPromptUtils.getAnswerText(fp, this, formController);
                         elementsToDisplay.add(
-                                new HierarchyElement(FormEntryPromptUtils.markQuestionIfIsRequired(label, fp.isRequired()), answerDisplay, null,
+                                new HierarchyElement(FormEntryPromptUtils.styledQuestionText(label, fp.isRequired()), answerDisplay, null,
                                         HierarchyElement.Type.QUESTION, fp.getIndex()));
                         break;
                     }
@@ -589,7 +590,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
 
                         FormEntryCaption caption = formController.getCaptionPrompt();
                         HierarchyElement groupElement = new HierarchyElement(
-                                caption.getShortText(), getString(R.string.group_label),
+                                HtmlUtils.textToHtml(caption.getShortText()), getString(R.string.group_label),
                                 ContextCompat.getDrawable(this, R.drawable.ic_folder_open),
                                 HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
                         elementsToDisplay.add(groupElement);
@@ -642,13 +643,13 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
                             }
 
                             HierarchyElement instance = new HierarchyElement(
-                                    repeatLabel, null,
+                                    HtmlUtils.textToHtml(repeatLabel), null,
                                     null, HierarchyElement.Type.REPEAT_INSTANCE, fc.getIndex());
                             elementsToDisplay.add(instance);
                         } else if (fc.getMultiplicity() == 0) {
                             // Display the repeat header for the group.
                             HierarchyElement group = new HierarchyElement(
-                                    fc.getShortText(), getString(R.string.repeatable_group_label),
+                                    HtmlUtils.textToHtml(fc.getShortText()), getString(R.string.repeatable_group_label),
                                     ContextCompat.getDrawable(this, R.drawable.ic_repeat),
                                     HierarchyElement.Type.REPEATABLE_GROUP, fc.getIndex());
                             elementsToDisplay.add(group);

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListItemView.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/HierarchyListItemView.kt
@@ -20,7 +20,7 @@ class HierarchyListItemView(context: Context) : FrameLayout(context) {
             binding.icon.visibility = GONE
         }
 
-        binding.primaryText.text = HtmlUtils.textToHtml(element.primaryText)
+        binding.primaryText.text = element.primaryText
 
         val secondaryText = element.secondaryText
         if (secondaryText != null && secondaryText.isNotEmpty()) {

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/questions/AudioVideoImageTextLabel.java
@@ -36,7 +36,6 @@ import org.odk.collect.android.audio.AudioHelper;
 import org.odk.collect.android.databinding.AudioVideoImageTextLabelBinding;
 import org.odk.collect.android.listeners.SelectItemClickListener;
 import org.odk.collect.android.utilities.FormEntryPromptUtils;
-import org.odk.collect.android.utilities.HtmlUtils;
 import org.odk.collect.android.utilities.MediaUtils;
 import org.odk.collect.android.utilities.ScreenContext;
 import org.odk.collect.android.utilities.ThemeUtils;
@@ -93,7 +92,7 @@ public class AudioVideoImageTextLabel extends RelativeLayout implements View.OnC
 
         if (questionText != null && !questionText.isEmpty()) {
             textLabel.setTextSize(TypedValue.COMPLEX_UNIT_DIP, fontSize);
-            textLabel.setText(HtmlUtils.textToHtml(FormEntryPromptUtils.markQuestionIfIsRequired(questionText, isRequiredQuestion)));
+            textLabel.setText(FormEntryPromptUtils.styledQuestionText(questionText, isRequiredQuestion));
             textLabel.setMovementMethod(LinkMovementMethod.getInstance());
 
             // Wrap to the size of the parent view

--- a/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
@@ -42,7 +42,7 @@ public class HierarchyElement {
      * The primary text this element should be displayed with.
      */
     @NonNull
-    private final String primaryText;
+    private final CharSequence primaryText;
 
     /**
      * The secondary text this element should be displayed with.
@@ -56,7 +56,7 @@ public class HierarchyElement {
     @Nullable
     private Drawable icon;
 
-    public HierarchyElement(@NonNull String primaryText, @Nullable String secondaryText,
+    public HierarchyElement(@NonNull CharSequence primaryText, @Nullable String secondaryText,
                             @Nullable Drawable icon, @NonNull Type type, @NonNull FormIndex formIndex) {
         this.primaryText = primaryText;
         this.secondaryText = secondaryText;
@@ -66,7 +66,7 @@ public class HierarchyElement {
     }
 
     @NonNull
-    public String getPrimaryText() {
+    public CharSequence getPrimaryText() {
         return primaryText;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.utilities;
 import static org.javarosa.core.model.Constants.DATATYPE_TEXT;
 
 import android.content.Context;
+import android.text.SpannableStringBuilder;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.data.DateData;
@@ -119,15 +120,11 @@ public final class FormEntryPromptUtils {
         return fep.getAnswerText();
     }
 
-    public static String markQuestionIfIsRequired(String questionText, boolean isRequired) {
-        if (isRequired) {
-            if (questionText == null) {
-                questionText = "";
-            }
-            questionText = "<span style=\"color:#F44336\">*</span> " + questionText;
-        }
-
-        return questionText;
+    public static CharSequence styledQuestionText(String questionText, boolean isRequired) {
+        CharSequence styledQuestionText = HtmlUtils.textToHtml(questionText);
+       return isRequired
+                ? new SpannableStringBuilder(HtmlUtils.textToHtml("<span style=\"color:#F44336\">*</span>")).append(" ").append(styledQuestionText)
+                : styledQuestionText;
     }
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FormEntryPromptUtils.java
@@ -122,9 +122,15 @@ public final class FormEntryPromptUtils {
 
     public static CharSequence styledQuestionText(String questionText, boolean isRequired) {
         CharSequence styledQuestionText = HtmlUtils.textToHtml(questionText);
-       return isRequired
-                ? new SpannableStringBuilder(HtmlUtils.textToHtml("<span style=\"color:#F44336\">*</span>")).append(" ").append(styledQuestionText)
-                : styledQuestionText;
+        return isRequired
+               /*
+                Question text should be added first, then the asterisk mark which represents
+                required questions. If the order is changed some styling might not work well.
+                */
+               ? new SpannableStringBuilder(styledQuestionText)
+                    .insert(0, " ")
+                    .insert(0, HtmlUtils.textToHtml("<span style=\"color:#F44336\">*</span>"))
+               : styledQuestionText;
     }
 
     @Nullable

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -323,7 +323,7 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
             // wrap to the widget of vi
             helpText.setHorizontallyScrolling(false);
             if (prompt.getLongText() == null || prompt.getLongText().isEmpty()) {
-                helpText.setText(HtmlUtils.textToHtml(FormEntryPromptUtils.markQuestionIfIsRequired(s, prompt.isRequired())));
+                helpText.setText(FormEntryPromptUtils.styledQuestionText(s, prompt.isRequired()));
             } else {
                 helpText.setText(HtmlUtils.textToHtml(s));
             }

--- a/collect_app/src/test/java/org/odk/collect/android/adapters/HierarchyListItemViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/adapters/HierarchyListItemViewTest.kt
@@ -50,15 +50,6 @@ class HierarchyListItemViewTest {
     }
 
     @Test
-    fun `When primary text is html should be styled`() {
-        val view = HierarchyListItemView(context)
-
-        view.setElement(getHierarchyElement(null, "<h1>Primary text</h1>", ""))
-
-        assertThat(view.binding.primaryText.text.toString(), `is`("Primary text"))
-    }
-
-    @Test
     fun `When secondary text is not specified should be gone`() {
         val view = HierarchyListItemView(context)
 


### PR DESCRIPTION
Closes #5281 

#### What has been done to verify that this works as intended?
I've tested the fix manual and added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was that we were styling question labels with the asterisk mark (that represents required questions) as a one text. As a result styling headers with `#` (or `####` like in the issue) was broken because the first element in such a question label was `*` not `#`. If we style text with `#` it must start with it and if we need something more complex like mixing normal text with headers we can use `<h4>` tags.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test styling questions labels displayed in a form and in the hierarchy view. We also support styling other elements not only questions but the risk here is just related to questions.

#### Do we need any specific form for testing your changes? If so, please attach one.
I used [Required-style.xlsx](https://github.com/getodk/collect/files/9570037/Required-style.xlsx)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
