### PR TITLE
Prevent crash when trying to log with nullable value

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -372,7 +372,12 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Timber.w("onCreate %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        if (getIntent().getData() != null) {
+            Timber.w("onCreate %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        } else {
+            Timber.w("onCreate null");
+        }
+        
         // Workaround for https://issuetracker.google.com/issues/37124582. Some widgets trigger
         // this issue by including WebViews
         if (Build.VERSION.SDK_INT >= 24) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -783,7 +783,11 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-        Timber.w("onSaveInstanceState %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        if (getIntent().getData() != null) {
+            Timber.w("onSaveInstanceState %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        } else {
+            Timber.w("onSaveInstanceState null");
+        }
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_SESSION_ID, sessionId);
@@ -1890,7 +1894,11 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onStart() {
-        Timber.w("onStart %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        if (getIntent().getData() != null) {
+            Timber.w("onStart %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        } else {
+            Timber.w("onStart null");
+        }
         super.onStart();
         FormController formController = getFormController();
 
@@ -1909,7 +1917,11 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onPause() {
-        Timber.w("onPause %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        if (getIntent().getData() != null) {
+            Timber.w("onPause %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        } else {
+            Timber.w("onPause null");
+        }
         backgroundLocationViewModel.activityHidden();
 
         super.onPause();
@@ -1917,7 +1929,11 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onResume() {
-        Timber.w("onResume %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        if (getIntent().getData() != null) {
+            Timber.w("onResume %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        } else {
+            Timber.w("onResume null");
+        }
         super.onResume();
 
         activityDisplayed();
@@ -2022,7 +2038,11 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onDestroy() {
-        Timber.w("onDestroy %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        if (getIntent().getData() != null) {
+            Timber.w("onDestroy %s", Md5.getMd5Hash(getIntent().getData().toString()));
+        } else {
+            Timber.w("onDestroy null");
+        }
         if (formLoaderTask != null) {
             formLoaderTask.setFormLoaderListener(null);
             // We have to call cancel to terminate the thread, otherwise it


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/9fd11d0579e8fab8fc9eb02dcdf96f4f?time=last-seven-days&versions=v2023.1-beta.2%20(4588)&types=crash&sessionEventKey=6401ABDB018D000111324FDE750750DD_1784676745862188586).

#### What has been done to verify that this works as intended?

Ran tests.

#### Why is this the best possible solution? Were any other approaches considered?

It looks like `getData()` can be `null` in `FormEntryActivity` - there are other checks for that, so checking for `null` seems like the simplest solution.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I don't think there's any risk here. Can be merged without QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
