### PR TITLE
Use JavaRosa snapshot

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -43,7 +43,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.7.1"
-    const val javarosa = "org.getodk:javarosa:4.0.0"
+    const val javarosa = "org.getodk:javarosa:4.0.1-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:4.3.0"


### PR DESCRIPTION
Sets the JavaRosa version to match the development snapshot.

It would be good to do a quick verification of https://github.com/getodk/javarosa/issues/703 before merge.