### PR TITLE
Make shapes more transparent

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/geo/GoogleMapFragment.java
@@ -908,7 +908,7 @@ public class GoogleMapFragment extends SupportMapFragment implements
                     .addAll(markers.stream().map(Marker::getPosition).collect(Collectors.toList()))
                     .strokeColor(strokeLineColor)
                     .strokeWidth(5)
-                    .fillColor(ColorUtils.setAlphaComponent(strokeLineColor, 150))
+                    .fillColor(ColorUtils.setAlphaComponent(strokeLineColor, 68))
                     .clickable(true)
             );
         }

--- a/mapbox/src/main/java/org/odk/collect/mapbox/PolygonFeature.kt
+++ b/mapbox/src/main/java/org/odk/collect/mapbox/PolygonFeature.kt
@@ -28,7 +28,7 @@ class PolygonFeature(
             .withFillColor(
                 ColorUtils.setAlphaComponent(
                     context.resources.getColor(R.color.mapLineColor),
-                    150
+                    68
                 )
             )
     )

--- a/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
+++ b/osmdroid/src/main/java/org/odk/collect/osmdroid/OsmDroidMapFragment.java
@@ -907,7 +907,7 @@ public class OsmDroidMapFragment extends Fragment implements MapFragment,
             map.getOverlays().add(polygon);
             int strokeColor = map.getContext().getResources().getColor(R.color.mapLineColor);
             polygon.getOutlinePaint().setColor(strokeColor);
-            polygon.getFillPaint().setColor(ColorUtils.setAlphaComponent(strokeColor, 150));
+            polygon.getFillPaint().setColor(ColorUtils.setAlphaComponent(strokeColor, 68));
             polygon.setPoints(StreamSupport.stream(points.spliterator(), false).map(point -> {
                 return new GeoPoint(point.latitude, point.longitude);
             }).collect(Collectors.toList()));


### PR DESCRIPTION
Minor follow-on to https://github.com/getodk/collect/pull/5478. @grzesiek2010 had said "the red color used for filling the area of polygons could be brighter/more transparent."

I tried various values and landed on 25% transparency. I think the contrast between the border and the contents is helpful and the lightness makes it easier to actually look at the shape without being overwhelmed.

Before:
![](https://user-images.githubusercontent.com/56479916/224344266-050b69bc-2092-4789-9e1e-d65a708e835e.png)

After:
![lighter](https://user-images.githubusercontent.com/967540/226803931-60ed5b7a-eb5a-4bf6-a472-b95902c0a0e6.png)

#### What has been done to verify that this works as intended?
Tried it with OSM.

#### Why is this the best possible solution? Were any other approaches considered?
I briefly explored more orange or lighter shades. The transparency change is what had a big impact. I have a slight preference for a more orange red side-by-side (like ff3300) but I don’t think it really matters. 

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
we haven’t released any of this and it’s just an alpha change. 

#### Do we need any specific form for testing your changes? If so, please attach one.
See original PR. 

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No. 

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
