### PR TITLE
Don't include vertical space for read-only questions with no answer

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/QuestionWidget.java
@@ -360,13 +360,11 @@ public abstract class QuestionWidget extends FrameLayout implements Widget {
 
     private void hideAnswerContainerIfNeeded() {
         if (questionDetails.isReadOnly() && formEntryPrompt.getAnswerValue() == null) {
-            findViewById(R.id.space_box).setVisibility(VISIBLE);
             findViewById(R.id.answer_container).setVisibility(GONE);
         }
     }
 
     public void showAnswerContainer() {
-        findViewById(R.id.space_box).setVisibility(GONE);
         findViewById(R.id.answer_container).setVisibility(VISIBLE);
     }
 

--- a/collect_app/src/main/res/layout/label_widget.xml
+++ b/collect_app/src/main/res/layout/label_widget.xml
@@ -44,12 +44,4 @@
         tools:ignore="RtlHardcoded">
 
     </LinearLayout>
-
-    <FrameLayout
-        android:id="@+id/space_box"
-        android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:layout_below="@+id/help_text"
-        android:visibility="gone"/>
-
 </RelativeLayout>

--- a/collect_app/src/main/res/layout/question_widget.xml
+++ b/collect_app/src/main/res/layout/question_widget.xml
@@ -26,11 +26,4 @@
         android:layout_height="wrap_content">
 
     </RelativeLayout>
-
-    <FrameLayout
-        android:id="@+id/space_box"
-        android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:visibility="gone"/>
-
 </LinearLayout>

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralExStringWidgetTest.java
@@ -57,14 +57,12 @@ public abstract class GeneralExStringWidgetTest<W extends ExStringWidget, A exte
         StringWidget widget = createWidget();
         List<View> viewsRegisterForContextMenu = ((WidgetTestActivity) activity).viewsRegisterForContextMenu;
 
-        assertThat(viewsRegisterForContextMenu.size(), is(3));
+        assertThat(viewsRegisterForContextMenu.size(), is(2));
 
         assertTrue(viewsRegisterForContextMenu.contains(widget.findViewWithTag(R.id.question_label)));
         assertTrue(viewsRegisterForContextMenu.contains(widget.findViewWithTag(R.id.help_text)));
-        assertTrue(viewsRegisterForContextMenu.contains(widget.findViewWithTag(R.id.space_box)));
 
         assertThat(viewsRegisterForContextMenu.get(0).getId(), is(widget.getId()));
         assertThat(viewsRegisterForContextMenu.get(1).getId(), is(widget.getId()));
-        assertThat(viewsRegisterForContextMenu.get(2).getId(), is(widget.getId()));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/GeneralStringWidgetTest.java
@@ -95,14 +95,12 @@ public abstract class GeneralStringWidgetTest<W extends StringWidget, A extends 
         StringWidget widget = createWidget();
         List<View> viewsRegisterForContextMenu = ((WidgetTestActivity) activity).viewsRegisterForContextMenu;
 
-        assertThat(viewsRegisterForContextMenu.size(), is(3));
+        assertThat(viewsRegisterForContextMenu.size(), is(2));
 
         assertTrue(viewsRegisterForContextMenu.contains(widget.findViewWithTag(R.id.question_label)));
         assertTrue(viewsRegisterForContextMenu.contains(widget.findViewWithTag(R.id.help_text)));
-        assertTrue(viewsRegisterForContextMenu.contains(widget.findViewWithTag(R.id.space_box)));
 
         assertThat(viewsRegisterForContextMenu.get(0).getId(), is(widget.getId()));
         assertThat(viewsRegisterForContextMenu.get(1).getId(), is(widget.getId()));
-        assertThat(viewsRegisterForContextMenu.get(2).getId(), is(widget.getId()));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/base/QuestionWidgetTest.java
@@ -141,7 +141,6 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
         when(formEntryPrompt.isReadOnly()).thenReturn(true);
         QuestionWidget widget = (QuestionWidget) getWidget();
         assertThat(widget.findViewById(R.id.answer_container).getVisibility(), is(View.GONE));
-        assertThat(widget.findViewById(R.id.space_box).getVisibility(), is(View.VISIBLE));
     }
 
     @Test
@@ -150,7 +149,6 @@ public abstract class QuestionWidgetTest<W extends Widget, A extends IAnswerData
         when(formEntryPrompt.getAnswerValue()).thenReturn(getInitialAnswer());
         QuestionWidget widget = (QuestionWidget) getWidget();
         assertThat(widget.findViewById(R.id.answer_container).getVisibility(), is(View.VISIBLE));
-        assertThat(widget.findViewById(R.id.space_box).getVisibility(), is(View.GONE));
     }
 
     // The whole widget should be registered for context menu to support removing answers/groups


### PR DESCRIPTION
Closes #5352 

#### What has been done to verify that this works as intended?
I've verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
Removing the space box is the only solution what we discussed in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
This change is related to widgets displayed on one page ([field-list](https://xlsform.org/en/#appearance) appearance). On master when we had a [Note widget](https://docs.getodk.org/form-question-types/#note-widget) or any[ read-only](https://xlsform.org/en/#read-only) widget with no answer we added some empty space between widgets. Now we decided to get rid of that to allow users to use such widgets (especially the Note widget) as titles (see: https://forum.getodk.org/t/form-with-appearance-field-list-and-nested-group-label/39625/4?u=ln)

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with the Note widget in a filed-list group or any read-only widget with no answer also in a filed-list group like:
[NoteAndReadOnlyWidgetsInFieldListGroup.xlsx](https://github.com/getodk/collect/files/10084528/NoteAndReadOnlyWidgetsInFieldListGroup.xlsx)

The form attached to this issue: https://github.com/getodk/collect/issues/4260

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
