### PR TITLE
Lock Jackson version to prevent problems with older Android APIs

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -228,6 +228,9 @@ configurations.all {
         cacheChangingModulesFor(0, 'seconds')
 
         force 'org.objenesis:objenesis:2.6'
+
+        // Newer Jackson versions cannot be ued until Collect minSDK >= 26 (https://github.com/FasterXML/jackson-databind#android)
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
     }
     
     transitive = true


### PR DESCRIPTION
Closes #5458

Newer versions of Jackson that weren't compatible with Android API 24 and under were ending up being used by JavaRosa because both it and `json-schema-validator` use it as a dependency. Gradle will go with the ["highest" (or newest) version](https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:resolution-strategy) to resolve version conflicts, which in this case meant the latter's version (which includes the incompatibilities) was always used. I've set a forced version for Jackson to prevent this from happening.

#### What has been done to verify that this works as intended?

Verified manually. I think it'd be good to think about some automated testing strategies that might catch something like this in future, but I'll leave that for the moment, and we can discuss later as a team.

#### Why is this the best possible solution? Were any other approaches considered?

An alternative would have been to exclude Jackson as a transitive dependency from `json-schema-validator`, but given how popular it is, it felt safer to force a known "safe" version for all dependencies.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Should just fix the crash in forms with GeoJSON select one from map questions.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
