### PR TITLE
Fixed setting timezones

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/DateTimeUtilsTest.java
@@ -19,7 +19,6 @@ package org.odk.collect.android.instrumented.utilities;
 import android.content.Context;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.logic.DatePickerDetails;
 import org.odk.collect.android.widgets.utilities.DateTimeWidgetUtils;
+import org.odk.collect.testshared.TimeZoneSetter;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -69,8 +69,7 @@ public class DateTimeUtilsTest {
     @Test
     public void getDateTimeLabelTest() {
         Locale.setDefault(Locale.ENGLISH);
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-        DateTimeZone.setDefault(DateTimeZone.forID("GMT"));
+        TimeZoneSetter.setTimezone(TimeZone.getTimeZone("GMT"));
 
         // 20 Oct 1991 14:00 GMT
         Calendar calendar = Calendar.getInstance();
@@ -102,7 +101,6 @@ public class DateTimeUtilsTest {
     @After
     public void resetTimeZone() {
         Locale.setDefault(defaultLocale);
-        TimeZone.setDefault(defaultTimezone);
-        DateTimeZone.setDefault(DateTimeZone.forID(defaultTimezone.getID()));
+        TimeZoneSetter.setTimezone(defaultTimezone);
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/utilities/DateTimeUtilsTest.java
@@ -19,6 +19,7 @@ package org.odk.collect.android.instrumented.utilities;
 import android.content.Context;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,6 +70,7 @@ public class DateTimeUtilsTest {
     public void getDateTimeLabelTest() {
         Locale.setDefault(Locale.ENGLISH);
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        DateTimeZone.setDefault(DateTimeZone.forID("GMT"));
 
         // 20 Oct 1991 14:00 GMT
         Calendar calendar = Calendar.getInstance();
@@ -101,5 +103,6 @@ public class DateTimeUtilsTest {
     public void resetTimeZone() {
         Locale.setDefault(defaultLocale);
         TimeZone.setDefault(defaultTimezone);
+        DateTimeZone.setDefault(DateTimeZone.forID(defaultTimezone.getID()));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -28,6 +28,8 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.TimeZone;
+
 @RunWith(AndroidJUnit4.class)
 public class DateTimeUtilsTest {
     private final LocalDateTime date = new LocalDateTime().withDate(2010, 5, 12);
@@ -82,6 +84,7 @@ public class DateTimeUtilsTest {
     @Test
     public void skipDaylightSavingGapIfExistsTest() {
         DateTimeZone originalDefaultTimeZone = DateTimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
         DateTimeZone.setDefault(DateTimeZone.forID("Europe/Warsaw"));
 
         // 29 March 2020 at 02:00:00 clocks were turned forward to 03:00:00
@@ -89,6 +92,7 @@ public class DateTimeUtilsTest {
         LocalDateTime ldtExpected = new LocalDateTime().withYear(2020).withMonthOfYear(3).withDayOfMonth(29).withHourOfDay(3).withMinuteOfHour(0).withSecondOfMinute(0).withMillisOfSecond(0);
 
         assertEquals(ldtExpected, DateTimeUtils.skipDaylightSavingGapIfExists(ldtOriginal));
+        TimeZone.setDefault(TimeZone.getTimeZone(originalDefaultTimeZone.getID()));
         DateTimeZone.setDefault(originalDefaultTimeZone);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DateTimeUtilsTest.java
@@ -20,11 +20,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.core.model.data.TimeData;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.joda.time.chrono.GregorianChronology;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.odk.collect.testshared.TimeZoneSetter;
 
 import static org.junit.Assert.assertEquals;
 
@@ -83,16 +83,14 @@ public class DateTimeUtilsTest {
 
     @Test
     public void skipDaylightSavingGapIfExistsTest() {
-        DateTimeZone originalDefaultTimeZone = DateTimeZone.getDefault();
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Warsaw"));
-        DateTimeZone.setDefault(DateTimeZone.forID("Europe/Warsaw"));
+        TimeZone originalDefaultTimeZone = TimeZone.getDefault();
+        TimeZoneSetter.setTimezone(TimeZone.getTimeZone("Europe/Warsaw"));
 
         // 29 March 2020 at 02:00:00 clocks were turned forward to 03:00:00
         LocalDateTime ldtOriginal = new LocalDateTime().withYear(2020).withMonthOfYear(3).withDayOfMonth(29).withHourOfDay(2).withMinuteOfHour(30).withSecondOfMinute(0).withMillisOfSecond(0);
         LocalDateTime ldtExpected = new LocalDateTime().withYear(2020).withMonthOfYear(3).withDayOfMonth(29).withHourOfDay(3).withMinuteOfHour(0).withSecondOfMinute(0).withMillisOfSecond(0);
 
         assertEquals(ldtExpected, DateTimeUtils.skipDaylightSavingGapIfExists(ldtOriginal));
-        TimeZone.setDefault(TimeZone.getTimeZone(originalDefaultTimeZone.getID()));
-        DateTimeZone.setDefault(originalDefaultTimeZone);
+        TimeZoneSetter.setTimezone(originalDefaultTimeZone);
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
@@ -29,6 +29,7 @@ import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -70,12 +71,15 @@ public class DaylightSavingTest {
     @After
     public void tearDown() {
         TimeZone.setDefault(currentTimeZone);
+        DateTimeZone.setDefault(DateTimeZone.forID(currentTimeZone.getID()));
     }
 
     @Test
     // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00.
     public void testESTTimeZoneWithDateTimeWidget() {
         TimeZone.setDefault(TimeZone.getTimeZone(CET_TIME_ZONE));
+        DateTimeZone.setDefault(DateTimeZone.forID(CET_TIME_ZONE));
+
         DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 3, 26, 2, 30);
 
         /*
@@ -89,6 +93,8 @@ public class DaylightSavingTest {
     // 1 Jan 1960 at 00:00:00 clocks were turned forward to 00:15:00
     public void testEATTimezoneWithDateWidget() {
         TimeZone.setDefault(TimeZone.getTimeZone(EAT_IME_ZONE));
+        DateTimeZone.setDefault(DateTimeZone.forID(EAT_IME_ZONE));
+
         DateWidget dateWidget = prepareDateWidget(1960, 0, 1);
 
         /*

--- a/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/utilities/DaylightSavingTest.java
@@ -29,7 +29,6 @@ import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.QuestionDef;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDateTime;
 import org.junit.After;
 import org.junit.Before;
@@ -42,6 +41,7 @@ import org.odk.collect.android.support.WidgetTestActivity;
 import org.odk.collect.android.widgets.DateTimeWidget;
 import org.odk.collect.android.widgets.DateWidget;
 import org.odk.collect.android.widgets.utilities.DateTimeWidgetUtils;
+import org.odk.collect.testshared.TimeZoneSetter;
 
 import java.util.TimeZone;
 
@@ -70,15 +70,13 @@ public class DaylightSavingTest {
 
     @After
     public void tearDown() {
-        TimeZone.setDefault(currentTimeZone);
-        DateTimeZone.setDefault(DateTimeZone.forID(currentTimeZone.getID()));
+        TimeZoneSetter.setTimezone(currentTimeZone);
     }
 
     @Test
     // 26 Mar 2017 at 02:00:00 clocks were turned forward to 03:00:00.
     public void testESTTimeZoneWithDateTimeWidget() {
-        TimeZone.setDefault(TimeZone.getTimeZone(CET_TIME_ZONE));
-        DateTimeZone.setDefault(DateTimeZone.forID(CET_TIME_ZONE));
+        TimeZoneSetter.setTimezone(TimeZone.getTimeZone(CET_TIME_ZONE));
 
         DateTimeWidget dateTimeWidget = prepareDateTimeWidget(2017, 3, 26, 2, 30);
 
@@ -92,8 +90,7 @@ public class DaylightSavingTest {
     @Test
     // 1 Jan 1960 at 00:00:00 clocks were turned forward to 00:15:00
     public void testEATTimezoneWithDateWidget() {
-        TimeZone.setDefault(TimeZone.getTimeZone(EAT_IME_ZONE));
-        DateTimeZone.setDefault(DateTimeZone.forID(EAT_IME_ZONE));
+        TimeZoneSetter.setTimezone(TimeZone.getTimeZone(EAT_IME_ZONE));
 
         DateWidget dateWidget = prepareDateWidget(1960, 0, 1);
 

--- a/testshared/build.gradle
+++ b/testshared/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation Dependencies.junit
     implementation Dependencies.androidx_test_espresso_intents
     implementation Dependencies.android_material
+    implementation Dependencies.danlew_android_joda
     implementation(Dependencies.androidx_fragment_testing) {
         exclude group: 'androidx.test', module: 'monitor' //fixes issue https://github.com/android/android-test/issues/731
     }

--- a/testshared/src/main/java/org/odk/collect/testshared/TimeZoneSetter.kt
+++ b/testshared/src/main/java/org/odk/collect/testshared/TimeZoneSetter.kt
@@ -1,0 +1,16 @@
+package org.odk.collect.testshared
+
+import org.joda.time.DateTimeZone
+import java.util.TimeZone
+
+object TimeZoneSetter {
+    /**
+     * Always update both java.util.TimeZone and org.joda.time.DateTimeZone to avoid weird bugs in
+     * tests that depend on time zones.
+     */
+    @JvmStatic
+    fun setTimezone(timezone: TimeZone) {
+        TimeZone.setDefault(timezone)
+        DateTimeZone.setDefault(DateTimeZone.forID(timezone.id))
+    }
+}


### PR DESCRIPTION
#### What has been done to verify that this works as intended?
I've confirmed that failing prs are now green.

#### Why is this the best possible solution? Were any other approaches considered?
It turned out that somehow sometimes we ended up with different timezones used by two different libraries (jodatime/java.util). I reviewed our tests and made sure that we always update both together. As I said on slack we haven't merged anything that would introduce this problem. It must be related to how CircleCi works under the hood.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It doesn't require testing.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
