### PR TITLE
Fixed SelectImageMapWidgets

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiImageMapWidget.java
@@ -37,7 +37,6 @@ import java.util.List;
 public class SelectMultiImageMapWidget extends SelectImageMapWidget {
     public SelectMultiImageMapWidget(Context context, QuestionDetails questionDetails, SelectChoiceLoader selectChoiceLoader) {
         super(context, questionDetails, selectChoiceLoader);
-        render();
 
         if (questionDetails.getPrompt().getAnswerValue() != null) {
             selections = (List<Selection>) getFormEntryPrompt().getAnswerValue().getValue();

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneImageMapWidget.java
@@ -44,7 +44,6 @@ public class SelectOneImageMapWidget extends SelectImageMapWidget {
 
     public SelectOneImageMapWidget(Context context, QuestionDetails questionDetails, boolean autoAdvance, SelectChoiceLoader selectChoiceLoader) {
         super(context, questionDetails, selectChoiceLoader);
-        render();
 
         this.autoAdvance = autoAdvance;
 


### PR DESCRIPTION
Closes #5310 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The problem was called by render() called twice from a base class and from an actual SelectOne/SelectMulti implementation class.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should just fix the bug. Please tests SelectImageMapWidgets (select_one + select_multiple). I've noticed that removing answers from those widgets was also broken so please test it too.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
