### PR TITLE
Fix branch name for nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,6 +350,6 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - master
     jobs:
       - test_instrumented


### PR DESCRIPTION
Switch from `main` to `master`. We'll probably need to look at changing our default branch at some point, my impression is that it's going to be more of an opt-in transition than initially hinted.