### PR TITLE
Bumped database version

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
@@ -4,7 +4,7 @@ public final class DatabaseConstants {
 
     public static final String FORMS_DATABASE_NAME = "forms.db";
     public static final String FORMS_TABLE_NAME = "forms";
-    public static final int FORMS_DATABASE_VERSION = 11;
+    public static final int FORMS_DATABASE_VERSION = 12;
 
     public static final String INSTANCES_DATABASE_NAME = "instances.db";
     public static final String INSTANCES_TABLE_NAME = "instances";

--- a/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
@@ -52,7 +52,7 @@ public class FormDatabaseMigratorTest {
 
     @Before
     public void setup() {
-        assertThat("Test expects different Forms DB version", DatabaseConstants.FORMS_DATABASE_VERSION, is(11));
+        assertThat("Test expects different Forms DB version", DatabaseConstants.FORMS_DATABASE_VERSION, is(12));
         database = SQLiteDatabase.create(null);
     }
 


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've manually cases 1 and 3 described below.

#### Why is this the best possible solution? Were any other approaches considered?
I've bumped the database version which should fix the problem. When it comes to tests there is not much I can do in a short time. The way we test upgrades is just faulty because we manually call `onUpgrade` in tests so even in cases where we forgot to bump the version number like here tests work well. We need to review those tests and find a more reliable way for testing upgrades automatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test scenarios like:
1. Upgrading v2022.4.2 -> v2022.4.3 -> this pr
2. Upgrading v2022.4.2 -> this pr
3. Upgrading v2022.4.3 -> this pr

In all cases downloading new forms is required to make sure everything is fine.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
