### PR TITLE
Add checking update path to release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Maintainers keep a folder with a clean checkout of the code and use [jenv.be](ht
 - run `./gradlew assembleOdkCollectRelease`. If successful, a signed release will be at `collect_app/build/outputs/apk`.
 - verify the apk size. If it has grown more than a few hundred kilobytes, discuss with the dev team.
 - verify a basic "happy path": scan a QR code to configure a new project, get a blank form, fill it, open the form map (confirms that the Google Maps key is correct), send form
+- verify new APK can be installed as update to previous version and that above "happy path" works in that case also
 - create and publish scheduled forum post with release description
 - write Play Store release notes, include link to forum post
 - upload to Play Store


### PR DESCRIPTION
We recently ended up with a production crash based on a bug in our update path. There's not currently a simple way to check this in our automated test suite (or certainly not in a way that would have caught the recent bug), and we don't want to check it on every PR, so I think we should make it a manual pre-release check for the moment to catch us missing any problems in a PR.