### PR TITLE
Do not change the direction of the slider in vertical mode between ltr and rtl languages

### DIFF
--- a/collect_app/src/main/res/layout/range_widget_vertical.xml
+++ b/collect_app/src/main/res/layout/range_widget_vertical.xml
@@ -35,7 +35,8 @@ limitations under the License.
         android:layout_width="50dp"
         android:layout_height="330dp"
         android:clipChildren="false"
-        android:clipToPadding="false">
+        android:clipToPadding="false"
+        android:layoutDirection="ltr">
 
         <org.odk.collect.android.views.TrackingTouchSlider
             android:id="@+id/slider"


### PR DESCRIPTION
Closes #5298 

#### What has been done to verify that this works as intended?
I've tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
The real problem is not as it was described in the issue that min/max value doesn't change its position vertically (top/bottom) when a user switches between ltr/rtl languages but the fact that the slider changed its orientation. When we switch between ltr/rtl, elements should be moved from left to right and from right to left (horizontally) but not vertically. The fact that the slider in `vertical` mode changed its orientation stems from the fact that it is a vertical view rotated to be a horizontal one (that's how we implemented that). In this case, the easiest solution was forcing using ltr direction.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test the Range widget with `vertical` appearance. It's an isolated change so other parts of the app or even similar types of widgets like the same widget but without the `vertical` appearance won't be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
