### PR TITLE
Stop showing "Updated at" after redownloading identical media files

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/BadServerTest.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 @RunWith(AndroidJUnit4.class)
 public class BadServerTest {
 
-
     private final CollectTestRule rule = new CollectTestRule(false);
     private final TestDependencies testDependencies = new TestDependencies();
 
@@ -71,9 +70,6 @@ public class BadServerTest {
      would fool Collect into thinking there was a new one each time. Collect should still redownload
      the file in this case (there's nothing else it can do), but it should only identify the form
      as being updated if the file actually changed.
-
-     Open Rosa does not actually specify that the hash should be the literal md5 file hash, but
-     Collect has historically expected that.
     */
     public void whenMediaFileHasUnstableHash_butIsIdentical_doesNotShowAsUpdatedAfterRedownload() {
         testDependencies.server.returnRandomMediaFileHash();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/StubOpenRosaServer.java
@@ -19,6 +19,7 @@ import org.odk.collect.android.openrosa.HttpPostResult;
 import org.odk.collect.android.openrosa.OpenRosaConstants;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.shared.strings.Md5;
+import org.odk.collect.shared.strings.RandomString;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -43,6 +44,7 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
     private boolean fetchingFormsError;
     private boolean noHashInFormList;
     private boolean noHashPrefixInMediaFiles;
+    private boolean randomHash;
 
     @NonNull
     @Override
@@ -150,6 +152,10 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
         noHashPrefixInMediaFiles = true;
     }
 
+    public void returnRandomMediaFileHash() {
+        randomHash = true;
+    }
+
     public String getURL() {
         return "https://" + HOST;
     }
@@ -233,7 +239,13 @@ public class StubOpenRosaServer implements OpenRosaHttpInterface {
 
             for (String mediaFile : xformItem.getMediaFiles()) {
                 AssetManager assetManager = InstrumentationRegistry.getInstrumentation().getContext().getAssets();
-                String mediaFileHash = Md5.getMd5Hash(assetManager.open("media/" + mediaFile));
+                String mediaFileHash;
+
+                if (randomHash) {
+                    mediaFileHash = RandomString.randomString(8);
+                } else {
+                    mediaFileHash = Md5.getMd5Hash(assetManager.open("media/" + mediaFile));
+                }
 
                 stringBuilder
                         .append("<mediaFile>")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -110,6 +110,7 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
+    @JvmOverloads
     fun assertTextThatContainsExists(text: String, index: Int = 0): T {
         onView(
             withIndex(
@@ -121,6 +122,21 @@ abstract class Page<T : Page<T>> {
                 index
             )
         ).check(matches(not(doesNotExist())))
+        return this as T
+    }
+
+    @JvmOverloads
+    fun assertTextThatContainsDoesNoExist(text: String, index: Int = 0): T {
+        onView(
+            withIndex(
+                withText(
+                    containsString(
+                        text
+                    )
+                ),
+                index
+            )
+        ).check(doesNotExist())
         return this as T
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormMediaDownloader.kt
@@ -20,7 +20,6 @@ class FormMediaDownloader(
     @Throws(IOException::class, FormSourceException::class, InterruptedException::class)
     fun download(
         formToDownload: ServerFormDetails,
-        files: List<MediaFile>,
         tempMediaPath: String,
         tempDir: File,
         stateListener: OngoingWorkListener
@@ -28,7 +27,7 @@ class FormMediaDownloader(
         var atLeastOneNewMediaFileDetected = false
         val tempMediaDir = File(tempMediaPath).also { it.mkdir() }
 
-        files.forEachIndexed { i, mediaFile ->
+        formToDownload.manifest!!.mediaFiles.forEachIndexed { i, mediaFile ->
             stateListener.progressUpdate(i + 1)
 
             val tempMediaFile = File(tempMediaDir, mediaFile.filename)
@@ -63,7 +62,9 @@ class FormMediaDownloader(
         mediaFile: MediaFile
     ): File? {
         val allFormVersions = formsRepository.getAllByFormId(formToDownload.formId)
-        return allFormVersions.map { form: Form ->
+        return allFormVersions.sortedByDescending {
+            it.date
+        }.map { form: Form ->
             File(form.formMediaPath, mediaFile.filename)
         }.firstOrNull { file: File ->
             file.exists()

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/ServerFormDownloader.java
@@ -98,7 +98,7 @@ public class ServerFormDownloader implements FormDownloader {
             // download media files if there are any
             if (fd.getManifest() != null && !fd.getManifest().getMediaFiles().isEmpty()) {
                 FormMediaDownloader mediaDownloader = new FormMediaDownloader(formsRepository, formSource);
-                newAttachmentsDetected = mediaDownloader.download(fd, fd.getManifest().getMediaFiles(), tempMediaPath, tempDir, stateListener);
+                newAttachmentsDetected = mediaDownloader.download(fd, tempMediaPath, tempDir, stateListener);
             }
         } catch (FormDownloadException.DownloadingInterrupted | InterruptedException e) {
             Timber.i(e);

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMediaDownloaderTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormMediaDownloaderTest.kt
@@ -1,0 +1,97 @@
+package org.odk.collect.android.formmanagement
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.odk.collect.forms.FormSource
+import org.odk.collect.forms.ManifestFile
+import org.odk.collect.forms.MediaFile
+import org.odk.collect.formstest.FormFixtures
+import org.odk.collect.formstest.InMemFormsRepository
+import org.odk.collect.shared.TempFiles
+import org.odk.collect.shared.strings.Md5
+import java.io.File
+
+class FormMediaDownloaderTest {
+
+    @Test
+    fun `returns false when there is an existing copy of a media file and an older one`() {
+        // Save forms
+        val formsRepository = InMemFormsRepository()
+        val form1 = FormFixtures.form(
+            version = "1",
+            date = 1,
+            mediaFiles = listOf(Pair("file", "old"))
+        )
+        formsRepository.save(form1)
+
+        val form2 = FormFixtures.form(
+            version = "2",
+            date = 2,
+            mediaFiles = listOf(Pair("file", "existing"))
+        )
+        formsRepository.save(form2)
+
+        // Set up same media file on server
+        val existingMediaFileHash = Md5.getMd5Hash(File(form2.formMediaPath, "file"))!!
+        val mediaFile = MediaFile("file", existingMediaFileHash, "downloadUrl")
+        val manifestFile = ManifestFile(null, listOf(mediaFile))
+        val serverFormDetails =
+            ServerFormDetails(null, null, "formId", "3", null, false, true, manifestFile)
+        val formSource = mock<FormSource> {
+            on { fetchMediaFile(mediaFile.downloadUrl) } doReturn "existing".toByteArray()
+                .inputStream()
+        }
+
+        val formMediaDownloader = FormMediaDownloader(formsRepository, formSource)
+        val result = formMediaDownloader.download(
+            serverFormDetails,
+            File(TempFiles.createTempDir(), "temp").absolutePath,
+            TempFiles.createTempDir(),
+            mock()
+        )
+
+        assertThat(result, equalTo(false))
+    }
+
+    @Test
+    fun `returns false when there is an existing copy of a media file and an older one and server hash doesn't match existing copy`() {
+        // Save forms
+        val formsRepository = InMemFormsRepository()
+        val form1 = FormFixtures.form(
+            version = "1",
+            date = 1,
+            mediaFiles = listOf(Pair("file", "old"))
+        )
+        formsRepository.save(form1)
+
+        val form2 = FormFixtures.form(
+            version = "2",
+            date = 2,
+            mediaFiles = listOf(Pair("file", "existing"))
+        )
+        formsRepository.save(form2)
+
+        // Set up same media file on server
+        val mediaFile = MediaFile("file", "somethingElse", "downloadUrl")
+        val manifestFile = ManifestFile(null, listOf(mediaFile))
+        val serverFormDetails =
+            ServerFormDetails(null, null, "formId", "3", null, false, true, manifestFile)
+        val formSource = mock<FormSource> {
+            on { fetchMediaFile(mediaFile.downloadUrl) } doReturn "existing".toByteArray()
+                .inputStream()
+        }
+
+        val formMediaDownloader = FormMediaDownloader(formsRepository, formSource)
+        val result = formMediaDownloader.download(
+            serverFormDetails,
+            File(TempFiles.createTempDir(), "temp").absolutePath,
+            TempFiles.createTempDir(),
+            mock()
+        )
+
+        assertThat(result, equalTo(false))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -12,8 +12,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
 import org.odk.collect.android.support.MockFormEntryPromptBuilder
-import org.odk.collect.android.widgets.support.FormFixtures.selectChoice
-import org.odk.collect.android.widgets.support.FormFixtures.treeElement
+import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
+import org.odk.collect.android.widgets.support.FormElementFixtures.treeElement
 import org.odk.collect.androidtest.getOrAwaitValue
 import org.odk.collect.geo.selection.MappableSelectItem.IconifiedText
 import org.odk.collect.testshared.FakeScheduler

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapDialogFragmentTest.kt
@@ -31,8 +31,8 @@ import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.utilities.Appearances
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_FORM_INDEX
 import org.odk.collect.android.widgets.items.SelectOneFromMapDialogFragment.Companion.ARG_SELECTED_INDEX
-import org.odk.collect.android.widgets.support.FormFixtures.selectChoice
-import org.odk.collect.android.widgets.support.FormFixtures.treeElement
+import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
+import org.odk.collect.android.widgets.support.FormElementFixtures.treeElement
 import org.odk.collect.android.widgets.support.NoOpMapFragment
 import org.odk.collect.async.Scheduler
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectOneFromMapWidgetTest.kt
@@ -25,7 +25,7 @@ import org.odk.collect.android.preferences.GuidanceHint
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.MockFormEntryPromptBuilder
 import org.odk.collect.android.support.WidgetTestActivity
-import org.odk.collect.android.widgets.support.FormFixtures.selectChoice
+import org.odk.collect.android.widgets.support.FormElementFixtures.selectChoice
 import org.odk.collect.android.widgets.support.NoOpMapFragment
 import org.odk.collect.android.widgets.support.QuestionWidgetHelpers.mockValueChangedListener
 import org.odk.collect.android.widgets.support.QuestionWidgetHelpers.promptWithAnswer

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/FormElementFixtures.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/FormElementFixtures.kt
@@ -4,7 +4,7 @@ import org.javarosa.core.model.SelectChoice
 import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.instance.TreeElement
 
-object FormFixtures {
+object FormElementFixtures {
 
     fun selectChoice(
         value: String = "foo",

--- a/formstest/src/main/java/org/odk/collect/formstest/FormFixtures.kt
+++ b/formstest/src/main/java/org/odk/collect/formstest/FormFixtures.kt
@@ -1,0 +1,30 @@
+package org.odk.collect.formstest
+
+import org.odk.collect.forms.Form
+import org.odk.collect.shared.TempFiles
+import java.io.File
+
+object FormFixtures {
+    fun form(
+        formId: String = "formId",
+        version: String = "1",
+        date: Long = 1,
+        mediaFiles: List<Pair<String, String>> = emptyList()
+    ): Form {
+        val formFilesPath = TempFiles.createTempDir().absolutePath
+        val mediaFilePath = TempFiles.createTempDir().absolutePath
+
+        mediaFiles.forEach { (name, contents) ->
+            File(mediaFilePath, name).also { it.writeBytes(contents.toByteArray()) }
+        }
+
+        return Form.Builder()
+            .displayName("Test Form")
+            .formId(formId)
+            .version(version)
+            .formFilePath(FormUtils.createFormFixtureFile(formId, version, formFilesPath))
+            .formMediaPath(mediaFilePath)
+            .date(date)
+            .build()
+    }
+}

--- a/formstest/src/main/java/org/odk/collect/formstest/FormUtils.kt
+++ b/formstest/src/main/java/org/odk/collect/formstest/FormUtils.kt
@@ -4,7 +4,6 @@ import org.apache.commons.io.FileUtils
 import org.odk.collect.forms.Form
 import java.io.File
 import java.io.IOException
-import java.lang.RuntimeException
 import java.nio.charset.Charset
 
 object FormUtils {
@@ -49,6 +48,22 @@ object FormUtils {
         xform: String = createXFormBody(formId, version),
         autosend: String? = null
     ): Form.Builder {
+        val formFilePath = createFormFixtureFile(formId, version, formFilesPath, xform)
+
+        return Form.Builder()
+            .displayName("Test Form")
+            .formId(formId)
+            .version(version)
+            .formFilePath(formFilePath)
+            .autoSend(autosend)
+    }
+
+    fun createFormFixtureFile(
+        formId: String,
+        version: String?,
+        formFilesPath: String,
+        xform: String = createXFormBody(formId, version)
+    ): String {
         val fileName = formId + "-" + version + "-" + Math.random()
         val formFile = File("$formFilesPath/$fileName.xml")
 
@@ -58,11 +73,6 @@ object FormUtils {
             throw RuntimeException(e)
         }
 
-        return Form.Builder()
-            .displayName("Test Form")
-            .formFilePath(formFile.absolutePath)
-            .formId(formId)
-            .version(version)
-            .autoSend(autosend)
+        return formFile.absolutePath
     }
 }


### PR DESCRIPTION
Central currently doesn't return hashes that match the actual file MD5 hash for entity lists. This means that they will get redownloaded on every update check (match exactly or previously downloaded only). As well as the wasted redownload, this will confusingly make the form show up as "Updated at" after every update check (which could be as frequent as every 15 mins). This PR changes that so that we only show "Updated at" on forms where a redownloaded media file has actually changed.

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

Not sure if there are many alternatives here. The key change was to move the check about a media file being updated to after downloading so that we can compare the "new" file with the old one to see if there's actually been a change.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Changes to form download are always risky as it's a surprisingly complex area of the code and there are many hidden subtleties. It'd be good to check/think about different form download/update scenarios against various different servers.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
