### PR TITLE
Zoom out as far as possible when Google Maps can't handle lat/lng bounds for zoom to fit

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -260,7 +260,8 @@ public class GoogleMapFragment extends SupportMapFragment implements
                     try {
                         moveOrAnimateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), animate);
                     } catch (IllegalArgumentException e) { // https://github.com/getodk/collect/issues/5379
-                        zoomToPoint(getCenter(), map.getMinZoomLevel(), false);
+                        LatLng boxCenter = bounds.getCenter();
+                        zoomToPoint(new MapPoint(boxCenter.latitude, boxCenter.longitude), map.getMinZoomLevel(), false);
                     }
                 }, 100);
             }

--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -56,10 +56,10 @@ import org.odk.collect.maps.MapConfigurator;
 import org.odk.collect.maps.MapFragment;
 import org.odk.collect.maps.MapFragmentDelegate;
 import org.odk.collect.maps.MapPoint;
-import org.odk.collect.maps.markers.MarkerDescription;
-import org.odk.collect.maps.markers.MarkerIconDescription;
 import org.odk.collect.maps.layers.MapFragmentReferenceLayerUtils;
 import org.odk.collect.maps.layers.ReferenceLayerRepository;
+import org.odk.collect.maps.markers.MarkerDescription;
+import org.odk.collect.maps.markers.MarkerIconDescription;
 import org.odk.collect.settings.SettingsProvider;
 
 import java.io.File;
@@ -257,7 +257,11 @@ public class GoogleMapFragment extends SupportMapFragment implements
             } else if (count > 1) {
                 final LatLngBounds bounds = expandBounds(builder.build(), 1 / scaleFactor);
                 new Handler().postDelayed(() -> {
-                    moveOrAnimateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), animate);
+                    try {
+                        moveOrAnimateCamera(CameraUpdateFactory.newLatLngBounds(bounds, 0), animate);
+                    } catch (IllegalArgumentException e) { // https://github.com/getodk/collect/issues/5379
+                        zoomToPoint(getCenter(), map.getMinZoomLevel(), false);
+                    }
                 }, 100);
             }
         }


### PR DESCRIPTION
Closes #5379

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Discussed in the issue.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The main thing to check (other than that the issue is fixed) is that the "zoom to fit" button works as expected wherever it appears (select one from map etc). The button should only resort to zooming out all the way in rare cases, the form used in the issue being the only current real world example we have.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
