### PR TITLE
Close the form after denying read phone state permission and opening settings in the explanation dialog

### DIFF
--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsDialogCreator.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsDialogCreator.kt
@@ -67,6 +67,7 @@ internal object PermissionsDialogCreatorImpl : PermissionsDialogCreator {
                     data = Uri.fromParts("package", activity.packageName, null)
                     activity.startActivity(this)
                 }
+                action.additionalExplanationClosed()
             }
             .create()
             .show()

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsDialogCreatorTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsDialogCreatorTest.kt
@@ -36,7 +36,7 @@ class PermissionsDialogCreatorTest {
     }
 
     @Test
-    fun `PermissionListener should not be called immediatelly after displaying enable gps dialog`() {
+    fun `PermissionListener should not be called immediately after displaying enable gps dialog`() {
         PermissionsDialogCreatorImpl.showEnableGPSDialog(
             activity,
             permissionListener
@@ -75,7 +75,7 @@ class PermissionsDialogCreatorTest {
     }
 
     @Test
-    fun `PermissionListener should not be called immediatelly after displaying explanation dialog`() {
+    fun `PermissionListener should not be called immediately after displaying explanation dialog`() {
         PermissionsDialogCreatorImpl.showAdditionalExplanation(
             activity,
             R.string.camera_runtime_permission_denied_title,
@@ -106,6 +106,24 @@ class PermissionsDialogCreatorTest {
     }
 
     @Test
+    fun `PermissionListener#additionalExplanationClosed should be called after clicking on the 'Open Settings' button in explanation dialog`() {
+        PermissionsDialogCreatorImpl.showAdditionalExplanation(
+            activity,
+            R.string.camera_runtime_permission_denied_title,
+            R.string.camera_runtime_permission_denied_desc,
+            R.drawable.ic_photo_camera,
+            permissionListener
+        )
+
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
+        RobolectricHelpers.runLooper()
+
+        verify(permissionListener).additionalExplanationClosed()
+        verifyNoMoreInteractions(permissionListener)
+    }
+
+    @Test
     fun `Settings should be open after clicking on the neutral button in explanation dialog`() {
         PermissionsDialogCreatorImpl.showAdditionalExplanation(
             activity,
@@ -121,7 +139,5 @@ class PermissionsDialogCreatorTest {
 
         Intents.intended(IntentMatchers.hasAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS))
         Intents.intended(IntentMatchers.hasData(Uri.fromParts("package", activity.packageName, null)))
-
-        verifyNoInteractions(permissionListener)
     }
 }


### PR DESCRIPTION
Closes #5272 
Closes #5290 

#### What has been done to verify that this works as intended?
I've verified the fix manually and improved the tests.

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in the issue it's easier to close the form when the read phone state permission is denied than handle granting this permission in settings manually.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
The change affects all types of permissions so please test denying other permissions too to make sure the behavior is correct when we close the dialog with an additional explanation no matter if we click `ok` or `open settings`.

#### Do we need any specific form for testing your changes? If so, please attach one.
The form attached to the issue.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
