### PR TITLE
Always use ltr direction for number picker

### DIFF
--- a/collect_app/src/main/res/layout/number_picker_dialog.xml
+++ b/collect_app/src/main/res/layout/number_picker_dialog.xml
@@ -19,6 +19,7 @@ limitations under the License.
         android:layout_height="wrap_content"
         android:descendantFocusability="blocksDescendants"
         android:scrollbars="none"
+        android:layoutDirection="ltr"
         android:layout_gravity="center_horizontal">
     </org.odk.collect.android.views.CustomNumberPicker>
 </FrameLayout>


### PR DESCRIPTION
Closes #5387 

#### What has been done to verify that this works as intended?
I've verified the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
It looks like another bug in the implementation of `NumberPicker`. After working on https://github.com/getodk/collect/pull/5371 I know it's buggy and it doesn't seem to be an easy way to fix it. Taking that into account I've decided to just force displaying numbers in ltr way so that they look in the same way and the minus sign doesn't move on runtime left to right (what looked weird)

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just test the case described in the issue. Nothing else should be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
