### PR TITLE
Fix crash when exiting geo trace/shape screen

### DIFF
--- a/androidtest/src/main/java/org/odk/collect/androidtest/ActivityScenarioExtensions.kt
+++ b/androidtest/src/main/java/org/odk/collect/androidtest/ActivityScenarioExtensions.kt
@@ -10,6 +10,7 @@ object ActivityScenarioExtensions {
      * ActivityScenario but `isFinishing` appears to work correctly. Bug for this is tracked
      * at https://github.com/android/android-test/issues/978.
      */
+    @JvmStatic
     val <T : Activity> ActivityScenario<T>.isFinishing: Boolean
         get() {
             var isFinishing = false

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
@@ -463,11 +463,17 @@ public class AllWidgetsFormTest {
     public void testGeotraceWidget() {
         Screengrab.screenshot("geo-trace");
 
+        onView(withText("Start GeoTrace")).perform(click());
+        pressBack();
+
         onView(withText("Geotrace widget")).perform(swipeLeft());
     }
 
     public void testGeoshapeWidget() {
         Screengrab.screenshot("geo-space");
+
+        onView(withText("Start GeoShape")).perform(click());
+        pressBack();
 
         onView(withText("Geoshape widget")).perform(swipeLeft());
     }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -26,7 +26,6 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
-import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentContainerView;
 
@@ -517,9 +516,5 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
             .setNegativeButton(R.string.cancel, null)
             .show();
 
-    }
-
-    @VisibleForTesting public MapFragment getMapFragment() {
-        return map;
     }
 }

--- a/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
+++ b/geo/src/main/java/org/odk/collect/geo/geopoly/GeoPolyActivity.java
@@ -248,15 +248,16 @@ public class GeoPolyActivity extends LocalizedActivity implements GeoPolySetting
             ArrayList<MapPoint> extraPoly = intent.getParcelableArrayListExtra(EXTRA_POLYGON);
 
             if (!extraPoly.isEmpty()) {
-                originalPoly = extraPoly;
-
                 if (outputMode == OutputMode.GEOSHAPE) {
                     points = extraPoly.subList(0, extraPoly.size() - 1);
                 } else {
                     points = extraPoly;
                 }
             }
+
+            originalPoly = extraPoly;
         }
+
         if (restoredPoints != null) {
             points = restoredPoints;
         }

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.odk.collect.androidtest.ActivityScenarioExtensions.isFinishing;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
@@ -34,6 +35,7 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.espresso.Espresso;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Before;
@@ -84,7 +86,8 @@ public class GeoPolyActivityTest {
                     @NonNull
                     @Override
                     public ReferenceLayerSettingsNavigator providesReferenceLayerSettingsNavigator() {
-                        return (activity) -> {};
+                        return (activity) -> {
+                        };
                     }
 
                     @NonNull
@@ -165,7 +168,7 @@ public class GeoPolyActivityTest {
     }
 
     @Test
-    public void whenPolygonExtraPresent_andPolyIsEmpty__andOutputModeIsShape_doesNotShowPoly() {
+    public void whenPolygonExtraPresent_andPolyIsEmpty_andOutputModeIsShape_doesNotShowPoly() {
         Intent intent = new Intent(ApplicationProvider.getApplicationContext(), GeoPolyActivity.class);
 
         ArrayList<MapPoint> polygon = new ArrayList<>();
@@ -178,6 +181,20 @@ public class GeoPolyActivityTest {
         List<List<MapPoint>> polys = mapFragment.getPolys();
         assertThat(polys.size(), equalTo(1));
         assertThat(polys.get(0).isEmpty(), equalTo(true));
+    }
+
+    @Test
+    public void whenPolygonExtraPresent_andPolyIsEmpty_pressingBack_finishes() {
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), GeoPolyActivity.class);
+
+        ArrayList<MapPoint> polygon = new ArrayList<>();
+        intent.putExtra(GeoPolyActivity.EXTRA_POLYGON, polygon);
+        intent.putExtra(GeoPolyActivity.OUTPUT_MODE_KEY, GeoPolyActivity.OutputMode.GEOSHAPE);
+        ActivityScenario<GeoPolyActivity> scenario = launcherRule.launch(intent);
+
+        mapFragment.ready();
+        Espresso.pressBack();
+        assertThat(isFinishing(scenario), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
Closes #5453
Fixes [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/059323cc2800086434ec39df13dc5698?time=last-seven-days&versions=v2023.1-beta.1%20(4579)&types=crash&sessionEventKey=63EDDDB4002A00016AB567C1781D7558_1779167429219300249).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

Just a simple (yet always nasty) `NullPointerException` that was caused by a field not always being initialized. Luckily, it was easy to just always initialize the field, so this was a simple fix.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Only area of risk here is answer and editing geo trace/shape questions. Different basemap sources shouldn't matter here, so just testing with one is fine. 

To reproduce the original crash:

1. Open a form with a geo shape/trace question
2. Go to the question and click "Start ..."
3. Press back without adding any points

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
