### PR TITLE
Removed support for selfie video widget

### DIFF
--- a/collect_app/src/androidTest/assets/forms/all-widgets.xml
+++ b/collect_app/src/androidTest/assets/forms/all-widgets.xml
@@ -293,7 +293,6 @@
             <barcode_widget/>
             <audio_widget/>
             <video_widget/>
-            <selfie_video_widget/>
             <file_widget/>
           </media_widgets>
           <date_time_widgets>
@@ -407,7 +406,6 @@
       <bind nodeset="/data/media_widgets/barcode_widget" type="barcode"/>
       <bind nodeset="/data/media_widgets/audio_widget" type="binary"/>
       <bind nodeset="/data/media_widgets/video_widget" type="binary"/>
-      <bind nodeset="/data/media_widgets/selfie_video_widget" type="binary"/>
       <bind nodeset="/data/media_widgets/file_widget" type="binary"/>
       <bind nodeset="/data/date_time_widgets/date_widget" type="date"/>
       <bind nodeset="/data/date_time_widgets/date_widget_nocalendar" type="date"/>
@@ -605,10 +603,6 @@
       <upload mediatype="video/*" ref="/data/media_widgets/video_widget">
         <label>Video widget</label>
         <hint>video type with no appearance</hint>
-      </upload>
-      <upload appearance="new-front" mediatype="video/*" ref="/data/media_widgets/selfie_video_widget">
-        <label>Selfie video widget</label>
-        <hint>video type with new-front appearance</hint>
       </upload>
       <upload mediatype="application/*" ref="/data/media_widgets/file_widget">
         <label>File widget</label>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
@@ -89,7 +89,6 @@ public class AllWidgetsFormTest {
 
         testAudioWidget();
         testVideoWidget();
-        testSelfieVideoWidget();
 
         testFileWidget();
 
@@ -339,15 +338,6 @@ public class AllWidgetsFormTest {
         Screengrab.screenshot("video");
 
         onView(withText("Video widget")).perform(swipeLeft());
-    }
-
-    public void testSelfieVideoWidget() {
-        Screengrab.screenshot("selfie-video");
-
-        onView(withText("Record Video")).perform(click());
-        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack();
-
-        onView(withText("Selfie video widget")).perform(swipeLeft());
     }
 
     public void testFileWidget() {

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/AnalyticsEvents.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/AnalyticsEvents.kt
@@ -1,9 +1,0 @@
-package org.odk.collect.selfiecamera
-
-internal object AnalyticsEvents {
-
-    /**
-     * Tracks how often (and in how many forms) a video selfie is recorded
-     */
-    const val RECORD_SELFIE_VIDEO = "RecordSelfieVideo"
-}

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/Camera.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/Camera.kt
@@ -9,13 +9,11 @@ internal interface Camera {
 
     fun state(): NonNullLiveData<State>
 
+    fun takePicture(imagePath: String, onImageSaved: () -> Unit, onImageSaveError: () -> Unit)
+
     enum class State {
         UNINITIALIZED,
         INITIALIZED,
         FAILED_TO_INITIALIZE
     }
-}
-
-internal interface StillCamera : Camera {
-    fun takePicture(imagePath: String, onImageSaved: () -> Unit, onImageSaveError: () -> Unit)
 }

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/Camera.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/Camera.kt
@@ -19,9 +19,3 @@ internal interface Camera {
 internal interface StillCamera : Camera {
     fun takePicture(imagePath: String, onImageSaved: () -> Unit, onImageSaveError: () -> Unit)
 }
-
-internal interface VideoCamera : Camera {
-    fun isRecording(): Boolean
-    fun startVideo(videoPath: String, onVideoSaved: () -> Unit, onVideoSaveError: () -> Unit)
-    fun stopVideo()
-}

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CameraXCamera.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CameraXCamera.kt
@@ -6,7 +6,6 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview
-import androidx.camera.core.UseCase
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
@@ -14,12 +13,11 @@ import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
 import org.odk.collect.androidshared.livedata.NonNullLiveData
 import java.io.File
 
-internal abstract class CameraXCamera : Camera {
+internal class CameraXCamera : Camera {
 
-    protected var activity: ComponentActivity? = null
+    private var activity: ComponentActivity? = null
     private var state = MutableNonNullLiveData(Camera.State.UNINITIALIZED)
-
-    protected abstract fun getUseCase(): UseCase
+    private var imageCapture = ImageCapture.Builder().build()
 
     override fun initialize(activity: ComponentActivity, previewView: View) {
         this.activity = activity
@@ -37,7 +35,7 @@ internal abstract class CameraXCamera : Camera {
                         activity,
                         CameraSelector.DEFAULT_FRONT_CAMERA,
                         preview,
-                        getUseCase()
+                        imageCapture
                     )
 
                     state.value = Camera.State.INITIALIZED
@@ -51,15 +49,6 @@ internal abstract class CameraXCamera : Camera {
 
     override fun state(): NonNullLiveData<Camera.State> {
         return state
-    }
-}
-
-internal class CameraXStillCamera : CameraXCamera(), StillCamera {
-
-    private var imageCapture = ImageCapture.Builder().build()
-
-    override fun getUseCase(): UseCase {
-        return imageCapture
     }
 
     override fun takePicture(

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CameraXCamera.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CameraXCamera.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.selfiecamera
 
-import android.annotation.SuppressLint
 import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.camera.core.CameraSelector
@@ -9,11 +8,6 @@ import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview
 import androidx.camera.core.UseCase
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.video.FileOutputOptions
-import androidx.camera.video.Recorder
-import androidx.camera.video.Recording
-import androidx.camera.video.VideoCapture
-import androidx.camera.video.VideoRecordEvent
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import org.odk.collect.androidshared.livedata.MutableNonNullLiveData
@@ -95,59 +89,5 @@ internal class CameraXStillCamera : CameraXCamera(), StillCamera {
                 }
             )
         }
-    }
-}
-
-internal class CameraXVideoCamera : CameraXCamera(), VideoCamera {
-
-    private val videoCapture by lazy {
-        val recorder = Recorder.Builder()
-            .setExecutor(ContextCompat.getMainExecutor(activity!!))
-            .build()
-
-        VideoCapture.withOutput(recorder)
-    }
-
-    private var recording: Recording? = null
-
-    override fun getUseCase(): UseCase {
-        return videoCapture
-    }
-
-    @SuppressLint("MissingPermission")
-    override fun startVideo(
-        videoPath: String,
-        onVideoSaved: () -> Unit,
-        onVideoSaveError: () -> Unit,
-    ) {
-        Pair(videoCapture, activity).let { (v, a) ->
-            if (v == null || a == null) {
-                return
-            }
-
-            val outputFile = File(videoPath)
-            val outputFileOptions = FileOutputOptions.Builder(outputFile).build()
-
-            recording = v.output
-                .prepareRecording(a, outputFileOptions)
-                .withAudioEnabled()
-                .start(ContextCompat.getMainExecutor(a)) { event ->
-                    if (event is VideoRecordEvent.Finalize) {
-                        if (event.hasError()) {
-                            onVideoSaveError()
-                        } else {
-                            onVideoSaved()
-                        }
-                    }
-                }
-        }
-    }
-
-    override fun stopVideo() {
-        recording?.stop()
-    }
-
-    override fun isRecording(): Boolean {
-        return recording != null
     }
 }

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CaptureSelfieActivity.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CaptureSelfieActivity.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import org.odk.collect.analytics.Analytics
 import org.odk.collect.androidshared.ui.ToastUtils.showLongToast
 import org.odk.collect.externalapp.ExternalAppUtils
 import org.odk.collect.permissions.PermissionsChecker
@@ -31,9 +30,6 @@ class CaptureSelfieActivity : LocalizedActivity() {
 
     @Inject
     internal lateinit var stillCamera: StillCamera
-
-    @Inject
-    internal lateinit var videoCamera: VideoCamera
 
     @Inject
     lateinit var permissionsChecker: PermissionsChecker
@@ -56,17 +52,11 @@ class CaptureSelfieActivity : LocalizedActivity() {
 
         val previewView = findViewById<View>(R.id.preview)
 
-        val camera = if (intent.getBooleanExtra(EXTRA_VIDEO, false)) {
-            videoCamera
-        } else {
-            stillCamera
-        }
-
-        camera.initialize(this, previewView)
-        camera.state().observe(this) {
+        stillCamera.initialize(this, previewView)
+        stillCamera.state().observe(this) {
             when (it) {
                 Camera.State.UNINITIALIZED -> {}
-                Camera.State.INITIALIZED -> setupCamera(camera)
+                Camera.State.INITIALIZED -> setupCamera(stillCamera)
                 Camera.State.FAILED_TO_INITIALIZE -> {
                     showLongToast(this, R.string.camera_failed_to_initialize)
                 }
@@ -74,54 +64,26 @@ class CaptureSelfieActivity : LocalizedActivity() {
         }
     }
 
-    private fun setupCamera(camera: Camera) {
+    private fun setupCamera(camera: StillCamera) {
         val previewView = findViewById<View>(R.id.preview)
 
-        if (camera is VideoCamera) {
-            val videoPath = intent.getStringExtra(EXTRA_TMP_PATH) + "/tmp.mp4"
-            previewView.setOnClickListener {
-                if (!camera.isRecording()) {
-                    camera.startVideo(
-                        videoPath,
-                        { ExternalAppUtils.returnSingleValue(this, videoPath) },
-                        { showLongToast(this, R.string.camera_error) }
-                    )
-
-                    showLongToast(this, getString(R.string.stop_video_capture_instruction))
-                } else {
-                    camera.stopVideo()
-                }
-            }
-
-            showLongToast(this, getString(R.string.start_video_capture_instruction))
-            Analytics.log(AnalyticsEvents.RECORD_SELFIE_VIDEO, "form")
-        } else if (camera is StillCamera) {
-            val imagePath = intent.getStringExtra(EXTRA_TMP_PATH) + "/tmp.jpg"
-            previewView.setOnClickListener {
-                camera.takePicture(
-                    imagePath,
-                    { ExternalAppUtils.returnSingleValue(this, imagePath) },
-                    { showLongToast(this, R.string.camera_error) }
-                )
-            }
-
-            showLongToast(this, R.string.take_picture_instruction)
+        val imagePath = intent.getStringExtra(EXTRA_TMP_PATH) + "/tmp.jpg"
+        previewView.setOnClickListener {
+            camera.takePicture(
+                imagePath,
+                { ExternalAppUtils.returnSingleValue(this, imagePath) },
+                { showLongToast(this, R.string.camera_error) }
+            )
         }
+
+        showLongToast(this, R.string.take_picture_instruction)
     }
 
     private fun permissionsGranted(): Boolean {
-        return if (intent.getBooleanExtra(EXTRA_VIDEO, false)) {
-            return permissionsChecker.isPermissionGranted(
-                Manifest.permission.CAMERA,
-                Manifest.permission.RECORD_AUDIO
-            )
-        } else {
-            permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA)
-        }
+        return permissionsChecker.isPermissionGranted(Manifest.permission.CAMERA)
     }
 
     companion object {
         const val EXTRA_TMP_PATH = "tmpPath"
-        const val EXTRA_VIDEO = "video"
     }
 }

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CaptureSelfieActivity.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/CaptureSelfieActivity.kt
@@ -29,7 +29,7 @@ import javax.inject.Inject
 class CaptureSelfieActivity : LocalizedActivity() {
 
     @Inject
-    internal lateinit var stillCamera: StillCamera
+    internal lateinit var camera: Camera
 
     @Inject
     lateinit var permissionsChecker: PermissionsChecker
@@ -52,11 +52,11 @@ class CaptureSelfieActivity : LocalizedActivity() {
 
         val previewView = findViewById<View>(R.id.preview)
 
-        stillCamera.initialize(this, previewView)
-        stillCamera.state().observe(this) {
+        camera.initialize(this, previewView)
+        camera.state().observe(this) {
             when (it) {
                 Camera.State.UNINITIALIZED -> {}
-                Camera.State.INITIALIZED -> setupCamera(stillCamera)
+                Camera.State.INITIALIZED -> setupCamera(camera)
                 Camera.State.FAILED_TO_INITIALIZE -> {
                     showLongToast(this, R.string.camera_failed_to_initialize)
                 }
@@ -64,7 +64,7 @@ class CaptureSelfieActivity : LocalizedActivity() {
         }
     }
 
-    private fun setupCamera(camera: StillCamera) {
+    private fun setupCamera(camera: Camera) {
         val previewView = findViewById<View>(R.id.preview)
 
         val imagePath = intent.getStringExtra(EXTRA_TMP_PATH) + "/tmp.jpg"

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/DaggerSetup.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/DaggerSetup.kt
@@ -28,9 +28,4 @@ open class SelfieCameraDependencyModule {
     internal open fun providesStillCamera(): StillCamera {
         return CameraXStillCamera()
     }
-
-    @Provides
-    internal open fun providesVideoCamera(): VideoCamera {
-        return CameraXVideoCamera()
-    }
 }

--- a/selfie-camera/src/main/java/org/odk/collect/selfiecamera/DaggerSetup.kt
+++ b/selfie-camera/src/main/java/org/odk/collect/selfiecamera/DaggerSetup.kt
@@ -25,7 +25,7 @@ open class SelfieCameraDependencyModule {
     }
 
     @Provides
-    internal open fun providesStillCamera(): StillCamera {
-        return CameraXStillCamera()
+    internal open fun providesCamera(): Camera {
+        return CameraXCamera()
     }
 }

--- a/strings/src/main/res/values-ar/strings.xml
+++ b/strings/src/main/res/values-ar/strings.xml
@@ -207,8 +207,6 @@
   <string name="set_color">تحديد اللون</string>
   <string name="capture_video">سجل فيديو</string>
   <string name="choose_video">إختر فيديو</string>
-  <string name="start_video_capture_instruction">إنقر على الشاشة لبدء التسجيل</string>
-  <string name="stop_video_capture_instruction">بدأ التسجيل. إنقر مجددا للتوقف</string>
   <string name="play_video">تشغيل تسجيل الفيديو</string>
   <string name="choose_file">إختر ملف</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-cs/strings.xml
+++ b/strings/src/main/res/values-cs/strings.xml
@@ -212,8 +212,6 @@
   <string name="set_color">Nastavit barvu</string>
   <string name="capture_video">Nahrát video</string>
   <string name="choose_video">Vyberte video</string>
-  <string name="start_video_capture_instruction">Klepnutím na obrazovku spustíte nahrávání</string>
-  <string name="stop_video_capture_instruction">Nahrávání začalo. Klepnutím znovu zastavíte</string>
   <string name="play_video">Přehrát video</string>
   <string name="choose_file">Vybrat soubor</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-de/strings.xml
+++ b/strings/src/main/res/values-de/strings.xml
@@ -214,8 +214,6 @@
   <string name="set_color">Farbe wählen</string>
   <string name="capture_video">Video aufnehmen</string>
   <string name="choose_video">Video auswählen</string>
-  <string name="start_video_capture_instruction">Bildschirm berühren um eine Aufnahme zu starten</string>
-  <string name="stop_video_capture_instruction">Aufnahme gestartet. Zum Stoppen Bildschirm erneut berühren.</string>
   <string name="play_video">Video abspielen</string>
   <string name="choose_file">Datei auswählen</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-es/strings.xml
+++ b/strings/src/main/res/values-es/strings.xml
@@ -212,8 +212,6 @@
   <string name="set_color">Seleccionar Color</string>
   <string name="capture_video">Grabar el Video</string>
   <string name="choose_video">Escoja el Video</string>
-  <string name="start_video_capture_instruction">Toque a pantalla para iniciar grabación</string>
-  <string name="stop_video_capture_instruction">Grabación iniciada. Toque otra vez para detener.</string>
   <string name="play_video">Reproducir el Video</string>
   <string name="choose_file">Escoger Archivo</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-fa/strings.xml
+++ b/strings/src/main/res/values-fa/strings.xml
@@ -213,8 +213,6 @@
   <string name="set_color">تنظیم رنگ</string>
   <string name="capture_video">ثبت ویدیو</string>
   <string name="choose_video">انتخاب ویدیو</string>
-  <string name="start_video_capture_instruction">برای آغاز کردن ثبت روی صفحه را فشار دهید</string>
-  <string name="stop_video_capture_instruction">ثبت آغاز شد. برای توقف آن دوباره روی صفحه را فشار دهید</string>
   <string name="play_video">پخش ویدیو</string>
   <string name="choose_file">انتخاب فایل</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-fi/strings.xml
+++ b/strings/src/main/res/values-fi/strings.xml
@@ -214,8 +214,6 @@
   <string name="set_color">Aseta väri</string>
   <string name="capture_video">Tallenna video</string>
   <string name="choose_video">Valitse video</string>
-  <string name="start_video_capture_instruction">Napsauta näyttöä käynnistääksesi tallennuksen.</string>
-  <string name="stop_video_capture_instruction">Tallennus aloitettu. Napsauta uudelleen lopettaaksesi.</string>
   <string name="play_video">Näytä video</string>
   <string name="choose_file">Valitse tiedosto</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-fr/strings.xml
+++ b/strings/src/main/res/values-fr/strings.xml
@@ -214,8 +214,6 @@
   <string name="set_color">Sélectionner la couleur</string>
   <string name="capture_video">Enregistrer une vidéo</string>
   <string name="choose_video">Choisir une Vidéo</string>
-  <string name="start_video_capture_instruction">Toucher l\'écran pour commencer l\'enregistrement</string>
-  <string name="stop_video_capture_instruction">Enregistrement commencé. Toucher l\'écran pour l\'arrêter.</string>
   <string name="play_video">Jouer la vidéo</string>
   <string name="choose_file">Choisir un fichier</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-hi/strings.xml
+++ b/strings/src/main/res/values-hi/strings.xml
@@ -168,7 +168,6 @@
   <string name="set_color">रंग सेट करें</string>
   <string name="capture_video">विडियो रिकार्ड करे</string>
   <string name="choose_video">वीडियो चुनें</string>
-  <string name="start_video_capture_instruction">रिकॉर्डिंग प्रारंभ करने के लिए स्क्रीन को टैप करें</string>
   <string name="play_video">वीडियो चलाएं</string>
   <!--Text for button that deletes a file that is the answer to a question-->
   <!--Text for button that starts recording sound-->

--- a/strings/src/main/res/values-in/strings.xml
+++ b/strings/src/main/res/values-in/strings.xml
@@ -210,8 +210,6 @@
   <string name="set_color">Atur Warna</string>
   <string name="capture_video">Rekam Video</string>
   <string name="choose_video">Pilih Video</string>
-  <string name="start_video_capture_instruction">Sentuh layar untuk mulai merekam</string>
-  <string name="stop_video_capture_instruction">Perekaman dimulai. Sentuh lagi untuk berhenti.</string>
   <string name="play_video">Mainkan video</string>
   <string name="choose_file">Pilih Berkas</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-it/strings.xml
+++ b/strings/src/main/res/values-it/strings.xml
@@ -210,8 +210,6 @@
   <string name="set_color">Imposta Colore</string>
   <string name="capture_video">Registra Video</string>
   <string name="choose_video">Seleziona Video</string>
-  <string name="start_video_capture_instruction">Tocca lo schermo per iniziare a registrare</string>
-  <string name="stop_video_capture_instruction">Registrazione avviata. Per fermare, tocca lo schermo</string>
   <string name="play_video">Riproduci Video</string>
   <string name="choose_file">Seleziona File</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-ja/strings.xml
+++ b/strings/src/main/res/values-ja/strings.xml
@@ -207,8 +207,6 @@
   <string name="set_color">色を設定</string>
   <string name="capture_video">ビデオを録画</string>
   <string name="choose_video">ビデオを選択</string>
-  <string name="start_video_capture_instruction">画面をタップすると記録を開始します</string>
-  <string name="stop_video_capture_instruction">記録を開始しました。もう一度タップすると停止します</string>
   <string name="play_video">ビデオを再生</string>
   <string name="choose_file">ファイルを選択</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-km/strings.xml
+++ b/strings/src/main/res/values-km/strings.xml
@@ -187,8 +187,6 @@
   <string name="set_color">កំណត់ពណ៌</string>
   <string name="capture_video">ថត​វីដេអូ</string>
   <string name="choose_video">ជ្រើសរើសវីដេអូ</string>
-  <string name="start_video_capture_instruction">ប៉ះលើផ្ទៃ​អេក្រង់​ដើម្បីចាប់​ផ្តើម​ថត</string>
-  <string name="stop_video_capture_instruction">ការថតបានចាប់ផ្តើម, ប៉ះវាម្តងទៀតដើម្បីបញ្ចប់</string>
   <string name="play_video">ចាក់វីដេអូ</string>
   <string name="choose_file">ជ្រើសរើស​ឯកសារ</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-ne-rNP/strings.xml
+++ b/strings/src/main/res/values-ne-rNP/strings.xml
@@ -151,7 +151,6 @@
   <string name="set_color">रंग छान्नुहोस् </string>
   <string name="capture_video">भिडियो रेकर्ड गर्नुहोस् </string>
   <string name="choose_video">भिडियो छान्नुहोस् </string>
-  <string name="stop_video_capture_instruction">रेकर्डिङ सुरु भयो। रोक्न फेरि छुनुहोस् ।</string>
   <string name="play_video">भिडियो हेर्नुहोस्</string>
   <string name="choose_file">फाइलहरू छान्नुहोस्</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-pl/strings.xml
+++ b/strings/src/main/res/values-pl/strings.xml
@@ -202,8 +202,6 @@
   <string name="set_color">Ustaw Kolor</string>
   <string name="capture_video">Nagraj Wideo</string>
   <string name="choose_video">Wybierz Wideo</string>
-  <string name="start_video_capture_instruction">Dotknij ekranu, by rozpocząć nagrywanie.</string>
-  <string name="stop_video_capture_instruction">Rozpoczęto nagrywanie. Kliknij ponownie, by zakończyć.</string>
   <string name="play_video">Odtwórz Wideo</string>
   <string name="choose_file">Wybierz plik</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-pt/strings.xml
+++ b/strings/src/main/res/values-pt/strings.xml
@@ -210,8 +210,6 @@
   <string name="set_color">Definir Cor</string>
   <string name="capture_video">Gravar Vídeo</string>
   <string name="choose_video">Escolher Vídeo</string>
-  <string name="start_video_capture_instruction">Toque na tela para iniciar a gravação</string>
-  <string name="stop_video_capture_instruction">Gravação iniciada. Toque novamente para parar</string>
   <string name="play_video">Assistir o Vídeo</string>
   <string name="choose_file">Escolher Arquivo</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-ru/strings.xml
+++ b/strings/src/main/res/values-ru/strings.xml
@@ -189,8 +189,6 @@
   <string name="set_color">Выбрать цвет</string>
   <string name="capture_video">Записать видео</string>
   <string name="choose_video">Выберите видео</string>
-  <string name="start_video_capture_instruction">Коснитесь экрана, чтобы начать запись</string>
-  <string name="stop_video_capture_instruction">Запись началась. Коснитесь экрана ещё раз, чтобы остановить.</string>
   <string name="play_video">Проиграть видео</string>
   <string name="choose_file">Выберите файл</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-rw/strings.xml
+++ b/strings/src/main/res/values-rw/strings.xml
@@ -211,8 +211,6 @@ N\'ukomea guhura n\'iki kibazo, wakigeza kuwa gusabye gukusanya  amakuru.</strin
   <string name="set_color">Hitamo ibara</string>
   <string name="capture_video">Fata Video </string>
   <string name="choose_video">Hitamo Video</string>
-  <string name="start_video_capture_instruction">Kora kuri screen utangire kurikodinga </string>
-  <string name="stop_video_capture_instruction">Kurikodinga byatangiye. Ongera ukoreho ubihagarike</string>
   <string name="play_video">Kina Video </string>
   <string name="choose_file">Hitamo dokima </string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-sq/strings.xml
+++ b/strings/src/main/res/values-sq/strings.xml
@@ -180,8 +180,6 @@
   <string name="set_color">Cakto ngjyrën</string>
   <string name="capture_video">Regjistro video</string>
   <string name="choose_video">Zgjidh video</string>
-  <string name="start_video_capture_instruction">Prekni ekranin për të nisur regjistrimin</string>
-  <string name="stop_video_capture_instruction">Regjistrimi nisi. Prekni sërish ekranin për ta ndaluar</string>
   <string name="play_video">Shih videon</string>
   <string name="choose_file">Përzgjidh file</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-sr/strings.xml
+++ b/strings/src/main/res/values-sr/strings.xml
@@ -199,8 +199,6 @@
   <string name="set_color">Postavi boje</string>
   <string name="capture_video">Snimi video sadržaj</string>
   <string name="choose_video">Izaberi video</string>
-  <string name="start_video_capture_instruction">Dodirni ekran kako bi počeli sa snimanjem</string>
-  <string name="stop_video_capture_instruction">Snimanje je počelo. Dodirni za prekid</string>
   <string name="play_video">Pusti video</string>
   <string name="choose_file">Izaberi fajl</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-sv-rSE/strings.xml
+++ b/strings/src/main/res/values-sv-rSE/strings.xml
@@ -191,8 +191,6 @@
   <string name="set_color">Välj färg</string>
   <string name="capture_video">Spela in film</string>
   <string name="choose_video">Välj film</string>
-  <string name="start_video_capture_instruction">Tryck på skärmen för att starta inspelning</string>
-  <string name="stop_video_capture_instruction">Inspelning startad. Tryck igen för att stoppa.</string>
   <string name="play_video">Spela upp film</string>
   <string name="choose_file">Välj fil</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-sw/strings.xml
+++ b/strings/src/main/res/values-sw/strings.xml
@@ -209,8 +209,6 @@
   <string name="set_color">Weka rangi</string>
   <string name="capture_video">Rekodi video</string>
   <string name="choose_video">Chagua video</string>
-  <string name="start_video_capture_instruction">Bofya kioo kuanza kurekodi</string>
-  <string name="stop_video_capture_instruction">Imeanza kurekodi. Bofya tena kusitisha</string>
   <string name="play_video">Cheza video</string>
   <string name="choose_file">Chagua faili</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-te/strings.xml
+++ b/strings/src/main/res/values-te/strings.xml
@@ -202,8 +202,6 @@
   <string name="set_color">రంగును సెట్ చేయండి</string>
   <string name="capture_video">వీడియో రికార్డు చెయ్యి </string>
   <string name="choose_video">వీడియోను ఎంచుకోండి</string>
-  <string name="start_video_capture_instruction">రికార్డింగ్ ప్రారంభించడానికి స్క్రీన్ పైన నొక్కండి</string>
-  <string name="stop_video_capture_instruction">రికార్డింగ్ ప్రారంభమైంది. ఆపడానికి మళ్ళీ నొక్కండి</string>
   <string name="play_video">వీడియో ప్లే చెయ్యి</string>
   <string name="choose_file">ఫైల్‌ను ఎంచుకోండి</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-uk/strings.xml
+++ b/strings/src/main/res/values-uk/strings.xml
@@ -196,8 +196,6 @@
   <string name="set_color">Колір</string>
   <string name="capture_video">Записати відео</string>
   <string name="choose_video">Оберіть відео</string>
-  <string name="start_video_capture_instruction">Щоб почати запис торкніться екрану</string>
-  <string name="stop_video_capture_instruction">Запис розпочато. Торкніться знову щоб зупинити</string>
   <string name="play_video">Відтворити відео</string>
   <string name="choose_file">Обрати файл</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-ur/strings.xml
+++ b/strings/src/main/res/values-ur/strings.xml
@@ -192,8 +192,6 @@
   <string name="set_color">رنگ ترتیب دیں</string>
   <string name="capture_video">وڈیو ریکارڈ کریں</string>
   <string name="choose_video">ویڈیو منتخب کریں </string>
-  <string name="start_video_capture_instruction">ریکارڈ کرنے کے لیے سکرین پر ٹیپ کریں</string>
-  <string name="stop_video_capture_instruction">ریکارڈنگ شروع ہوئی. روکنے کے لئے دوبارہ ٹیپ کریں</string>
   <string name="play_video">وڈیو لگا دیں</string>
   <string name="choose_file">فائل منتخب کریں</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values-zh/strings.xml
+++ b/strings/src/main/res/values-zh/strings.xml
@@ -215,8 +215,6 @@
   <string name="set_color">选择颜色</string>
   <string name="capture_video">拍摄视频</string>
   <string name="choose_video">选择视频</string>
-  <string name="start_video_capture_instruction">点击屏幕开始录制</string>
-  <string name="stop_video_capture_instruction">录制已开始。再次点击以停止</string>
   <string name="play_video">播放视频</string>
   <string name="choose_file">选择文件</string>
   <!--Text for button that deletes a file that is the answer to a question-->

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -272,8 +272,6 @@
 
     <string name="capture_video">Record Video</string>
     <string name="choose_video">Choose Video</string>
-    <string name="start_video_capture_instruction">Tap the screen to start recording</string>
-    <string name="stop_video_capture_instruction">Recording started. Tap again to stop</string>
     <string name="play_video">Play Video</string>
 
     <string name="choose_file">Choose File</string>


### PR DESCRIPTION
Closes #5467 

#### What has been done to verify that this works as intended?
I've verified that the `selfie` appearance is now ignored in the Video widget and it works like without any appearance.

#### Why is this the best possible solution? Were any other approaches considered?
As discussed in the issue. This was an unused feature that only required our work to maintain it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that Video and Image widgets work well with and without the `selfie` appearance. Other parts of the app should not be affected.

#### Do we need any specific form for testing your changes? If so, please attach one.
AllWidgets form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
Yes https://github.com/getodk/docs/issues/1583
I've also update the AllWidgets form https://docs.google.com/spreadsheets/d/1af_Sl8A_L8_EULbhRLHVl8OclCfco09Hq2tqb9CslwQ/edit#gid=0

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
