### PR TITLE
Use READ_PHONE_NUMBERS instead of READ_PHONE_STATE permission on android 11+

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -23,7 +23,7 @@ object TestRuleChain {
                     Manifest.permission.ACCESS_COARSE_LOCATION,
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.CAMERA,
-                    Manifest.permission.READ_PHONE_STATE,
+                    Manifest.permission.READ_PHONE_NUMBERS,
                     Manifest.permission.RECORD_AUDIO,
                     Manifest.permission.GET_ACCOUNTS
                 )

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@ the specific language governing permissions and limitations under the License.
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsProvider.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.ContentResolver
 import android.net.Uri
+import android.os.Build
 
 /**
  * PermissionsProvider allows all permission related messages and checks to be encapsulated in one
@@ -48,7 +49,13 @@ open class PermissionsProvider internal constructor(
         get() = permissionsChecker.isPermissionGranted(Manifest.permission.GET_ACCOUNTS)
 
     open val isReadPhoneStatePermissionGranted: Boolean
-        get() = permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_STATE)
+        get() = permissionsChecker.isPermissionGranted(
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+                Manifest.permission.READ_PHONE_NUMBERS
+            } else {
+                Manifest.permission.READ_PHONE_STATE
+            }
+        )
 
     open fun requestCameraPermission(activity: Activity, action: PermissionListener) {
         requestPermissions(
@@ -202,7 +209,11 @@ open class PermissionsProvider internal constructor(
                     )
                 }
             },
-            Manifest.permission.READ_PHONE_STATE
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+                Manifest.permission.READ_PHONE_NUMBERS
+            } else {
+                Manifest.permission.READ_PHONE_STATE
+            }
         )
     }
 

--- a/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
+++ b/permissions/src/test/java/org/odk/collect/permissions/PermissionsProviderTest.kt
@@ -269,22 +269,22 @@ class PermissionsProviderTest {
     }
 
     @Test
-    fun `isReadPhoneStatePermissionGranted() when read phone state permission is granted returns true`() {
-        whenever(permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_STATE)).thenReturn(true)
+    fun `isReadPhoneStatePermissionGranted() when read phone numbers permission is granted returns true`() {
+        whenever(permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_NUMBERS)).thenReturn(true)
 
         assertThat(permissionsProvider.isReadPhoneStatePermissionGranted, `is`(true))
     }
 
     @Test
-    fun `isReadPhoneStatePermissionGranted() when read phone state permission is not granted returns false`() {
-        whenever(permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_STATE)).thenReturn(false)
+    fun `isReadPhoneStatePermissionGranted() when read phone numbers permission is not granted returns false`() {
+        whenever(permissionsChecker.isPermissionGranted(Manifest.permission.READ_PHONE_NUMBERS)).thenReturn(false)
 
         assertThat(permissionsProvider.isReadPhoneStatePermissionGranted, `is`(false))
     }
 
     @Test
-    fun `requestReadPhoneStatePermission() when read phone state permission is granted calls PermissionListener#granted`() {
-        permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_STATE)
+    fun `requestReadPhoneStatePermission() when read phone numbers permission is granted calls PermissionListener#granted`() {
+        permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_NUMBERS)
 
         permissionsProvider.requestReadPhoneStatePermission(activity, permissionListener)
 
@@ -342,14 +342,14 @@ class PermissionsProviderTest {
 
     @Test
     fun `granted listener is not called when Activity is finishing`() {
-        permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_STATE)
+        permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_NUMBERS)
 
         whenever(activity.isFinishing).doReturn(true)
 
         permissionsProvider.requestPermissions(
             activity,
             permissionListener,
-            Manifest.permission.READ_PHONE_STATE
+            Manifest.permission.READ_PHONE_NUMBERS
         )
 
         verifyNoInteractions(permissionListener)
@@ -357,14 +357,14 @@ class PermissionsProviderTest {
 
     @Test
     fun `denied listener is not called when Activity is finishing`() {
-        permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_STATE)
+        permissionsApi.setGrantedPermission(Manifest.permission.READ_PHONE_NUMBERS)
 
         whenever(activity.isFinishing).doReturn(true)
 
         permissionsProvider.requestPermissions(
             activity,
             permissionListener,
-            Manifest.permission.READ_PHONE_STATE
+            Manifest.permission.READ_PHONE_NUMBERS
         )
 
         verifyNoInteractions(permissionListener)


### PR DESCRIPTION
Closes #4838 
Blocked by #5481 

#### What has been done to verify that this works as intended?
I've tested the fix manually on android 10 and >10

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please verify that requesting permission when the phone number needs to be used works without regression, especially on older devices android <=10 and newer >10.
Phone number is used in two places:
- in Form metadata (in settings)
- in a form, if it contains `phonenumber` question https://docs.getodk.org/form-question-types/#metadata

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
