### PR TITLE
Fixed building map fragments based on settings

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/MapFragmentFactoryImpl.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/MapFragmentFactoryImpl.kt
@@ -4,17 +4,19 @@ import org.odk.collect.android.application.MapboxClassInstanceCreator
 import org.odk.collect.maps.MapFragment
 import org.odk.collect.maps.MapFragmentFactory
 import org.odk.collect.osmdroid.OsmDroidMapFragment
+import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys.BASEMAP_SOURCE_CARTO
 import org.odk.collect.settings.keys.ProjectKeys.BASEMAP_SOURCE_MAPBOX
 import org.odk.collect.settings.keys.ProjectKeys.BASEMAP_SOURCE_OSM
 import org.odk.collect.settings.keys.ProjectKeys.BASEMAP_SOURCE_STAMEN
 import org.odk.collect.settings.keys.ProjectKeys.BASEMAP_SOURCE_USGS
 import org.odk.collect.settings.keys.ProjectKeys.KEY_BASEMAP_SOURCE
-import org.odk.collect.shared.settings.Settings
 
-class MapFragmentFactoryImpl(private val settings: Settings) : MapFragmentFactory {
+class MapFragmentFactoryImpl(private val settingsProvider: SettingsProvider) : MapFragmentFactory {
 
     override fun createMapFragment(): MapFragment {
+        val settings = settingsProvider.getUnprotectedSettings()
+
         return when {
             isBasemapOSM(settings.getString(KEY_BASEMAP_SOURCE)) -> OsmDroidMapFragment()
             settings.getString(KEY_BASEMAP_SOURCE) == BASEMAP_SOURCE_MAPBOX -> MapboxClassInstanceCreator.createMapboxMapFragment() ?: GoogleMapFragment()

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -627,7 +627,7 @@ public class AppDependencyModule {
 
     @Provides
     public MapFragmentFactory providesMapFragmentFactory(SettingsProvider settingsProvider) {
-        return new MapFragmentFactoryImpl(settingsProvider.getUnprotectedSettings());
+        return new MapFragmentFactoryImpl(settingsProvider);
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/geo/MapFragmentFactoryImplTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/geo/MapFragmentFactoryImplTest.kt
@@ -1,0 +1,81 @@
+package org.odk.collect.android.geo
+
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.odk.collect.osmdroid.OsmDroidMapFragment
+import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.settings.keys.ProjectKeys
+
+class MapFragmentFactoryImplTest {
+
+    private val settingsProvider = InMemSettingsProvider()
+    private val mapFragmentFactoryImpl = MapFragmentFactoryImpl(settingsProvider)
+
+    @Test
+    fun `OsmDroidMapFragment should be return if any of OSM options selected in settings`() {
+        // BASEMAP_SOURCE_OSM
+        settingsProvider
+            .getUnprotectedSettings()
+            .save(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_OSM)
+
+        assertThat(
+            mapFragmentFactoryImpl.createMapFragment(),
+            instanceOf(OsmDroidMapFragment::class.java)
+        )
+
+        // BASEMAP_SOURCE_USGS
+        settingsProvider
+            .getUnprotectedSettings()
+            .save(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_USGS)
+
+        assertThat(
+            mapFragmentFactoryImpl.createMapFragment(),
+            instanceOf(OsmDroidMapFragment::class.java)
+        )
+
+        // BASEMAP_SOURCE_CARTO
+        settingsProvider
+            .getUnprotectedSettings()
+            .save(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_CARTO)
+
+        assertThat(
+            mapFragmentFactoryImpl.createMapFragment(),
+            instanceOf(OsmDroidMapFragment::class.java)
+        )
+
+        // BASEMAP_SOURCE_STAMEN
+        settingsProvider
+            .getUnprotectedSettings()
+            .save(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_STAMEN)
+
+        assertThat(
+            mapFragmentFactoryImpl.createMapFragment(),
+            instanceOf(OsmDroidMapFragment::class.java)
+        )
+    }
+
+    @Test
+    fun `GoogleMapFragment should be return if Google Maps selected in settings`() {
+        settingsProvider
+            .getUnprotectedSettings()
+            .save(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_GOOGLE)
+
+        assertThat(
+            mapFragmentFactoryImpl.createMapFragment(),
+            instanceOf(GoogleMapFragment::class.java)
+        )
+    }
+
+    @Test
+    fun `GoogleMapFragment should be return if corresponding value stored in settings is unsupported`() {
+        settingsProvider
+            .getUnprotectedSettings()
+            .save(ProjectKeys.KEY_BASEMAP_SOURCE, "Blah")
+
+        assertThat(
+            mapFragmentFactoryImpl.createMapFragment(),
+            instanceOf(GoogleMapFragment::class.java)
+        )
+    }
+}


### PR DESCRIPTION
Closes #5322 

#### What has been done to verify that this works as intended?
I've tested the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
`MapFragmentFactoryImpl` is created once and passed to the geo module so that it can be injected in the classes that belong to that module. The problem was that as a constructor parameter we passed settings to `MapFragmentFactoryImpl` like it was created for every single usage. As a result `MapFragmentFactoryImpl` was always used with the same settings (from the first project). I fixed it passing settingsProvider to `MapFragmentFactoryImpl` instead.

BTW. it is a bit misleading that such dependencies that we pass to other modules are singletons but they are not annotated with `@Singleton` annotation. This is something we might want to change in the future @seadowg.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The implemented changes are only in the class responsible for creating map views (Google/Mapbox/OSM) based on settings so this is the only source of risk.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
