### PR TITLE
Only run smoke tests on commit but run all instrumentation tests every night

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
           name: Assemble self signed release build
           command: ./gradlew assembleSelfSignedRelease
 
-  test_instrumented:
+  test_smoke_instrumented:
     <<: *android_config
     steps:
       - attach_workspace:
@@ -259,14 +259,64 @@ jobs:
               --test collect_app/build/outputs/apk/androidTest/debug/*.apk \
               --device model=Pixel2,version=29,locale=en,orientation=portrait \
               --results-bucket opendatakit-collect-test-results \
-              --environment-variables coverage=true,coverageFile=/sdcard/coverage.ec \
+              --directories-to-pull /sdcard --timeout 20m \
+              --test-targets "package org.odk.collect.android.feature.smoke"
+            fi
+          no_output_timeout: 25m
+
+  test_instrumented:
+    <<: *android_config
+    steps:
+      - attach_workspace:
+          at: ~/work
+      - restore_cache:
+          keys:
+            - intrumented-deps-{{ checksum "deps.txt" }}
+            - intrumented-deps
+            - compile-deps-
+      - restore_cache:
+          keys:
+            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+
+      - run:
+          name: Copy gradle config
+          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+
+      - run:
+          name: Assemble test build
+          command: ./gradlew assembleDebug assembleDebugAndroidTest
+
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: intrumented-deps-{{ checksum "deps.txt" }}
+
+      - run:
+          name: Authorize gcloud
+          command: |
+            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+              gcloud config set project api-project-322300403941
+              echo $GCLOUD_SERVICE_KEY | base64 --decode > client-secret.json
+              gcloud auth activate-service-account --key-file client-secret.json
+            fi
+      - run:
+          name: Run integration tests
+          command: |
+            if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
+              echo "y" | gcloud beta firebase test android run \
+              --type instrumentation \
+              --num-uniform-shards=25 \
+              --app collect_app/build/outputs/apk/debug/*.apk \
+              --test collect_app/build/outputs/apk/androidTest/debug/*.apk \
+              --device model=Pixel2,version=29,locale=en,orientation=portrait \
+              --results-bucket opendatakit-collect-test-results \
               --directories-to-pull /sdcard --timeout 20m
             fi
           no_output_timeout: 25m
 
 workflows:
   version: 2
-  workflow:
+  commit:
     jobs:
       - compile
       - check_quality:
@@ -287,9 +337,20 @@ workflows:
           filters:
             branches:
               ignore: master
-      - test_instrumented:
+      - test_smoke_instrumented:
           requires:
             - compile
           filters:
             branches:
               only: master
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - test_instrumented


### PR DESCRIPTION
This is discussed [on Slack](https://getodk.slack.com/archives/C35ENHA64/p1666009973651459), but here's a summary from @seadowg:

> Ok so I’m having a tough time getting a clean run every time although it does seem more stable (a rough guess gives me a 1 in 4 chance of a fail at the moment). I’d like to propose changing how we run tests.

> Right now, I’m starting with the (potentially overly optimistic) premise that all our flakes are solvable either by fixing the test or replacing its coverage with lower level tests. That being the case, the big problem we have right now is discovering these flakes when CI runs on merges. It’s easy for us to run test lab while working on something, never see a fail and then have a flake appear on merge. That means one of us dropping what we’re doing to fix the flake or give in and rerun repeatedly until we see green (which we know isn’t good). This is frustrating and time consuming.

> I propose to ease the pain we’re having, we only run our smoke tests (which we’ve not seen flake out) on each commitand run the whole suite once a day (probably at UTC midnight) and before releases. My hope is that this makes maintaining our instrumentation tests easier as:
> * We’ll be running our full suite more often which should make flakey tests more obvious
> * Fixing flakes should be something we can plan better as it’ll be based on the last nightly run rather than a merge that happened at the end of someone’s day
> * In theory, we should be able to take a more iterative approach, fixing the last flake we saw rather than ending up down rabbit wholes where we discover steadily more flakes while fixing others