### PR TITLE
Prevent filled form from being edited if sending is canceled or crashes

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -126,14 +126,15 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
             return;
         }
 
-        int checkedItemCount = getCheckedCount();
+        long[] instanceIds = listView.getCheckedItemIds();
 
-        if (checkedItemCount > 0) {
-            // items selected
-            uploadSelectedFiles();
+        if (instanceIds.length > 0) {
+            selectedInstances.clear();
             setAllToCheckedState(listView, false);
             toggleButtonLabel(findViewById(R.id.toggle_button), listView);
             binding.uploadButton.setEnabled(false);
+
+            uploadSelectedFiles(instanceIds);
         } else {
             // no items selected
             ToastUtils.showLongToast(this, R.string.noselect_error);
@@ -205,9 +206,7 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
         binding.uploadButton.setText(R.string.send_selected_data);
     }
 
-    private void uploadSelectedFiles() {
-        long[] instanceIds = listView.getCheckedItemIds();
-
+    private void uploadSelectedFiles(long[] instanceIds) {
         String server = settingsProvider.getUnprotectedSettings().getString(KEY_PROTOCOL);
 
         if (server.equalsIgnoreCase(ProjectKeys.PROTOCOL_GOOGLE_SHEETS)) {

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
@@ -121,8 +121,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
                 key = PropertyUtils.genUUID();
             }
             insertRows(instance, instanceElement, null, key, instanceFile, spreadsheet.getSheets().get(0).getProperties().getTitle());
-        } catch (FormUploadException e) {
-            throw e;
         } catch (GoogleJsonResponseException e) {
             throw new FormUploadException(getErrorMessageFromGoogleJsonResponseException(e));
         }

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
@@ -88,6 +88,8 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
     @Override
     public String uploadOneSubmission(Instance instance, String spreadsheetUrl) throws FormUploadException {
+        markSubmissionFailed(instance);
+
         File instanceFile = new File(instance.getInstanceFilePath());
         if (!instanceFile.exists()) {
             throw new FormUploadException(FAIL + "instance XML file does not exist!");

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/InstanceGoogleSheetsUploader.java
@@ -105,7 +105,6 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
             Form form = forms.get(0);
             if (form.getBASE64RSAPublicKey() != null) {
-                submissionComplete(instance, false);
                 throw new FormUploadException(getLocalizedString(Collect.getInstance(), R.string.google_sheets_encrypted_message));
             }
 
@@ -123,14 +122,12 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
             }
             insertRows(instance, instanceElement, null, key, instanceFile, spreadsheet.getSheets().get(0).getProperties().getTitle());
         } catch (FormUploadException e) {
-            submissionComplete(instance, false);
             throw e;
         } catch (GoogleJsonResponseException e) {
-            submissionComplete(instance, false);
             throw new FormUploadException(getErrorMessageFromGoogleJsonResponseException(e));
         }
 
-        submissionComplete(instance, true);
+        markSubmissionComplete(instance);
         // Google Sheets can't provide a custom success message
         return null;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/instancemanagement/InstanceSubmitter.kt
@@ -96,7 +96,6 @@ class InstanceSubmitter(
         return InstanceServerUploader(
             httpInterface,
             WebCredentialsUtils(generalSettings),
-            HashMap(),
             generalSettings
         )
     }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/InstanceServerUploaderTask.java
@@ -25,7 +25,6 @@ import org.odk.collect.android.upload.FormUploadAuthRequestedException;
 import org.odk.collect.android.upload.FormUploadException;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 
-import java.util.HashMap;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -62,7 +61,7 @@ public class InstanceServerUploaderTask extends InstanceUploaderTask {
     public Outcome doInBackground(Long... instanceIdsToUpload) {
         Outcome outcome = new Outcome();
 
-        InstanceServerUploader uploader = new InstanceServerUploader(httpInterface, webCredentialsUtils, new HashMap<>(), settingsProvider.getUnprotectedSettings());
+        InstanceServerUploader uploader = new InstanceServerUploader(httpInterface, webCredentialsUtils, settingsProvider.getUnprotectedSettings());
         List<Instance> instancesToUpload = uploader.getInstancesFromIds(instanceIdsToUpload);
 
         String deviceId = new PropertyManager().getSingularProperty(PropertyManager.PROPMGR_DEVICE_ID);

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,15 +52,14 @@ public class InstanceServerUploader extends InstanceUploader {
 
     private final OpenRosaHttpInterface httpInterface;
     private final WebCredentialsUtils webCredentialsUtils;
-    private final Map<Uri, Uri> uriRemap;
     private final Settings generalSettings;
+    private final Map<Uri, Uri> uriRemap = new HashMap<>();
 
     public InstanceServerUploader(OpenRosaHttpInterface httpInterface,
                                   WebCredentialsUtils webCredentialsUtils,
-                                  Map<Uri, Uri> uriRemap, Settings generalSettings) {
+                                  Settings generalSettings) {
         this.httpInterface = httpInterface;
         this.webCredentialsUtils = webCredentialsUtils;
-        this.uriRemap = uriRemap;
         this.generalSettings = generalSettings;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -86,7 +86,6 @@ public class InstanceServerUploader extends InstanceUploader {
                     submissionUri.toString());
         } else {
             if (submissionUri.getHost() == null) {
-                submissionComplete(instance, false);
                 throw new FormUploadException(FAIL + "Host name may not be null");
             }
 
@@ -94,7 +93,6 @@ public class InstanceServerUploader extends InstanceUploader {
             try {
                 uri = URI.create(submissionUri.toString());
             } catch (IllegalArgumentException e) {
-                submissionComplete(instance, false);
                 Timber.d(e.getMessage() != null ? e.getMessage() : e.toString());
                 throw new FormUploadException(getLocalizedString(Collect.getInstance(), R.string.url_error));
             }
@@ -115,13 +113,11 @@ public class InstanceServerUploader extends InstanceUploader {
                 }
 
             } catch (Exception e) {
-                submissionComplete(instance, false);
                 throw new FormUploadException(FAIL
                         + (e.getMessage() != null ? e.getMessage() : e.toString()));
             }
 
             if (headResult.getStatusCode() == HttpsURLConnection.HTTP_UNAUTHORIZED) {
-                submissionComplete(instance, false);
                 throw new FormUploadAuthRequestedException(getLocalizedString(Collect.getInstance(), R.string.server_auth_credentials, submissionUri.getHost()),
                         submissionUri);
             } else if (headResult.getStatusCode() == HttpsURLConnection.HTTP_NO_CONTENT) {
@@ -142,20 +138,17 @@ public class InstanceServerUploader extends InstanceUploader {
                         } else {
                             // Don't follow a redirection attempt to a different host.
                             // We can't tell if this is a spoof or not.
-                            submissionComplete(instance, false);
                             throw new FormUploadException(FAIL
                                     + "Unexpected redirection attempt to a different host: "
                                     + newURI.toString());
                         }
                     } catch (Exception e) {
-                        submissionComplete(instance, false);
                         throw new FormUploadException(FAIL + urlString + " " + e.toString());
                     }
                 }
             } else {
                 if (headResult.getStatusCode() >= HttpsURLConnection.HTTP_OK
                         && headResult.getStatusCode() < HttpsURLConnection.HTTP_MULT_CHOICE) {
-                    submissionComplete(instance, false);
                     throw new FormUploadException("Failed to send to " + uri + ". Is this an OpenRosa " +
                             "submission endpoint? If you have a web proxy you may need to log in to " +
                             "your network.\n\nHEAD request result status code: " + headResult.getStatusCode());
@@ -177,7 +170,6 @@ public class InstanceServerUploader extends InstanceUploader {
         }
 
         if (!instanceFile.exists() && !submissionFile.exists()) {
-            submissionComplete(instance, false);
             throw new FormUploadException(FAIL + "instance XML file does not exist!");
         }
 
@@ -218,17 +210,15 @@ public class InstanceServerUploader extends InstanceUploader {
                     }
 
                 }
-                submissionComplete(instance, false);
                 throw exception;
             }
 
         } catch (Exception e) {
-            submissionComplete(instance, false);
             throw new FormUploadException(FAIL + "Generic Exception: "
                     + (e.getMessage() != null ? e.getMessage() : e.toString()));
         }
 
-        submissionComplete(instance, true);
+        markSubmissionComplete(instance);
 
         if (messageParser.isValid()) {
             return messageParser.getMessageResponse();

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceServerUploader.java
@@ -71,6 +71,8 @@ public class InstanceServerUploader extends InstanceUploader {
      */
     @Override
     public String uploadOneSubmission(Instance instance, String urlString) throws FormUploadException {
+        markSubmissionFailed(instance);
+
         Uri submissionUri = Uri.parse(urlString);
 
         long contentLength = 10000000L;

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
@@ -62,7 +62,7 @@ public abstract class InstanceUploader {
         List<Instance> instances = new ArrayList<>();
 
         for (Long id : instanceDatabaseIds) {
-            instances.add(new InstancesRepositoryProvider(Collect.getInstance()).get().get(id));
+            instances.add(instancesRepositoryProvider.get().get(id));
         }
 
         return instances;

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
@@ -68,6 +68,17 @@ public abstract class InstanceUploader {
         return instances;
     }
 
+    public void markSubmissionFailed(Instance instance) {
+        instancesRepositoryProvider
+                .get()
+                .save(new Instance.Builder(instance)
+                        .status(Instance.STATUS_SUBMISSION_FAILED)
+                        .build()
+                );
+
+        instancesAppState.update();
+    }
+
     public void submissionComplete(Instance instance, boolean successful) {
         InstancesRepository instancesRepository = instancesRepositoryProvider.get();
 

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceUploader.java
@@ -22,7 +22,6 @@ import org.odk.collect.android.formmanagement.InstancesAppState;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
 import org.odk.collect.forms.instances.Instance;
-import org.odk.collect.forms.instances.InstancesRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,20 +78,13 @@ public abstract class InstanceUploader {
         instancesAppState.update();
     }
 
-    public void submissionComplete(Instance instance, boolean successful) {
-        InstancesRepository instancesRepository = instancesRepositoryProvider.get();
-
-        if (successful) {
-            instancesRepository.save(new Instance.Builder(instance)
-                    .status(Instance.STATUS_SUBMITTED)
-                    .build()
-            );
-        } else {
-            instancesRepository.save(new Instance.Builder(instance)
-                    .status(Instance.STATUS_SUBMISSION_FAILED)
-                    .build()
-            );
-        }
+    public void markSubmissionComplete(Instance instance) {
+        instancesRepositoryProvider
+                .get()
+                .save(new Instance.Builder(instance)
+                        .status(Instance.STATUS_SUBMITTED)
+                        .build()
+                );
 
         instancesAppState.update();
     }


### PR DESCRIPTION
Closes #5317 

#### What has been done to verify that this works as intended?
I've tested uploading forms, canceling the process of uploading.

#### Why is this the best possible solution? Were any other approaches considered?
We shooed mark submission as submission failed before trying to send it in order to make sure it's not possible to edit it when something goes wrong during uploading when it's xml file can be already sent.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test uploading finalized forms to make sure there is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
