### PR TITLE
Add tests for save points

### DIFF
--- a/collect_app/src/androidTest/assets/forms/two-question-audit.xml
+++ b/collect_app/src/androidTest/assets/forms/two-question-audit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Two Question</h:title>
+        <model>
+            <instance>
+                <data id="two_question">
+                    <name/>
+                    <age/>
+                    <meta>
+                        <audit />
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="name" type="string"/>
+            <bind nodeset="age" type="int"/>
+            <bind nodeset="/data/meta/audit" type="binary"/>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/name">
+            <label>What is your name?</label>
+        </input>
+        <input ref="/data/age">
+            <label>What is your age?</label>
+        </input>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -13,7 +13,6 @@ import org.odk.collect.android.R
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.pages.AppClosedPage
-import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.FormHierarchyPage
 import org.odk.collect.android.support.pages.OkDialog
 import org.odk.collect.android.support.rules.CollectTestRule
@@ -109,7 +108,7 @@ class InstanceEditActionTest {
             .build()
 
         val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
-        rule.launch(intent, FormEntryPage("One Question"))
+        rule.launch(intent, FormHierarchyPage("One Question"))
     }
 
     @Test

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ContextMenuTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ContextMenuTest.java
@@ -4,13 +4,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
 public class ContextMenuTest {
     private static final String STRING_WIDGETS_TEST_FORM = "string_widgets_in_field_list.xml";
 
-    public FormActivityTestRule activityTestRule = new FormActivityTestRule(STRING_WIDGETS_TEST_FORM, "fl");
+    public BlankFormTestRule activityTestRule = new BlankFormTestRule(STRING_WIDGETS_TEST_FORM, "fl");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DeletingRepeatGroupsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DeletingRepeatGroupsTest.java
@@ -11,14 +11,14 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.support.pages.FormEndPage;
 import org.odk.collect.android.support.pages.FormEntryPage;
 import org.odk.collect.android.support.pages.FormHierarchyPage;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.testshared.RecyclerViewMatcher;
 
 public class DeletingRepeatGroupsTest {
     private static final String TEST_FORM = "repeat_groups.xml";
 
-    private final FormActivityTestRule activityTestRule = new FormActivityTestRule(TEST_FORM, "repeatGroups");
+    private final BlankFormTestRule activityTestRule = new BlankFormTestRule(TEST_FORM, "repeatGroups");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DynamicPreLoadedDataSelects.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/DynamicPreLoadedDataSelects.java
@@ -3,7 +3,7 @@ package org.odk.collect.android.feature.formentry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
 import java.util.Collections;
@@ -17,7 +17,7 @@ public class DynamicPreLoadedDataSelects {
 
     private static final String EXTERNAL_CSV_SEARCH_FORM = "external-csv-search.xml";
 
-    public FormActivityTestRule rule = new FormActivityTestRule(EXTERNAL_CSV_SEARCH_FORM, "external-csv-search", Collections.singletonList("external-csv-search-produce.csv"));
+    public BlankFormTestRule rule = new BlankFormTestRule(EXTERNAL_CSV_SEARCH_FORM, "external-csv-search", Collections.singletonList("external-csv-search-produce.csv"));
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EntityFormTest.kt
@@ -23,7 +23,7 @@ class EntityFormTest {
         rule.startAtMainMenu()
             .copyForm("one-question-entity.xml")
             .startBlankForm("One Question Entity")
-            .fillOutAndSave(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Logan Roy"))
             .openEntityBrowser()
             .clickOnDataset("people")
             .assertEntity("full_name: Logan Roy")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalDataFileNotFoundTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/ExternalDataFileNotFoundTest.java
@@ -6,13 +6,13 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
 public class ExternalDataFileNotFoundTest {
     private static final String EXTERNAL_DATA_QUESTIONS = "external_data_questions.xml";
 
-    public FormActivityTestRule activityTestRule = new FormActivityTestRule(EXTERNAL_DATA_QUESTIONS, "externalDataQuestions");
+    public BlankFormTestRule activityTestRule = new BlankFormTestRule(EXTERNAL_DATA_QUESTIONS, "externalDataQuestions");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -64,7 +64,7 @@ import org.odk.collect.android.TestSettingsProvider;
 import org.odk.collect.android.preferences.GuidanceHint;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.support.pages.FormEntryPage;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.androidtest.RecordedIntentsRule;
 import org.odk.collect.settings.keys.ProjectKeys;
@@ -80,7 +80,7 @@ public class FieldListUpdateTest {
 
     private static final String FIELD_LIST_TEST_FORM = "fieldlist-updates.xml";
 
-    public FormActivityTestRule rule = new FormActivityTestRule(
+    public BlankFormTestRule rule = new BlankFormTestRule(
             FIELD_LIST_TEST_FORM,
             "fieldlist-updates",
             Collections.singletonList("fruits.csv")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/GuidanceHintFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/GuidanceHintFormTest.java
@@ -17,7 +17,7 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
 import org.odk.collect.android.TestSettingsProvider;
 import org.odk.collect.android.preferences.GuidanceHint;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.settings.keys.ProjectKeys;
 
@@ -32,7 +32,7 @@ public class GuidanceHintFormTest {
         Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
     }
 
-    public FormActivityTestRule activityTestRule = new FormActivityTestRule(GUIDANCE_SAMPLE_FORM, "Guidance Form Sample");
+    public BlankFormTestRule activityTestRule = new BlankFormTestRule(GUIDANCE_SAMPLE_FORM, "Guidance Form Sample");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/IntentGroupTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/IntentGroupTest.java
@@ -57,7 +57,7 @@ import org.junit.rules.RuleChain;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.androidtest.RecordedIntentsRule;
 
@@ -70,7 +70,7 @@ import java.io.IOException;
 public class IntentGroupTest {
     private static final String INTENT_GROUP_FORM = "intent-group.xml";
 
-    public FormActivityTestRule rule = new FormActivityTestRule(INTENT_GROUP_FORM, "intent-group");
+    public BlankFormTestRule rule = new BlankFormTestRule(INTENT_GROUP_FORM, "intent-group");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/LikertTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/LikertTest.java
@@ -18,7 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.ResetStateRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
@@ -27,7 +27,7 @@ import java.util.Collections;
 public class LikertTest {
     private static final String LIKERT_TEST_FORM = "likert_test.xml";
 
-    public FormActivityTestRule activityTestRule = new FormActivityTestRule(LIKERT_TEST_FORM, "All widgets likert icon", Collections.singletonList("famous.jpg"));
+    public BlankFormTestRule activityTestRule = new BlankFormTestRule(LIKERT_TEST_FORM, "All widgets likert icon", Collections.singletonList("famous.jpg"));
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
@@ -80,7 +80,7 @@ public class QuickSaveTest {
         rule.startAtMainMenu()
                 .copyForm("two-question-required.xml")
                 .startBlankForm("Two Question Required")
-                .fillOutAndSave(
+                .fillOutAndFinalize(
                         new QuestionAndAnswer("What is your name?", "Reuben"),
                         new QuestionAndAnswer("What is your age?", "32", true)
                 )
@@ -107,7 +107,7 @@ public class QuickSaveTest {
         rule.startAtMainMenu()
                 .copyForm("two-question-required.xml")
                 .startBlankForm("Two Question Required")
-                .fillOutAndSave(
+                .fillOutAndFinalize(
                         new QuestionAndAnswer("What is your name?", "Reuben"),
                         new QuestionAndAnswer("What is your age?", "32", true)
                 )

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -115,7 +115,7 @@ public class QuittingFormTest {
         rule.startAtMainMenu()
                 .copyForm("two-question-required.xml")
                 .startBlankForm("Two Question Required")
-                .fillOutAndSave(
+                .fillOutAndFinalize(
                         new QuestionAndAnswer("What is your name?", "Reuben"),
                         new QuestionAndAnswer("What is your age?", "32", true)
                 )
@@ -143,7 +143,7 @@ public class QuittingFormTest {
         rule.startAtMainMenu()
                 .copyForm("two-question-required.xml")
                 .startBlankForm("Two Question Required")
-                .fillOutAndSave(
+                .fillOutAndFinalize(
                         new QuestionAndAnswer("What is your name?", "Reuben"),
                         new QuestionAndAnswer("What is your age?", "32", true)
                 )

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RankingWidgetWithCSVTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/RankingWidgetWithCSVTest.java
@@ -3,7 +3,7 @@ package org.odk.collect.android.feature.formentry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.support.pages.FormEntryPage;
 
@@ -13,7 +13,7 @@ public class RankingWidgetWithCSVTest {
 
     private static final String TEST_FORM = "ranking_widget.xml";
 
-    public FormActivityTestRule activityTestRule = new FormActivityTestRule(TEST_FORM, "ranking_widget", Collections.singletonList("fruits.csv"));
+    public BlankFormTestRule activityTestRule = new BlankFormTestRule(TEST_FORM, "ranking_widget", Collections.singletonList("fruits.csv"));
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveIncompleteTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveIncompleteTest.kt
@@ -51,7 +51,7 @@ class SaveIncompleteTest {
         rule.startAtMainMenu()
             .copyForm("two-question-save-incomplete-required.xml")
             .startBlankForm("Two Question Save Incomplete Required")
-            .fillOutAndSave(
+            .fillOutAndFinalize(
                 QuestionAndAnswer("What is your name?", "Dez"),
                 QuestionAndAnswer("[saveIncomplete] What is your age?", "56", true)
             )
@@ -76,7 +76,7 @@ class SaveIncompleteTest {
         rule.startAtMainMenu()
             .copyForm("two-question-save-incomplete-required.xml")
             .startBlankForm("Two Question Save Incomplete Required")
-            .fillOutAndSave(
+            .fillOutAndFinalize(
                 QuestionAndAnswer("What is your name?", "Dez"),
                 QuestionAndAnswer("[saveIncomplete] What is your age?", "56", true)
             )

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -83,7 +83,7 @@ class SavePointTest {
      * being battery dying).
      */
     private fun simulateBatteryDeath(): FormActivityTestRule {
-        return rule.restartProcess()
+        return rule.reset()
     }
 
     /**
@@ -93,6 +93,6 @@ class SavePointTest {
     private fun simulateProcessRestore(): FormActivityTestRule {
         return rule.saveInstanceStateForActivity()
             .destroyActivity()
-            .restartProcess()
+            .reset()
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -24,7 +24,7 @@ class SavePointTest {
     val ruleChain: RuleChain = TestRuleChain.chain().around(rule)
 
     @Test
-    fun savePointIsCreateWhenMovingForwardInForm() {
+    fun savePointIsCreatedWhenMovingForwardInForm() {
         // Create save point
         rule.setUpProjectAndCopyForm("two-question-audit.xml")
             .fillNewForm("two-question-audit.xml", "Two Question")
@@ -58,7 +58,7 @@ class SavePointTest {
     }
 
     @Test
-    fun whenEditing_savePointIsCreateWhenMovingForwardInForm() {
+    fun whenEditing_savePointIsCreatedWhenMovingForwardInForm() {
         // Create instance
         rule.setUpProjectAndCopyForm("two-question-audit.xml")
             .fillNewForm("two-question-audit.xml", "Two Question")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -1,0 +1,35 @@
+package org.odk.collect.android.feature.formentry
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.odk.collect.android.support.pages.FormEntryPage
+import org.odk.collect.android.support.rules.FormActivityTestRule
+import org.odk.collect.android.support.rules.TestRuleChain
+
+@RunWith(AndroidJUnit4::class)
+class SavePointTest {
+
+    private val rule = FormActivityTestRule("two-question.xml", "Two Question")
+
+    @get:Rule
+    val ruleChain: RuleChain = TestRuleChain.chain().around(rule)
+
+    @Test
+    fun savePointIsCreateWhenMovingForwardInForm() {
+        rule.startInFormEntry()
+            .answerQuestion("What is your name?", "Alexei")
+            .swipeToNextQuestion("What is your age?")
+            .answerQuestion("What is your age?", "46")
+            .then { rule.destroy() }
+            .restartProcess()
+
+            .startInFormHierarchy()
+            .assertText("Alexei")
+            .assertTextDoesNotExist("46")
+            .pressBack(FormEntryPage("Two Question"))
+            .assertQuestion("What is your name?")
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -153,6 +153,7 @@ class SavePointTest {
         // Edit instance and check save point is loaded
         rule.editForm("two-question-audit.xml", "Two Question")
             .assertText("Alexei")
+            .assertText("52")
             .pressBack(FormEntryPage("Two Question"))
             .assertQuestion("What is your name?")
             .pressBack(SaveOrIgnoreDialog("Two Question", AppClosedPage()))

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -193,6 +193,7 @@ class SavePointTest {
         // Check editing instance doesn't load save point
         rule.editForm("two-question-audit.xml", "Two Question")
             .assertText("Pasquale")
+            .assertText("52")
             .assertTextDoesNotExist("Alexei")
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -197,7 +197,7 @@ class SavePointTest {
     }
 
     @Test
-    fun instanceSavePointIsNotUsedWhenFillingBlankForm() {
+    fun editedInstanceSavePointIsNotUsedWhenFillingBlankFormOfTheSameForm() {
         // Create instance
         rule.setUpProjectAndCopyForm("two-question-audit.xml")
             .fillNewForm("two-question-audit.xml", "Two Question")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -23,12 +23,25 @@ class SavePointTest {
             .answerQuestion("What is your name?", "Alexei")
             .swipeToNextQuestion("What is your age?")
             .answerQuestion("What is your age?", "46")
-            .then { rule.destroy() }
+            .let { rule.destroyActivity() }
             .restartProcess()
 
             .startInFormHierarchy()
             .assertText("Alexei")
             .assertTextDoesNotExist("46")
+            .pressBack(FormEntryPage("Two Question"))
+            .assertQuestion("What is your name?")
+    }
+
+    @Test
+    fun savePointIsCreatedWhenLeavingTheApp() {
+        rule.startInFormEntry()
+            .answerQuestion("What is your name?", "Alexei")
+            .let { rule.saveInstanceStateForActivity().destroyActivity() }
+            .restartProcess()
+
+            .startInFormHierarchy()
+            .assertText("Alexei")
             .pressBack(FormEntryPage("Two Question"))
             .assertQuestion("What is your name?")
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -23,8 +23,7 @@ class SavePointTest {
             .answerQuestion("What is your name?", "Alexei")
             .swipeToNextQuestion("What is your age?")
             .answerQuestion("What is your age?", "46")
-            .let { rule.destroyActivity() }
-            .restartProcess()
+            .let { simulateBatteryDeath() }
 
             .startInFormHierarchy()
             .assertText("Alexei")
@@ -37,12 +36,29 @@ class SavePointTest {
     fun savePointIsCreatedWhenLeavingTheApp() {
         rule.startInFormEntry()
             .answerQuestion("What is your name?", "Alexei")
-            .let { rule.saveInstanceStateForActivity().destroyActivity() }
-            .restartProcess()
+            .let { simulateProcessRestore() }
 
             .startInFormHierarchy()
             .assertText("Alexei")
             .pressBack(FormEntryPage("Two Question"))
             .assertQuestion("What is your name?")
+    }
+
+    /**
+     * Simulates a case where the process is killed without lifecycle clean up (like a phone
+     * being battery dying).
+     */
+    private fun simulateBatteryDeath(): FormActivityTestRule {
+        return rule.restartProcess()
+    }
+
+    /**
+     * Simulate a "process restore" case where an app in the background is killed by Android
+     * to reclaim memory, change permissions etc
+     */
+    private fun simulateProcessRestore(): FormActivityTestRule {
+        return rule.saveInstanceStateForActivity()
+            .destroyActivity()
+            .restartProcess()
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -7,6 +7,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.StorageUtils
 import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
@@ -220,7 +221,8 @@ class SavePointTest {
      * being battery dying).
      */
     private fun simulateBatteryDeath(): FormEntryActivityTestRule {
-        return rule.reset()
+        CollectHelpers.simulateProcessRestart()
+        return rule
     }
 
     /**
@@ -228,8 +230,10 @@ class SavePointTest {
      * to reclaim memory, change permissions etc
      */
     private fun simulateProcessRestore(): FormEntryActivityTestRule {
-        return rule.saveInstanceStateForActivity()
+        rule.saveInstanceStateForActivity()
             .destroyActivity()
-            .reset()
+
+        CollectHelpers.simulateProcessRestart()
+        return rule
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -1,18 +1,23 @@
 package org.odk.collect.android.feature.formentry
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.odk.collect.android.support.StorageUtils
+import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormEntryPage
+import org.odk.collect.android.support.pages.SaveOrIgnoreDialog
 import org.odk.collect.android.support.rules.FormActivityTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
 
 @RunWith(AndroidJUnit4::class)
 class SavePointTest {
 
-    private val rule = FormActivityTestRule("two-question.xml", "Two Question")
+    private val rule = FormActivityTestRule("two-question-audit.xml", "Two Question")
 
     @get:Rule
     val ruleChain: RuleChain = TestRuleChain.chain().around(rule)
@@ -30,6 +35,21 @@ class SavePointTest {
             .assertTextDoesNotExist("46")
             .pressBack(FormEntryPage("Two Question"))
             .assertQuestion("What is your name?")
+            .pressBack(SaveOrIgnoreDialog("Two Question", AppClosedPage()))
+            .clickSaveChanges()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog.size, equalTo(7))
+
+        assertThat(auditLog[0].get("event"), equalTo("form start"))
+        assertThat(auditLog[1].get("event"), equalTo("question"))
+        // Second question event not logged - possibly a problem
+
+        assertThat(auditLog[2].get("event"), equalTo("form resume"))
+        assertThat(auditLog[3].get("event"), equalTo("jump"))
+        assertThat(auditLog[4].get("event"), equalTo("question"))
+        assertThat(auditLog[5].get("event"), equalTo("form save"))
+        assertThat(auditLog[6].get("event"), equalTo("form exit"))
     }
 
     @Test
@@ -42,6 +62,20 @@ class SavePointTest {
             .assertText("Alexei")
             .pressBack(FormEntryPage("Two Question"))
             .assertQuestion("What is your name?")
+            .pressBack(SaveOrIgnoreDialog("Two Question", AppClosedPage()))
+            .clickSaveChanges()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog.size, equalTo(6))
+
+        assertThat(auditLog[0].get("event"), equalTo("form start"))
+        // Question event not logged - possibly a problem
+
+        assertThat(auditLog[1].get("event"), equalTo("form resume"))
+        assertThat(auditLog[2].get("event"), equalTo("jump"))
+        assertThat(auditLog[3].get("event"), equalTo("question"))
+        assertThat(auditLog[4].get("event"), equalTo("form save"))
+        assertThat(auditLog[5].get("event"), equalTo("form exit"))
     }
 
     /**

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SavePointTest.kt
@@ -79,6 +79,7 @@ class SavePointTest {
         // Edit instance and check save point is loaded
         rule.editForm("two-question-audit.xml", "Two Question")
             .assertText("Alexei")
+            .assertText("52")
             .assertTextDoesNotExist("46")
             .pressBack(FormEntryPage("Two Question"))
             .assertQuestion("What is your name?")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -26,13 +26,13 @@ class AuditTest {
         rule.startAtMainMenu()
             .copyForm("one-question-audit.xml")
             .startBlankForm("One Question Audit")
-            .fillOutAndSave(
+            .fillOutAndFinalize(
                 FormEntryPage.QuestionAndAnswer("what is your age", "31")
             )
             .clickEditSavedForm(1)
             .clickOnForm("One Question Audit")
             .clickGoToStart()
-            .fillOutAndSave(
+            .fillOutAndFinalize(
                 FormEntryPage.QuestionAndAnswer("what is your age", "32")
             )
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/LocationTrackingAuditTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/LocationTrackingAuditTest.java
@@ -13,7 +13,7 @@ import org.odk.collect.android.R;
 import org.odk.collect.android.support.FakeLocationClient;
 import org.odk.collect.android.support.StorageUtils;
 import org.odk.collect.android.support.TestDependencies;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.location.LocationClient;
 import org.odk.collect.testshared.FakeLocation;
@@ -25,7 +25,7 @@ public class LocationTrackingAuditTest {
 
     private final FakeLocationClient locationClient = new FakeLocationClient();
 
-    public FormActivityTestRule rule = new FormActivityTestRule("location-audit.xml", "Audit with Location");
+    public BlankFormTestRule rule = new BlankFormTestRule("location-audit.xml", "Audit with Location");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain(new TestDependencies() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/SetGeopointActionTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/backgroundlocation/SetGeopointActionTest.java
@@ -11,13 +11,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.odk.collect.android.R;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
 public class SetGeopointActionTest {
     private static final String SETGEOPOINT_ACTION_FORM = "setgeopoint-action.xml";
 
-    public FormActivityTestRule rule = new FormActivityTestRule(SETGEOPOINT_ACTION_FORM, "setgeopoint-action-instance-load");
+    public BlankFormTestRule rule = new BlankFormTestRule(SETGEOPOINT_ACTION_FORM, "setgeopoint-action-instance-load");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
@@ -78,7 +78,7 @@ class SwitchProjectTest {
 
             // Fill form
             .startBlankForm("One Question Entity")
-            .fillOutAndSave(FormEntryPage.QuestionAndAnswer("Name", "Alice"))
+            .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Alice"))
             .clickEditSavedForm(1)
             .assertText("One Question Entity")
             .pressBack(MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/smoke/AllWidgetsFormTest.java
@@ -18,7 +18,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.odk.collect.android.support.rules.FormActivityTestRule;
+import org.odk.collect.android.support.rules.BlankFormTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
 
 import tools.fastlane.screengrab.Screengrab;
@@ -37,7 +37,7 @@ public class AllWidgetsFormTest {
     @ClassRule
     public static final LocaleTestRule LOCALE_TEST_RULE = new LocaleTestRule();
 
-    public FormActivityTestRule activityTestRule = new FormActivityTestRule("all-widgets.xml", "All widgets");
+    public BlankFormTestRule activityTestRule = new BlankFormTestRule("all-widgets.xml", "All widgets");
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -25,15 +25,16 @@ import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.support.ActivityHelpers;
 import org.odk.collect.android.support.pages.AddNewRepeatDialog;
-import org.odk.collect.android.support.rules.CollectTestRule;
-import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.support.pages.BlankFormSearchPage;
 import org.odk.collect.android.support.pages.ExitFormDialog;
 import org.odk.collect.android.support.pages.FillBlankFormPage;
 import org.odk.collect.android.support.pages.FormEndPage;
 import org.odk.collect.android.support.pages.FormEntryPage;
+import org.odk.collect.android.support.pages.FormHierarchyPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.ProjectSettingsPage;
+import org.odk.collect.android.support.rules.CollectTestRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -689,9 +690,9 @@ public class FillBlankFormTest {
                 .clickGoToArrow()
                 .clickGoUpIcon()
                 .checkIfElementInHierarchyMatchesToText("Group Name", 0)
-                .rotateToLandscape(new FormEntryPage("Repeat Group"))
+                .rotateToLandscape(new FormHierarchyPage("Repeat Group"))
                 .checkIfElementInHierarchyMatchesToText("Group Name", 0)
-                .rotateToPortrait(new FormEntryPage("Repeat Group"))
+                .rotateToPortrait(new FormHierarchyPage("Repeat Group"))
                 .checkIfElementInHierarchyMatchesToText("Group Name", 0);
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
@@ -21,6 +21,14 @@ object CollectHelpers {
         return testComponent
     }
 
+    fun simulateProcessRestart(appDependencyModule: AppDependencyModule? = null) {
+        val newComponent =
+            CollectHelpers.overrideAppDependencyModule(appDependencyModule ?: AppDependencyModule())
+
+        // Reinitialize any application state with new deps/state
+        newComponent.applicationInitializer().initialize()
+    }
+
     @JvmStatic
     fun addGDProject(gdProject: Project.New, accountName: String, testDependencies: TestDependencies) {
         testDependencies.googleAccountPicker.setDeviceAccount(accountName)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/CollectHelpers.kt
@@ -23,7 +23,7 @@ object CollectHelpers {
 
     fun simulateProcessRestart(appDependencyModule: AppDependencyModule? = null) {
         val newComponent =
-            CollectHelpers.overrideAppDependencyModule(appDependencyModule ?: AppDependencyModule())
+            overrideAppDependencyModule(appDependencyModule ?: AppDependencyModule())
 
         // Reinitialize any application state with new deps/state
         newComponent.applicationInitializer().initialize()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AppClosedPage.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/AppClosedPage.kt
@@ -1,5 +1,10 @@
 package org.odk.collect.android.support.pages
 
+import android.app.Activity
+import androidx.test.espresso.core.internal.deps.guava.collect.Iterables
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 
@@ -9,4 +14,22 @@ class AppClosedPage : Page<AppClosedPage>() {
         assertThat(currentActivity, equalTo(null))
         return this
     }
+
+    private val currentActivity: Activity?
+        get() {
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+            val activity = arrayOfNulls<Activity>(1)
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                val activities =
+                    ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(
+                        Stage.RESUMED
+                    )
+                if (!activities.isEmpty()) {
+                    activity[0] = Iterables.getOnlyElement(activities) as Activity
+                } else {
+                    activity[0] = null
+                }
+            }
+            return activity[0]
+        }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -47,6 +47,8 @@ public class FormEntryPage extends Page<FormEntryPage> {
         });
 
         assertToolbarTitle(formName);
+        assertTextDoesNotExist(R.string.jump_to_beginning);
+        assertTextDoesNotExist(R.string.jump_to_end);
         return this;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -68,7 +68,13 @@ public class FormEntryPage extends Page<FormEntryPage> {
         return page;
     }
 
-    public MainMenuPage fillOutAndSave(QuestionAndAnswer... questionsAndAnswers) {
+    public <D extends Page<D>> D fillOutAndSave(D destination, QuestionAndAnswer... questionsAndAnswers) {
+        return fillOut(questionsAndAnswers)
+                .pressBack(new SaveOrIgnoreDialog<>(formName, destination))
+                .clickSaveChanges();
+    }
+
+    public MainMenuPage fillOutAndFinalize(QuestionAndAnswer... questionsAndAnswers) {
         return fillOut(questionsAndAnswers)
                 .swipeToEndScreen()
                 .clickSaveAndExit();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEntryPage.java
@@ -47,8 +47,11 @@ public class FormEntryPage extends Page<FormEntryPage> {
         });
 
         assertToolbarTitle(formName);
+
+        // Check we are not on the Form Hierarchy page
         assertTextDoesNotExist(R.string.jump_to_beginning);
         assertTextDoesNotExist(R.string.jump_to_end);
+        
         return this;
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.support.pages
 
-import android.app.Activity
 import android.content.pm.ActivityInfo
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
@@ -16,7 +15,6 @@ import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
-import androidx.test.espresso.core.internal.deps.guava.collect.Iterables
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
@@ -30,9 +28,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
-import androidx.test.runner.lifecycle.Stage
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.core.StringContains.containsString
@@ -438,20 +433,5 @@ abstract class Page<T : Page<T>> {
         private fun rotateToPortrait(): ViewAction {
             return RotateAction(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)
         }
-
-        val currentActivity: Activity?
-            get() {
-                InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-                val activity = arrayOfNulls<Activity>(1)
-                InstrumentationRegistry.getInstrumentation().runOnMainSync {
-                    val activities = ActivityLifecycleMonitorRegistry.getInstance().getActivitiesInStage(Stage.RESUMED)
-                    if (!activities.isEmpty()) {
-                        activity[0] = Iterables.getOnlyElement(activities) as Activity
-                    } else {
-                        activity[0] = null
-                    }
-                }
-                return activity[0]
-            }
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -426,6 +426,10 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
+    fun <T> then(work: () -> T): T {
+        return work()
+    }
+
     companion object {
         private fun rotateToLandscape(): ViewAction {
             return RotateAction(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/Page.kt
@@ -421,10 +421,6 @@ abstract class Page<T : Page<T>> {
         return this as T
     }
 
-    fun <T> then(work: () -> T): T {
-        return work()
-    }
-
     companion object {
         private fun rotateToLandscape(): ViewAction {
             return RotateAction(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
@@ -6,8 +6,7 @@ import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
-import org.odk.collect.android.activities.FormEntryActivity
-import org.odk.collect.android.external.FormsContract
+import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.StorageUtils
@@ -64,8 +63,7 @@ class BlankFormTestRule @JvmOverloads constructor(
                 .getOneByPath(formPath)
             val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
                 .getCurrentProject().uuid
-            val intent = Intent(application, FormEntryActivity::class.java)
-            intent.data = FormsContract.getUri(projectId, form!!.dbId)
-            return intent
+
+            return FormNavigator.newInstanceIntent(application, projectId, form!!.dbId)
         }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
@@ -3,73 +3,43 @@ package org.odk.collect.android.support.rules
 import android.app.Activity
 import android.app.Application
 import android.content.Intent
-import android.os.Bundle
-import android.os.PersistableBundle
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import org.junit.rules.ExternalResource
 import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
-import org.odk.collect.android.support.ActivityHelpers
-import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.StorageUtils
 import org.odk.collect.android.support.pages.FormEntryPage
-import org.odk.collect.android.support.pages.FormHierarchyPage
-import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.Project.Companion.DEMO_PROJECT
+import timber.log.Timber
 import java.io.IOException
 
-class FormActivityTestRule @JvmOverloads constructor(
+class BlankFormTestRule @JvmOverloads constructor(
     private val formFilename: String,
     private val formName: String,
     private val mediaFilePaths: List<String>? = null
-) : ActivityScenarioLauncherRule() {
+) : ExternalResource() {
 
     private lateinit var scenario: ActivityScenario<Activity>
 
     override fun before() {
-        super.before()
         setUpProjectAndCopyForm()
-        scenario = launch(activityIntent)
+        scenario = ActivityScenario.launch(activityIntent)
+    }
+
+    override fun after() {
+        try {
+            scenario.close()
+        } catch (e: Throwable) {
+            Timber.e(Error("Error closing ActivityScenario: $e"))
+        }
     }
 
     fun startInFormEntry(): FormEntryPage {
         return FormEntryPage(formName).assertOnPage()
-    }
-
-    fun startInFormHierarchy(): FormHierarchyPage {
-        return FormHierarchyPage(formName).assertOnPage()
-    }
-
-    fun saveInstanceStateForActivity(): FormActivityTestRule {
-        scenario.onActivity {
-            it.onSaveInstanceState(Bundle(), PersistableBundle())
-        }
-
-        return this
-    }
-
-    fun destroyActivity(): FormActivityTestRule {
-        lateinit var scenarioActivity: Activity
-        scenario.onActivity {
-            scenarioActivity = it
-        }
-
-        if (ActivityHelpers.getActivity() != scenarioActivity) {
-            throw IllegalStateException("Can't destroy backstack!")
-        }
-
-        scenario.moveToState(Lifecycle.State.DESTROYED)
-        return this
-    }
-
-    fun reset(): FormActivityTestRule {
-        CollectHelpers.simulateProcessRestart()
-        scenario = launch(activityIntent)
-        return this
     }
 
     private fun setUpProjectAndCopyForm() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
@@ -3,6 +3,8 @@ package org.odk.collect.android.support.rules
 import android.app.Activity
 import android.app.Application
 import android.content.Intent
+import android.os.Bundle
+import android.os.PersistableBundle
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -43,7 +45,15 @@ class FormActivityTestRule @JvmOverloads constructor(
         return FormHierarchyPage(formName).assertOnPage()
     }
 
-    fun destroy(): FormActivityTestRule {
+    fun saveInstanceStateForActivity(): FormActivityTestRule {
+        scenario.onActivity {
+            it.onSaveInstanceState(Bundle(), PersistableBundle())
+        }
+
+        return this
+    }
+
+    fun destroyActivity(): FormActivityTestRule {
         lateinit var scenarioActivity: Activity
         scenario.onActivity {
             scenarioActivity = it

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
@@ -33,15 +33,14 @@ class FormActivityTestRule @JvmOverloads constructor(
     override fun before() {
         super.before()
         setUpProjectAndCopyForm()
+        scenario = launch(activityIntent)
     }
 
     fun startInFormEntry(): FormEntryPage {
-        scenario = launch(activityIntent)
         return FormEntryPage(formName).assertOnPage()
     }
 
     fun startInFormHierarchy(): FormHierarchyPage {
-        scenario = launch(activityIntent)
         return FormHierarchyPage(formName).assertOnPage()
     }
 
@@ -67,8 +66,9 @@ class FormActivityTestRule @JvmOverloads constructor(
         return this
     }
 
-    fun restartProcess(): FormActivityTestRule {
+    fun reset(): FormActivityTestRule {
         CollectHelpers.simulateProcessRestart()
+        scenario = launch(activityIntent)
         return this
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
@@ -3,13 +3,17 @@ package org.odk.collect.android.support.rules
 import android.app.Activity
 import android.app.Application
 import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
+import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.StorageUtils
 import org.odk.collect.android.support.pages.FormEntryPage
+import org.odk.collect.android.support.pages.FormHierarchyPage
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.Project.Companion.DEMO_PROJECT
@@ -21,19 +25,31 @@ class FormActivityTestRule @JvmOverloads constructor(
     private val mediaFilePaths: List<String>? = null
 ) : ActivityScenarioLauncherRule() {
 
-    private lateinit var formEntryPage: FormEntryPage
+    private lateinit var scenario: ActivityScenario<Activity>
 
     override fun before() {
         super.before()
-
         setUpProjectAndCopyForm()
-        launch<Activity>(activityIntent)
-        formEntryPage = FormEntryPage(formName)
-        formEntryPage.assertOnPage()
     }
 
     fun startInFormEntry(): FormEntryPage {
-        return formEntryPage
+        scenario = launch(activityIntent)
+        return FormEntryPage(formName).assertOnPage()
+    }
+
+    fun startInFormHierarchy(): FormHierarchyPage {
+        scenario = launch(activityIntent)
+        return FormHierarchyPage(formName).assertOnPage()
+    }
+
+    fun destroy(): FormActivityTestRule {
+        scenario.moveToState(Lifecycle.State.DESTROYED)
+        return this
+    }
+
+    fun restartProcess(): FormActivityTestRule {
+        CollectHelpers.simulateProcessRestart()
+        return this
     }
 
     private fun setUpProjectAndCopyForm() {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormActivityTestRule.kt
@@ -10,6 +10,7 @@ import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
+import org.odk.collect.android.support.ActivityHelpers
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.StorageUtils
 import org.odk.collect.android.support.pages.FormEntryPage
@@ -43,6 +44,15 @@ class FormActivityTestRule @JvmOverloads constructor(
     }
 
     fun destroy(): FormActivityTestRule {
+        lateinit var scenarioActivity: Activity
+        scenario.onActivity {
+            scenarioActivity = it
+        }
+
+        if (ActivityHelpers.getActivity() != scenarioActivity) {
+            throw IllegalStateException("Can't destroy backstack!")
+        }
+
         scenario.moveToState(Lifecycle.State.DESTROYED)
         return this
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -1,0 +1,102 @@
+package org.odk.collect.android.support.rules
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import android.os.Bundle
+import android.os.PersistableBundle
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import org.junit.rules.ExternalResource
+import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.external.FormsContract
+import org.odk.collect.android.injection.DaggerUtils
+import org.odk.collect.android.storage.StorageSubdirectory
+import org.odk.collect.android.support.ActivityHelpers
+import org.odk.collect.android.support.CollectHelpers
+import org.odk.collect.android.support.StorageUtils
+import org.odk.collect.android.support.pages.FormEntryPage
+import org.odk.collect.android.support.pages.Page
+import org.odk.collect.projects.Project
+import timber.log.Timber
+import java.io.IOException
+
+class FormEntryActivityTestRule : ExternalResource() {
+
+    private lateinit var intent: Intent
+    private lateinit var scenario: ActivityScenario<Activity>
+
+    override fun after() {
+        try {
+            scenario.close()
+        } catch (e: Throwable) {
+            Timber.e(Error("Error closing ActivityScenario: $e"))
+        }
+    }
+
+    fun setUpProjectAndCopyForm(formFilename: String): FormEntryActivityTestRule {
+        try {
+            // Set up demo project
+            val component =
+                DaggerUtils.getComponent(ApplicationProvider.getApplicationContext<Application>())
+            component.projectsRepository().save(Project.DEMO_PROJECT)
+            component.currentProjectProvider().setCurrentProject(Project.DEMO_PROJECT_ID)
+            StorageUtils.copyFormToDemoProject(formFilename, null, true)
+        } catch (e: IOException) {
+            throw RuntimeException(e)
+        }
+
+        return this
+    }
+
+    fun <D : Page<D>> fillNewForm(formFilename: String, destination: D): D {
+        intent = createIntent(formFilename)
+        scenario = ActivityScenario.launch(intent)
+        return destination.assertOnPage() as D
+    }
+
+    fun fillNewForm(formFilename: String, formName: String): FormEntryPage {
+        return fillNewForm(formFilename, FormEntryPage(formName))
+    }
+
+    fun saveInstanceStateForActivity(): FormEntryActivityTestRule {
+        scenario.onActivity {
+            it.onSaveInstanceState(Bundle(), PersistableBundle())
+        }
+
+        return this
+    }
+
+    fun destroyActivity(): FormEntryActivityTestRule {
+        lateinit var scenarioActivity: Activity
+        scenario.onActivity {
+            scenarioActivity = it
+        }
+
+        if (ActivityHelpers.getActivity() != scenarioActivity) {
+            throw IllegalStateException("Can't destroy backstack!")
+        }
+
+        scenario.moveToState(Lifecycle.State.DESTROYED)
+        return this
+    }
+
+    fun reset(): FormEntryActivityTestRule {
+        CollectHelpers.simulateProcessRestart()
+        return this
+    }
+
+    private fun createIntent(formFilename: String): Intent {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val formPath = DaggerUtils.getComponent(application).storagePathProvider()
+            .getOdkDirPath(StorageSubdirectory.FORMS) + "/" + formFilename
+        val form = DaggerUtils.getComponent(application).formsRepositoryProvider().get()
+            .getOneByPath(formPath)
+        val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
+            .getCurrentProject().uuid
+        val intent = Intent(application, FormEntryActivity::class.java)
+        intent.data = FormsContract.getUri(projectId, form!!.dbId)
+        return intent
+    }
+}

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -53,7 +53,7 @@ class FormEntryActivityTestRule : ExternalResource() {
     fun <D : Page<D>> fillNewForm(formFilename: String, destination: D): D {
         intent = createNewFormIntent(formFilename)
         scenario = ActivityScenario.launch(intent)
-        return destination.assertOnPage() as D
+        return destination.assertOnPage()
     }
 
     fun fillNewForm(formFilename: String, formName: String): FormEntryPage {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -13,7 +13,6 @@ import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.ActivityHelpers
-import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.support.StorageUtils
 import org.odk.collect.android.support.pages.FormEntryPage
 import org.odk.collect.android.support.pages.FormHierarchyPage
@@ -85,11 +84,6 @@ class FormEntryActivityTestRule : ExternalResource() {
         }
 
         scenario.moveToState(Lifecycle.State.DESTROYED)
-        return this
-    }
-
-    fun reset(): FormEntryActivityTestRule {
-        CollectHelpers.simulateProcessRestart()
         return this
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -9,8 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
-import org.odk.collect.android.activities.FormEntryActivity
-import org.odk.collect.android.external.FormsContract
+import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.ActivityHelpers
@@ -95,8 +94,7 @@ class FormEntryActivityTestRule : ExternalResource() {
             .getOneByPath(formPath)
         val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
             .getCurrentProject().uuid
-        val intent = Intent(application, FormEntryActivity::class.java)
-        intent.data = FormsContract.getUri(projectId, form!!.dbId)
-        return intent
+
+        return FormNavigator.newInstanceIntent(application, projectId, form!!.dbId)
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetStateRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/ResetStateRule.kt
@@ -32,12 +32,7 @@ private class ResetStateStatement(
         clearDisk(oldComponent)
         clearAppState(application)
         setTestState()
-
-        val newComponent =
-            CollectHelpers.overrideAppDependencyModule(appDependencyModule ?: AppDependencyModule())
-
-        // Reinitialize any application state with new deps/state
-        newComponent.applicationInitializer().initialize()
+        CollectHelpers.simulateProcessRestart(appDependencyModule)
         base.evaluate()
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
@@ -11,11 +11,10 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import org.odk.collect.android.R
-import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.activities.FormMapActivity
+import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.dialogs.ServerAuthDialogFragment
-import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.androidshared.network.NetworkStateProvider
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
 import org.odk.collect.androidshared.ui.SnackbarUtils
@@ -75,16 +74,7 @@ class BlankFormListActivity : LocalizedActivity(), OnFormItemClickListener {
             setResult(RESULT_OK, Intent().setData(formUri))
         } else {
             // caller wants to view/edit a form, so launch formentryactivity
-            Intent(this, FormEntryActivity::class.java).apply {
-                action = Intent.ACTION_EDIT
-                data = formUri
-                putExtra(
-                    ApplicationConstants.BundleKeys.FORM_MODE,
-                    ApplicationConstants.FormModes.EDIT_SAVED
-                )
-
-                startActivity(this)
-            }
+            startActivity(FormNavigator.newInstanceIntent(this, formUri))
         }
         finish()
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
@@ -1,7 +1,9 @@
 package org.odk.collect.android.formmanagement
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.external.InstancesContract
@@ -39,12 +41,22 @@ class FormNavigator(
         )
     }
 
-    fun newInstance(activity: Activity, formId: Long) {
-        activity.startActivity(
-            Intent(activity, FormEntryActivity::class.java).also {
-                it.action = Intent.ACTION_EDIT
-                it.data = FormsContract.getUri(projectId, formId)
-            }
+    fun newInstance(context: Context, formId: Long) {
+        context.startActivity(
+            newInstanceIntent(context, projectId, formId)
         )
+    }
+
+    companion object {
+        fun newInstanceIntent(context: Context, uri: Uri?): Intent {
+            return Intent(context, FormEntryActivity::class.java).also {
+                it.action = Intent.ACTION_EDIT
+                it.data = uri
+            }
+        }
+
+        fun newInstanceIntent(context: Context, projectId: String, formId: Long): Intent {
+            return newInstanceIntent(context, FormsContract.getUri(projectId, formId))
+        }
     }
 }


### PR DESCRIPTION
Closes #5338 

This fills in a bunch of missing coverage around save points, as detailed in the issue. Can be merged without QA.