### PR TITLE
Do not use dagger in AudioRecorderFactory

### DIFF
--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
@@ -15,7 +15,6 @@ import org.odk.collect.audiorecorder.mediarecorder.AMRRecordingResource
 import org.odk.collect.audiorecorder.recorder.Output
 import org.odk.collect.audiorecorder.recorder.Recorder
 import org.odk.collect.audiorecorder.recorder.RecordingResourceRecorder
-import org.odk.collect.audiorecorder.recording.AudioRecorderFactory
 import org.odk.collect.audiorecorder.recording.AudioRecorderService
 import org.odk.collect.audiorecorder.recording.internal.RecordingRepository
 import java.io.File
@@ -49,7 +48,6 @@ interface AudioRecorderDependencyComponent {
     }
 
     fun inject(activity: AudioRecorderService)
-    fun inject(activity: AudioRecorderFactory)
 }
 
 @Module

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/DaggerSetup.kt
@@ -7,7 +7,6 @@ import dagger.Component
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
-import org.odk.collect.androidshared.data.getState
 import org.odk.collect.async.CoroutineScheduler
 import org.odk.collect.async.Scheduler
 import org.odk.collect.audiorecorder.mediarecorder.AACRecordingResource
@@ -16,7 +15,6 @@ import org.odk.collect.audiorecorder.recorder.Output
 import org.odk.collect.audiorecorder.recorder.Recorder
 import org.odk.collect.audiorecorder.recorder.RecordingResourceRecorder
 import org.odk.collect.audiorecorder.recording.AudioRecorderService
-import org.odk.collect.audiorecorder.recording.internal.RecordingRepository
 import java.io.File
 import javax.inject.Singleton
 
@@ -81,10 +79,5 @@ open class AudioRecorderDependencyModule {
     @Provides
     open fun providesScheduler(application: Application): Scheduler {
         return CoroutineScheduler(Dispatchers.Main, Dispatchers.IO)
-    }
-
-    @Provides
-    internal open fun providesRecordingRepository(application: Application): RecordingRepository {
-        return RecordingRepository(application.getState())
     }
 }

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderFactory.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderFactory.kt
@@ -1,20 +1,13 @@
 package org.odk.collect.audiorecorder.recording
 
 import android.app.Application
-import org.odk.collect.audiorecorder.AudioRecorderDependencyComponentProvider
+import org.odk.collect.androidshared.data.getState
 import org.odk.collect.audiorecorder.recording.internal.ForegroundServiceAudioRecorder
 import org.odk.collect.audiorecorder.recording.internal.RecordingRepository
-import javax.inject.Inject
 
 open class AudioRecorderFactory(private val application: Application) {
 
-    @Inject
-    internal lateinit var recordingRepository: RecordingRepository
-
     open fun create(): AudioRecorder {
-        val provider = application.applicationContext as AudioRecorderDependencyComponentProvider
-        provider.audioRecorderDependencyComponent.inject(this)
-
-        return ForegroundServiceAudioRecorder(application, recordingRepository)
+        return ForegroundServiceAudioRecorder(application, RecordingRepository(application.getState()))
     }
 }

--- a/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderService.kt
+++ b/audiorecorder/src/main/java/org/odk/collect/audiorecorder/recording/AudioRecorderService.kt
@@ -1,8 +1,10 @@
 package org.odk.collect.audiorecorder.recording
 
+import android.app.Application
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import org.odk.collect.androidshared.data.getState
 import org.odk.collect.async.Cancellable
 import org.odk.collect.async.Scheduler
 import org.odk.collect.audiorecorder.AudioRecorderDependencyComponentProvider
@@ -19,12 +21,11 @@ class AudioRecorderService : Service() {
     internal lateinit var recorder: Recorder
 
     @Inject
-    internal lateinit var recordingRepository: RecordingRepository
-
-    @Inject
     internal lateinit var scheduler: Scheduler
 
+    private lateinit var recordingRepository: RecordingRepository
     private lateinit var notification: RecordingForegroundServiceNotification
+
     private var duration = 0L
     private var durationUpdates: Cancellable? = null
     private var amplitudeUpdates: Cancellable? = null
@@ -34,6 +35,7 @@ class AudioRecorderService : Service() {
         val provider = applicationContext as AudioRecorderDependencyComponentProvider
         provider.audioRecorderDependencyComponent.inject(this)
 
+        recordingRepository = RecordingRepository((applicationContext as Application).getState())
         notification = RecordingForegroundServiceNotification(this, recordingRepository)
     }
 

--- a/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
+++ b/audiorecorder/src/test/java/org/odk/collect/audiorecorder/recording/internal/AudioRecorderServiceTest.kt
@@ -33,7 +33,6 @@ class AudioRecorderServiceTest {
     private val application: RobolectricApplication by lazy { ApplicationProvider.getApplicationContext() }
     private val recorder = FakeRecorder()
     private val scheduler = FakeScheduler()
-    private val recordingRepository = RecordingRepository(application.getState())
 
     private var serviceInstance: ServiceScenario<AudioRecorderService>? = null
 
@@ -47,10 +46,6 @@ class AudioRecorderServiceTest {
 
                 override fun providesScheduler(application: Application): Scheduler {
                     return scheduler
-                }
-
-                override fun providesRecordingRepository(application: Application): RecordingRepository {
-                    return recordingRepository
                 }
             }
         )
@@ -258,6 +253,7 @@ class AudioRecorderServiceTest {
         stopAction()
         pauseAction()
 
+        val recordingRepository = RecordingRepository(application.getState())
         assertThat(recordingRepository.currentSession.value!!.paused, equalTo(false))
     }
 


### PR DESCRIPTION
Closes #5445 

#### What has been done to verify that this works as intended?
I've tested recording audio.

#### Why is this the best possible solution? Were any other approaches considered?
We don't know why there is a problem with initializing that particular field (`internal lateinit var recordingRepository: RecordingRepository`). I guess dagger might have some problems with injecting objects into regular classes that are not components like activity/fragment/service, or maybe it's related to modularizing the app too, or maybe even with kotlin... it's difficult to tell. Fortunately in AudioRecorderFactory we don't have to use dagger and we can just create a new instance of `RecordingRepository`.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test recording audios with the forms available on the demo server.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms with audio recording.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
