### PR TITLE
Exclude settings not supported by a particular device like Mapbox for example

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -27,6 +27,8 @@ import com.google.api.services.drive.DriveScopes;
 import com.google.gson.Gson;
 
 import org.javarosa.core.reference.ReferenceManager;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.odk.collect.analytics.Analytics;
 import org.odk.collect.analytics.BlockableFirebaseAnalytics;
 import org.odk.collect.analytics.NoopAnalytics;
@@ -147,14 +149,13 @@ import org.odk.collect.settings.ODKAppSettingsMigrator;
 import org.odk.collect.settings.SettingsProvider;
 import org.odk.collect.settings.importing.ProjectDetailsCreatorImpl;
 import org.odk.collect.settings.importing.SettingsChangeHandler;
+import org.odk.collect.settings.keys.AppConfigurationKeys;
 import org.odk.collect.settings.keys.MetaKeys;
 import org.odk.collect.settings.keys.ProjectKeys;
 import org.odk.collect.shared.strings.UUIDGenerator;
 import org.odk.collect.utilities.UserAgentProvider;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -324,9 +325,16 @@ public class AppDependencyModule {
 
     @Provides
     public ODKAppSettingsImporter providesODKAppSettingsImporter(Context context, ProjectsRepository projectsRepository, SettingsProvider settingsProvider, SettingsChangeHandler settingsChangeHandler) {
-        Map<String, String> deviceUnsupportedSettings = new HashMap<>();
+        JSONObject deviceUnsupportedSettings = new JSONObject();
         if (!MapboxClassInstanceCreator.isMapboxAvailable()) {
-            deviceUnsupportedSettings.put(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_MAPBOX);
+            try {
+                deviceUnsupportedSettings.put(
+                        AppConfigurationKeys.GENERAL,
+                        new JSONObject().put(ProjectKeys.KEY_BASEMAP_SOURCE, new JSONArray(singletonList(ProjectKeys.BASEMAP_SOURCE_MAPBOX)))
+                );
+            } catch (Throwable ignored) {
+                // ignore
+            }
         }
 
         return new ODKAppSettingsImporter(

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -35,6 +35,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel;
 import org.odk.collect.android.activities.viewmodels.MainMenuViewModel;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
+import org.odk.collect.android.application.MapboxClassInstanceCreator;
 import org.odk.collect.android.application.initialization.AnalyticsInitializer;
 import org.odk.collect.android.application.initialization.ApplicationInitializer;
 import org.odk.collect.android.application.initialization.ExistingProjectMigrator;
@@ -147,10 +148,13 @@ import org.odk.collect.settings.SettingsProvider;
 import org.odk.collect.settings.importing.ProjectDetailsCreatorImpl;
 import org.odk.collect.settings.importing.SettingsChangeHandler;
 import org.odk.collect.settings.keys.MetaKeys;
+import org.odk.collect.settings.keys.ProjectKeys;
 import org.odk.collect.shared.strings.UUIDGenerator;
 import org.odk.collect.utilities.UserAgentProvider;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -320,13 +324,19 @@ public class AppDependencyModule {
 
     @Provides
     public ODKAppSettingsImporter providesODKAppSettingsImporter(Context context, ProjectsRepository projectsRepository, SettingsProvider settingsProvider, SettingsChangeHandler settingsChangeHandler) {
+        Map<String, String> deviceUnsupportedSettings = new HashMap<>();
+        if (!MapboxClassInstanceCreator.isMapboxAvailable()) {
+            deviceUnsupportedSettings.put(ProjectKeys.KEY_BASEMAP_SOURCE, ProjectKeys.BASEMAP_SOURCE_MAPBOX);
+        }
+
         return new ODKAppSettingsImporter(
                 projectsRepository,
                 settingsProvider,
                 Defaults.getUnprotected(),
                 Defaults.getProtected(),
                 asList(context.getResources().getStringArray(R.array.project_colors)),
-                settingsChangeHandler
+                settingsChangeHandler,
+                deviceUnsupportedSettings
         );
     }
 

--- a/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/MapboxMapFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.startup.AppInitializer
 import com.google.android.gms.location.LocationListener
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
@@ -29,6 +30,7 @@ import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.RasterSource
 import com.mapbox.maps.extension.style.sources.generated.VectorSource
 import com.mapbox.maps.extension.style.sources.getSource
+import com.mapbox.maps.loader.MapboxMapsInitializer
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions.Companion.mapAnimationOptions
 import com.mapbox.maps.plugin.animation.flyTo
@@ -132,6 +134,7 @@ class MapboxMapFragment :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        AppInitializer.getInstance(requireContext()).initializeComponent(MapboxMapsInitializer::class.java)
         mapFragmentDelegate.onCreate(savedInstanceState)
     }
 

--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
@@ -13,7 +13,8 @@ class ODKAppSettingsImporter(
     generalDefaults: Map<String, Any>,
     adminDefaults: Map<String, Any>,
     projectColors: List<String>,
-    settingsChangedHandler: SettingsChangeHandler
+    settingsChangedHandler: SettingsChangeHandler,
+    private val deviceUnsupportedSettings: Map<String, String>
 ) {
 
     private val settingsImporter = SettingsImporter(
@@ -29,7 +30,7 @@ class ODKAppSettingsImporter(
 
     fun fromJSON(json: String, project: Project.Saved): Boolean {
         return try {
-            settingsImporter.fromJSON(json, project)
+            settingsImporter.fromJSON(json, project, deviceUnsupportedSettings)
         } catch (e: Throwable) {
             false
         }

--- a/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/ODKAppSettingsImporter.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.settings
 
+import org.json.JSONObject
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.importing.ProjectDetailsCreatorImpl
@@ -14,7 +15,7 @@ class ODKAppSettingsImporter(
     adminDefaults: Map<String, Any>,
     projectColors: List<String>,
     settingsChangedHandler: SettingsChangeHandler,
-    private val deviceUnsupportedSettings: Map<String, String>
+    private val deviceUnsupportedSettings: JSONObject
 ) {
 
     private val settingsImporter = SettingsImporter(

--- a/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
+++ b/settings/src/main/java/org/odk/collect/settings/importing/SettingsImporter.kt
@@ -1,12 +1,12 @@
 package org.odk.collect.settings.importing
 
-import org.json.JSONArray
 import org.json.JSONObject
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.AppConfigurationKeys
 import org.odk.collect.settings.keys.ProjectKeys
+import org.odk.collect.shared.collections.CollectionExtensions.has
 import org.odk.collect.shared.settings.Settings
 
 internal class SettingsImporter(
@@ -81,21 +81,12 @@ internal class SettingsImporter(
             if (settingsValidator.isKeySupported(childJsonObjectName, it)) {
                 val value = childJsonObject[it]
                 if (settingsValidator.isValueSupported(childJsonObjectName, it, value)) {
-                    if (!deviceUnsupportedSettingsForGivenChildJson.has(it) || !hasValue(deviceUnsupportedSettingsForGivenChildJson.getJSONArray(it), value)) {
+                    if (!deviceUnsupportedSettingsForGivenChildJson.has(it) || !deviceUnsupportedSettingsForGivenChildJson.getJSONArray(it).has(value)) {
                         preferences.save(it, value)
                     }
                 }
             }
         }
-    }
-
-    private fun hasValue(jsonArray: JSONArray, value: Any): Boolean {
-        for (i in 0 until jsonArray.length()) {
-            if (jsonArray[i] == value) {
-                return true
-            }
-        }
-        return false
     }
 
     private fun loadDefaults(preferences: Settings, defaults: Map<String, Any>) {

--- a/settings/src/main/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidator.kt
+++ b/settings/src/main/java/org/odk/collect/settings/validation/JsonSchemaSettingsValidator.kt
@@ -7,6 +7,7 @@ import com.networknt.schema.SpecVersion
 import com.networknt.schema.ValidatorTypeCode
 import org.json.JSONObject
 import org.odk.collect.settings.importing.SettingsValidator
+import org.odk.collect.shared.collections.CollectionExtensions.has
 import java.io.InputStream
 
 internal class JsonSchemaSettingsValidator(private val schemaProvider: () -> InputStream) :
@@ -52,14 +53,7 @@ internal class JsonSchemaSettingsValidator(private val schemaProvider: () -> Inp
                 .getJSONObject(key)
 
             return if (settingJsonObject.has("enum")) {
-                val supportedValues = settingJsonObject.getJSONArray("enum")
-
-                for (i in 0 until supportedValues.length()) {
-                    if (supportedValues[i] == value) {
-                        return true
-                    }
-                }
-                false
+                settingJsonObject.getJSONArray("enum").has(value)
             } else {
                 true
             }

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
@@ -23,7 +23,8 @@ class ODKAppSettingsImporterTest {
         mapOf("server_url" to "https://demo.getodk.org"),
         emptyMap(),
         listOf("#00000"),
-        settingsChangeHandler
+        settingsChangeHandler,
+        emptyMap()
     )
 
     @Test

--- a/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/ODKAppSettingsImporterTest.kt
@@ -2,6 +2,7 @@ package org.odk.collect.settings
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.json.JSONObject
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -24,7 +25,7 @@ class ODKAppSettingsImporterTest {
         emptyMap(),
         listOf("#00000"),
         settingsChangeHandler,
-        emptyMap()
+        JSONObject()
     )
 
     @Test

--- a/settings/src/test/java/org/odk/collect/settings/importing/SettingsImporterTest.kt
+++ b/settings/src/test/java/org/odk/collect/settings/importing/SettingsImporterTest.kt
@@ -2,6 +2,7 @@ package org.odk.collect.settings.importing
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -67,7 +68,7 @@ class SettingsImporterTest {
     @Test
     fun whenJSONSettingsAreInvalid_returnsFalse() {
         whenever(settingsValidator.isValid(emptySettings())).thenReturn(false)
-        assertThat(importer.fromJSON(emptySettings(), currentProject, emptyMap()), `is`(false))
+        assertThat(importer.fromJSON(emptySettings(), currentProject, JSONObject()), `is`(false))
     }
 
     @Test
@@ -85,7 +86,7 @@ class SettingsImporterTest {
                 JSONObject().put("key3", 5)
             )
 
-        assertThat(importer.fromJSON(json.toString(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(json.toString(), currentProject, JSONObject()), `is`(true))
 
         assertThat(generalSettings.contains("key3"), `is`(false))
         assertThat(adminSettings.contains("key3"), `is`(false))
@@ -107,13 +108,19 @@ class SettingsImporterTest {
                     .put("key6", "bar1")
             )
 
+        val deviceUnsupportedSettings = emptySettingsObject()
+            .put(
+                AppConfigurationKeys.GENERAL,
+                JSONObject().put("key4", JSONArray(listOf("foo1")))
+            )
+            .put(
+                AppConfigurationKeys.ADMIN,
+                JSONObject().put("key5", JSONArray(listOf("bar")))
+            )
+
         assertThat(
             importer.fromJSON(
-                json.toString(), currentProject,
-                mapOf(
-                    "key4" to "foo1",
-                    "key5" to "bar"
-                )
+                json.toString(), currentProject, deviceUnsupportedSettings
             ),
             `is`(true)
         )
@@ -126,7 +133,7 @@ class SettingsImporterTest {
 
     @Test
     fun `for supported settings that do not exist in json save defaults`() {
-        assertThat(importer.fromJSON(emptySettings(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(emptySettings(), currentProject, JSONObject()), `is`(true))
         assertSettings(
             generalSettings,
             "key1", "default",
@@ -153,7 +160,7 @@ class SettingsImporterTest {
                 JSONObject().put("key1", 6)
             )
 
-        assertThat(importer.fromJSON(json.toString(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(json.toString(), currentProject, JSONObject()), `is`(true))
         assertSettings(
             generalSettings,
             "key1", "default",
@@ -176,7 +183,7 @@ class SettingsImporterTest {
             adminSettings,
             "key1", 0
         )
-        assertThat(importer.fromJSON(emptySettings(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(emptySettings(), currentProject, JSONObject()), `is`(true))
         assertSettings(
             generalSettings,
             "key1", "default",
@@ -206,7 +213,7 @@ class SettingsImporterTest {
             projectsRepository,
             projectDetailsCreator
         )
-        assertThat(importer.fromJSON(emptySettings(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(emptySettings(), currentProject, JSONObject()), `is`(true))
     }
 
     @Test // Migrations might use old keys that are "unknown" to the app
@@ -232,7 +239,7 @@ class SettingsImporterTest {
             projectsRepository,
             projectDetailsCreator
         )
-        assertThat(importer.fromJSON(json.toString(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(json.toString(), currentProject, JSONObject()), `is`(true))
     }
 
     @Test
@@ -247,7 +254,7 @@ class SettingsImporterTest {
             projectsRepository,
             projectDetailsCreator
         )
-        assertThat(importer.fromJSON(emptySettings(), currentProject, emptyMap()), `is`(true))
+        assertThat(importer.fromJSON(emptySettings(), currentProject, JSONObject()), `is`(true))
         verify(settingsChangeHandler).onSettingsChanged("1")
         verifyNoMoreInteractions(settingsChangeHandler)
     }
@@ -274,7 +281,7 @@ class SettingsImporterTest {
             )
         ).thenReturn(newProject)
 
-        importer.fromJSON(settings.toString(), currentProject, emptyMap())
+        importer.fromJSON(settings.toString(), currentProject, JSONObject())
         verify(projectsRepository)
             .save(
                 Project.Saved(
@@ -303,7 +310,7 @@ class SettingsImporterTest {
             )
         ).thenReturn(Project.New("A", "B", "C"))
 
-        importer.fromJSON(settings.toString(), currentProject, emptyMap())
+        importer.fromJSON(settings.toString(), currentProject, JSONObject())
         verify(projectDetailsCreator).createProjectFromDetails("", "", "", "foo")
     }
 
@@ -325,7 +332,7 @@ class SettingsImporterTest {
             )
         ).thenReturn(Project.New("A", "B", "C"))
 
-        importer.fromJSON(settings.toString(), currentProject, emptyMap())
+        importer.fromJSON(settings.toString(), currentProject, JSONObject())
         verify(projectDetailsCreator).createProjectFromDetails("", "", "", "foo@bar.baz")
     }
 

--- a/shared/src/main/java/org/odk/collect/shared/collections/CollectionExtensions.kt
+++ b/shared/src/main/java/org/odk/collect/shared/collections/CollectionExtensions.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.shared.collections
 
+import org.json.JSONArray
 import kotlin.math.abs
 
 object CollectionExtensions {
@@ -7,5 +8,14 @@ object CollectionExtensions {
     fun <T> List<T>.itemFromHashOf(any: Any): T {
         val index = abs(any.hashCode()) % this.size
         return this[index]
+    }
+
+    fun JSONArray.has(value: Any): Boolean {
+        for (i in 0 until this.length()) {
+            if (this[i] == value) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/shared/src/test/java/org/odk/collect/shared/collections/CollectionExtensionsTest.kt
+++ b/shared/src/test/java/org/odk/collect/shared/collections/CollectionExtensionsTest.kt
@@ -2,7 +2,9 @@ package org.odk.collect.shared.collections
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.json.JSONArray
 import org.junit.Test
+import org.odk.collect.shared.collections.CollectionExtensions.has
 import org.odk.collect.shared.collections.CollectionExtensions.itemFromHashOf
 
 class CollectionExtensionsTest {
@@ -22,6 +24,21 @@ class CollectionExtensionsTest {
     @Test
     fun `itemFromHashOf works with negative hashcode`() {
         assertThat(listOf("0", "1").itemFromHashOf(HashCode(-1)), equalTo("1"))
+    }
+
+    @Test
+    fun `has returns true if given value exists in json array`() {
+        assertThat(JSONArray(listOf("blah")).has("blah"), equalTo(true))
+    }
+
+    @Test
+    fun `has returns false if given value does not exist in json array`() {
+        assertThat(JSONArray(listOf("blah")).has("blah2"), equalTo(false))
+    }
+
+    @Test
+    fun `has returns false if json array is empty`() {
+        assertThat(JSONArray().has("blah"), equalTo(false))
     }
 }
 


### PR DESCRIPTION
Closes #5431 

#### What has been done to verify that this works as intended?
I've tested the fix manually and also added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I was thinking about importing all settings like before and checking if Mapbox is supported before starting maps but this solution seems to be better/clearer and easier to test automatically.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I've implemented changes in the code responsible for importing new settings so that's the area of risk. The intended change is to only exclude settings unsupported by a particular device we use. At this moment the only setting that might be unsupported is Mapbox.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
