### PR TITLE
Add warning when typing in instance name

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.java
@@ -1,6 +1,8 @@
 package org.odk.collect.android.formentry;
 
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
@@ -67,6 +69,13 @@ public class FormEndView extends SwipeHandler.View {
 
         findViewById(R.id.save_exit_button).setOnClickListener(v -> {
             listener.onSaveClicked(markAsFinalized.isChecked());
+        });
+
+        findViewById(R.id.instance_name_learn_more).setOnClickListener(v -> {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setData(Uri.parse("https://forum.getodk.org/t/collect-manual-instance-naming-will-be-removed-in-v2023-2/40313"));
+            context.startActivity(intent);
         });
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEndView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
+import android.view.View;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -35,6 +36,11 @@ public class FormEndView extends SwipeHandler.View {
         ((TextView) findViewById(R.id.description)).setText(context.getString(R.string.save_enter_data_description, formTitle));
 
         EditText saveAs = findViewById(R.id.save_name);
+        saveAs.setOnFocusChangeListener((view, isFocused) -> {
+            if (isFocused) {
+                findViewById(R.id.manual_name_warning).setVisibility(View.VISIBLE);
+            }
+        });
 
         // disallow carriage returns in the name
         InputFilter returnFilter = (source, start, end, dest, dstart, dend) -> FormNameUtils.normalizeFormName(source.toString().substring(start, end), true);

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -12,6 +12,7 @@ the specific language governing permissions and limitations under the License.
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:fillViewport="true"
     android:id="@+id/scroll_view"
     android:orientation="vertical">
@@ -47,7 +48,8 @@ the specific language governing permissions and limitations under the License.
             style="@style/Widget.Material3.CardView.Filled"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone">
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -11,6 +11,7 @@ the specific language governing permissions and limitations under the License.
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:fillViewport="true"
     android:id="@+id/scroll_view"
     android:orientation="vertical">
@@ -41,7 +42,42 @@ the specific language governing permissions and limitations under the License.
             android:textSize="21sp"
             android:textStyle="bold" />
 
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/manual_name_warning"
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/margin">
+
+                <ImageView
+                    android:id="@+id/info_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_outline_info_24"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:tint="?colorOnSurface" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin"
+                    android:text="@string/manual_instance_name_warning"
+                    android:textAppearance="?textAppearanceBody1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/info_icon"
+                    app:layout_constraintTop_toTopOf="@id/info_icon" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+
         <TextView
+            android:layout_marginTop="@dimen/margin"
             android:id="@+id/save_form_as"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -57,7 +57,7 @@ the specific language governing permissions and limitations under the License.
                 android:padding="@dimen/margin">
 
                 <ImageView
-                    android:id="@+id/info_icon"
+                    android:id="@+id/instance_name_info_icon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:src="@drawable/ic_outline_info_24"
@@ -66,14 +66,25 @@ the specific language governing permissions and limitations under the License.
                     app:tint="?colorPrimary" />
 
                 <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/instance_name_info_text"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin"
                     android:text="@string/manual_instance_name_warning"
                     android:textAppearance="?textAppearanceBodyLarge"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/info_icon"
-                    app:layout_constraintTop_toTopOf="@id/info_icon" />
+                    app:layout_constraintStart_toEndOf="@id/instance_name_info_icon"
+                    app:layout_constraintTop_toTopOf="@id/instance_name_info_icon" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/instance_name_learn_more"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/manual_instance_learn_more_button"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/instance_name_info_text" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -9,12 +9,12 @@ the specific language governing permissions and limitations under the License.
 -->
 
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:fillViewport="true"
     android:id="@+id/scroll_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
     android:orientation="vertical">
 
     <LinearLayout

--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -63,14 +63,14 @@ the specific language governing permissions and limitations under the License.
                     android:src="@drawable/ic_outline_info_24"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:tint="?colorOnSurface" />
+                    app:tint="?colorPrimary" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin"
                     android:text="@string/manual_instance_name_warning"
-                    android:textAppearance="?textAppearanceBody1"
+                    android:textAppearance="?textAppearanceBodyLarge"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/info_icon"
                     app:layout_constraintTop_toTopOf="@id/info_icon" />

--- a/collect_app/src/main/res/values-night/colors.xml
+++ b/collect_app/src/main/res/values-night/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="colorSurface">#121212</color>
+    <color name="colorSurfaceVariant">#41484d</color>
     <color name="colorOnSurface">#FFFFFF</color>
 
     <bool name="lightStatusBar">false</bool>

--- a/collect_app/src/main/res/values/colors.xml
+++ b/collect_app/src/main/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="colorOnError">#ffffff</color>
 
     <color name="colorSurface">#FFFFFF</color>
+    <color name="colorSurfaceVariant">#dce3e9</color>
     <color name="colorOnSurface">#000000</color>
 
     <bool name="lightStatusBar">true</bool>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -55,6 +55,7 @@
 
         <item name="colorOnPrimaryContainer">?colorOnPrimary</item>
 
+        <item name="textAppearanceBodyLarge">?textAppearanceBody1</item>
         <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
 
         <item name="shapeAppearanceCornerMedium">@style/ShapeAppearance.Material3.Corner.Medium</item>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -50,6 +50,7 @@
 
         <!-- Material3 attributes (needed for Material3 styles/components because theme is
         Theme.MaterialComponents). These can be added on-demand for components that need them. -->
+        <item name="colorSurfaceVariant">@color/colorSurfaceVariant</item>
         <item name="colorPrimaryContainer">?colorPrimary</item>
 
         <item name="colorOnPrimaryContainer">?colorOnPrimary</item>

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -56,6 +56,8 @@
         <item name="colorOnPrimaryContainer">?colorOnPrimary</item>
 
         <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
+
+        <item name="shapeAppearanceCornerMedium">@style/ShapeAppearance.Material3.Corner.Medium</item>
         <!--/Material3 attributes-->
 
         <!-- Needed to customize the status bar color -->

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
@@ -1,0 +1,36 @@
+package org.odk.collect.android.formentry
+
+import android.content.Context
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.odk.collect.android.R
+
+@RunWith(AndroidJUnit4::class)
+class FormEndViewTest {
+
+    @Test
+    fun `focusing on save as field shows warning`() {
+        val context = ApplicationProvider.getApplicationContext<Context>().also {
+            it.setTheme(R.style.Theme_Material3_Light)
+        }
+
+        val formEndView = FormEndView(
+            context,
+            null,
+            null,
+            false,
+            null
+        )
+
+        val warningView = formEndView.findViewById<View>(R.id.manual_name_warning)
+        assertThat(warningView.visibility, equalTo(View.GONE))
+
+        formEndView.findViewById<View>(R.id.save_name).requestFocus()
+        assertThat(warningView.visibility, equalTo(View.VISIBLE))
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
@@ -1,6 +1,8 @@
 package org.odk.collect.android.formentry
 
-import android.content.Context
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -9,16 +11,18 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.odk.collect.android.R
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(AndroidJUnit4::class)
 class FormEndViewTest {
 
-    @Test
-    fun `focusing on save as field shows warning`() {
-        val context = ApplicationProvider.getApplicationContext<Context>().also {
+    private val context: Application =
+        ApplicationProvider.getApplicationContext<Application>().also {
             it.setTheme(R.style.Theme_Material3_Light)
         }
 
+    @Test
+    fun `focusing on save as field shows warning`() {
         val formEndView = FormEndView(
             context,
             null,
@@ -32,5 +36,27 @@ class FormEndViewTest {
 
         formEndView.findViewById<View>(R.id.save_name).requestFocus()
         assertThat(warningView.visibility, equalTo(View.VISIBLE))
+    }
+
+    @Test
+    fun `clicking learn more in warning opens forum post`() {
+        val formEndView = FormEndView(
+            context,
+            null,
+            null,
+            false,
+            null
+        )
+
+        formEndView.findViewById<View>(R.id.save_name).requestFocus()
+        formEndView.findViewById<View>(R.id.instance_name_learn_more).performClick()
+
+        val intent = shadowOf(context).nextStartedActivity
+        assertThat(intent.action, equalTo(Intent.ACTION_VIEW))
+        assertThat(intent.flags, equalTo(Intent.FLAG_ACTIVITY_NEW_TASK))
+        assertThat(
+            intent.data,
+            equalTo(Uri.parse("https://forum.getodk.org/t/collect-manual-instance-naming-will-be-removed-in-v2023-2/40313"))
+        )
     }
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -167,6 +167,7 @@
     <string name="mark_finished">Mark form as finalized</string>
     <string name="quit_entry">Save Form and Exit</string>
     <string name="manual_instance_name_warning">Soon manually naming forms will be removed. Form design needs to be updated.</string>
+    <string name="manual_instance_learn_more_button">Learn more</string>
 
     <string name="data_saved_error">Sorry, form save failed!</string>
     <string name="data_saved_ok">Form successfully saved!</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="save_as_error">Saved name must not be blank!</string>
     <string name="mark_finished">Mark form as finalized</string>
     <string name="quit_entry">Save Form and Exit</string>
+    <string name="manual_instance_name_warning">Soon manually naming forms will be removed. Form design needs to be updated.</string>
 
     <string name="data_saved_error">Sorry, form save failed!</string>
     <string name="data_saved_ok">Form successfully saved!</string>


### PR DESCRIPTION
Closes #5489

A warning will appear when adding/editing an instance name (in the "Save as" field) at the end of a form.

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

A few choices to discuss here:

* The warning is shown as soon as the user taps on/focuses on the instance name field.
* I opted to use a light grey instead of a light blue for our theme's ['Surface Variant' color](https://m3.material.io/styles/color/the-color-system/key-colors-tones) (which is used as the background for Filled Cards). This was because it seemed more consistent with the Material 3 examples I looked at.
* I moved the "Learn more..." out of the text (where it was as a link) and into a Text Button in the standard space for Card actions. Links in text are far harder to implement than distinct buttons, and I don't think what I've got for has any drawbacks (as far as I'm aware).
* I decided to have the forum post open in the system browser in a new task. This way, the user can multitask or press back to return to Collect. I figured giving them options for returning to form entry while also keeping the relevant information up would be useful if they needed to then send that/show it to someone else.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Just adds the warning, so not a lot of risk here. This can probably merge without QA provided the reviewers have a quick play with it.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
