### PR TITLE
Create maven repo of deps as build artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,6 +343,11 @@ workflows:
       - create_dependency_backup:
           requires:
             - compile
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
       - check_quality:
           requires:
             - compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ workflows:
             - compile
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/ # matches semvers like v1.2.3
+              only: /^v((20)[0-9]{2})\.\d+\.\d+$/ # matches semvers like v1.2.3
             branches:
               ignore: /.*/
       - check_quality:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - save_cache:
           paths:
-            - ~/.gradle/caches
+            - ~/.gradle/caches/modules-2/files-2.1
           key: compile-deps-{{ checksum "deps.txt" }}
       - persist_to_workspace:
           root: ~/work
@@ -135,7 +135,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches
+            - ~/.gradle/caches/modules-2/files-2.1
           key: test-modules-deps-{{ checksum "deps.txt" }}
 
   test_app:
@@ -184,7 +184,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches
+            - ~/.gradle/caches/modules-2/files-2.1
           key: test-app-deps-{{ checksum "deps.txt" }}
 
   build_instrumented:
@@ -211,7 +211,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches
+            - ~/.gradle/caches/modules-2/files-2.1
           key: intrumented-deps-{{ checksum "deps.txt" }}
 
   build_release:
@@ -259,7 +259,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches
+            - ~/.gradle/caches/modules-2/files-2.1
           key: intrumented-deps-{{ checksum "deps.txt" }}
 
       - run:
@@ -309,7 +309,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ~/.gradle/caches
+            - ~/.gradle/caches/modules-2/files-2.1
           key: intrumented-deps-{{ checksum "deps.txt" }}
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           command: ./gradlew cacheToMavenLocal
       - run:
           name: Compress Maven repo
-          command: tar -cvzf maven.tar .local-m2
+          command: tar -cvzf $(git describe --tags).tar .local-m2
       - store_artifacts:
           path: maven.tar
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,20 @@ jobs:
           root: ~/work
           paths:
             - .
+
+  create_dependency_backup:
+    <<: *android_config
+    steps:
+      - attach_workspace:
+          at: ~/work
+      - restore_cache:
+          keys:
+            - compile-deps-{{ checksum "deps.txt" }}
+            - compile-deps-
+      - restore_cache:
+          keys:
+            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+
       - run:
           name: Create Maven repo from dependencies
           command: ./gradlew cacheToMavenLocal
@@ -57,7 +71,6 @@ jobs:
           command: tar -cvzf maven.tar .local-m2
       - store_artifacts:
           path: maven.tar
-
 
   check_quality:
     <<: *android_config
@@ -327,6 +340,9 @@ workflows:
   commit:
     jobs:
       - compile
+      - create_dependency_backup:
+          requires:
+            - compile
       - check_quality:
           requires:
             - compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Generate combined build.gradle file for cache key
-          command: cat build.gradle */build.gradle .circleci/gradle.properties > deps.txt
+          command: cat build.gradle */build.gradle .circleci/gradle.properties .circleci/config.yml > deps.txt
       - restore_cache:
           keys:
             - compile-deps-{{ checksum "deps.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,15 @@ jobs:
           root: ~/work
           paths:
             - .
+      - run:
+          name: Create Maven repo from dependencies
+          command: ./gradlew cacheToMavenLocal
+      - run:
+          name: Compress Maven repo
+          command: tar -cvzf maven.tar .local-m2
+      - store_artifacts:
+          path: maven.tar
+
 
   check_quality:
     <<: *android_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ workflows:
             - compile
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$/ # matches semvers like v1.2.3
             branches:
               ignore: /.*/
       - check_quality:

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ collect_app/src/odkCollectRelease/
 # Robolectric dependencies
 robolectric-deps/
 **/robolectric-deps.properties
+
+.local-m2

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - upload to Play Store
 - if there was an active beta before release (this can happen with point releases), publish a new beta release to replace the previous one which was disabled by the production release
 - attach APK to previously create Github Release with the name `ODK-Collect-vX.X.X.apk`
-- backup dependencies for building release by downloading the `maven.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) 
+- backup dependencies for building release by downloading the `vX.X.X.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) and uploading them to the "Collect Dependency Backups" folder in GetODK's Google Drive
 
 ## Compiling a previous release using backed-up dependencies
 

--- a/README.md
+++ b/README.md
@@ -269,3 +269,14 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - if there was an active beta before release (this can happen with point releases), publish a new beta release to replace the previous one which was disabled by the production release
 - attach APK to previously create Github Release with the name `ODK-Collect-vX.X.X.apk`
 - backup dependencies for building release by downloading the `maven.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) 
+
+## Compiling a previous release using backed-up dependencies
+
+1. Download the `.tar` for relevant release tag
+2. Extract into the project directory:
+    ```bash
+    tar -xf maven.tar -C <collect project directory>
+    ```
+   
+The project will now be able to fetch dependencies that are no longer available (but were used to compile the release) from the `.local-m2` Maven repo.
+

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 ## Compiling a previous release using backed-up dependencies
 
 1. Download the `.tar` for relevant release tag
-2. Extract into the project directory:
+2. Extract `.local-m2` into the project directory:
     ```bash
     tar -xf maven.tar -C <collect project directory>
     ```

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - upload to Play Store
 - if there was an active beta before release (this can happen with point releases), publish a new beta release to replace the previous one which was disabled by the production release
 - attach APK to previously create Github Release with the name `ODK-Collect-vX.X.X.apk`
-- backup dependencies for building release by downloading the `vX.X.X.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) and uploading them to the "Collect Dependency Backups" folder in GetODK's Google Drive
+- backup dependencies for the release by downloading the `vX.X.X.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) and then uploading it to the "Collect Dependency Backups" folder in GetODK's Google Drive
 
 ## Compiling a previous release using backed-up dependencies
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - write Play Store release notes, include link to forum post
 - upload to Play Store
 - if there was an active beta before release (this can happen with point releases), publish a new beta release to replace the previous one which was disabled by the production release
-- attach APK to previously create Github Release with the name `ODK-Collect-vX.X.X.apk`
+- attach APK to previously created Github Release with the name `ODK-Collect-vX.X.X.apk`
 - backup dependencies for the release by downloading the `vX.X.X.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) and then uploading it to the "Collect Dependency Backups" folder in GetODK's Google Drive
 
 ## Compiling a previous release using backed-up dependencies

--- a/README.md
+++ b/README.md
@@ -267,3 +267,5 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - write Play Store release notes, include link to forum post
 - upload to Play Store
 - if there was an active beta before release (this can happen with point releases), publish a new beta release to replace the previous one which was disabled by the production release
+- attach APK to previously create Github Release with the name `ODK-Collect-vX.X.X.apk`
+- backup dependencies for building release by downloading the `maven.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) 

--- a/build.gradle
+++ b/build.gradle
@@ -62,11 +62,6 @@ allprojects {
                 password = getSecrets().getProperty('MAPBOX_DOWNLOADS_TOKEN', '')
             }
         }
-
-        // Local repo for dependencies that only existed in the defunct JCenter repo
-        maven {
-          url "${rootDir}/jcenter-local-m2"
-        }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,16 @@ buildscript {
 
 allprojects {
     repositories {
+        maven {
+            url "${rootDir}/.local-m2/"
+        }
+
+        // Supports artifact only dependencies like those from medicmobile repo
+        maven {
+            url "${rootDir}/.local-m2/"
+            metadataSources { artifact() }
+        }
+
         // Needs to go first to get specialty libraries https://stackoverflow.com/a/48438866/137744
         google()
 
@@ -95,4 +105,23 @@ task checkRegression(type: GradleBuild) {
 task checkInstrumented(type: GradleBuild) {
     tasks = ["connectedDebugAndroidTest"]
     startParameter.projectProperties = ["android.testInstrumentationRunnerArguments.package": "org.odk.collect.android.instrumented"]
+}
+
+// Create local Maven repo from cached Gradle dependencies
+task cacheToMavenLocal(type: Sync) {
+    from new File(gradle.gradleUserHomeDir, 'caches/modules-2/files-2.1')
+    into "${rootDir}/.local-m2"
+
+    duplicatesStrategy = 'include'
+
+    // Convert from Gradle cache to Maven format
+    eachFile {
+        List<String> parts = it.path.split('/')
+        it.path = parts[0].replace('.','/') +
+                '/' + parts[1] +
+                '/' + parts[2] +
+                '/' + parts[4]
+    }
+
+    includeEmptyDirs false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,10 @@ allprojects {
     repositories {
         maven {
             url "${rootDir}/.local-m2/"
-        }
-
-        // Supports artifact only dependencies like those from medicmobile repo
-        maven {
-            url "${rootDir}/.local-m2/"
-            metadataSources { artifact() }
+            metadataSources {
+                mavenPom()
+                artifact() // Supports artifact only dependencies like those from medicmobile repo
+            }
         }
 
         // Needs to go first to get specialty libraries https://stackoverflow.com/a/48438866/137744


### PR DESCRIPTION
Closes #4973

This adds a new step to the release process:

> backup dependencies for building release by downloading the `vX.X.X.tar` artifact from the `create_dependency_backup` job on Circle CI (for the release commit) and uploading them to the "Collect Dependency Backups" folder in GetODK's Google Drive
