### PR TITLE
Correct nightly build workflow setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 0 * * 1-5"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,4 +352,7 @@ workflows:
               only:
                 - master
     jobs:
-      - test_instrumented
+      - compile
+      - test_instrumented:
+          requires:
+            - compile


### PR DESCRIPTION
`test_instrumented` needs to run after `compile` as that sets up a lot of the dependency caching we need.