### PR TITLE
Add HTTP caching

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
@@ -1,5 +1,6 @@
 package org.odk.collect.android.support;
 
+import android.app.Application;
 import android.content.Context;
 import android.webkit.MimeTypeMap;
 
@@ -26,7 +27,7 @@ public class TestDependencies extends AppDependencyModule {
     public final StubBarcodeViewDecoder stubBarcodeViewDecoder = new StubBarcodeViewDecoder();
 
     @Override
-    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, StoragePathProvider storagePathProvider) {
+    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application) {
         return server;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
@@ -26,7 +26,7 @@ public class TestDependencies extends AppDependencyModule {
     public final StubBarcodeViewDecoder stubBarcodeViewDecoder = new StubBarcodeViewDecoder();
 
     @Override
-    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider) {
+    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, StoragePathProvider storagePathProvider) {
         return server;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/TestDependencies.java
@@ -13,6 +13,7 @@ import org.odk.collect.android.gdrive.sheets.SheetsApi;
 import org.odk.collect.android.injection.config.AppDependencyModule;
 import org.odk.collect.android.openrosa.OpenRosaHttpInterface;
 import org.odk.collect.android.storage.StoragePathProvider;
+import org.odk.collect.android.version.VersionInformation;
 import org.odk.collect.android.views.BarcodeViewDecoder;
 import org.odk.collect.async.Scheduler;
 import org.odk.collect.utilities.UserAgentProvider;
@@ -27,7 +28,7 @@ public class TestDependencies extends AppDependencyModule {
     public final StubBarcodeViewDecoder stubBarcodeViewDecoder = new StubBarcodeViewDecoder();
 
     @Override
-    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application) {
+    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application, VersionInformation versionInformation) {
         return server;
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -186,11 +186,9 @@ public class AppDependencyModule {
     @Provides
     @Singleton
     public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application, VersionInformation versionInformation) {
-        String cacheDir;
+        String cacheDir = null;
         if (!versionInformation.isRelease() || BuildConfig.DEBUG) {
             cacheDir = application.getCacheDir().getAbsolutePath();
-        } else {
-            cacheDir = null;
         }
 
         return new OkHttpConnection(

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -185,9 +185,9 @@ public class AppDependencyModule {
 
     @Provides
     @Singleton
-    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider) {
+    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, StoragePathProvider storagePathProvider) {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientProvider(new OkHttpClient()),
+                new OkHttpOpenRosaServerClientProvider(new OkHttpClient(), storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)),
                 new CollectThenSystemContentTypeMapper(mimeTypeMap),
                 userAgentProvider.getUserAgent()
         );

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -185,9 +185,16 @@ public class AppDependencyModule {
 
     @Provides
     @Singleton
-    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application) {
+    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application, VersionInformation versionInformation) {
+        String cacheDir;
+        if (!versionInformation.isRelease() || BuildConfig.DEBUG) {
+            cacheDir = application.getCacheDir().getAbsolutePath();
+        } else {
+            cacheDir = null;
+        }
+
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientProvider(new OkHttpClient(), application.getCacheDir().getAbsolutePath()),
+                new OkHttpOpenRosaServerClientProvider(new OkHttpClient(), cacheDir),
                 new CollectThenSystemContentTypeMapper(mimeTypeMap),
                 userAgentProvider.getUserAgent()
         );

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -185,9 +185,9 @@ public class AppDependencyModule {
 
     @Provides
     @Singleton
-    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, StoragePathProvider storagePathProvider) {
+    public OpenRosaHttpInterface provideHttpInterface(MimeTypeMap mimeTypeMap, UserAgentProvider userAgentProvider, Application application) {
         return new OkHttpConnection(
-                new OkHttpOpenRosaServerClientProvider(new OkHttpClient(), storagePathProvider.getOdkDirPath(StorageSubdirectory.CACHE)),
+                new OkHttpOpenRosaServerClientProvider(new OkHttpClient(), application.getCacheDir().getAbsolutePath()),
                 new CollectThenSystemContentTypeMapper(mimeTypeMap),
                 userAgentProvider.getUserAgent()
         );

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaHttpInterface.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaHttpInterface.java
@@ -36,7 +36,7 @@ public interface OpenRosaHttpInterface {
      * @throws Exception various Exceptions such as IOException can be thrown
      */
     @NonNull
-    HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable String contentType, @Nullable HttpCredentialsInterface credentials) throws Exception;
+    HttpGetResult executeGetRequest(@NonNull URI uri, @Nullable String contentType, @NonNull HttpCredentialsInterface credentials) throws Exception;
 
     /**
      * Performs a Http Head request.
@@ -47,7 +47,7 @@ public interface OpenRosaHttpInterface {
      * @throws Exception various Exceptions such as IOException can be thrown
      */
     @NonNull
-    HttpHeadResult executeHeadRequest(@NonNull URI uri, @Nullable HttpCredentialsInterface credentials) throws Exception;
+    HttpHeadResult executeHeadRequest(@NonNull URI uri, @NonNull HttpCredentialsInterface credentials) throws Exception;
 
     /**
      * Uploads submission files and then list of other files to server
@@ -63,7 +63,7 @@ public interface OpenRosaHttpInterface {
     HttpPostResult uploadSubmissionAndFiles(@NonNull File submissionFile,
                                             @NonNull List<File> fileList,
                                             @NonNull URI uri,
-                                            @Nullable HttpCredentialsInterface credentials,
+                                            @NonNull HttpCredentialsInterface credentials,
                                             @NonNull long contentLength) throws Exception;
 
     interface FileToContentTypeMapper {

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaServerClientProvider.java
@@ -1,8 +1,8 @@
 package org.odk.collect.android.openrosa;
 
-import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 public interface OpenRosaServerClientProvider {
 
-    OpenRosaServerClient get(String schema, String userAgent, @Nullable HttpCredentialsInterface credentialsInterface);
+    OpenRosaServerClient get(String schema, String userAgent, @NonNull HttpCredentialsInterface credentialsInterface);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -66,7 +66,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
     }
 
     @Override
-    public OpenRosaServerClient get(String scheme, String userAgent, @Nullable HttpCredentialsInterface credentials) {
+    public synchronized OpenRosaServerClient get(String scheme, String userAgent, @Nullable HttpCredentialsInterface credentials) {
         if (client == null || credentialsHaveChanged(credentials)) {
             lastCredentials = credentials;
             client = createNewClient(scheme, userAgent, credentials);

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -75,7 +75,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
         return client;
     }
 
-    public boolean credentialsHaveChanged(@Nullable HttpCredentialsInterface credentials) {
+    private boolean credentialsHaveChanged(@Nullable HttpCredentialsInterface credentials) {
         return lastCredentials != null && !lastCredentials.equals(credentials)
                 || lastCredentials == null && credentials != null;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -87,7 +87,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
                 .readTimeout(READ_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .followRedirects(true);
 
-        if (cacheDir != null) {
+        if (cacheDir != null && new File(cacheDir).exists()) {
             builder.cache(new Cache(
                     new File(cacheDir, "http_" + credentials.hashCode()),
                     50L * 1024L * 1024L // 50 MiB

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -3,7 +3,6 @@ package org.odk.collect.android.openrosa.okhttp;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.burgstaller.okhttp.AuthenticationCacheInterceptor;
 import com.burgstaller.okhttp.CachingAuthenticatorDecorator;
@@ -67,7 +66,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
     }
 
     @Override
-    public synchronized OpenRosaServerClient get(String scheme, String userAgent, @Nullable HttpCredentialsInterface credentials) {
+    public synchronized OpenRosaServerClient get(String scheme, String userAgent, @NonNull HttpCredentialsInterface credentials) {
         OkHttpOpenRosaServerClient existingClient = clients.get(credentials);
 
         if (existingClient == null) {
@@ -80,7 +79,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
     }
 
     @NonNull
-    private OkHttpOpenRosaServerClient createNewClient(String scheme, String userAgent, @Nullable HttpCredentialsInterface credentials) {
+    private OkHttpOpenRosaServerClient createNewClient(String scheme, String userAgent, @NonNull HttpCredentialsInterface credentials) {
         OkHttpClient.Builder builder = baseClient.newBuilder()
                 .connectTimeout(CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(WRITE_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -89,7 +88,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
 
         if (cacheDir != null) {
             builder.cache(new Cache(
-                    new File(cacheDir, "http"),
+                    new File(cacheDir, "http_" + credentials.hashCode()),
                     50L * 1024L * 1024L // 50 MiB
             ));
         }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/okhttp/OkHttpOpenRosaServerClientProvider.java
@@ -34,6 +34,7 @@ import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import kotlin.Pair;
 import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -54,7 +55,7 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
     private final OkHttpClient baseClient;
     private final String cacheDir;
 
-    private final Map<HttpCredentialsInterface, OkHttpOpenRosaServerClient> clients = new HashMap<>();
+    private final Map<Pair<String, HttpCredentialsInterface>, OkHttpOpenRosaServerClient> clients = new HashMap<>();
 
     public OkHttpOpenRosaServerClientProvider(@NonNull OkHttpClient baseClient) {
         this(baseClient, null);
@@ -67,11 +68,11 @@ public class OkHttpOpenRosaServerClientProvider implements OpenRosaServerClientP
 
     @Override
     public synchronized OpenRosaServerClient get(String scheme, String userAgent, @NonNull HttpCredentialsInterface credentials) {
-        OkHttpOpenRosaServerClient existingClient = clients.get(credentials);
+        OkHttpOpenRosaServerClient existingClient = clients.get(new Pair<>(scheme, credentials));
 
         if (existingClient == null) {
             OkHttpOpenRosaServerClient newClient = createNewClient(scheme, userAgent, credentials);
-            clients.put(credentials, newClient);
+            clients.put(new Pair<>(scheme, credentials), newClient);
             return newClient;
         } else {
             return existingClient;

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/WebCredentialsUtils.java
@@ -3,7 +3,6 @@ package org.odk.collect.android.utilities;
 import android.net.Uri;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import org.odk.collect.android.logic.PropertyManager;
 import org.odk.collect.android.openrosa.HttpCredentials;
@@ -87,21 +86,27 @@ public class WebCredentialsUtils {
      * @param url to find the credentials object
      * @return either null or an instance of HttpCredentialsInterface
      */
-    public @Nullable HttpCredentialsInterface getCredentials(@NonNull URI url) {
+    public @NonNull HttpCredentialsInterface getCredentials(@NonNull URI url) {
         String host = url.getHost();
         String serverPrefsUrl = getServerUrlFromPreferences();
         String prefsServerHost = (serverPrefsUrl == null) ? null : Uri.parse(serverPrefsUrl).getHost();
 
+        HttpCredentialsInterface hostCredentials = HOST_CREDENTIALS.get(host);
+
         // URL host is the same as the host in preferences
         if (prefsServerHost != null && prefsServerHost.equalsIgnoreCase(host)) {
             // Use the temporary credentials if they exist, otherwise use the credentials saved to preferences
-            if (HOST_CREDENTIALS.containsKey(host)) {
-                return HOST_CREDENTIALS.get(host);
+            if (hostCredentials != null) {
+                return hostCredentials;
             } else {
                 return new HttpCredentials(getUserNameFromPreferences(), getPasswordFromPreferences());
             }
         } else {
-            return HOST_CREDENTIALS.get(host);
+            if (hostCredentials != null) {
+                return hostCredentials;
+            } else {
+                return new HttpCredentials("", "");
+            }
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OkHttpOpenRosaServerClientProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OkHttpOpenRosaServerClientProviderTest.java
@@ -1,13 +1,9 @@
 package org.odk.collect.android.openrosa;
 
-import org.junit.Test;
 import org.odk.collect.android.openrosa.okhttp.OkHttpOpenRosaServerClientProvider;
 
 import okhttp3.OkHttpClient;
 import okhttp3.tls.internal.TlsUtil;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClientProviderTest {
 
@@ -20,19 +16,5 @@ public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClient
                 .build();
         
         return new OkHttpOpenRosaServerClientProvider(baseClient);
-    }
-
-    @Test
-    public void credentialsHaveChangedTest() {
-        OkHttpOpenRosaServerClientProvider clientProvider = (OkHttpOpenRosaServerClientProvider) buildSubject();
-        HttpCredentials newCredentials = new HttpCredentials("Admin", "Admin");
-
-        assertFalse(clientProvider.credentialsHaveChanged(null));
-        assertTrue(clientProvider.credentialsHaveChanged(newCredentials));
-
-        clientProvider.get("https", "Dalvik/2.1.0 (Linux; U; Android 9; Android SDK built for x86 Build/PSR1.180720.093) org.odk.collect.android/v1.23.3-127-g2e2b1ac76", newCredentials);
-
-        assertTrue(clientProvider.credentialsHaveChanged(null));
-        assertFalse(clientProvider.credentialsHaveChanged(newCredentials));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OkHttpOpenRosaServerClientProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OkHttpOpenRosaServerClientProviderTest.java
@@ -1,5 +1,10 @@
 package org.odk.collect.android.openrosa;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.Test;
 import org.odk.collect.android.openrosa.okhttp.OkHttpOpenRosaServerClientProvider;
 
 import okhttp3.OkHttpClient;
@@ -16,5 +21,18 @@ public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClient
                 .build();
         
         return new OkHttpOpenRosaServerClientProvider(baseClient);
+    }
+
+    @Test
+    public void differentCredentialsHaveDifferentInstances() {
+        OpenRosaServerClientProvider provider = buildSubject();
+
+        OpenRosaServerClient instance1 = provider.get("http", "Android", new HttpCredentials("user", "pass"));
+        OpenRosaServerClient instance2 = provider.get("http", "Android", new HttpCredentials("other", "pass"));
+        OpenRosaServerClient instance3 = provider.get("http", "Android", new HttpCredentials("user", "pass"));
+
+
+        assertThat(instance1, not(equalTo(instance2)));
+        assertThat(instance1, equalTo(instance3));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OkHttpOpenRosaServerClientProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OkHttpOpenRosaServerClientProviderTest.java
@@ -3,24 +3,34 @@ package org.odk.collect.android.openrosa;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.odk.collect.android.openrosa.support.MockWebServerHelper.buildRequest;
 
 import org.junit.Test;
 import org.odk.collect.android.openrosa.okhttp.OkHttpOpenRosaServerClientProvider;
+import org.odk.collect.shared.TempFiles;
+
+import java.io.File;
+import java.util.Date;
 
 import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.tls.internal.TlsUtil;
 
 public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClientProviderTest {
 
     @Override
     protected OpenRosaServerClientProvider buildSubject() {
+        return buildSubject(null);
+    }
+
+    private OkHttpOpenRosaServerClientProvider buildSubject(String cacheDir) {
         OkHttpClient baseClient = new OkHttpClient.Builder()
                 .sslSocketFactory(
                         TlsUtil.localhost().sslSocketFactory(),
                         TlsUtil.localhost().trustManager())
                 .build();
-        
-        return new OkHttpOpenRosaServerClientProvider(baseClient);
+
+        return new OkHttpOpenRosaServerClientProvider(baseClient, cacheDir);
     }
 
     @Test
@@ -34,5 +44,38 @@ public class OkHttpOpenRosaServerClientProviderTest extends OpenRosaServerClient
 
         assertThat(instance1, not(equalTo(instance2)));
         assertThat(instance1, equalTo(instance3));
+    }
+
+    @Test
+    public void whenCacheDirDoesNotExist_doesNotCreateCache() throws Exception {
+        File noneExistingFile = new File(TempFiles.getPathInTempDir());
+        assertThat(noneExistingFile.exists(), equalTo(false));
+
+        MockWebServer mockWebServer = mockWebServerRule.start();
+        enqueueSuccess(mockWebServer);
+
+        OkHttpOpenRosaServerClientProvider provider = buildSubject(noneExistingFile.getAbsolutePath());
+        OpenRosaServerClient client = provider.get("http", "Android", new HttpCredentials("", ""));
+        client.makeRequest(buildRequest(mockWebServer, ""), new Date());
+
+        assertThat(noneExistingFile.exists(), equalTo(false));
+    }
+
+    @Test
+    public void whenCacheDirIsFile_doesNotCreateCache() throws Exception {
+        File file = new File(TempFiles.getPathInTempDir());
+        file.createNewFile();
+        assertThat(file.exists(), equalTo(true));
+        assertThat(file.isDirectory(), equalTo(false));
+
+        MockWebServer mockWebServer = mockWebServerRule.start();
+        enqueueSuccess(mockWebServer);
+
+        OkHttpOpenRosaServerClientProvider provider = buildSubject(file.getAbsolutePath());
+        OpenRosaServerClient client = provider.get("http", "Android", new HttpCredentials("", ""));
+        client.makeRequest(buildRequest(mockWebServer, ""), new Date());
+
+        assertThat(file.exists(), equalTo(true));
+        assertThat(file.isDirectory(), equalTo(false));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaServerClientProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaServerClientProviderTest.java
@@ -1,10 +1,10 @@
 package org.odk.collect.android.openrosa;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 import static org.odk.collect.android.openrosa.support.MockWebServerHelper.buildRequest;
 
 import org.junit.Before;

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaServerClientProviderTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaServerClientProviderTest.java
@@ -304,7 +304,7 @@ public abstract class OpenRosaServerClientProviderTest {
         assertThat(request.getHeader("Cookie"), isEmptyOrNullString());
     }
 
-    private void enqueueSuccess(MockWebServer mockWebServer) {
+    protected void enqueueSuccess(MockWebServer mockWebServer) {
         mockWebServer.enqueue(new MockResponse());
     }
 


### PR DESCRIPTION
This enables caching so that we don't make network requests we don't need to make. This is specially useful for the new entity list media files (which get redownloaded on every form update check), but will save on general network usage for pretty much everything else when used with servers that support standard HTTP caching (etags etc).

I've introduced this as a beta/debug only feature so that we can experiment with it to get us confident enough to allow it in full releases.

#### What has been done to verify that this works as intended?

Used network debugging tool.

#### Why is this the best possible solution? Were any other approaches considered?

OkHttp has built in caching so going with that seemed like the simplest option (rather than rolling our own). I've left some further comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should be no visible changes for normal Collect users. I haven't had a chance to debug this with server logs so that would be a good exercise for a reviewer. QA should probably focus on checking for any regressions in form download or update behaviour.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
