### PR TITLE
Improve selecting shapes/traces

### DIFF
--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -387,7 +387,7 @@ class SelectionMapFragment(
             ids + map.addPoly(item.points, false, false)
         }
 
-        items.zip(pointIds + traceIds).forEach { (item, featureId) ->
+        (singlePoints + traces).zip(pointIds + traceIds).forEach { (item, featureId) ->
             itemsByFeatureId[featureId] = item
             points.addAll(item.points)
         }

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -273,12 +273,16 @@ class SelectionMapFragment(
         val item = itemsByFeatureId[featureId]
         if (item != null) {
             if (!skipSummary) {
-                val point = item.points[0]
-
-                if (maintainZoom) {
-                    map.zoomToPoint(MapPoint(point.latitude, point.longitude), map.zoom, true)
+                if (item.points.size > 1) {
+                    map.zoomToBoundingBox(item.points, 0.8, true)
                 } else {
-                    map.zoomToPoint(MapPoint(point.latitude, point.longitude), true)
+                    val point = item.points[0]
+
+                    if (maintainZoom) {
+                        map.zoomToPoint(MapPoint(point.latitude, point.longitude), map.zoom, true)
+                    } else {
+                        map.zoomToPoint(MapPoint(point.latitude, point.longitude), true)
+                    }
                 }
 
                 map.setMarkerIcon(

--- a/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
+++ b/geo/src/main/java/org/odk/collect/geo/selection/SelectionMapFragment.kt
@@ -234,10 +234,10 @@ class SelectionMapFragment(
 
         bottomSheetCallback = object : BottomSheetCallback() {
             override fun onStateChanged(onStateChangedbottomSheet: View, newState: Int) {
-                val selectedFeatureId = selectedFeatureViewModel.getSelectedFeatureId()
-                if (newState == STATE_HIDDEN && selectedFeatureId != null) {
+                val selectedItemId = selectedFeatureViewModel.getSelectedFeatureId()
+                if (newState == STATE_HIDDEN && selectedItemId != null) {
                     selectedFeatureViewModel.setSelectedFeatureId(null)
-                    resetIcon(selectedFeatureId)
+                    resetIcon(selectedItemId)
 
                     closeSummarySheet.isEnabled = false
                 } else {
@@ -265,9 +265,9 @@ class SelectionMapFragment(
     }
 
     private fun onFeatureClicked(featureId: Int, maintainZoom: Boolean = true) {
-        val selectedFeatureId = selectedFeatureViewModel.getSelectedFeatureId()
-        if (selectedFeatureId != null && selectedFeatureId != featureId) {
-            resetIcon(selectedFeatureId)
+        val selectedItemId = selectedFeatureViewModel.getSelectedFeatureId()
+        if (selectedItemId != null && selectedItemId != itemsByFeatureId[featureId]!!.id) {
+            resetIcon(selectedItemId)
         }
 
         val item = itemsByFeatureId[featureId]
@@ -302,7 +302,7 @@ class SelectionMapFragment(
                     }
                 )
 
-                selectedFeatureViewModel.setSelectedFeatureId(featureId)
+                selectedFeatureViewModel.setSelectedFeatureId(item.id)
             } else {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_SELECT_ITEM,
@@ -327,10 +327,14 @@ class SelectionMapFragment(
 
         val previouslySelectedItem =
             itemsByFeatureId.filter { it.value.selected }.map { it.key }.firstOrNull()
-        val selectedFeatureId = selectedFeatureViewModel.getSelectedFeatureId()
+        val selectedItemId = selectedFeatureViewModel.getSelectedFeatureId()
 
-        if (selectedFeatureId != null) {
-            onFeatureClicked(selectedFeatureId)
+        if (selectedItemId != null) {
+            val (featureId, _) = itemsByFeatureId.entries.find {
+                it.value.id == selectedItemId
+            }!!
+
+            onFeatureClicked(featureId)
         } else if (previouslySelectedItem != null) {
             onFeatureClicked(previouslySelectedItem, maintainZoom = false)
         } else if (!map.hasCenter()) {
@@ -345,10 +349,13 @@ class SelectionMapFragment(
         }
     }
 
-    private fun resetIcon(selectedFeatureId: Int) {
-        val item = itemsByFeatureId[selectedFeatureId]!!
+    private fun resetIcon(selectedItemId: Long) {
+        val (featureId, item) = itemsByFeatureId.entries.find {
+            it.value.id == selectedItemId
+        }!!
+
         map.setMarkerIcon(
-            selectedFeatureId,
+            featureId,
             MarkerIconDescription(item.smallIcon, item.color, item.symbol)
         )
     }
@@ -397,14 +404,14 @@ class SelectionMapFragment(
 
 internal class SelectedFeatureViewModel : ViewModel() {
 
-    private var selectedFeatureId: Int? = null
+    private var selectedItemId: Long? = null
 
-    fun getSelectedFeatureId(): Int? {
-        return selectedFeatureId
+    fun getSelectedFeatureId(): Long? {
+        return selectedItemId
     }
 
-    fun setSelectedFeatureId(itemId: Int?) {
-        selectedFeatureId = itemId
+    fun setSelectedFeatureId(itemId: Long?) {
+        selectedItemId = itemId
     }
 }
 

--- a/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
+++ b/geo/src/test/java/org/odk/collect/geo/geopoly/GeoPolyActivityTest.java
@@ -231,7 +231,7 @@ public class GeoPolyActivityTest {
         mapFragment.setLocation(new MapPoint(1, 1));
         onView(withId(R.id.record_button)).perform(click());
         onView(withId(R.id.record_button)).perform(click());
-        assertThat(mapFragment.getPolyPoints(0).size(), equalTo(1));
+        assertThat(mapFragment.getPolys().get(0).size(), equalTo(1));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class GeoPolyActivityTest {
 
         mapFragment.click(new MapPoint(1, 1));
         mapFragment.click(new MapPoint(1, 1));
-        assertThat(mapFragment.getPolyPoints(0).size(), equalTo(1));
+        assertThat(mapFragment.getPolys().get(0).size(), equalTo(1));
     }
 
     private void startInput(int mode) {

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -206,7 +206,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `zooms to fit all points in polys`() {
+    fun `zooms to fit all points in for item with multiple points`() {
         val points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
         val items: List<MappableSelectItem> = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = points)
@@ -400,6 +400,22 @@ class SelectionMapFragmentTest {
         map.clickOnFeature(1)
         assertThat(map.center, equalTo(items[1].toMapPoint()))
         assertThat(map.zoom, equalTo(2.0))
+    }
+
+    @Test
+    fun `tapping on item with multiple points zooms to fit all item points`() {
+        val itemPoints = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
+            Fixtures.actionMappableSelectItem().copy(id = 1, points = itemPoints)
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java)
+        map.ready()
+
+        map.clickOnFeature(1)
+        assertThat(map.getZoomBoundingBox(), equalTo(Pair(itemPoints, 0.8)))
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -329,7 +329,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping current location button zooms to gps location`() {
+    fun `clicking current location button zooms to gps location`() {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
@@ -341,7 +341,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping zoom to fit button zooms to fit all items`() {
+    fun `clicking zoom to fit button zooms to fit all items`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
             Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
@@ -358,7 +358,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping zoom to fit button zooms to fit all polys`() {
+    fun `clicking zoom to fit button zooms to fit all polys`() {
         val points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
         val items: List<MappableSelectItem> = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = points)
@@ -373,7 +373,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping layers button navigates to layers settings`() {
+    fun `clicking layers button navigates to layers settings`() {
         val scenario = launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
@@ -385,7 +385,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping on item centers on that item with current zoom level`() {
+    fun `clicking on item centers on that item with current zoom level`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
             Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(41.0, 0.0)))
@@ -403,7 +403,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping on item with multiple points zooms to fit all item points`() {
+    fun `clicking on item with multiple points zooms to fit all item points`() {
         val itemPoints = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0))),
@@ -419,7 +419,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping on item switches item marker to large icon`() {
+    fun `clicking on item switches item marker to large icon`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(
                 id = 0,
@@ -455,7 +455,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping on item when another has been tapped switches the first one back to its small icon`() {
+    fun `clicking on item when another has been tapped switches the first one back to its small icon`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(
                 id = 0,
@@ -492,7 +492,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping on item sets item on summary sheet`() {
+    fun `clicking on item sets item on summary sheet`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0, name = "Blah1"),
             Fixtures.actionMappableSelectItem().copy(id = 1, name = "Blah2"),
@@ -508,7 +508,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping on item returns item ID as result when skipSummary is true`() {
+    fun `clicking on item returns item ID as result when skipSummary is true`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(id = 0),
             Fixtures.actionMappableSelectItem().copy(id = 1),
@@ -619,7 +619,7 @@ class SelectionMapFragmentTest {
     }
 
     @Test
-    fun `tapping action hides summary sheet`() {
+    fun `clicking action hides summary sheet`() {
         val items = listOf(
             Fixtures.actionMappableSelectItem().copy(
                 id = 0,

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -690,8 +690,8 @@ class SelectionMapFragmentTest {
         launcherRule.launchInContainer(SelectionMapFragment::class.java)
         map.ready()
 
-        map.clickOnFeature(-1)
-        map.clickOnFeature(-2) // First click is fine but second could use the ID and crash
+        map.clickOnFeatureId(-1)
+        map.clickOnFeatureId(-2) // First click is fine but second could use the ID and crash
     }
 
     @Test

--- a/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
+++ b/geo/src/test/java/org/odk/collect/geo/selection/SelectionMapFragmentTest.kt
@@ -418,6 +418,25 @@ class SelectionMapFragmentTest {
         assertThat(map.getZoomBoundingBox(), equalTo(Pair(itemPoints, 0.8)))
     }
 
+    /**
+     * This looks like a duplicated test, but it's easy to write an implementation that will work
+     * for everything else and break for interleaved points and traces.
+     */
+    @Test
+    fun `clicking on item always selects correct item`() {
+        val items = listOf(
+            Fixtures.actionMappableSelectItem().copy(id = 0, points = listOf(MapPoint(40.0, 0.0), MapPoint(41.0, 0.0))),
+            Fixtures.actionMappableSelectItem().copy(id = 1, points = listOf(MapPoint(45.0, 0.0))),
+        )
+        whenever(data.getMappableItems()).thenReturn(MutableLiveData(items))
+
+        launcherRule.launchInContainer(SelectionMapFragment::class.java)
+        map.ready()
+
+        map.clickOnFeatureId(map.getFeatureId(items[1].points))
+        assertThat(map.center, equalTo(items[1].points[0]))
+    }
+
     @Test
     fun `clicking on item switches item marker to large icon`() {
         val items = listOf(

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -8,6 +8,7 @@ import org.odk.collect.maps.MapFragment.ReadyListener
 import org.odk.collect.maps.MapPoint
 import org.odk.collect.maps.markers.MarkerDescription
 import org.odk.collect.maps.markers.MarkerIconDescription
+import kotlin.random.Random
 
 class FakeMapFragment : Fragment(), MapFragment {
 
@@ -28,7 +29,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     private val polyDraggable: MutableList<Boolean> = ArrayList()
     private var hasCenter = false
     private val polyPoints = mutableMapOf<Int, MutableList<MapPoint>>()
-    private var featureCount = 0;
+    private val featureIds = mutableListOf<Int>()
 
     override fun init(
         readyListener: ReadyListener?,
@@ -83,9 +84,13 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun addMarker(markerDescription: MarkerDescription): Int {
-        markers[featureCount] = markerDescription.point
-        markerIcons[featureCount] = markerDescription.iconDescription
-        return featureCount++
+        val featureId = generateFeatureId()
+
+        markers[featureId] = markerDescription.point
+        markerIcons[featureId] = markerDescription.iconDescription
+
+        featureIds.add(featureId)
+        return featureId
     }
 
     override fun addMarkers(markers: List<MarkerDescription>): List<Int> {
@@ -107,10 +112,14 @@ class FakeMapFragment : Fragment(), MapFragment {
         closedPolygon: Boolean,
         draggable: Boolean
     ): Int {
-        polys[featureCount] = points.toList()
+        val featureId = generateFeatureId()
+
+        polys[featureId] = points.toList()
         polyClosed.add(closedPolygon)
         polyDraggable.add(draggable)
-        return featureCount++
+
+        featureIds.add(featureId)
+        return featureId
     }
 
     override fun appendPointToPoly(featureId: Int, point: MapPoint) {
@@ -186,7 +195,11 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     fun clickOnFeature(index: Int) {
-        featureClickListener!!.onFeature(index)
+        featureClickListener!!.onFeature(featureIds[index])
+    }
+
+    fun clickOnFeatureId(featureId: Int) {
+        featureClickListener!!.onFeature(featureId)
     }
 
     fun getMarkers(): List<MapPoint> {
@@ -211,6 +224,15 @@ class FakeMapFragment : Fragment(), MapFragment {
 
     fun isPolyDraggable(index: Int): Boolean {
         return polyDraggable[index]
+    }
+
+    private fun generateFeatureId(): Int {
+        var featureId = Random.nextInt()
+        while (featureIds.contains(featureId)) {
+            featureId = Random.nextInt()
+        }
+
+        return featureId
     }
 
     companion object {

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -21,13 +21,14 @@ class FakeMapFragment : Fragment(), MapFragment {
     private var readyListener: ReadyListener? = null
     private var gpsLocation: MapPoint? = null
     private var featureClickListener: FeatureListener? = null
-    private val markers: MutableList<MapPoint> = ArrayList()
-    private val markerIcons: MutableList<MarkerIconDescription?> = ArrayList()
-    private val polys: MutableList<List<MapPoint>> = ArrayList()
+    private val markers = mutableMapOf<Int, MapPoint>()
+    private val markerIcons = mutableMapOf<Int, MarkerIconDescription?>()
+    private val polys = mutableMapOf<Int, List<MapPoint>>()
     private val polyClosed: MutableList<Boolean> = ArrayList()
     private val polyDraggable: MutableList<Boolean> = ArrayList()
     private var hasCenter = false
     private val polyPoints = mutableMapOf<Int, MutableList<MapPoint>>()
+    private var featureCount = 0;
 
     override fun init(
         readyListener: ReadyListener?,
@@ -82,9 +83,9 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun addMarker(markerDescription: MarkerDescription): Int {
-        markers.add(markerDescription.point)
-        markerIcons.add(markerDescription.iconDescription)
-        return markers.size - 1
+        markers[featureCount] = markerDescription.point
+        markerIcons[featureCount] = markerDescription.iconDescription
+        return featureCount++
     }
 
     override fun addMarkers(markers: List<MarkerDescription>): List<Int> {
@@ -98,7 +99,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun getMarkerPoint(featureId: Int): MapPoint {
-        return markers[featureId]
+        return markers[featureId]!!
     }
 
     override fun addPoly(
@@ -106,10 +107,10 @@ class FakeMapFragment : Fragment(), MapFragment {
         closedPolygon: Boolean,
         draggable: Boolean
     ): Int {
-        polys.add(points.toList())
+        polys[featureCount] = points.toList()
         polyClosed.add(closedPolygon)
         polyDraggable.add(draggable)
-        return polys.size - 1
+        return featureCount++
     }
 
     override fun appendPointToPoly(featureId: Int, point: MapPoint) {
@@ -189,11 +190,11 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     fun getMarkers(): List<MapPoint> {
-        return markers
+        return markers.values.toList()
     }
 
     fun getMarkerIcons(): List<MarkerIconDescription?> {
-        return markerIcons
+        return markerIcons.values.toList()
     }
 
     fun getZoomBoundingBox(): Pair<Iterable<MapPoint>, Double>? {
@@ -201,7 +202,7 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     fun getPolys(): List<List<MapPoint>> {
-        return polys
+        return polys.values.toList()
     }
 
     fun isPolyClosed(index: Int): Boolean {

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -28,7 +28,6 @@ class FakeMapFragment : Fragment(), MapFragment {
     private val polyClosed: MutableList<Boolean> = ArrayList()
     private val polyDraggable: MutableList<Boolean> = ArrayList()
     private var hasCenter = false
-    private val polyPoints = mutableMapOf<Int, MutableList<MapPoint>>()
     private val featureIds = mutableListOf<Int>()
 
     override fun init(
@@ -123,15 +122,17 @@ class FakeMapFragment : Fragment(), MapFragment {
     }
 
     override fun appendPointToPoly(featureId: Int, point: MapPoint) {
-        polyPoints.getOrPut(featureId) { mutableListOf() }.add(point)
+        val poly = polys[featureId]!!
+        polys[featureId] = poly + point
     }
 
     override fun removePolyLastPoint(featureId: Int) {
-        polyPoints.getOrPut(featureId) { mutableListOf() }.removeLast()
+        val poly = polys[featureId]!!
+        polys[featureId] = poly.dropLast(1)
     }
 
     override fun getPolyPoints(featureId: Int): List<MapPoint> {
-        return polyPoints.getOrPut(featureId) { mutableListOf() }
+        return polys[featureId]!!
     }
 
     override fun clearFeatures() {

--- a/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
+++ b/geo/src/test/java/org/odk/collect/geo/support/FakeMapFragment.kt
@@ -226,6 +226,18 @@ class FakeMapFragment : Fragment(), MapFragment {
         return polyDraggable[index]
     }
 
+    fun getFeatureId(points: List<MapPoint>): Int {
+        return if (points.size == 1) {
+            markers.entries.find {
+                it.value == points[0]
+            }!!.key
+        } else {
+            polys.entries.find {
+                it.value == points
+            }!!.key
+        }
+    }
+
     private fun generateFeatureId(): Int {
         var featureId = Random.nextInt()
         while (featureIds.contains(featureId)) {

--- a/mapbox/src/main/java/org/odk/collect/mapbox/PolyFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/PolyFeature.kt
@@ -50,6 +50,16 @@ internal class PolyFeature(
 
         pointAnnotationManager.addClickListener(pointAnnotationClickListener)
         pointAnnotationManager.addDragListener(pointAnnotationDragListener)
+        polylineAnnotationManager.addClickListener { annotation ->
+            polylineAnnotation?.let {
+                if (annotation.id == it.id && featureClickListener != null) {
+                    featureClickListener.onFeature(featureId)
+                    true
+                } else {
+                    false
+                }
+            } ?: false
+        }
     }
 
     override fun dispose() {


### PR DESCRIPTION
Closes #5447

As well as improving the zoom behaviour on selection and fixing Mapbox, this PR fixes a bug we hadn't found that would only crop up in cases where traces and shapes were interleaved in the data.

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As well as the changes described in the issue, it'd be good to test select one from map with both points and traces/shapes in a single question. There were some problems we hadn't caught in this scenario if the points and traces are interleaved in the form data set or the GeoJSON file that this PR should address.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
