### PR TITLE
Add "Updated at" subtext for forms that get updated attachments

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/UpdateFormAttachmentsTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/UpdateFormAttachmentsTest.kt
@@ -1,0 +1,116 @@
+package org.odk.collect.android.feature.formmanagement
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.R
+import org.odk.collect.android.support.TestDependencies
+import org.odk.collect.android.support.pages.MainMenuPage
+import org.odk.collect.android.support.rules.CollectTestRule
+import org.odk.collect.android.support.rules.TestRuleChain.chain
+
+// https://github.com/getodk/collect/issues/5384
+@RunWith(AndroidJUnit4::class)
+class UpdateFormAttachmentsTest {
+
+    private val rule = CollectTestRule(false)
+    private val testDependencies = TestDependencies()
+
+    @get:Rule
+    var chain: RuleChain = chain(testDependencies).around(rule)
+
+    @Test
+    fun updateOn_instead_addedOn_subtextShouldBeDisplayedAfterDownloadingNewAttachments() {
+        testDependencies.server.addForm(
+            "One Question",
+            "one_question",
+            "1",
+            "one-question.xml"
+        )
+
+        val mainMenuPage = rule.withProject(testDependencies.server.url)
+            .clickGetBlankForm()
+            .assertTextNotDisplayed(R.string.newer_version_of_a_form_info)
+            .clickGetSelected()
+            .assertMessage("All downloads succeeded!")
+            .clickOKOnDialog(MainMenuPage())
+            .clickFillBlankForm()
+            .assertTextThatContainsExists("Added on")
+            .pressBack(MainMenuPage())
+            .clickDeleteSavedForm()
+            .clickBlankForms()
+            .assertTextThatContainsExists("Added on")
+            .pressBack(MainMenuPage())
+
+        testDependencies.server.removeForm("One Question")
+
+        testDependencies.server.addForm(
+            "One Question",
+            "one_question",
+            "1",
+            "one-question.xml",
+            listOf("fruits.csv")
+        )
+
+        mainMenuPage.clickGetBlankForm()
+            .assertText(R.string.newer_version_of_a_form_info)
+            .clickGetSelected()
+            .assertMessage("All downloads succeeded!")
+            .clickOKOnDialog(MainMenuPage())
+            .clickFillBlankForm()
+            .assertTextThatContainsExists("Updated on")
+            .pressBack(MainMenuPage())
+            .clickDeleteSavedForm()
+            .clickBlankForms()
+            .assertTextThatContainsExists("Updated on")
+    }
+
+    @Test
+    fun addedOn_subtextShouldBeDisplayedAfterDownloadingNewFormVersionEvenIfThatFormHasNewAttachments() {
+        testDependencies.server.addForm(
+            "One Question",
+            "one_question",
+            "1",
+            "one-question.xml"
+        )
+
+        val mainMenuPage = rule.withProject(testDependencies.server.url)
+            .clickGetBlankForm()
+            .assertTextNotDisplayed(R.string.newer_version_of_a_form_info)
+            .clickGetSelected()
+            .assertMessage("All downloads succeeded!")
+            .clickOKOnDialog(MainMenuPage())
+            .clickFillBlankForm()
+            .assertTextThatContainsExists("Added on")
+            .pressBack(MainMenuPage())
+            .clickDeleteSavedForm()
+            .clickBlankForms()
+            .assertTextThatContainsExists("Added on")
+            .pressBack(MainMenuPage())
+
+        testDependencies.server.removeForm("One Question")
+
+        testDependencies.server.addForm(
+            "One Question Updated",
+            "one_question",
+            "2",
+            "one-question-updated.xml",
+            listOf("fruits.csv")
+        )
+
+        mainMenuPage.clickGetBlankForm()
+            .assertText(R.string.newer_version_of_a_form_info)
+            .clickGetSelected()
+            .assertMessage("All downloads succeeded!")
+            .clickOKOnDialog(MainMenuPage())
+            .clickFillBlankForm()
+            .assertTextThatContainsExists("Added on")
+            .pressBack(MainMenuPage())
+            .clickDeleteSavedForm()
+            .clickBlankForms()
+            .assertTextThatContainsExists("Added on")
+            .assertTextThatContainsExists("Added on", 1)
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -71,6 +71,8 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
             } else {
                 return new HttpGetResult(null, new HashMap<>(), "", 404);
             }
+        } else if (uri.getPath().equals("/mediaFile")) {
+            return new HttpGetResult(getMediaFile(uri), new HashMap<>(), "", 200);
         } else {
             return new HttpGetResult(null, new HashMap<>(), "", 404);
         }
@@ -259,6 +261,14 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
 
         AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
         return assetManager.open("forms/" + xmlPath);
+    }
+
+    @NotNull
+    private InputStream getMediaFile(URI uri) throws IOException {
+        String mediaFileName = uri.getQuery().split("=")[1];
+
+        AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
+        return assetManager.open("media/" + mediaFileName);
     }
 
     private static class XFormItem {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -97,6 +97,20 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
+    fun assertTextThatContainsExists(text: String, index: Int = 0): T {
+        onView(
+            withIndex(
+                withText(
+                    containsString(
+                        text
+                    )
+                ),
+                index
+            )
+        ).check(matches(isDisplayed()))
+        return this as T
+    }
+
     fun assertText(vararg text: String?): T {
         closeSoftKeyboard()
         for (t in text) {

--- a/collect_app/src/main/java/org/odk/collect/android/adapters/FormListAdapter.java
+++ b/collect_app/src/main/java/org/odk/collect/android/adapters/FormListAdapter.java
@@ -52,7 +52,9 @@ public class FormListAdapter extends SimpleCursorAdapter {
         setViewBinder((view, cursor, columnIndex) -> {
             String columnName = cursor.getColumnName(columnIndex);
             if (columnName.equals(DatabaseFormColumns.DATE)) {
-                String timestampText = getTimestampText(new Date(cursor.getLong(columnIndex)));
+                Long dateOfCreation = cursor.getLong(columnIndex);
+                Long dateOfLastAttachmentsUpdate = cursor.isNull(cursor.getColumnIndex(DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)) ? null : cursor.getLong(cursor.getColumnIndex(DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE));
+                String timestampText = getTimestampText(dateOfCreation, dateOfLastAttachmentsUpdate);
                 if (!timestampText.isEmpty()) {
                     TextView v = (TextView) view;
                     v.setText(timestampText);
@@ -103,12 +105,14 @@ public class FormListAdapter extends SimpleCursorAdapter {
         }
     }
 
-    private String getTimestampText(Date date) {
+    private String getTimestampText(Long dateOfCreation, Long dateOfLastAttachmentsUpdate) {
         try {
             if (context != null) {
-                return new SimpleDateFormat(
-                    context.getString(R.string.added_on_date_at_time), Locale.getDefault()
-                ).format(date);
+                if (dateOfLastAttachmentsUpdate != null) {
+                    return new SimpleDateFormat(context.getString(R.string.updated_on_date_at_time), Locale.getDefault()).format(new Date(dateOfLastAttachmentsUpdate));
+                } else {
+                    return new SimpleDateFormat(context.getString(R.string.added_on_date_at_time), Locale.getDefault()).format(new Date(dateOfCreation));
+                }
             }
         } catch (IllegalArgumentException e) {
             Timber.e(e, "Current locale: %s", Locale.getDefault());

--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseObjectMapper.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseObjectMapper.kt
@@ -33,6 +33,7 @@ object DatabaseObjectMapper {
         values.put(DatabaseFormColumns.AUTO_SEND, form.autoSend)
         values.put(DatabaseFormColumns.AUTO_DELETE, form.autoDelete)
         values.put(DatabaseFormColumns.GEOMETRY_XPATH, form.geometryXpath)
+        values.put(DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE, form.lastDetectedAttachmentsUpdateDate)
         return values
     }
 
@@ -69,6 +70,7 @@ object DatabaseObjectMapper {
             .autoDelete(values.getAsString(DatabaseFormColumns.AUTO_DELETE))
             .geometryXpath(values.getAsString(DatabaseFormColumns.GEOMETRY_XPATH))
             .deleted(values.getAsLong(DatabaseFormColumns.DELETED_DATE) != null)
+            .lastDetectedAttachmentsUpdateDate(values.getAsLong(DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE))
             .build()
     }
 
@@ -97,6 +99,7 @@ object DatabaseObjectMapper {
         val autoDeleteColumnIndex = cursor.getColumnIndex(DatabaseFormColumns.AUTO_DELETE)
         val geometryXpathColumnIndex = cursor.getColumnIndex(DatabaseFormColumns.GEOMETRY_XPATH)
         val deletedDateColumnIndex = cursor.getColumnIndex(DatabaseFormColumns.DELETED_DATE)
+        val lastDetectedAttachmentsUpdateDateColumnIndex = cursor.getColumnIndex(DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)
         return Form.Builder()
             .dbId(cursor.getLong(idColumnIndex))
             .displayName(cursor.getString(displayNameColumnIndex))
@@ -130,6 +133,7 @@ object DatabaseObjectMapper {
             .autoDelete(cursor.getString(autoDeleteColumnIndex))
             .geometryXpath(cursor.getString(geometryXpathColumnIndex))
             .deleted(!cursor.isNull(deletedDateColumnIndex))
+            .lastDetectedAttachmentsUpdateDate(if (cursor.isNull(lastDetectedAttachmentsUpdateDateColumnIndex)) null else cursor.getLong(lastDetectedAttachmentsUpdateDateColumnIndex))
             .build()
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormColumns.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormColumns.kt
@@ -29,6 +29,7 @@ object DatabaseFormColumns : BaseColumns {
     // this is null on create, and can only be set on an update.
     const val LANGUAGE = "language"
     const val DELETED_DATE = "deleted_date"
+    const val LAST_DETECTED_ATTACHMENTS_UPDATE_DATE = "lastDetectedAttachmentsUpdateDate"
 
     // not used in the newest database version
     const val DISPLAY_SUBTEXT = "displaySubtext"

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormColumns.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/DatabaseFormColumns.kt
@@ -21,7 +21,6 @@ object DatabaseFormColumns : BaseColumns {
     const val GEOMETRY_XPATH = "geometryXpath" // can be null
 
     // these are generated for you (but you can insert something else if you want)
-    const val DISPLAY_SUBTEXT = "displaySubtext" // not used in the newest database version
     const val MD5_HASH = "md5Hash"
     const val DATE = "date"
     const val JRCACHE_FILE_PATH = "jrcacheFilePath"
@@ -30,4 +29,8 @@ object DatabaseFormColumns : BaseColumns {
     // this is null on create, and can only be set on an update.
     const val LANGUAGE = "language"
     const val DELETED_DATE = "deleted_date"
+
+    // not used in the newest database version
+    const val DISPLAY_SUBTEXT = "displaySubtext"
+    const val LAST_DETECTED_FORM_VERSION_HASH = "lastDetectedFormVersionHash"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
@@ -23,6 +23,7 @@ import static org.odk.collect.android.database.forms.DatabaseFormColumns.JRCACHE
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_FORM_ID;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_VERSION;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LANGUAGE;
+import static org.odk.collect.android.database.forms.DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LAST_DETECTED_FORM_VERSION_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.MD5_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.SUBMISSION_URI;
@@ -39,7 +40,7 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
     private static final String MODEL_VERSION = "modelVersion";
 
     public void onCreate(SQLiteDatabase db) {
-        createFormsTableV11(db);
+        createFormsTableV12(db);
     }
 
     @SuppressWarnings({"checkstyle:FallThrough"})
@@ -64,12 +65,14 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
                 upgradeToVersion10(db);
             case 10:
                 upgradeToVersion11(db);
+            case 11:
+                upgradeToVersion12(db);
         }
     }
 
     public void onDowngrade(SQLiteDatabase db) throws SQLException {
         SQLiteUtils.dropTable(db, FORMS_TABLE_NAME);
-        createFormsTableV11(db);
+        createFormsTableV12(db);
     }
 
     private void upgradeToVersion2(SQLiteDatabase db) {
@@ -251,6 +254,10 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
         SQLiteUtils.dropTable(db, temporaryTable);
     }
 
+    private void upgradeToVersion12(SQLiteDatabase db) {
+        SQLiteUtils.addColumn(db, FORMS_TABLE_NAME, LAST_DETECTED_ATTACHMENTS_UPDATE_DATE, "integer");
+    }
+
     private void createFormsTableV4(SQLiteDatabase db, String tableName) {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + tableName + " ("
                 + _ID + " integer primary key, "
@@ -353,5 +360,27 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
                 + AUTO_DELETE + " text, "
                 + GEOMETRY_XPATH + " text, "
                 + DELETED_DATE + " integer);");
+    }
+
+    private void createFormsTableV12(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + FORMS_TABLE_NAME + " ("
+                + _ID + " integer primary key, "
+                + DISPLAY_NAME + " text not null, "
+                + DESCRIPTION + " text, "
+                + JR_FORM_ID + " text not null, "
+                + JR_VERSION + " text, "
+                + MD5_HASH + " text not null UNIQUE ON CONFLICT IGNORE, "
+                + DATE + " integer not null, " // milliseconds
+                + FORM_MEDIA_PATH + " text not null, "
+                + FORM_FILE_PATH + " text not null, "
+                + LANGUAGE + " text, "
+                + SUBMISSION_URI + " text, "
+                + BASE64_RSA_PUBLIC_KEY + " text, "
+                + JRCACHE_FILE_PATH + " text not null, "
+                + AUTO_SEND + " text, "
+                + AUTO_DELETE + " text, "
+                + GEOMETRY_XPATH + " text, "
+                + DELETED_DATE + " integer, "
+                + LAST_DETECTED_ATTACHMENTS_UPDATE_DATE + " integer);"); // milliseconds
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
@@ -23,6 +23,7 @@ import static org.odk.collect.android.database.forms.DatabaseFormColumns.JRCACHE
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_FORM_ID;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_VERSION;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LANGUAGE;
+import static org.odk.collect.android.database.forms.DatabaseFormColumns.LAST_DETECTED_FORM_VERSION_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.MD5_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.SUBMISSION_URI;
 
@@ -31,7 +32,7 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
     private static final String[] COLUMN_NAMES_V7 = {_ID, DISPLAY_NAME, DESCRIPTION,
             JR_FORM_ID, JR_VERSION, MD5_HASH, DATE, FORM_MEDIA_PATH, FORM_FILE_PATH, LANGUAGE,
             SUBMISSION_URI, BASE64_RSA_PUBLIC_KEY, JRCACHE_FILE_PATH, AUTO_SEND, AUTO_DELETE,
-            "lastDetectedFormVersionHash"};
+            LAST_DETECTED_FORM_VERSION_HASH};
 
     // These exist in database versions 2 and 3, but not in 4...
     private static final String TEMP_FORMS_TABLE_NAME = "forms_v4";
@@ -202,7 +203,7 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
     }
 
     private void upgradeToVersion6(SQLiteDatabase db) {
-        SQLiteUtils.addColumn(db, FORMS_TABLE_NAME, "lastDetectedFormVersionHash", "text");
+        SQLiteUtils.addColumn(db, FORMS_TABLE_NAME, LAST_DETECTED_FORM_VERSION_HASH, "text");
     }
 
     private void upgradeToVersion7(SQLiteDatabase db) {
@@ -268,7 +269,7 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
                 + JRCACHE_FILE_PATH + " text not null, "
                 + AUTO_SEND + " text, "
                 + AUTO_DELETE + " text, "
-                + "lastDetectedFormVersionHash" + " text);");
+                + LAST_DETECTED_FORM_VERSION_HASH + " text);");
     }
 
     private void createFormsTableV7(SQLiteDatabase db) {
@@ -288,7 +289,7 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
                 + JRCACHE_FILE_PATH + " text not null, "
                 + AUTO_SEND + " text, "
                 + AUTO_DELETE + " text, "
-                + "lastDetectedFormVersionHash" + " text);");
+                + LAST_DETECTED_FORM_VERSION_HASH + " text);");
     }
 
     private void createFormsTableV9(SQLiteDatabase db) {

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListAdapter.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListAdapter.kt
@@ -32,7 +32,11 @@ class BlankFormListAdapter(
                 binding.formSubtitle.visibility = if (this.formVersion.isNotBlank()) View.VISIBLE else View.GONE
 
                 binding.formSubtitle2.text = try {
-                    SimpleDateFormat(binding.root.context.getString(R.string.added_on_date_at_time), Locale.getDefault()).format(this.dateOfCreation)
+                    if (this.dateOfLastDetectedAttachmentsUpdate != null) {
+                        SimpleDateFormat(binding.root.context.getString(R.string.updated_on_date_at_time), Locale.getDefault()).format(this.dateOfLastDetectedAttachmentsUpdate)
+                    } else {
+                        SimpleDateFormat(binding.root.context.getString(R.string.added_on_date_at_time), Locale.getDefault()).format(this.dateOfCreation)
+                    }
                 } catch (e: IllegalArgumentException) {
                     Timber.e(e)
                     ""

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListItem.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListItem.kt
@@ -13,6 +13,7 @@ data class BlankFormListItem(
     val geometryPath: String,
     val dateOfCreation: Long,
     val dateOfLastUsage: Long,
+    val dateOfLastDetectedAttachmentsUpdate: Long?,
     val contentUri: Uri
 )
 
@@ -27,5 +28,6 @@ fun Form.toBlankFormListItem(projectId: String, instancesRepository: InstancesRe
         .getAllByFormId(this.formId)
         .filter { it.formVersion == this.version }
         .maxByOrNull { it.lastStatusChangeDate }?.lastStatusChangeDate ?: 0L,
+    dateOfLastDetectedAttachmentsUpdate = this.lastDetectedAttachmentsUpdateDate,
     contentUri = FormsContract.getUri(projectId, this.dbId)
 )

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -24,7 +24,8 @@ class FormMediaDownloader(
         tempMediaPath: String,
         tempDir: File,
         stateListener: OngoingWorkListener
-    ) {
+    ): Boolean {
+        var atLeastOneNewMediaFileDetected = false
         val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
 
         files.forEachIndexed { i, mediaFile ->
@@ -36,11 +37,13 @@ class FormMediaDownloader(
                 if (it != null) {
                     copyFile(it, tempMediaFile)
                 } else {
+                    atLeastOneNewMediaFileDetected = true
                     val file = formSource.fetchMediaFile(mediaFile.downloadUrl)
                     interuptablyWriteFile(file, tempMediaFile, tempDir, stateListener)
                 }
             }
         }
+        return atLeastOneNewMediaFileDetected
     }
 
     private fun searchForExistingMediaFile(

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsUpdater.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormsUpdater.kt
@@ -11,13 +11,15 @@ import org.odk.collect.android.utilities.FormsDirDiskFormsSynchronizer
 import org.odk.collect.forms.FormSourceException
 import org.odk.collect.settings.keys.ProjectKeys
 import java.io.File
+import java.util.function.Supplier
 import java.util.stream.Collectors
 
 class FormsUpdater(
     private val context: Context,
     private val notifier: Notifier,
     private val syncStatusAppState: SyncStatusAppState,
-    private val projectDependencyProviderFactory: ProjectDependencyProviderFactory
+    private val projectDependencyProviderFactory: ProjectDependencyProviderFactory,
+    private val clock: Supplier<Long>
 ) {
 
     /**
@@ -29,7 +31,7 @@ class FormsUpdater(
 
         val diskFormsSynchronizer = diskFormsSynchronizer(sandbox)
         val serverFormsDetailsFetcher = serverFormsDetailsFetcher(sandbox, diskFormsSynchronizer)
-        val formDownloader = formDownloader(sandbox)
+        val formDownloader = formDownloader(sandbox, clock)
 
         try {
             val serverForms: List<ServerFormDetails> = serverFormsDetailsFetcher.fetchFormDetails()
@@ -67,7 +69,7 @@ class FormsUpdater(
 
         val diskFormsSynchronizer = diskFormsSynchronizer(sandbox)
         val serverFormsDetailsFetcher = serverFormsDetailsFetcher(sandbox, diskFormsSynchronizer)
-        val formDownloader = formDownloader(sandbox)
+        val formDownloader = formDownloader(sandbox, clock)
 
         val serverFormsSynchronizer = ServerFormsSynchronizer(
             serverFormsDetailsFetcher,
@@ -103,13 +105,14 @@ class FormsUpdater(
     }
 }
 
-private fun formDownloader(projectDependencyProvider: ProjectDependencyProvider): ServerFormDownloader {
+private fun formDownloader(projectDependencyProvider: ProjectDependencyProvider, clock: Supplier<Long>): ServerFormDownloader {
     return ServerFormDownloader(
         projectDependencyProvider.formSource,
         projectDependencyProvider.formsRepository,
         File(projectDependencyProvider.cacheDir),
         projectDependencyProvider.formsDir,
-        FormMetadataParser()
+        FormMetadataParser(),
+        clock
     )
 }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -160,6 +160,13 @@ public class ServerFormDownloader implements FormDownloader {
             FileUtils.copyFile(fileResult.file, formFile);
         } else {
             formFile = fileResult.file;
+
+            if (newAttachmentsDetected) {
+                Form existingForm = formsRepository.getOneByPath(formFile.getAbsolutePath());
+                if (existingForm != null) {
+                    formsRepository.save(new Form.Builder(existingForm).lastDetectedAttachmentsUpdateDate(clock.get()).build());
+                }
+            }
         }
 
         // Save form in database
@@ -180,13 +187,6 @@ public class ServerFormDownloader implements FormDownloader {
                 }
 
                 throw new FormDownloadException.DiskError();
-            }
-        }
-
-        if (!fileResult.isNew && newAttachmentsDetected) {
-            Form existingForm = formsRepository.getOneByPath(formFile.getAbsolutePath());
-            if (existingForm != null) {
-                formsRepository.save(new Form.Builder(existingForm).lastDetectedAttachmentsUpdateDate(clock.get()).build());
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -200,7 +200,7 @@ public class AppDependencyModule {
 
     @Provides
     public FormDownloader providesFormDownloader(FormSourceProvider formSourceProvider, FormsRepositoryProvider formsRepositoryProvider, StoragePathProvider storagePathProvider, Analytics analytics) {
-        return new ServerFormDownloader(formSourceProvider.get(), formsRepositoryProvider.get(), new File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)), storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS), new FormMetadataParser());
+        return new ServerFormDownloader(formSourceProvider.get(), formsRepositoryProvider.get(), new File(storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)), storagePathProvider.getOdkDirPath(StorageSubdirectory.FORMS), new FormMetadataParser(), System::currentTimeMillis);
     }
 
     @Provides
@@ -547,7 +547,7 @@ public class AppDependencyModule {
 
     @Provides
     public FormsUpdater providesFormsUpdater(Context context, Notifier notifier, SyncStatusAppState syncStatusAppState, ProjectDependencyProviderFactory projectDependencyProviderFactory) {
-        return new FormsUpdater(context, notifier, syncStatusAppState, projectDependencyProviderFactory);
+        return new FormsUpdater(context, notifier, syncStatusAppState, projectDependencyProviderFactory, System::currentTimeMillis);
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
@@ -33,6 +33,7 @@ import static org.odk.collect.android.database.forms.DatabaseFormColumns.JRCACHE
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_FORM_ID;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_VERSION;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LANGUAGE;
+import static org.odk.collect.android.database.forms.DatabaseFormColumns.LAST_DETECTED_FORM_VERSION_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.MD5_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.SUBMISSION_URI;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns._ID;
@@ -224,7 +225,7 @@ public class FormDatabaseMigratorTest {
                 + BASE64_RSA_PUBLIC_KEY + " text, "
                 + AUTO_SEND + " text, "
                 + AUTO_DELETE + " text, "
-                + "lastDetectedFormVersionHash" + " text, "
+                + LAST_DETECTED_FORM_VERSION_HASH + " text, "
                 + GEOMETRY_XPATH + " text);");
 
         ContentValues contentValues = createVersion8Form();
@@ -256,7 +257,7 @@ public class FormDatabaseMigratorTest {
         contentValues.put(JRCACHE_FILE_PATH, "Jr/Cache/File/Path");
         contentValues.put(AUTO_SEND, "AutoSend");
         contentValues.put(AUTO_DELETE, "AutoDelete");
-        contentValues.put("lastDetectedFormVersionHash", "LastDetectedFormVersionHash");
+        contentValues.put(LAST_DETECTED_FORM_VERSION_HASH, "LastDetectedFormVersionHash");
         contentValues.put(GEOMETRY_XPATH, "GeometryXPath");
         return contentValues;
     }
@@ -277,7 +278,7 @@ public class FormDatabaseMigratorTest {
         contentValues.put(JRCACHE_FILE_PATH, "Jr/Cache/File/Path");
         contentValues.put(AUTO_SEND, "AutoSend");
         contentValues.put(AUTO_DELETE, "AutoDelete");
-        contentValues.put("lastDetectedFormVersionHash", "LastDetectedFormVersionHash");
+        contentValues.put(LAST_DETECTED_FORM_VERSION_HASH, "LastDetectedFormVersionHash");
         return contentValues;
     }
 
@@ -340,7 +341,7 @@ public class FormDatabaseMigratorTest {
                 + JRCACHE_FILE_PATH + " text not null, "
                 + AUTO_SEND + " text, "
                 + AUTO_DELETE + " text, "
-                + "lastDetectedFormVersionHash" + " text);");
+                + LAST_DETECTED_FORM_VERSION_HASH + " text);");
     }
 
     private void createVersion8Database(SQLiteDatabase database) {
@@ -360,7 +361,7 @@ public class FormDatabaseMigratorTest {
                 + JRCACHE_FILE_PATH + " text not null, "
                 + AUTO_SEND + " text, "
                 + AUTO_DELETE + " text, "
-                + "lastDetectedFormVersionHash" + " text, "
+                + LAST_DETECTED_FORM_VERSION_HASH + " text, "
                 + GEOMETRY_XPATH + " text);");
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.odk.collect.android.database.DatabaseConstants.FORMS_TABLE_NAME;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.AUTO_DELETE;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.AUTO_SEND;
@@ -33,6 +34,7 @@ import static org.odk.collect.android.database.forms.DatabaseFormColumns.JRCACHE
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_FORM_ID;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.JR_VERSION;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LANGUAGE;
+import static org.odk.collect.android.database.forms.DatabaseFormColumns.LAST_DETECTED_ATTACHMENTS_UPDATE_DATE;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.LAST_DETECTED_FORM_VERSION_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.MD5_HASH;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.SUBMISSION_URI;
@@ -44,7 +46,7 @@ public class FormDatabaseMigratorTest {
     public static final List<String> CURRENT_VERSION_COLUMNS = asList(_ID, DISPLAY_NAME, DESCRIPTION,
             JR_FORM_ID, JR_VERSION, MD5_HASH, DATE, FORM_MEDIA_PATH, FORM_FILE_PATH, LANGUAGE,
             SUBMISSION_URI, BASE64_RSA_PUBLIC_KEY, JRCACHE_FILE_PATH, AUTO_SEND, AUTO_DELETE,
-            GEOMETRY_XPATH, DELETED_DATE);
+            GEOMETRY_XPATH, DELETED_DATE, LAST_DETECTED_ATTACHMENTS_UPDATE_DATE);
 
     private SQLiteDatabase database;
 
@@ -60,15 +62,15 @@ public class FormDatabaseMigratorTest {
     }
 
     @Test
-    public void onUpgrade_fromVersion10() {
-        createVersion10Database(database);
-        ContentValues contentValues = createVersion10Form();
+    public void onUpgrade_fromVersion11() {
+        createVersion11Database(database);
+        ContentValues contentValues = createVersion11Form();
         database.insert(FORMS_TABLE_NAME, null, contentValues);
 
-        new FormDatabaseMigrator().onUpgrade(database, 10);
+        new FormDatabaseMigrator().onUpgrade(database, 11);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
             assertThat(cursor.getCount(), is(1));
 
             cursor.moveToFirst();
@@ -88,6 +90,40 @@ public class FormDatabaseMigratorTest {
             assertThat(cursor.getString(cursor.getColumnIndex(AUTO_DELETE)), is(contentValues.getAsString(AUTO_DELETE)));
             assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_XPATH)), is(contentValues.getAsString(GEOMETRY_XPATH)));
             assertThat(cursor.getInt(cursor.getColumnIndex(DELETED_DATE)), is(contentValues.getAsInteger(DELETED_DATE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)), is(nullValue()));
+        }
+    }
+
+    @Test
+    public void onUpgrade_fromVersion10() {
+        createVersion10Database(database);
+        ContentValues contentValues = createVersion10Form();
+        database.insert(FORMS_TABLE_NAME, null, contentValues);
+
+        new FormDatabaseMigrator().onUpgrade(database, 10);
+
+        try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
+            assertThat(cursor.getColumnCount(), is(18));
+            assertThat(cursor.getCount(), is(1));
+
+            cursor.moveToFirst();
+            assertThat(cursor.getString(cursor.getColumnIndex(DISPLAY_NAME)), is(contentValues.getAsString(DISPLAY_NAME)));
+            assertThat(cursor.getString(cursor.getColumnIndex(DESCRIPTION)), is(contentValues.getAsString(DESCRIPTION)));
+            assertThat(cursor.getString(cursor.getColumnIndex(JR_FORM_ID)), is(contentValues.getAsString(JR_FORM_ID)));
+            assertThat(cursor.getString(cursor.getColumnIndex(JR_VERSION)), is(contentValues.getAsString(JR_VERSION)));
+            assertThat(cursor.getString(cursor.getColumnIndex(MD5_HASH)), is(contentValues.getAsString(MD5_HASH)));
+            assertThat(cursor.getInt(cursor.getColumnIndex(DATE)), is(contentValues.getAsInteger(DATE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(FORM_MEDIA_PATH)), is(contentValues.getAsString(FORM_MEDIA_PATH)));
+            assertThat(cursor.getString(cursor.getColumnIndex(FORM_FILE_PATH)), is(contentValues.getAsString(FORM_FILE_PATH)));
+            assertThat(cursor.getString(cursor.getColumnIndex(LANGUAGE)), is(contentValues.getAsString(LANGUAGE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(SUBMISSION_URI)), is(contentValues.getAsString(SUBMISSION_URI)));
+            assertThat(cursor.getString(cursor.getColumnIndex(BASE64_RSA_PUBLIC_KEY)), is(contentValues.getAsString(BASE64_RSA_PUBLIC_KEY)));
+            assertThat(cursor.getString(cursor.getColumnIndex(JRCACHE_FILE_PATH)), is(contentValues.getAsString(JRCACHE_FILE_PATH)));
+            assertThat(cursor.getString(cursor.getColumnIndex(AUTO_SEND)), is(contentValues.getAsString(AUTO_SEND)));
+            assertThat(cursor.getString(cursor.getColumnIndex(AUTO_DELETE)), is(contentValues.getAsString(AUTO_DELETE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_XPATH)), is(contentValues.getAsString(GEOMETRY_XPATH)));
+            assertThat(cursor.getInt(cursor.getColumnIndex(DELETED_DATE)), is(contentValues.getAsInteger(DELETED_DATE)));
+            assertThat(cursor.getString(cursor.getColumnIndex(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)), is(nullValue()));
         }
     }
 
@@ -100,7 +136,7 @@ public class FormDatabaseMigratorTest {
         new FormDatabaseMigrator().onUpgrade(database, 9);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
             assertThat(cursor.getCount(), is(1));
 
             cursor.moveToFirst();
@@ -121,6 +157,7 @@ public class FormDatabaseMigratorTest {
             assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_XPATH)), is(contentValues.getAsString(GEOMETRY_XPATH)));
             assertThat(cursor.getInt(cursor.getColumnIndex(DELETED_DATE)), is(0));
             assertThat(cursor.getColumnIndex("deleted"), is(-1));
+            assertThat(cursor.getString(cursor.getColumnIndex(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)), is(nullValue()));
         }
     }
 
@@ -133,7 +170,7 @@ public class FormDatabaseMigratorTest {
         new FormDatabaseMigrator().onUpgrade(database, 8);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
             assertThat(cursor.getCount(), is(1));
 
             cursor.moveToFirst();
@@ -153,6 +190,7 @@ public class FormDatabaseMigratorTest {
             assertThat(cursor.getString(cursor.getColumnIndex(AUTO_DELETE)), is(contentValues.getAsString(AUTO_DELETE)));
             assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_XPATH)), is(contentValues.getAsString(GEOMETRY_XPATH)));
             assertThat(cursor.isNull(cursor.getColumnIndex(DELETED_DATE)), is(true));
+            assertThat(cursor.getString(cursor.getColumnIndex(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)), is(nullValue()));
         }
     }
 
@@ -165,7 +203,7 @@ public class FormDatabaseMigratorTest {
         new FormDatabaseMigrator().onUpgrade(database, 7);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
             assertThat(cursor.getCount(), is(1));
 
             cursor.moveToFirst();
@@ -185,6 +223,7 @@ public class FormDatabaseMigratorTest {
             assertThat(cursor.getString(cursor.getColumnIndex(AUTO_DELETE)), is(contentValues.getAsString(AUTO_DELETE)));
             assertThat(cursor.getString(cursor.getColumnIndex(GEOMETRY_XPATH)), is(contentValues.getAsString(GEOMETRY_XPATH)));
             assertThat(cursor.isNull(cursor.getColumnIndex(DELETED_DATE)), is(true));
+            assertThat(cursor.getString(cursor.getColumnIndex(LAST_DETECTED_ATTACHMENTS_UPDATE_DATE)), is(nullValue()));
         }
     }
 
@@ -200,7 +239,7 @@ public class FormDatabaseMigratorTest {
         formDatabaseMigrator.onDowngrade(database);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
             assertThat(cursor.getCount(), is(0));
             assertThat(asList(cursor.getColumnNames()), is(CURRENT_VERSION_COLUMNS));
         }
@@ -235,7 +274,7 @@ public class FormDatabaseMigratorTest {
         formDatabaseMigrator.onDowngrade(database);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
             assertThat(cursor.getCount(), is(0));
             assertThat(asList(cursor.getColumnNames()), is(CURRENT_VERSION_COLUMNS));
         }
@@ -304,6 +343,27 @@ public class FormDatabaseMigratorTest {
     }
 
     private ContentValues createVersion10Form() {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(DISPLAY_NAME, "DisplayName");
+        contentValues.put(DESCRIPTION, "Description");
+        contentValues.put(JR_FORM_ID, "FormId");
+        contentValues.put(JR_VERSION, "FormVersion");
+        contentValues.put(MD5_HASH, "Md5Hash");
+        contentValues.put(DATE, 0);
+        contentValues.put(FORM_MEDIA_PATH, "Form/Media/Path");
+        contentValues.put(FORM_FILE_PATH, "Form/File/Path");
+        contentValues.put(LANGUAGE, "Language");
+        contentValues.put(SUBMISSION_URI, "submission.uri");
+        contentValues.put(BASE64_RSA_PUBLIC_KEY, "Base64RsaPublicKey");
+        contentValues.put(JRCACHE_FILE_PATH, "Jr/Cache/File/Path");
+        contentValues.put(AUTO_SEND, "AutoSend");
+        contentValues.put(AUTO_DELETE, "AutoDelete");
+        contentValues.put(GEOMETRY_XPATH, "GeometryXPath");
+        contentValues.put(DELETED_DATE, 0);
+        return contentValues;
+    }
+
+    private ContentValues createVersion11Form() {
         ContentValues contentValues = new ContentValues();
         contentValues.put(DISPLAY_NAME, "DisplayName");
         contentValues.put(DESCRIPTION, "Description");
@@ -394,6 +454,27 @@ public class FormDatabaseMigratorTest {
                 + JR_FORM_ID + " text not null, "
                 + JR_VERSION + " text, "
                 + MD5_HASH + " text not null, "
+                + DATE + " integer not null, " // milliseconds
+                + FORM_MEDIA_PATH + " text not null, "
+                + FORM_FILE_PATH + " text not null, "
+                + LANGUAGE + " text, "
+                + SUBMISSION_URI + " text, "
+                + BASE64_RSA_PUBLIC_KEY + " text, "
+                + JRCACHE_FILE_PATH + " text not null, "
+                + AUTO_SEND + " text, "
+                + AUTO_DELETE + " text, "
+                + GEOMETRY_XPATH + " text, "
+                + DELETED_DATE + " integer);");
+    }
+
+    private void createVersion11Database(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS " + FORMS_TABLE_NAME + " ("
+                + _ID + " integer primary key, "
+                + DISPLAY_NAME + " text not null, "
+                + DESCRIPTION + " text, "
+                + JR_FORM_ID + " text not null, "
+                + JR_VERSION + " text, "
+                + MD5_HASH + " text not null UNIQUE ON CONFLICT IGNORE, "
                 + DATE + " integer not null, " // milliseconds
                 + FORM_MEDIA_PATH + " text not null, "
                 + FORM_FILE_PATH + " text not null, "

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormsProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormsProviderTest.java
@@ -205,7 +205,7 @@ public class FormsProviderTest {
         Uri uri = addFormsToDirAndDb(firstProjectId, "external_app_form", "External app form", "1");
 
         try (Cursor cursor = contentResolver.query(uri, null, null, null, null)) {
-            assertThat(cursor.getColumnCount(), is(17));
+            assertThat(cursor.getColumnCount(), is(18));
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsUpdaterTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormsUpdaterTest.kt
@@ -83,7 +83,8 @@ class FormsUpdaterTest {
             context = application,
             notifier = notifier,
             syncStatusAppState = syncStatusAppState,
-            projectDependencyProviderFactory = projectDependencyProviderFactory
+            projectDependencyProviderFactory = projectDependencyProviderFactory,
+            clock = { 0 }
         )
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/ServerFormDownloaderTest.java
@@ -48,6 +48,7 @@ public class ServerFormDownloaderTest {
     private final FormsRepository formsRepository = new InMemFormsRepository();
     private final File cacheDir = Files.createTempDir();
     private final File formsDir = Files.createTempDir();
+    private final Supplier<Long> clock = () -> 0L;
 
     @Test
     public void downloadsAndSavesForm() throws Exception {
@@ -65,7 +66,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
 
         List<Form> allForms = formsRepository.getAll();
@@ -94,7 +95,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
 
         String xformUpdate = createXFormBody("id", "updated");
@@ -138,7 +139,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
 
         List<Form> formsBeforeUpdate = formsRepository.getAllByFormIdAndVersion("id", "version");
@@ -191,7 +192,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         try {
             downloader.downloadForm(serverFormDetails, null, null);
             fail("Expected exception because of missing form hash");
@@ -221,7 +222,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents2".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
 
         List<Form> allForms = formsRepository.getAll();
@@ -263,7 +264,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents2".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
 
         String xformUpdate = createXFormBody("id", "updated");
@@ -308,7 +309,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents1".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents2".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
 
         String xformUpdate = createXFormBody("id", "updated");
@@ -371,7 +372,7 @@ public class ServerFormDownloaderTest {
             }
         };
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), formMetadataParser);
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), formMetadataParser, clock);
         downloader.downloadForm(serverFormDetails, null, null);
     }
 
@@ -394,7 +395,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
         when(formSource.fetchMediaFile("http://file1")).thenThrow(new FormSourceException.FetchError());
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         try {
             downloader.downloadForm(serverFormDetails, null, null);
@@ -428,7 +429,7 @@ public class ServerFormDownloaderTest {
         // Create file where media dir would go
         assertThat(new File(formsDir, "Form-media").createNewFile(), is(true));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         try {
             downloader.downloadForm(serverFormDetails, null, null);
@@ -461,7 +462,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
         when(formSource.fetchMediaFile("http://file2")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         RecordingProgressReporter progressReporter = new RecordingProgressReporter();
         downloader.downloadForm(serverFormDetails, progressReporter, null);
 
@@ -490,7 +491,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
         assertThat(formsRepository.get(1L).isDeleted(), is(false));
     }
@@ -522,7 +523,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform2.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
         downloader.downloadForm(serverFormDetails, null, null);
         assertThat(formsRepository.get(1L).isDeleted(), is(true));
         assertThat(formsRepository.get(2L).isDeleted(), is(false));
@@ -545,7 +546,7 @@ public class ServerFormDownloaderTest {
         FormSource formSource = mock(FormSource.class);
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         // Initial download
         downloader.downloadForm(serverFormDetails, null, null);
@@ -590,7 +591,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         // Initial download
         downloader.downloadForm(serverFormDetails, null, null);
@@ -646,7 +647,7 @@ public class ServerFormDownloaderTest {
         when(formSource.fetchForm("http://downloadUrl")).thenReturn(new ByteArrayInputStream(xform.getBytes()));
         when(formSource.fetchMediaFile("http://file1")).thenReturn(new ByteArrayInputStream("contents".getBytes()));
 
-        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formSource, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         // Initial download
         downloader.downloadForm(serverFormDetails, null, null);
@@ -695,7 +696,7 @@ public class ServerFormDownloaderTest {
                 null);
 
         CancelAfterFormDownloadFormSource formListApi = new CancelAfterFormDownloadFormSource(xform);
-        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         try {
             downloader.downloadForm(serverFormDetails, null, formListApi);
@@ -724,7 +725,7 @@ public class ServerFormDownloaderTest {
                 )));
 
         CancelAfterMediaFileDownloadFormSource formListApi = new CancelAfterMediaFileDownloadFormSource(xform);
-        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser());
+        ServerFormDownloader downloader = new ServerFormDownloader(formListApi, formsRepository, cacheDir, formsDir.getAbsolutePath(), new FormMetadataParser(), clock);
 
         try {
             downloader.downloadForm(serverFormDetails, null, formListApi);

--- a/forms/src/main/java/org/odk/collect/forms/Form.java
+++ b/forms/src/main/java/org/odk/collect/forms/Form.java
@@ -43,6 +43,7 @@ public final class Form {
     private final String autoDelete;
     private final String geometryXPath;
     private final boolean deleted;
+    private final Long lastDetectedAttachmentsUpdateDate;
 
     private Form(Form.Builder builder) {
         dbId = builder.dbId;
@@ -62,6 +63,7 @@ public final class Form {
         autoDelete = builder.autoDelete;
         geometryXPath = builder.geometryXpath;
         deleted = builder.deleted;
+        lastDetectedAttachmentsUpdateDate = builder.lastDetectedAttachmentsUpdateDate;
     }
 
     public static class Builder {
@@ -82,6 +84,7 @@ public final class Form {
         private String autoDelete;
         private String geometryXpath;
         private boolean deleted;
+        private Long lastDetectedAttachmentsUpdateDate;
 
         public Builder() {
         }
@@ -103,7 +106,8 @@ public final class Form {
             autoSend = form.autoSend;
             autoDelete = form.autoDelete;
             geometryXpath = form.geometryXPath;
-            this.deleted = form.deleted;
+            deleted = form.deleted;
+            lastDetectedAttachmentsUpdateDate = form.lastDetectedAttachmentsUpdateDate;
         }
 
         public Builder dbId(Long id) {
@@ -191,6 +195,11 @@ public final class Form {
             return this;
         }
 
+        public Builder lastDetectedAttachmentsUpdateDate(Long lastDetectedAttachmentsUpdateDate) {
+            this.lastDetectedAttachmentsUpdateDate = lastDetectedAttachmentsUpdateDate;
+            return this;
+        }
+
         public Form build() {
             return new Form(this);
         }
@@ -265,6 +274,10 @@ public final class Form {
 
     public boolean isDeleted() {
         return deleted;
+    }
+
+    public Long getLastDetectedAttachmentsUpdateDate() {
+        return lastDetectedAttachmentsUpdateDate;
     }
 
     @Override

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
     <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
     <string name="added_on_date_at_time">\'Added on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
     <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
+    <string name="updated_on_date_at_time">\'Updated on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
+    <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
     <string name="saved_on_date_at_time">\'Saved on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>
     <!-- Please format date appropriately for your language: http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
     <string name="finalized_on_date_at_time">\'Finalized on\' EEE, MMM dd, yyyy \'at\' HH:mm</string>


### PR DESCRIPTION
Closes #5384 

#### What has been done to verify that this works as intended?
I've verified the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
Not much to describe here... I've just updated the current implementation to display proper subtext.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
As described in the issue a proper subtext should be displayed in the list of forms (in both the list of forms to open and the list of forms to delete). Please test both lists to make sure it works as expected. I can't see any risk in other parts of the app. The description in the issue lists possible cases very well so please read.

#### Do we need any specific form for testing your changes? If so, please attach one.
Any form with attachments.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
