### PR TITLE
Fix change reason behaviour after minimizing app

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -78,6 +78,12 @@ public class FormEntryPage extends Page<FormEntryPage> {
     public FormEntryPage swipeToNextQuestion(String questionText, boolean isRequired) {
         flingLeft();
 
+        // Make sure any saving finishes (can happen with saveIncomplete forms)
+        WaitFor.waitFor((Callable<Void>) () -> {
+            assertTextDoesNotExist(R.string.saving_form);
+            return null;
+        });
+
         if (isRequired) {
             assertQuestionText("* " + questionText);
         } else {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1912,7 +1912,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
         if (!formSaveViewModel.isSaving()) {
             if (currentView != null && formController != null
                     && formController.currentPromptIsQuestion()) {
-                formEntryViewModel.updateAnswersForScreen(getAnswers());
+                formEntryViewModel.saveScreenAnswersToFormController(getAnswers(), false);
             }
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -216,7 +216,7 @@ public class FormEntryViewModel extends ViewModel implements RequiresFormControl
         return success;
     }
 
-    private boolean saveScreenAnswersToFormController(HashMap<FormIndex, IAnswerData> answers, Boolean evaluateConstraints) {
+    public boolean saveScreenAnswersToFormController(HashMap<FormIndex, IAnswerData> answers, Boolean evaluateConstraints) {
         if (formController == null) {
             return false;
         }


### PR DESCRIPTION
Work towards #5291 (needs fix to `master` before closing)

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

Verified manually as I couldn't find a way to automate a pause/resume cycle in instrumented tests. Will have a look at that again for the `master` one.

#### Why is this the best possible solution? Were any other approaches considered?

Just made the most basic change here as this is going into a hotfix. I'd definitely like to clean up the relationship between screen saving and audit log flushing for the `master` version.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It'd be good to check form entry giving special attention to audit logging. We now have better automated tests, but I think (as the issue demonstrates) we still have use cases and flows that are missing coverage.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
