### PR TITLE
Remove accuracy threshold analytics

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -136,16 +136,6 @@ object AnalyticsEvents {
     const val INSTANCE_PROVIDER_DELETE = "InstanceProviderDelete"
 
     /**
-     * Tracks how many forms include an accuracy threshold for the default `geopoint` question
-     */
-    const val ACCURACY_THRESHOLD = "AccuracyThreshold"
-
-    /**
-     * Tracks how many forms use default accuracy thresholds for the default `geopoint` question
-     */
-    const val ACCURACY_THRESHOLD_DEFAULT = "AccuracyThresholdDefault"
-
-    /**
      * Tracks how often "cellular_only" option is used in auto send
      */
     const val CELLULAR_ONLY = "CellularOnly"

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -23,12 +23,9 @@ import android.view.View;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
-import org.odk.collect.analytics.Analytics;
 import org.odk.collect.android.R;
-import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.databinding.GeoWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
-import org.odk.collect.android.utilities.Appearances;
 import org.odk.collect.android.widgets.interfaces.GeoDataRequester;
 import org.odk.collect.android.widgets.interfaces.WidgetDataReceiver;
 import org.odk.collect.android.widgets.utilities.GeoWidgetUtils;
@@ -73,8 +70,6 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
             binding.simpleButton.setText(R.string.get_point);
         }
 
-        logAccuracyThresholdUse(prompt);
-
         return binding.getRoot();
     }
 
@@ -112,16 +107,5 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
         binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
         binding.simpleButton.setText(answerText == null || answerText.isEmpty() ? R.string.get_point : R.string.change_location);
         widgetValueChanged();
-    }
-
-    private void logAccuracyThresholdUse(FormEntryPrompt prompt) {
-        // Only default geopoint supports accuracy threshold
-        if (Appearances.getSanitizedAppearanceHint(prompt).isEmpty()) {
-            if (prompt.getQuestion().getAdditionalAttribute(null, "accuracyThreshold") != null) {
-                Analytics.log(AnalyticsEvents.ACCURACY_THRESHOLD, "form");
-            } else {
-                Analytics.log(AnalyticsEvents.ACCURACY_THRESHOLD_DEFAULT, "form");
-            }
-        }
     }
 }


### PR DESCRIPTION
About 12% of users who see a default geopoint widget see one that specifies a custom accuracy threshold. This has remained largely stable over the last year. I don't see us making any decisions based on this information any time soon.

(Context: I was reviewing analytics for `saveIncomplete` and this jumped out at me)