### PR TITLE
Improved user experience when using menu items in the form hierarchy view

### DIFF
--- a/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
+++ b/androidshared/src/main/java/org/odk/collect/androidshared/ui/multiclicksafe/MultiClickGuard.kt
@@ -3,23 +3,27 @@ package org.odk.collect.androidshared.ui.multiclicksafe
 import android.os.SystemClock
 
 object MultiClickGuard {
-    private const val CLICK_DEBOUNCE_MS = 1000
-
     @JvmField
     var test = false
 
     private var lastClickTime: Long = 0
     private var lastClickName: String = javaClass.name
 
+    @JvmStatic
+    fun allowClickFast(className: String = javaClass.name): Boolean {
+        return allowClick(className, 500)
+    }
+
     // Debounce multiple clicks within the same screen
     @JvmStatic
-    fun allowClick(className: String = javaClass.name): Boolean {
+    @JvmOverloads
+    fun allowClick(className: String = javaClass.name, clickDebounceMs: Long = 1000): Boolean {
         if (test) {
             return true
         }
         val elapsedRealtime = SystemClock.elapsedRealtime()
         val isSameClass = className == lastClickName
-        val isBeyondThreshold = elapsedRealtime - lastClickTime > CLICK_DEBOUNCE_MS
+        val isBeyondThreshold = elapsedRealtime - lastClickTime > clickDebounceMs
         val isBeyondTestThreshold =
             lastClickTime == 0L || lastClickTime == elapsedRealtime // just for tests
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -271,7 +271,7 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (!MultiClickGuard.allowClick(item.toString())) {
+        if (!MultiClickGuard.allowClickFast(item.toString())) {
             return true;
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -271,7 +271,7 @@ public class FormHierarchyActivity extends LocalizedActivity implements DeleteRe
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (!MultiClickGuard.allowClick(getClass().getName())) {
+        if (!MultiClickGuard.allowClick(item.toString())) {
             return true;
         }
 


### PR DESCRIPTION
Closes #4457
Closes #5362

Working on https://github.com/getodk/collect/issues/5264 I also investigated #4457 and #5362 and thought it would be good to fix them because the user experience is pretty bad because of how we protect users from multi clicking.

#### What has been done to verify that this works as intended?
I've tested the changes manually.

#### Why is this the best possible solution? Were any other approaches considered?
I've implemented two improvements:
- the first commit treats particular menu items in the form hierarchy as individual ones. That means we only protect users from multi clicking if they click multiple times on the same item. If a user click for example on the `up` icon and then on the `add repeat` one then they are not blocked.
- the second commit decreases the debounce time (from 1s to 0.5s) so that navigating through the hierarchy of questions (especially going up) is smoother. I think 0.5s might be a good balance between protecting users from multi clicking and providing good user experience.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It should make using menu items in the form hierarchy smoother. Before we would block users for 1s after clicking one item what made the user experience pretty bad. I hope 0.5s that we use now is better and still protects from weird bugs that can be caused by multi clicking. Please test the forms attached to the issues to make sure it works better now.

#### Do we need any specific form for testing your changes? If so, please attach one.
Forms are attached to the issues.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
