### PR TITLE
Fix Google Drive banner and server switching

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/GoogleDriveDeprecationBannerTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/GoogleDriveDeprecationBannerTest.kt
@@ -11,6 +11,7 @@ import org.odk.collect.android.R
 import org.odk.collect.android.activities.WebViewActivity
 import org.odk.collect.android.support.TestDependencies
 import org.odk.collect.android.support.pages.MainMenuPage
+import org.odk.collect.android.support.pages.ProjectSettingsPage
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
 import org.odk.collect.androidtest.RecordedIntentsRule
@@ -42,6 +43,27 @@ class GoogleDriveDeprecationBannerTest {
             .switchToManualMode()
             .openGooglePickerAndSelect(googleAccount)
             .assertText(R.string.google_drive_deprecation_message)
+    }
+
+    @Test
+    fun bannerDisappearsAfterSwitchingFromGoogleDriveProjectToOdkServer() {
+        val googleAccount = "steph@curry.basket"
+        testDependencies.googleAccountPicker.setDeviceAccount(googleAccount)
+
+        rule.startAtMainMenu()
+            .openProjectSettingsDialog()
+            .clickAddProject()
+            .switchToManualMode()
+            .openGooglePickerAndSelect(googleAccount)
+            .assertText(R.string.google_drive_deprecation_message)
+            .openProjectSettingsDialog()
+            .clickSettings()
+            .clickServerSettings()
+            .clickOnServerType()
+            .clickOnString(R.string.server_platform_odk)
+            .pressBack(ProjectSettingsPage())
+            .pressBack(MainMenuPage())
+            .assertTextDoesNotExist(R.string.google_drive_deprecation_message)
     }
 
     @Test

--- a/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/MainMenuActivity.java
@@ -328,6 +328,8 @@ public class MainMenuActivity extends LocalizedActivity {
                     unprotectedSettings.save(ProjectKeys.GOOGLE_DRIVE_DEPRECATION_BANNER_DISMISSED, true);
                 });
             }
+        } else {
+            findViewById(R.id.google_drive_deprecation_banner).setVisibility(View.GONE);
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/application/CollectSettingsChangeHandler.kt
@@ -2,17 +2,23 @@ package org.odk.collect.android.application
 
 import org.odk.collect.android.analytics.AnalyticsUtils
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
+import org.odk.collect.android.formmanagement.matchexactly.SyncStatusAppState
 import org.odk.collect.android.logic.PropertyManager
 import org.odk.collect.settings.importing.SettingsChangeHandler
 import org.odk.collect.settings.keys.ProjectKeys
 
 class CollectSettingsChangeHandler(
     private val propertyManager: PropertyManager,
-    private val formUpdateScheduler: FormUpdateScheduler
+    private val formUpdateScheduler: FormUpdateScheduler,
+    private val syncStatusAppState: SyncStatusAppState
 ) : SettingsChangeHandler {
 
     override fun onSettingChanged(projectId: String, newValue: Any?, changedKey: String) {
         propertyManager.reload()
+
+        if (changedKey == ProjectKeys.KEY_SERVER_URL || changedKey == ProjectKeys.KEY_PROTOCOL) {
+            syncStatusAppState.clear(projectId)
+        }
 
         if (changedKey == ProjectKeys.KEY_FORM_UPDATE_MODE ||
             changedKey == ProjectKeys.KEY_PERIODIC_FORM_UPDATES_CHECK ||

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusAppState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusAppState.kt
@@ -4,14 +4,10 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import org.odk.collect.android.external.FormsContract
+import org.odk.collect.androidshared.data.AppState
 import org.odk.collect.forms.FormSourceException
-import javax.inject.Singleton
 
-@Singleton
-class SyncStatusAppState(private val context: Context) {
-
-    private val syncing = mutableMapOf<String, MutableLiveData<Boolean>>()
-    private val lastSyncFailure = mutableMapOf<String, MutableLiveData<FormSourceException?>>()
+class SyncStatusAppState(private val appState: AppState, private val context: Context) {
 
     fun isSyncing(projectId: String): LiveData<Boolean> {
         return getSyncingLiveData(projectId)
@@ -32,8 +28,13 @@ class SyncStatusAppState(private val context: Context) {
     }
 
     private fun getSyncingLiveData(projectId: String) =
-        syncing.getOrPut(projectId) { MutableLiveData(false) }
+        appState.get("$KEY_PREFIX_SYNCING:$projectId", MutableLiveData(false))
 
     private fun getSyncErrorLiveData(projectId: String) =
-        lastSyncFailure.getOrPut(projectId) { MutableLiveData(null) }
+        appState.get("$KEY_PREFIX_ERROR:$projectId", MutableLiveData<FormSourceException>(null))
+
+    companion object {
+        const val KEY_PREFIX_SYNCING = "syncStatusSyncing"
+        const val KEY_PREFIX_ERROR = "syncStatusError"
+    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusAppState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/matchexactly/SyncStatusAppState.kt
@@ -33,6 +33,11 @@ class SyncStatusAppState(private val appState: AppState, private val context: Co
     private fun getSyncErrorLiveData(projectId: String) =
         appState.get("$KEY_PREFIX_ERROR:$projectId", MutableLiveData<FormSourceException>(null))
 
+    fun clear(projectId: String) {
+        getSyncingLiveData(projectId).value = false
+        getSyncErrorLiveData(projectId).value = null
+    }
+
     companion object {
         const val KEY_PREFIX_SYNCING = "syncStatusSyncing"
         const val KEY_PREFIX_ERROR = "syncStatusError"

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -98,7 +98,6 @@ import org.odk.collect.android.utilities.ExternalWebPageHelper;
 import org.odk.collect.android.utilities.FileProvider;
 import org.odk.collect.android.utilities.FormsDirDiskFormsSynchronizer;
 import org.odk.collect.android.utilities.FormsRepositoryProvider;
-import org.odk.collect.androidshared.bitmap.ImageCompressor;
 import org.odk.collect.android.utilities.ImageCompressionController;
 import org.odk.collect.android.utilities.InstancesRepositoryProvider;
 import org.odk.collect.android.utilities.MediaUtils;
@@ -108,6 +107,7 @@ import org.odk.collect.android.utilities.StaticCachingDeviceDetailsProvider;
 import org.odk.collect.android.utilities.WebCredentialsUtils;
 import org.odk.collect.android.version.VersionInformation;
 import org.odk.collect.android.views.BarcodeViewDecoder;
+import org.odk.collect.androidshared.bitmap.ImageCompressor;
 import org.odk.collect.androidshared.network.ConnectivityProvider;
 import org.odk.collect.androidshared.network.NetworkStateProvider;
 import org.odk.collect.androidshared.system.IntentLauncher;
@@ -314,8 +314,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public SettingsChangeHandler providesSettingsChangeHandler(PropertyManager propertyManager, FormUpdateScheduler formUpdateScheduler) {
-        return new CollectSettingsChangeHandler(propertyManager, formUpdateScheduler);
+    public SettingsChangeHandler providesSettingsChangeHandler(PropertyManager propertyManager, FormUpdateScheduler formUpdateScheduler, SyncStatusAppState syncStatusAppState) {
+        return new CollectSettingsChangeHandler(propertyManager, formUpdateScheduler, syncStatusAppState);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -1,6 +1,7 @@
 package org.odk.collect.android.injection.config;
 
 import static androidx.core.content.FileProvider.getUriForFile;
+import static org.odk.collect.androidshared.data.AppStateKt.getState;
 import static org.odk.collect.settings.keys.MetaKeys.KEY_INSTALL_ID;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -353,9 +354,8 @@ public class AppDependencyModule {
     }
 
     @Provides
-    @Singleton
-    public SyncStatusAppState providesServerFormSyncRepository(Context context) {
-        return new SyncStatusAppState(context);
+    public SyncStatusAppState providesServerFormSyncRepository(Application application) {
+        return new SyncStatusAppState(getState(application), application);
     }
 
     @Provides

--- a/collect_app/src/test/java/org/odk/collect/android/application/CollectSettingsChangeHandlerTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/application/CollectSettingsChangeHandlerTest.kt
@@ -5,13 +5,16 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.odk.collect.android.backgroundwork.FormUpdateScheduler
+import org.odk.collect.android.formmanagement.matchexactly.SyncStatusAppState
 import org.odk.collect.android.logic.PropertyManager
 import org.odk.collect.settings.keys.ProjectKeys
 
 class CollectSettingsChangeHandlerTest {
+
     private val propertyManager = mock<PropertyManager>()
     private val formUpdateScheduler = mock<FormUpdateScheduler>()
-    private var handler = CollectSettingsChangeHandler(propertyManager, formUpdateScheduler)
+    private val syncStatusAppState = mock<SyncStatusAppState>()
+    private val handler = CollectSettingsChangeHandler(propertyManager, formUpdateScheduler, syncStatusAppState)
 
     @Test
     fun `updates PropertyManager when a single setting is changed`() {
@@ -42,9 +45,27 @@ class CollectSettingsChangeHandlerTest {
     }
 
     @Test
+    fun `when changed key is PROTOCOL clears sync status`() {
+        handler.onSettingChanged("projectId", "anything", ProjectKeys.KEY_PROTOCOL)
+        verify(syncStatusAppState).clear("projectId")
+    }
+
+    @Test
+    fun `when changed key is SERVER_URL clears sync status`() {
+        handler.onSettingChanged("projectId", "anything", ProjectKeys.KEY_SERVER_URL)
+        verify(syncStatusAppState).clear("projectId")
+    }
+
+    @Test
     fun `do not schedule updates if other single settings are changed`() {
         handler.onSettingChanged("projectId", "anything", "blah")
         verifyNoInteractions(formUpdateScheduler)
+    }
+
+    @Test
+    fun `do not clear sync status if other single settings are changed`() {
+        handler.onSettingChanged("projectId", "anything", "blah")
+        verifyNoInteractions(syncStatusAppState)
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusAppStateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusAppStateTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.odk.collect.android.formmanagement.matchexactly.SyncStatusAppState;
 import org.odk.collect.android.external.FormsContract;
+import org.odk.collect.androidshared.data.AppState;
 import org.odk.collect.forms.FormSourceException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,6 +26,8 @@ public class SyncStatusAppStateTest {
     private final Context context = mock(Context.class);
     private final ContentResolver contentResolver = mock(ContentResolver.class);
 
+    private final AppState appState = new AppState();
+
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
 
@@ -35,13 +38,13 @@ public class SyncStatusAppStateTest {
 
     @Test
     public void getSyncError_isNullAtFirst() {
-        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
         assertThat(syncStatusAppState.getSyncError("projectId").getValue(), is(nullValue()));
     }
 
     @Test
     public void getSyncError_whenFinishSyncWithException_isException() {
-        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
         syncStatusAppState.startSync("projectId");
         FormSourceException exception = new FormSourceException.FetchError();
         syncStatusAppState.finishSync("projectId", exception);
@@ -51,7 +54,7 @@ public class SyncStatusAppStateTest {
 
     @Test
     public void getSyncError_whenFinishSyncWithNull_isNull() {
-        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
         syncStatusAppState.startSync("projectId");
         syncStatusAppState.finishSync("projectId", null);
 
@@ -60,7 +63,7 @@ public class SyncStatusAppStateTest {
 
     @Test
     public void isSyncing_isDifferentForDifferentProjects() {
-        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
         syncStatusAppState.startSync("projectId");
         assertThat(syncStatusAppState.isSyncing("projectId").getValue(), is(true));
         assertThat(syncStatusAppState.isSyncing("otherProjectId").getValue(), is(false));
@@ -68,7 +71,7 @@ public class SyncStatusAppStateTest {
 
     @Test
     public void getSyncError_isDifferentForDifferentProjects() {
-        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
         syncStatusAppState.startSync("projectId");
         syncStatusAppState.finishSync("projectId", new FormSourceException.FetchError());
         assertThat(syncStatusAppState.getSyncError("projectId").getValue(), is(notNullValue()));
@@ -77,7 +80,7 @@ public class SyncStatusAppStateTest {
 
     @Test
     public void finishSync_updatesFormsContentObserver() {
-        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(context);
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
         syncStatusAppState.startSync("projectId");
         syncStatusAppState.finishSync("projectId", null);
         verify(contentResolver).notifyChange(FormsContract.getUri("projectId"), null);

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusAppStateTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/SyncStatusAppStateTest.java
@@ -85,4 +85,17 @@ public class SyncStatusAppStateTest {
         syncStatusAppState.finishSync("projectId", null);
         verify(contentResolver).notifyChange(FormsContract.getUri("projectId"), null);
     }
+
+    @Test
+    public void clear_clearsSyncErrorAndIsSyncing() {
+        SyncStatusAppState syncStatusAppState = new SyncStatusAppState(appState, context);
+
+        syncStatusAppState.startSync("projectId");
+        syncStatusAppState.clear("projectId");
+        assertThat(syncStatusAppState.isSyncing("projectId").getValue(), is(false));
+
+        syncStatusAppState.finishSync("projectId", new FormSourceException.FetchError());
+        syncStatusAppState.clear("projectId");
+        assertThat(syncStatusAppState.getSyncError("projectId").getValue(), is(nullValue()));
+    }
 }


### PR DESCRIPTION
Closes #5499
Closes #5500

These issues ended up not being related, but I fixed them on one branch thinking they might be. To summarize the fixes:

* #5499: we needed to clear the state we keep track of for the "last sync" of a match exactly project when changing server/protocol so that we don't see sync errors in Fill Blank Form for the old settings
* #5500: we needed to hide the Google Drive deprecation prompt if Google Drive was no longer the protocol

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

As well as checking that the mentioned issues are fixed, I've refactored some code related to Exactly Match Server so that feature set is worth looking at.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
