### PR TITLE
Fixed refreshing the list of forms

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListMenuDelegate.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListMenuDelegate.kt
@@ -21,8 +21,8 @@ class BlankFormListMenuDelegate(
     private var syncing = false
 
     init {
-        viewModel.isSyncingWithServer().observe(activity) { syncing: Boolean ->
-            this.syncing = syncing
+        viewModel.isLoading.observe(activity) { isLoading: Boolean ->
+            this.syncing = isLoading
             activity.invalidateOptionsMenu()
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -79,9 +80,17 @@ class BlankFormListViewModel(
             return generalSettings.getBoolean(ProjectKeys.KEY_HIDE_OLD_FORM_VERSIONS)
         }
 
+    private val syncWithServerObserver = Observer<Boolean> {
+        if (!it) {
+            loadFromDatabase()
+        }
+    }
+
     init {
         loadFromDatabase()
         syncWithStorage()
+
+        syncRepository.isSyncing(projectId).observeForever(syncWithServerObserver)
     }
 
     fun getAllForms(): List<BlankFormListItem> {
@@ -247,5 +256,10 @@ class BlankFormListViewModel(
                 projectId
             ) as T
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        syncRepository.isSyncing(projectId).removeObserver(syncWithServerObserver)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
@@ -50,13 +50,12 @@ class BlankFormListViewModel(
 
     private val isFormLoadingRunning = MutableNonNullLiveData(false)
     private val isSyncingWithStorageRunning = MutableNonNullLiveData(false)
-    private val isSyncingWithServerRunning = MutableNonNullLiveData(false)
 
     val isLoading: LiveData<Boolean> = Transformations.map(
         LiveDataUtils.zip3(
             isFormLoadingRunning,
             isSyncingWithStorageRunning,
-            isSyncingWithServerRunning,
+            syncRepository.isSyncing(projectId),
         )
     ) { (one, two, three) -> one || two || three }
 
@@ -180,15 +179,6 @@ class BlankFormListViewModel(
             application,
             generalSettings
         ) == FormUpdateMode.MATCH_EXACTLY
-    }
-
-    fun isSyncingWithServer(): LiveData<Boolean> {
-        return Transformations.map(
-            syncRepository.isSyncing(projectId)
-        ) { isSyncing ->
-            isSyncingWithServerRunning.value = isSyncing
-            isSyncing
-        }
     }
 
     fun isOutOfSyncWithServer(): LiveData<Boolean> {

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListMenuDelegateTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListMenuDelegateTest.kt
@@ -41,7 +41,7 @@ class BlankFormListMenuDelegateTest {
     @Before
     fun setup() {
         whenever(networkStateProvider.isDeviceOnline).thenReturn(true)
-        whenever(viewModel.isSyncingWithServer()).thenReturn(MutableLiveData(false))
+        whenever(viewModel.isLoading).thenReturn(MutableLiveData(false))
         whenever(viewModel.isOutOfSyncWithServer()).thenReturn(MutableLiveData(false))
 
         activity = CollectHelpers.createThemedActivity(FragmentActivity::class.java)
@@ -78,8 +78,8 @@ class BlankFormListMenuDelegateTest {
     }
 
     @Test
-    fun `onPrepareOptionsMenu when syncing disables refresh button`() {
-        whenever(viewModel.isSyncingWithServer()).thenReturn(MutableLiveData(true))
+    fun `onPrepareOptionsMenu when loading disables refresh button`() {
+        whenever(viewModel.isLoading).thenReturn(MutableLiveData(true))
 
         val menuDelegate = createMenuDelegate()
         val menu = createdMenu()
@@ -91,7 +91,7 @@ class BlankFormListMenuDelegateTest {
     }
 
     @Test
-    fun `onPrepareOptionsMenu when not syncing enables refresh button`() {
+    fun `onPrepareOptionsMenu when not loading enables refresh button`() {
         val menuDelegate = createMenuDelegate()
         val menu = createdMenu()
 

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
@@ -76,6 +76,7 @@ class BlankFormListViewModelTest {
         doReturn(true).whenever(formsUpdater).matchFormsWithServer(projectId)
         val result = viewModel.syncWithServer()
         scheduler.runBackground()
+        scheduler.runBackground()
         assertThat(result.value, `is`(true))
     }
 
@@ -85,6 +86,7 @@ class BlankFormListViewModelTest {
         generalSettings.save(ProjectKeys.KEY_SERVER_URL, "https://sample.com")
         doReturn(false).whenever(formsUpdater).matchFormsWithServer(projectId)
         val result = viewModel.syncWithServer()
+        scheduler.runBackground()
         scheduler.runBackground()
         assertThat(result.value, `is`(false))
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
@@ -174,6 +174,28 @@ class BlankFormListViewModelTest {
     }
 
     @Test
+    fun `after finished syncing with server forms should be loaded from database`() {
+        createViewModel(false)
+        val liveData = MutableLiveData(true)
+        whenever(syncRepository.isSyncing(projectId)).thenReturn(liveData)
+
+        scheduler.runBackground() // load from database
+        scheduler.runBackground() // sync with storage
+
+        assertThat(viewModel.formsToDisplay.value!!.size, equalTo(0))
+
+        saveForms(
+            form(dbId = 1, formId = "1")
+        )
+
+        liveData.value = false
+
+        scheduler.runBackground() // load from database after syncing with server
+
+        assertThat(viewModel.formsToDisplay.value!!.size, equalTo(1))
+    }
+
+    @Test
     fun `deleted forms should be ignored`() {
         saveForms(
             form(dbId = 1, formId = "1"),

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
@@ -106,19 +106,6 @@ class BlankFormListViewModelTest {
     }
 
     @Test
-    fun `isSyncingWithServer follows repository isSyncing`() {
-        createViewModel()
-
-        val liveData = MutableLiveData(true)
-        whenever(syncRepository.isSyncing(projectId)).thenReturn(liveData)
-
-        val isSyncing = viewModel.isSyncingWithServer()
-        assertThat(isSyncing.getOrAwaitValue(), `is`(true))
-        liveData.value = false
-        assertThat(isSyncing.getOrAwaitValue(), `is`(false))
-    }
-
-    @Test
     fun `isOutOfSyncWithServer follows repository syncError`() {
         createViewModel()
 
@@ -346,6 +333,7 @@ class BlankFormListViewModelTest {
     }
 
     private fun createViewModel(runAllBackgroundTasks: Boolean = true, shouldHideOldFormVersions: Boolean = true) {
+        whenever(syncRepository.isSyncing(projectId)).thenReturn(MutableLiveData(false))
         whenever(changeLockProvider.getFormLock(projectId)).thenReturn(changeLock)
         generalSettings.save(ProjectKeys.KEY_HIDE_OLD_FORM_VERSIONS, shouldHideOldFormVersions)
 


### PR DESCRIPTION
Closes #5331

#### What has been done to verify that this works as intended?
I've tested the fix manually and added an automated test.

#### Why is this the best possible solution? Were any other approaches considered?
I've just added missing reloading of the list of forms after finished syncing with server. Not much to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I haven't implemented a lot of changes so generally the fix should be safe but please verify that the list of forms is updated in all expected cases:
- immediately after opening the list of forms
- after syncing with storage (this is triggered automatically after opening the list)
- after syncing with server in both cases if triggered automatically after adding a new project / after triggering by a user by clicking the refresh icon (it worked well only in the second case) 

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
