### PR TITLE
Fixed sorting by date

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModel.kt
@@ -200,8 +200,8 @@ class BlankFormListViewModel(
         _formsToDisplay.value = when (sortingOrder) {
             0 -> _allForms.value.sortedBy { it.formName.lowercase() }
             1 -> _allForms.value.sortedByDescending { it.formName.lowercase() }
-            2 -> _allForms.value.sortedByDescending { it.dateOfCreation }
-            3 -> _allForms.value.sortedBy { it.dateOfCreation }
+            2 -> _allForms.value.sortedByDescending { it.dateOfLastDetectedAttachmentsUpdate ?: it.dateOfCreation }
+            3 -> _allForms.value.sortedBy { it.dateOfLastDetectedAttachmentsUpdate ?: it.dateOfCreation }
             4 -> _allForms.value.sortedByDescending { it.dateOfLastUsage }
             else -> { _allForms.value }
         }.filter {

--- a/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formlists/blankformlist/BlankFormListViewModelTest.kt
@@ -283,9 +283,9 @@ class BlankFormListViewModelTest {
     fun `when list of forms sorted 'by date newest first', saved should forms be ordered properly`() {
         saveForms(
             form(dbId = 1, formId = "1", formName = "1Form"),
-            form(dbId = 2, formId = "2", formName = "BForm"),
+            form(dbId = 2, formId = "2", formName = "BForm", lastDetectedAttachmentsUpdateDate = 6),
             form(dbId = 3, formId = "3", formName = "aForm"),
-            form(dbId = 4, formId = "4", formName = "AForm"),
+            form(dbId = 4, formId = "4", formName = "AForm", lastDetectedAttachmentsUpdateDate = 7),
             form(dbId = 5, formId = "5", formName = "2Form")
         )
 
@@ -293,10 +293,10 @@ class BlankFormListViewModelTest {
 
         viewModel.sortingOrder = 2
 
-        assertFormItem(viewModel.formsToDisplay.value!![0], form(dbId = 5, formId = "5", formName = "2Form"))
-        assertFormItem(viewModel.formsToDisplay.value!![1], form(dbId = 4, formId = "4", formName = "AForm"))
-        assertFormItem(viewModel.formsToDisplay.value!![2], form(dbId = 3, formId = "3", formName = "aForm"))
-        assertFormItem(viewModel.formsToDisplay.value!![3], form(dbId = 2, formId = "2", formName = "BForm"))
+        assertFormItem(viewModel.formsToDisplay.value!![0], form(dbId = 4, formId = "4", formName = "AForm", lastDetectedAttachmentsUpdateDate = 7))
+        assertFormItem(viewModel.formsToDisplay.value!![1], form(dbId = 2, formId = "2", formName = "BForm", lastDetectedAttachmentsUpdateDate = 6))
+        assertFormItem(viewModel.formsToDisplay.value!![2], form(dbId = 5, formId = "5", formName = "2Form"))
+        assertFormItem(viewModel.formsToDisplay.value!![3], form(dbId = 3, formId = "3", formName = "aForm"))
         assertFormItem(viewModel.formsToDisplay.value!![4], form(dbId = 1, formId = "1", formName = "1Form"))
     }
 
@@ -304,9 +304,9 @@ class BlankFormListViewModelTest {
     fun `when list of forms sorted 'by date oldest first', saved should forms be ordered properly`() {
         saveForms(
             form(dbId = 1, formId = "1", formName = "1Form"),
-            form(dbId = 2, formId = "2", formName = "BForm"),
+            form(dbId = 2, formId = "2", formName = "BForm", lastDetectedAttachmentsUpdateDate = 6),
             form(dbId = 3, formId = "3", formName = "aForm"),
-            form(dbId = 4, formId = "4", formName = "AForm"),
+            form(dbId = 4, formId = "4", formName = "AForm", lastDetectedAttachmentsUpdateDate = 7),
             form(dbId = 5, formId = "5", formName = "2Form")
         )
 
@@ -315,10 +315,10 @@ class BlankFormListViewModelTest {
         viewModel.sortingOrder = 3
 
         assertFormItem(viewModel.formsToDisplay.value!![0], form(dbId = 1, formId = "1", formName = "1Form"))
-        assertFormItem(viewModel.formsToDisplay.value!![1], form(dbId = 2, formId = "2", formName = "BForm"))
-        assertFormItem(viewModel.formsToDisplay.value!![2], form(dbId = 3, formId = "3", formName = "aForm"))
-        assertFormItem(viewModel.formsToDisplay.value!![3], form(dbId = 4, formId = "4", formName = "AForm"))
-        assertFormItem(viewModel.formsToDisplay.value!![4], form(dbId = 5, formId = "5", formName = "2Form"))
+        assertFormItem(viewModel.formsToDisplay.value!![1], form(dbId = 3, formId = "3", formName = "aForm"))
+        assertFormItem(viewModel.formsToDisplay.value!![2], form(dbId = 5, formId = "5", formName = "2Form"))
+        assertFormItem(viewModel.formsToDisplay.value!![3], form(dbId = 2, formId = "2", formName = "BForm", lastDetectedAttachmentsUpdateDate = 6))
+        assertFormItem(viewModel.formsToDisplay.value!![4], form(dbId = 4, formId = "4", formName = "AForm", lastDetectedAttachmentsUpdateDate = 7))
     }
 
     @Test
@@ -540,7 +540,8 @@ class BlankFormListViewModelTest {
         formId: String = "1",
         version: String? = null,
         formName: String = "Form $formId",
-        deleted: Boolean = false
+        deleted: Boolean = false,
+        lastDetectedAttachmentsUpdateDate: Long? = null
     ) = Form.Builder()
         .dbId(dbId)
         .formId(formId)
@@ -549,6 +550,7 @@ class BlankFormListViewModelTest {
         .date(dbId)
         .deleted(deleted)
         .formFilePath(FormUtils.createXFormFile(formId, version).absolutePath)
+        .lastDetectedAttachmentsUpdateDate(lastDetectedAttachmentsUpdateDate)
         .build()
 
     private fun instance(


### PR DESCRIPTION
Closes #5413 

#### What has been done to verify that this works as intended?
I've verified the fix manually and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I've just added changes to take into account the last attachments update date when sorting forms by date. Unfortunately with the current implementation, it's not possible to do that in both: the list of blank forms and the list of forms to delete. So I only did that for the first one which is of course more important. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please just test sorting by date.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
