### PR TITLE
Remove analytics that are no longer used

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -1278,9 +1278,7 @@ public class FormEntryActivity extends CollectAbstractActivity implements Animat
                 if (saveName.length() < 1) {
                     showShortToast(FormEntryActivity.this, R.string.save_as_error);
                 } else {
-                    if (saveName.equals(formSaveViewModel.getFormName()) || saveName.equals(formController.getSubmissionMetadata().instanceName)) {
-                        Analytics.log(AnalyticsEvents.AUTOMATICALLY_SPECIFIED_INSTANCE_NAME, "form");
-                    } else {
+                    if (!saveName.equals(formSaveViewModel.getFormName()) && !saveName.equals(formController.getSubmissionMetadata().instanceName)) {
                         Analytics.log(AnalyticsEvents.MANUALLY_SPECIFIED_INSTANCE_NAME, "form");
                     }
                     formSaveViewModel.saveForm(getIntent().getData(), markAsFinalized, saveName, true);

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -152,11 +152,6 @@ object AnalyticsEvents {
     const val ACCURACY_THRESHOLD_DEFAULT = "AccuracyThresholdDefault"
 
     /**
-     * Tracks how often form details with invalid hashes are provided by a server
-     */
-    const val INVALID_FORM_HASH = "InvalidFormHash"
-
-    /**
      * Tracks how often "cellular_only" option is used in auto send
      */
     const val CELLULAR_ONLY = "CellularOnly"

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -172,11 +172,6 @@ object AnalyticsEvents {
     const val MANUALLY_SPECIFIED_INSTANCE_NAME = "ManuallySpecifiedInstanceName"
 
     /**
-     * Tracks how often automatically specified instance name is used
-     */
-    const val AUTOMATICALLY_SPECIFIED_INSTANCE_NAME = "AutomaticallySpecifiedInstanceName"
-
-    /**
      * Tracks how often the Text Number widget appears in forms and how often it's used with the
      * `thousand-sep` appearance.
      */

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsUtils.kt
@@ -35,11 +35,6 @@ object AnalyticsUtils {
         Analytics.log(AnalyticsEvents.SET_SERVER, scheme + " " + getHostFromUrl(url), urlHash!!)
     }
 
-    @JvmStatic
-    fun logInvalidFormHash(url: String?) {
-        Analytics.log(AnalyticsEvents.INVALID_FORM_HASH, "host", getHostFromUrl(url))
-    }
-
     private fun getHostFromUrl(url: String?): String {
         if (url == null || url.isEmpty()) {
             return ""

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaFormSource.java
@@ -1,7 +1,9 @@
 package org.odk.collect.android.openrosa;
 
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.utilities.DocumentFetchResult;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.forms.FormListItem;
@@ -17,9 +19,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import javax.net.ssl.SSLException;
-
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 public class OpenRosaFormSource implements FormSource {
 
@@ -54,22 +53,12 @@ public class OpenRosaFormSource implements FormSource {
             List<FormListItem> formList = openRosaResponseParser.parseFormList(result.doc);
 
             if (formList != null) {
-                checkForInvalidFormHashes(formList);
                 return formList;
             } else {
                 throw new FormSourceException.ParseError(serverURL);
             }
         } else {
             throw new FormSourceException.ServerNotOpenRosaError();
-        }
-    }
-
-    private void checkForInvalidFormHashes(List<FormListItem> formList) {
-        for (FormListItem item : formList) {
-            if (item.getHash() == null) {
-                AnalyticsUtils.logInvalidFormHash(serverURL);
-                break;
-            }
         }
     }
 


### PR DESCRIPTION
Cleans up some analytics we no longer use for decision-making.

#### What has been done to verify that this works as intended?
Verified that only analytics code was removed.

#### Why is this the best possible solution? Were any other approaches considered?
I think they're both worth removing: we now show an error message when there's no form hash sent and we haven't been using the automatic instance name count.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Biggest risk is that I messed up the logic for logging manually-specified instance names. That would only affect analytics.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
