### PR TITLE
Remove untested and (believed to be) unnecessary updateAnswersForScreen calls

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormLanguageTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormLanguageTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.rules.CollectTestRule;
-import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.SaveOrIgnoreDialog;
+import org.odk.collect.android.support.rules.CollectTestRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 
 @RunWith(AndroidJUnit4.class)
 public class FormLanguageTest {
@@ -25,11 +25,12 @@ public class FormLanguageTest {
         rule.startAtMainMenu()
                 .copyForm("one-question-translation.xml")
                 .startBlankForm("One Question")
-                .assertQuestion("what is your age")
+                .answerQuestion("what is your age", "64")
                 .clickOptionsIcon()
                 .clickOnString(R.string.change_language)
                 .clickOnText("French (fr)")
-                .assertQuestion("quel âge as-tu");
+                .assertQuestion("quel âge as-tu")
+                .assertText("64"); // Check answer hasn't been cleared/changed
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1125,17 +1125,12 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
      */
     @Override
     public Object onRetainCustomNonConfigurationInstance() {
-        FormController formController = getFormController();
         // if a form is loading, pass the loader task
         if (formLoaderTask != null
                 && formLoaderTask.getStatus() != AsyncTask.Status.FINISHED) {
             return formLoaderTask;
         }
 
-        // mFormEntryController is static so we don't need to pass it.
-        if (formController != null && formController.currentPromptIsQuestion()) {
-            formEntryViewModel.updateAnswersForScreen(getAnswers(), false);
-        }
         return null;
     }
 
@@ -1835,7 +1830,6 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
                 switch (i) {
                     case BUTTON_POSITIVE: // yes
                         clearAnswer(qw);
-                        formEntryViewModel.updateAnswersForScreen(getAnswers(), false);
                         break;
                 }
             }
@@ -1877,9 +1871,6 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
                             getFormController().setLanguage(languages[whichButton]);
                             dialog.dismiss();
-                            if (getFormController().currentPromptIsQuestion()) {
-                                formEntryViewModel.updateAnswersForScreen(getAnswers(), false);
-                            }
                             onScreenRefresh();
                         })
                 .setTitle(getString(R.string.change_language))

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1871,6 +1871,7 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
                             getFormController().setLanguage(languages[whichButton]);
                             dialog.dismiss();
+                            formEntryViewModel.updateAnswersForScreen(getAnswers(), false);
                             onScreenRefresh();
                         })
                 .setTitle(getString(R.string.change_language))


### PR DESCRIPTION
This is a follow-up to #5329. In working on that PR, I noticed a few places where `updateAnswersForScreeen` was called that I couldn't explain and that also didn't have any tests. We've run into bugs with screen answers being saved to the `FormEntryController` in the last couple of releases, so I'm very keen to tighten up our interactions there.

#### What has been done to verify that this works as intended?

Played around with form entry manually and ran existing tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This could definitely break something! Reviewers should think carefully around if the `updateAnswersForScreen` calls should be there or not and QA should take a general look at form entry to see if there's anything that might have changed.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
