### PR TITLE
Add support for shapes to select one map appearance

### DIFF
--- a/collect_app/src/androidTest/assets/forms/all-widgets.xml
+++ b/collect_app/src/androidTest/assets/forms/all-widgets.xml
@@ -374,6 +374,11 @@
             <label>C</label>
             <name>c</name>
           </item>
+          <item>
+            <geometry>53.40903732686215 -2.991905620523312 0 0; 51.505094241512666 -0.1321803079139272 0 0; 53.8052722823615 -1.5363611594108022 0 0; 53.40903732686215 -2.991905620523312 0 0</geometry>
+            <label>D</label>
+            <name>d</name>
+          </item>
         </root>
       </instance>
       <bind nodeset="/data/intro" readonly="true()" type="string"/>

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/items/SelectChoicesMapDataTest.kt
@@ -58,6 +58,36 @@ class SelectChoicesMapDataTest {
     }
 
     @Test
+    fun `choices with geo shape format geometry have multiple points`() {
+        val choices = listOf(
+            selectChoice(
+                value = "a",
+                item = treeElement(
+                    children = listOf(treeElement("geometry", "12.0 -1.0 3 4; 12.1 -1.0 3 4; 12.0 -1.0 3 4"))
+                )
+            )
+        )
+
+        val prompt = MockFormEntryPromptBuilder()
+            .withLongText("Which is your favourite place?")
+            .withSelectChoices(choices)
+            .withSelectChoiceText(mapOf(choices[0] to "A"))
+            .build()
+
+        val data = loadDataForPrompt(prompt)
+        assertThat(data.getItemCount().getOrAwaitValue(), equalTo(1))
+
+        val mappableItems = data.getMappableItems().getOrAwaitValue()!!
+        assertThat(mappableItems.size, equalTo(1))
+
+        val points = mappableItems[0].points
+        assertThat(
+            points,
+            equalTo(listOf(MapPoint(12.0, -1.0, 3.0, 4.0), MapPoint(12.1, -1.0, 3.0, 4.0), MapPoint(12.0, -1.0, 3.0, 4.0)))
+        )
+    }
+
+    @Test
     fun `choices without geometry are not included in mappable items`() {
         val choices = listOf(
             selectChoice(


### PR DESCRIPTION
Closes #4951 

#### What has been done to verify that this works as intended?
I've tested shapes using the form I've attached with 3 different sources `geojson`/`csv`/`xml` and three different types of elements `points`/`traces`/`shapes`.

#### Why is this the best possible solution? Were any other approaches considered?
SHapes work out of the box after merging #4950 so there is no need to change anything.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We should test the same as in the case of #4950 but for shapes. It doesn't make sense to test everything again because this pr does not change anything so it can't spoil anything too.

#### Do we need any specific form for testing your changes? If so, please attach one.
[SelectOneFromMap.zip](https://github.com/getodk/collect/files/10724699/SelectOneFromMap.zip)

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
