### PR TITLE
Prevent most common restore crashes

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/DialogFragmentUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/DialogFragmentUtils.kt
@@ -21,6 +21,10 @@ object DialogFragmentUtils {
         args: Bundle?,
         fragmentManager: FragmentManager
     ) {
+        if (fragmentManager.isDestroyed) {
+            return
+        }
+
         val fragmentFactory = fragmentManager.fragmentFactory
         val instance = fragmentFactory.instantiate(dialogClass.classLoader, dialogClass.name) as T
         instance.arguments = args

--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/DialogFragmentUtils.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/DialogFragmentUtils.kt
@@ -21,7 +21,10 @@ object DialogFragmentUtils {
         args: Bundle?,
         fragmentManager: FragmentManager
     ) {
-        showIfNotShowing(createNewInstance(dialogClass, args), dialogClass, fragmentManager)
+        val fragmentFactory = fragmentManager.fragmentFactory
+        val instance = fragmentFactory.instantiate(dialogClass.classLoader, dialogClass.name) as T
+        instance.arguments = args
+        showIfNotShowing(instance, dialogClass, fragmentManager)
     }
 
     @JvmStatic
@@ -77,19 +80,6 @@ object DialogFragmentUtils {
             } catch (e: IllegalStateException) {
                 Timber.w(e)
             }
-        }
-    }
-
-    private fun <T : DialogFragment> createNewInstance(dialogClass: Class<T>, args: Bundle?): T {
-        return try {
-            val instance = dialogClass.newInstance()
-            instance.arguments = args
-            instance
-        } catch (e: IllegalAccessException) {
-            // These would mean we have a non zero arg constructor for a Fragment
-            throw RuntimeException(e)
-        } catch (e: InstantiationException) {
-            throw RuntimeException(e)
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -385,8 +385,11 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             sessionId = savedInstanceState.getString(KEY_SESSION_ID);
         }
 
+        formSaveViewModelFactoryFactory.setSessionId(sessionId);
+
         this.getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(AudioRecordingControllerFragment.class, () -> new AudioRecordingControllerFragment(sessionId))
+                .forClass(QuitFormDialogFragment.class, () -> new QuitFormDialogFragment(formSaveViewModelFactoryFactory))
                 .build());
 
         super.onCreate(savedInstanceState);
@@ -500,7 +503,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         });
 
-        formSaveViewModelFactoryFactory.setSessionId(sessionId);
         formSaveViewModel = new ViewModelProvider(this, formSaveViewModelFactoryFactory.create(this, null)).get(FormSaveViewModel.class);
         formSaveViewModel.getSaveResult().observe(this, this::handleSaveResult);
         formSaveViewModel.isSavingAnswerFile().observe(this, isSavingAnswerFile -> {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -385,7 +385,9 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             sessionId = savedInstanceState.getString(KEY_SESSION_ID);
         }
 
+        formEntryViewModelFactory.setSessionId(sessionId);
         formSaveViewModelFactoryFactory.setSessionId(sessionId);
+        backgroundAudioViewModelFactory.setSessionId(sessionId);
 
         this.getSupportFragmentManager().setFragmentFactory(new FragmentFactoryBuilder()
                 .forClass(AudioRecordingControllerFragment.class, () -> new AudioRecordingControllerFragment(sessionId))
@@ -445,14 +447,12 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 new BackgroundLocationViewModel.Factory(permissionsProvider, settingsProvider.getUnprotectedSettings(), formSessionRepository, sessionId)
         ).get(BackgroundLocationViewModel.class);
 
-        backgroundAudioViewModelFactory.setSessionId(sessionId);
         backgroundAudioViewModel = new ViewModelProvider(this, backgroundAudioViewModelFactory).get(BackgroundAudioViewModel.class);
         backgroundAudioViewModel.isPermissionRequired().observe(this, isPermissionRequired -> {
             if (isPermissionRequired) {
                 showIfNotShowing(BackgroundAudioPermissionDialogFragment.class, getSupportFragmentManager());
             }
         });
-
 
         identityPromptViewModel = new ViewModelProvider(this).get(IdentityPromptViewModel.class);
         identityPromptViewModel.requiresIdentityToContinue().observe(this, requiresIdentity -> {
@@ -467,7 +467,6 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
             }
         });
 
-        formEntryViewModelFactory.setSessionId(sessionId);
         formEntryViewModel = new ViewModelProvider(this, formEntryViewModelFactory)
                 .get(FormEntryViewModel.class);
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -145,6 +145,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity implements De
         formEntryViewModel = new ViewModelProvider(this, formEntryViewModelFactory).get(FormEntryViewModel.class);
 
         FormController formController = formEntryViewModel.getFormController();
+        if (formController == null) {
+            finish();
+            return;
+        }
+
         startIndex = formController.getFormIndex();
 
         setTitle(formController.getFormTitle());

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/QuitFormDialogFragment.java
@@ -45,9 +45,6 @@ public class QuitFormDialogFragment extends DialogFragment {
     Scheduler scheduler;
 
     @Inject
-    FormSaveViewModel.FactoryFactory formSaveViewModelFactoryFactory;
-
-    @Inject
     SettingsProvider settingsProvider;
 
     @Inject
@@ -59,6 +56,12 @@ public class QuitFormDialogFragment extends DialogFragment {
     private FormSaveViewModel formSaveViewModel;
     private FormEntryViewModel formEntryViewModel;
     private Listener listener;
+
+    private final FormSaveViewModel.FactoryFactory formSaveViewModelFactoryFactory;
+
+    public QuitFormDialogFragment(FormSaveViewModel.FactoryFactory formSaveViewModelFactoryFactory) {
+        this.formSaveViewModelFactoryFactory = formSaveViewModelFactoryFactory;
+    }
 
     @Override
     public void onAttach(@NonNull Context context) {

--- a/collect_app/src/test/java/org/odk/collect/android/activities/FormHierarchyActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/activities/FormHierarchyActivityTest.kt
@@ -1,0 +1,31 @@
+package org.odk.collect.android.activities
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FormHierarchyActivityTest {
+
+    /**
+     * This can happen if the app process is restored after being kicked from memory.
+     */
+    @Test
+    fun whenFormHasNotLoadedYet_finishes() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val intent = Intent(context, FormHierarchyActivity::class.java).also {
+            it.putExtra(FormHierarchyActivity.EXTRA_SESSION_ID, "blah")
+        }
+
+        ActivityScenario.launch<FormHierarchyActivity>(intent).use { scenario ->
+            assertThat(scenario.state, equalTo(Lifecycle.State.DESTROYED))
+        }
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/QuitFormDialogFragmentTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/QuitFormDialogFragmentTest.java
@@ -39,6 +39,7 @@ import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.android.support.CollectHelpers;
 import org.odk.collect.android.utilities.MediaUtils;
+import org.odk.collect.androidshared.ui.FragmentFactoryBuilder;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.audiorecorder.recording.AudioRecorder;
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule;
@@ -51,9 +52,31 @@ public class QuitFormDialogFragmentTest {
     private final FormSaveViewModel formSaveViewModel = mock(FormSaveViewModel.class);
     private final FormEntryViewModel formEntryViewModel = mock(FormEntryViewModel.class);
 
+    private FormSaveViewModel.FactoryFactory formSaveViewModelFactoryFactory = new FormSaveViewModel.FactoryFactory() {
+        @Override
+        public void setSessionId(String sessionId) {
+
+        }
+
+        @Override
+        public ViewModelProvider.Factory create(@NonNull SavedStateRegistryOwner owner, @Nullable Bundle defaultArgs) {
+            return new ViewModelProvider.Factory() {
+
+                @NonNull
+                @Override
+                public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+                    return (T) formSaveViewModel;
+                }
+            };
+        }
+    };
+
     @Rule
     public FragmentScenarioLauncherRule launcherRule = new FragmentScenarioLauncherRule(
-            R.style.Theme_MaterialComponents
+            R.style.Theme_MaterialComponents,
+            new FragmentFactoryBuilder()
+                    .forClass(QuitFormDialogFragment.class, () -> new QuitFormDialogFragment(formSaveViewModelFactoryFactory))
+                    .build()
     );
 
     @Before
@@ -61,24 +84,7 @@ public class QuitFormDialogFragmentTest {
         CollectHelpers.overrideAppDependencyModule(new AppDependencyModule() {
             @Override
             public FormSaveViewModel.FactoryFactory providesFormSaveViewModelFactoryFactory(Analytics analytics, Scheduler scheduler, AudioRecorder audioRecorder, CurrentProjectProvider currentProjectProvider, MediaUtils mediaUtils, FormSessionRepository formSessionRepository, EntitiesRepositoryProvider entitiesRepositoryProvider) {
-                return new FormSaveViewModel.FactoryFactory() {
-                    @Override
-                    public void setSessionId(String sessionId) {
-
-                    }
-
-                    @Override
-                    public ViewModelProvider.Factory create(@NonNull SavedStateRegistryOwner owner, @Nullable Bundle defaultArgs) {
-                        return new ViewModelProvider.Factory() {
-
-                            @NonNull
-                            @Override
-                            public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
-                                return (T) formSaveViewModel;
-                            }
-                        };
-                    }
-                };
+                return formSaveViewModelFactoryFactory;
             }
 
             @Override

--- a/fragmentstest/src/main/java/org/odk/collect/fragmentstest/FragmentScenarioLauncherRule.kt
+++ b/fragmentstest/src/main/java/org/odk/collect/fragmentstest/FragmentScenarioLauncherRule.kt
@@ -61,14 +61,14 @@ class FragmentScenarioLauncherRule @JvmOverloads constructor(
                 fragmentClass = fragmentClass,
                 fragmentArgs = fragmentArgs,
                 themeResId = defaultThemeResId,
-                factory = null,
+                factory = defaultFactory,
                 initialState = initialState
             )
         } else {
             FragmentScenario.launch(
                 fragmentClass = fragmentClass,
                 fragmentArgs = fragmentArgs,
-                factory = null,
+                factory = defaultFactory,
                 initialState = initialState
             )
         }


### PR DESCRIPTION
Work towards #5240

This fixes crashes that occur when restoring to the quit form dialog or the form hierarchy which are currently the most "popular" crashes for v2022.4. Both cases result in slightly strange behaviour:

* Restoring to the quit form dialog will show the hierarchy and then the dialog when you exit the hierarchy. Additionally, the dialog title will just be "no form loaded".
* Restoring to the hierarchy will show normal form entry instead of the hierarchy

Both these quirks are definitely preferable to a crash and shouldn't be a huge problem for users (and I believe both would have been existing problems in earlier versions). I think we should merge this with them, and then update the issue so that we can fix them when we deal with the other related crashes and problems.

I ended up changing the structure of `QuitFormDialogFragment` to accommodate the restore scenario (where the dialog is recreated by the Activity before the form has loaded) and it led me down a path I've considered before (passing dependencies in Fragment constructors instead of using Dagger), but never really had the push to get there. That's discussed in https://github.com/getodk/collect/pull/5366/files#r1032477176, and I'd be especially interested in thoughts from @grzesiek2010.

#### What has been done to verify that this works as intended?

New tests where possible and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix restoring (the process of reproducing that is in the issue) for the quit form dialog and form hierarchy cases. It'd be good to test these flows as well as the dialog and hierarchy in more normal contexts.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
