### PR TITLE
Use UIAutomator for rotation

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/actions/RotateAction.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/actions/RotateAction.java
@@ -1,16 +1,15 @@
 package org.odk.collect.android.support.actions;
 
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
-import android.app.Activity;
-import android.app.Application;
-import android.content.Context;
-import android.view.ContextThemeWrapper;
+import android.content.pm.ActivityInfo;
+import android.os.RemoteException;
 import android.view.View;
-import android.view.ViewGroup;
 
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
+import androidx.test.uiautomator.UiDevice;
 
 import org.hamcrest.Matcher;
 
@@ -34,46 +33,16 @@ public class RotateAction implements ViewAction {
 
     @Override
     public void perform(UiController uiController, View view) {
-        uiController.loopMainThreadUntilIdle();
+        UiDevice device = UiDevice.getInstance(getInstrumentation());
 
-        Activity activity = getCurrentActivity(view);
-
-        if (activity != null) {
-            activity.setRequestedOrientation(screenOrientation);
-        } else {
-            throw new IllegalStateException("We don't know how to get the current Activity in this scenario");
-        }
-    }
-
-    private Activity getCurrentActivity(View view) {
-        Activity activity = getActivityFromContext(view.getContext());
-
-        if (activity != null) {
-            return activity;
-        } else if (view instanceof ViewGroup) {
-            ViewGroup viewGroup = (ViewGroup) view;
-
-            for (int i = 0; i < viewGroup.getChildCount(); i++) {
-                Activity childViewActivity = getCurrentActivity(viewGroup.getChildAt(0));
-                if (childViewActivity != null) {
-                    return childViewActivity;
-                }
+        try {
+            if (screenOrientation == ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE) {
+                device.setOrientationLeft();
+            } else {
+                device.setOrientationNatural();
             }
+        } catch (RemoteException e) {
+            throw new RuntimeException(e);
         }
-
-        return null;
-    }
-
-    private Activity getActivityFromContext(Context context) {
-        if (context instanceof Activity) {
-            return (Activity) context;
-        } else if (context instanceof Application) {
-            return null;
-        } else if (context instanceof ContextThemeWrapper) {
-            ContextThemeWrapper wrapper = (ContextThemeWrapper) context;
-            return getActivityFromContext(wrapper.getBaseContext());
-        }
-
-        return null;
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetRotationRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetRotationRule.kt
@@ -1,0 +1,22 @@
+package org.odk.collect.android.support.rules
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import timber.log.Timber
+
+class ResetRotationRule : TestRule {
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                Timber.d("Resetting rotation...")
+                val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+                device.setOrientationNatural()
+                base.evaluate()
+            }
+        }
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -28,6 +28,7 @@ object TestRuleChain {
                     Manifest.permission.GET_ACCOUNTS
                 )
             )
+            .around(ResetRotationRule())
             .around(DisableDeviceAnimationsRule())
             .around(ResetStateRule(testDependencies))
             .around(countingTaskExecutorIdlingResource)


### PR DESCRIPTION
Closes #5325

Switch to using `UIAutomator` for screen rotation in instrumentation tests. This rotates the device instead of changing the rotation on the currently displayed `Activity` which will hopefully be more reliable.