### PR TITLE
Remove shards from smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,6 @@ jobs:
             if [[ "$CIRCLE_PROJECT_USERNAME" == "getodk" ]]; then \
               echo "y" | gcloud beta firebase test android run \
               --type instrumentation \
-              --num-uniform-shards=50 \
               --app collect_app/build/outputs/apk/debug/*.apk \
               --test collect_app/build/outputs/apk/androidTest/debug/*.apk \
               --device model=Pixel2,version=29,locale=en,orientation=portrait \


### PR DESCRIPTION
This was left in by mistake. We can't have fewer tests than shards, and we don't want to bother sharding 4 tests anyway.