### PR TITLE
Avoid problems with upgrading databases

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/DatabaseConstants.java
@@ -4,10 +4,12 @@ public final class DatabaseConstants {
 
     public static final String FORMS_DATABASE_NAME = "forms.db";
     public static final String FORMS_TABLE_NAME = "forms";
+    // Please always test upgrades manually when you change this value
     public static final int FORMS_DATABASE_VERSION = 12;
 
     public static final String INSTANCES_DATABASE_NAME = "instances.db";
     public static final String INSTANCES_TABLE_NAME = "instances";
+    // Please always test upgrades manually when you change this value
     public static final int INSTANCES_DATABASE_VERSION = 6;
 
     private DatabaseConstants() {

--- a/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/forms/FormDatabaseMigrator.java
@@ -67,6 +67,10 @@ public class FormDatabaseMigrator implements DatabaseMigrator {
                 upgradeToVersion11(db);
             case 11:
                 upgradeToVersion12(db);
+                break;
+            case 12:
+                // Remember to bump the database version number in {@link org.odk.collect.android.database.DatabaseConstants}
+                // upgradeToVersion13(db);
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
+++ b/collect_app/src/main/java/org/odk/collect/android/database/instances/InstanceDatabaseMigrator.java
@@ -54,6 +54,9 @@ public class InstanceDatabaseMigrator implements DatabaseMigrator {
             case 5:
                 upgradeToVersion6(db, INSTANCES_TABLE_NAME);
                 break;
+            case 6:
+                // Remember to bump the database version number in {@link org.odk.collect.android.database.DatabaseConstants}
+                // upgradeToVersion7(db);
             default:
                 Timber.i("Unknown version %d", oldVersion);
         }

--- a/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/database/FormDatabaseMigratorTest.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertTrue;
 import static org.odk.collect.android.database.DatabaseConstants.FORMS_TABLE_NAME;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.AUTO_DELETE;
 import static org.odk.collect.android.database.forms.DatabaseFormColumns.AUTO_SEND;
@@ -63,11 +64,15 @@ public class FormDatabaseMigratorTest {
 
     @Test
     public void onUpgrade_fromVersion11() {
+        int oldVersion = 11;
+        assertTrue(oldVersion < DatabaseConstants.FORMS_DATABASE_VERSION);
+        database.setVersion(oldVersion);
+
         createVersion11Database(database);
         ContentValues contentValues = createVersion11Form();
         database.insert(FORMS_TABLE_NAME, null, contentValues);
 
-        new FormDatabaseMigrator().onUpgrade(database, 11);
+        new FormDatabaseMigrator().onUpgrade(database, oldVersion);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
             assertThat(cursor.getColumnCount(), is(18));
@@ -96,11 +101,15 @@ public class FormDatabaseMigratorTest {
 
     @Test
     public void onUpgrade_fromVersion10() {
+        int oldVersion = 10;
+        assertTrue(oldVersion < DatabaseConstants.FORMS_DATABASE_VERSION);
+        database.setVersion(oldVersion);
+
         createVersion10Database(database);
         ContentValues contentValues = createVersion10Form();
         database.insert(FORMS_TABLE_NAME, null, contentValues);
 
-        new FormDatabaseMigrator().onUpgrade(database, 10);
+        new FormDatabaseMigrator().onUpgrade(database, oldVersion);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
             assertThat(cursor.getColumnCount(), is(18));
@@ -129,11 +138,15 @@ public class FormDatabaseMigratorTest {
 
     @Test
     public void onUpgrade_fromVersion9() {
+        int oldVersion = 9;
+        assertTrue(oldVersion < DatabaseConstants.FORMS_DATABASE_VERSION);
+        database.setVersion(oldVersion);
+
         createVersion9Database(database);
         ContentValues contentValues = createVersion9Form();
         database.insert(FORMS_TABLE_NAME, null, contentValues);
 
-        new FormDatabaseMigrator().onUpgrade(database, 9);
+        new FormDatabaseMigrator().onUpgrade(database, oldVersion);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
             assertThat(cursor.getColumnCount(), is(18));
@@ -163,11 +176,15 @@ public class FormDatabaseMigratorTest {
 
     @Test
     public void onUpgrade_fromVersion8() {
+        int oldVersion = 8;
+        assertTrue(oldVersion < DatabaseConstants.FORMS_DATABASE_VERSION);
+        database.setVersion(oldVersion);
+
         createVersion8Database(database);
         ContentValues contentValues = createVersion8Form();
         database.insert(FORMS_TABLE_NAME, null, contentValues);
 
-        new FormDatabaseMigrator().onUpgrade(database, 8);
+        new FormDatabaseMigrator().onUpgrade(database, oldVersion);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
             assertThat(cursor.getColumnCount(), is(18));
@@ -196,11 +213,15 @@ public class FormDatabaseMigratorTest {
 
     @Test
     public void onUpgrade_fromVersion7() {
+        int oldVersion = 7;
+        assertTrue(oldVersion < DatabaseConstants.FORMS_DATABASE_VERSION);
+        database.setVersion(oldVersion);
+
         createVersion7Database(database);
         ContentValues contentValues = createVersion7Form();
         database.insert(FORMS_TABLE_NAME, null, contentValues);
 
-        new FormDatabaseMigrator().onUpgrade(database, 7);
+        new FormDatabaseMigrator().onUpgrade(database, oldVersion);
 
         try (Cursor cursor = database.rawQuery("SELECT * FROM " + FORMS_TABLE_NAME + ";", new String[]{})) {
             assertThat(cursor.getColumnCount(), is(18));


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've reviewed the improvements.

#### Why is this the best possible solution? Were any other approaches considered?
It was quite a shameful oversight and it made me think about what I can do to avoid it in the future. When it comes to me I'm pretty sure the lesson itself is enough to remember about testing upgrades but just in case (and of course for other devs) I wanted to do something to make the process a little bit safer. Testing upgrades can't be fully automated of course but at least I've come up with three improvements:
- I've improved tests a little bit to make them more related to the database version number used by our databases
- I've added commented-out upgrade methods for the future with a warning to remember about bumping the database version number. 
- I've added comments in the `DatabaseConstants` class where we keep database version numbers to remember about testing upgrades manually.

This should make the risk of having a similar bug in the future a little bit less likely.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
