### PR TITLE
Improved handling default images

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/BaseImageWidget.java
@@ -221,8 +221,9 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
         private void launchDrawActivity() {
             Intent i = new Intent(getContext(), DrawActivity.class);
             i.putExtra(DrawActivity.OPTION, drawOption);
-            if (binaryName != null) {
-                i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(getFile()));
+            File file = getFile();
+            if (file != null) {
+                i.putExtra(DrawActivity.REF_IMAGE, Uri.fromFile(file));
             }
 
             i.putExtra(DrawActivity.EXTRA_OUTPUT, Uri.fromFile(new File(tmpImageFilePath)));
@@ -279,9 +280,18 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
 
     @Nullable
     private File getFile() {
+        if (binaryName == null) {
+            return null;
+        }
+
         File file = questionMediaManager.getAnswerFile(binaryName);
         if ((file == null || !file.exists()) && doesSupportDefaultValues()) {
-            file = new File(getDefaultFilePath());
+            String filePath = getDefaultFilePath();
+            if (filePath != null) {
+                return new File(getDefaultFilePath());
+            } else {
+                return null;
+            }
         }
 
         return file;
@@ -294,7 +304,7 @@ public abstract class BaseImageWidget extends QuestionWidget implements FileWidg
             Timber.w(e);
         }
 
-        return "";
+        return null;
     }
 
     protected abstract boolean doesSupportDefaultValues();

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/AnnotateWidgetTest.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.widgets;
 import android.content.Intent;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.provider.MediaStore;
 import android.view.View;
 import android.widget.ImageView;
@@ -242,5 +243,55 @@ public class AnnotateWidgetTest extends FileWidgetTest<AnnotateWidget> {
                 .build();
 
         assertThat(getWidget().annotateButton.isEnabled(), is(false));
+    }
+
+    @Test
+    public void whenPromptHasDefaultAnswer_passUriToDrawActivity() throws Exception {
+        File file = File.createTempFile("default", ".bmp");
+        String imagePath = file.getAbsolutePath();
+
+        ReferenceManager referenceManager = setupFakeReferenceManager(singletonList(
+                new Pair<>(DrawWidgetTest.DEFAULT_IMAGE_ANSWER, imagePath)
+        ));
+        CollectHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ReferenceManager providesReferenceManager() {
+                return referenceManager;
+            }
+
+            @Override
+            public ImageLoader providesImageLoader() {
+                return new SynchronousImageLoader();
+            }
+        });
+
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
+                .build();
+
+        Intent intent = getIntentLaunchedByClick(R.id.markup_image);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE, intent);
+        assertExtraEquals(DrawActivity.REF_IMAGE, Uri.fromFile(file), intent);
+    }
+
+    @Test
+    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
+                .build();
+
+        Intent intent = getIntentLaunchedByClick(R.id.markup_image);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE, intent);
+        assertThat(intent.hasExtra(DrawActivity.REF_IMAGE), is(false));
+    }
+
+    @Test
+    public void whenThereIsNoAnswer_doNotPassUriToDrawActivity() {
+        Intent intent = getIntentLaunchedByClick(R.id.markup_image);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_ANNOTATE, intent);
+        assertThat(intent.hasExtra(DrawActivity.REF_IMAGE), is(false));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/DrawWidgetTest.java
@@ -3,6 +3,7 @@ package org.odk.collect.android.widgets;
 import android.content.Intent;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.view.View;
 import android.widget.ImageView;
 
@@ -78,15 +79,6 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
     @Override
     public StringData getNextAnswer() {
         return new StringData(RandomString.make());
-    }
-
-    @Test
-    public void buttonsShouldLaunchCorrectIntents() {
-        stubAllRuntimePermissionsGranted(true);
-
-        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
-        assertComponentEquals(activity, DrawActivity.class, intent);
-        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_DRAW, intent);
     }
 
     @Test
@@ -194,5 +186,55 @@ public class DrawWidgetTest extends FileWidgetTest<DrawWidget> {
 
         String loadedPath = shadowOf(((BitmapDrawable) drawable).getBitmap()).getCreatedFromPath();
         assertThat(loadedPath, equalTo(imagePath));
+    }
+
+    @Test
+    public void whenPromptHasDefaultAnswer_passUriToDrawActivity() throws Exception {
+        File file = File.createTempFile("default", ".bmp");
+        String imagePath = file.getAbsolutePath();
+
+        ReferenceManager referenceManager = setupFakeReferenceManager(singletonList(
+                new Pair<>(DrawWidgetTest.DEFAULT_IMAGE_ANSWER, imagePath)
+        ));
+        CollectHelpers.overrideAppDependencyModule(new AppDependencyModule() {
+            @Override
+            public ReferenceManager providesReferenceManager() {
+                return referenceManager;
+            }
+
+            @Override
+            public ImageLoader providesImageLoader() {
+                return new SynchronousImageLoader();
+            }
+        });
+
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
+                .build();
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_DRAW, intent);
+        assertExtraEquals(DrawActivity.REF_IMAGE, Uri.fromFile(file), intent);
+    }
+
+    @Test
+    public void whenPromptHasDefaultAnswerThatDoesNotExist_doNotPassUriToDrawActivity() {
+        formEntryPrompt = new MockFormEntryPromptBuilder()
+                .withAnswerDisplayText(DrawWidgetTest.DEFAULT_IMAGE_ANSWER)
+                .build();
+
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_DRAW, intent);
+        assertThat(intent.hasExtra(DrawActivity.REF_IMAGE), is(false));
+    }
+
+    @Test
+    public void whenThereIsNoAnswer_doNotPassUriToDrawActivity() {
+        Intent intent = getIntentLaunchedByClick(R.id.simple_button);
+        assertComponentEquals(activity, DrawActivity.class, intent);
+        assertExtraEquals(DrawActivity.OPTION, DrawActivity.OPTION_DRAW, intent);
+        assertThat(intent.hasExtra(DrawActivity.REF_IMAGE), is(false));
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/support/FakeQuestionMediaManager.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/support/FakeQuestionMediaManager.java
@@ -30,6 +30,10 @@ public class FakeQuestionMediaManager implements QuestionMediaManager {
 
     @Override
     public File getAnswerFile(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+
         File existing = answerFiles.stream().filter(f -> f.getName().equals(fileName)).findFirst().orElse(null);
 
         if (existing != null) {


### PR DESCRIPTION
Closes #5496

#### What has been done to verify that this works as intended?
I've added automated tests and tested the fix manually.

#### Why is this the best possible solution? Were any other approaches considered?
If there is a default image that does not exist its URI shouldn't be passed to the DrawActivity to avoid weird problems/crashes. I think it's the easiest solution. Passing the URI no matter if the image exist or not would be much more error prone.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test all image widgets (Image/Draw/Signature/Annotate) to make sure there is no regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
I've used: 
[DefaultImagesTest.zip](https://github.com/getodk/collect/files/11011090/DefaultImagesTest.zip) and the demo `All Widgets` form.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
