### PR TITLE
Downgrade play-services-location to prevent ANRs

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -28,7 +28,7 @@ object Dependencies {
     const val google_api_services_sheets = "com.google.apis:google-api-services-sheets:v4-rev20220927-2.0.0"
     const val play_services_auth = "com.google.android.gms:play-services-auth:20.4.0"
     const val play_services_maps = "com.google.android.gms:play-services-maps:18.1.0"
-    const val play_services_location = "com.google.android.gms:play-services-location:21.0.1"
+    const val play_services_location = "com.google.android.gms:play-services-location:20.0.0" // Check if map screens still work when upgrading
     const val play_services_oss_licenses = "com.google.android.gms:play-services-oss-licenses:17.0.0"
     const val mapbox_android_sdk = "com.mapbox.maps:android:10.10.0"
     const val osmdroid = "org.osmdroid:osmdroid-android:6.1.14"


### PR DESCRIPTION
`play-services-location` 21.0.1 seems to be causing the app to freeze up (an ANR error) when viewing a map screen. Downgrading will help us for the moment, and we should investigate this further when we look at upgrading next.