### PR TITLE
Fixed the text displayed when closing the draw activity

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/DrawWidgetTest.java
@@ -34,7 +34,7 @@ public class DrawWidgetTest {
                 .clickOnId(R.id.simple_button)
                 .waitForRotationToEnd()
                 .pressBack(new SaveOrIgnoreDialog<>("Sketch Image", new FormEntryPage("All widgets")))
-                .clickDiscardForm()
+                .clickDiscardChanges()
                 .waitForRotationToEnd()
                 .clickOnId(R.id.simple_button)
                 .waitForRotationToEnd()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/SignatureWidgetTest.java
@@ -37,7 +37,7 @@ public class SignatureWidgetTest {
                 .pressBack(new SaveOrIgnoreDialog<>("Gather Signature", new FormEntryPage("All widgets")))
                 .checkIsTranslationDisplayed("Exit Gather Signature", "Salir Adjuntar firma")
                 .assertText(R.string.keep_changes)
-                .clickDiscardForm()
+                .clickDiscardChanges()
                 .waitForRotationToEnd()
                 .clickWidgetButton()
                 .waitForRotationToEnd()

--- a/collect_app/src/main/java/org/odk/collect/android/draw/DrawActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/draw/DrawActivity.java
@@ -314,7 +314,7 @@ public class DrawActivity extends LocalizedActivity {
 
         List<IconMenuItem> items;
         items = ImmutableList.of(new IconMenuItem(R.drawable.ic_save, R.string.keep_changes),
-                new IconMenuItem(R.drawable.ic_delete, R.string.do_not_save));
+                new IconMenuItem(R.drawable.ic_delete, R.string.discard_changes));
 
         final IconMenuListAdapter adapter = new IconMenuListAdapter(this, items);
         listView.setAdapter(adapter);


### PR DESCRIPTION
Closes #5491 

#### What has been done to verify that this works as intended?
I've verified the fix manually and checked automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
It's just a small fix, nothing to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
It's a safe fix so you can verify the steps from the issue and just quickly make sure there is no regression when it comes to strings we use before closing a form.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
