### PR TITLE
Include submissions that failed in View Sent Form

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/AutoSendTest.kt
@@ -67,8 +67,8 @@ class AutoSendTest {
         testDependencies.scheduler.runDeferredTasks()
 
         mainMenuPage
-            .clickViewSentForm(0)
-            .assertTextDoesNotExist("One Question")
+            .clickViewSentForm(1)
+            .assertText("One Question")
 
         notificationDrawerRule
             .open()
@@ -129,8 +129,8 @@ class AutoSendTest {
         testDependencies.scheduler.runDeferredTasks()
 
         mainMenuPage
-            .clickViewSentForm(0)
-            .assertTextDoesNotExist("One Question Autosend")
+            .clickViewSentForm(1)
+            .assertText("One Question Autosend")
 
         notificationDrawerRule
             .open()

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -24,16 +24,18 @@ public class CursorLoaderFactory {
     public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            String selection = DatabaseInstanceColumns.STATUS + " =? ";
-            String[] selectionArgs = {Instance.STATUS_SUBMITTED};
+            String selection = DatabaseInstanceColumns.STATUS + "=? or " + DatabaseInstanceColumns.STATUS + "=?";
+            String[] selectionArgs = {Instance.STATUS_SUBMITTED, Instance.STATUS_SUBMISSION_FAILED};
 
             cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         } else {
             String selection =
-                    DatabaseInstanceColumns.STATUS + " =? and "
+                    "(" + DatabaseInstanceColumns.STATUS + "=? or "
+                            + DatabaseInstanceColumns.STATUS + "=?) and "
                             + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
             String[] selectionArgs = {
                     Instance.STATUS_SUBMITTED,
+                    Instance.STATUS_SUBMISSION_FAILED,
                     "%" + charSequence + "%"};
 
             cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -21,17 +21,13 @@ public class CursorLoaderFactory {
         this.currentProjectProvider = currentProjectProvider;
     }
 
-    public CursorLoader createSentInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {Instance.STATUS_SUBMITTED};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-    }
-
     public CursorLoader createSentInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            cursorLoader = createSentInstancesCursorLoader(sortOrder);
+            String selection = DatabaseInstanceColumns.STATUS + " =? ";
+            String[] selectionArgs = {Instance.STATUS_SUBMITTED};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         } else {
             String selection =
                     DatabaseInstanceColumns.STATUS + " =? and "

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesAppState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesAppState.kt
@@ -37,7 +37,7 @@ class InstancesAppState(
             Instance.STATUS_COMPLETE,
             Instance.STATUS_SUBMISSION_FAILED
         )
-        val sentInstances = instancesRepository.getCountByStatus(Instance.STATUS_SUBMITTED)
+        val sentInstances = instancesRepository.getCountByStatus(Instance.STATUS_SUBMITTED, Instance.STATUS_SUBMISSION_FAILED)
         val editableInstances = instancesRepository.getCountByStatus(
             Instance.STATUS_INCOMPLETE,
             Instance.STATUS_COMPLETE


### PR DESCRIPTION
Closes #5383 

#### What has been done to verify that this works as intended?
I've tested the fix manually and updated automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
Not much to discuss here it's just the simplest implementation of what was described in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that now forms that failed are displayed in `View Sent Form`. Other parts of the app should not be affected but you never know.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
