### PR TITLE
Show parsing error when receiving empty form list

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImpl.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImpl.kt
@@ -126,7 +126,12 @@ class OpenRosaResponseParserImpl : OpenRosaResponseParser {
 
     override fun parseManifest(document: Document): List<MediaFile>? {
         // Attempt OpenRosa 1.0 parsing
-        val manifestElement = document.rootElement
+        val manifestElement = try {
+            document.rootElement
+        } catch (e: RuntimeException) {
+            return null
+        }
+
         if (manifestElement.name != "manifest") {
             return null
         }

--- a/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImpl.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImpl.kt
@@ -6,13 +6,17 @@ import org.kxml2.kdom.Element
 import org.odk.collect.forms.FormListItem
 import org.odk.collect.forms.MediaFile
 import org.odk.collect.shared.strings.StringUtils.isBlank
-import java.util.ArrayList
 
 class OpenRosaResponseParserImpl : OpenRosaResponseParser {
 
     override fun parseFormList(document: Document): List<FormListItem>? {
         // Attempt OpenRosa 1.0 parsing
-        val xformsElement = document.rootElement
+        val xformsElement = try {
+            document.rootElement
+        } catch (e: RuntimeException) {
+            return null
+        }
+
         if (xformsElement.name != "xforms") {
             return null
         }

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
@@ -12,14 +12,7 @@ class OpenRosaResponseParserImplTest {
 
     @Test
     fun `parseFormList() when document is empty, returns null`() {
-        val doc = StringReader("").use { reader ->
-            val parser = KXmlParser()
-            parser.setInput(reader)
-            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
-            Document().also { it.parse(parser) }
-        }
-
-        val formList = OpenRosaResponseParserImpl().parseFormList(doc)
+        val formList = OpenRosaResponseParserImpl().parseFormList(Document())
         assertThat(formList, equalTo(null))
     }
 
@@ -75,14 +68,7 @@ class OpenRosaResponseParserImplTest {
 
     @Test
     fun `parseManifest() when document is empty, returns null`() {
-        val doc = StringReader("").use { reader ->
-            val parser = KXmlParser()
-            parser.setInput(reader)
-            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
-            Document().also { it.parse(parser) }
-        }
-
-        val formList = OpenRosaResponseParserImpl().parseManifest(doc)
+        val formList = OpenRosaResponseParserImpl().parseManifest(Document())
         assertThat(formList, equalTo(null))
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
@@ -7,9 +7,21 @@ import org.kxml2.io.KXmlParser
 import org.kxml2.kdom.Document
 import org.xmlpull.v1.XmlPullParser
 import java.io.StringReader
-import java.lang.StringBuilder
 
 class OpenRosaResponseParserImplTest {
+
+    @Test
+    fun `when document is empty, returns null`() {
+        val doc = StringReader("").use { reader ->
+            val parser = KXmlParser()
+            parser.setInput(reader)
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
+            Document().also { it.parse(parser) }
+        }
+
+        val formList = OpenRosaResponseParserImpl().parseFormList(doc)
+        assertThat(formList, equalTo(null))
+    }
 
     @Test
     fun `when xform hash is missing prefix, parseFormList returns null hash for item`() {

--- a/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/openrosa/OpenRosaResponseParserImplTest.kt
@@ -11,7 +11,7 @@ import java.io.StringReader
 class OpenRosaResponseParserImplTest {
 
     @Test
-    fun `when document is empty, returns null`() {
+    fun `parseFormList() when document is empty, returns null`() {
         val doc = StringReader("").use { reader ->
             val parser = KXmlParser()
             parser.setInput(reader)
@@ -24,7 +24,7 @@ class OpenRosaResponseParserImplTest {
     }
 
     @Test
-    fun `when xform hash is missing prefix, parseFormList returns null hash for item`() {
+    fun `parseFormList() when xform hash is missing prefix, returns null hash for item`() {
         val response = StringBuilder()
             .appendLine("<?xml version='1.0' encoding='UTF-8' ?>")
             .appendLine("<xforms xmlns=\"http://openrosa.org/xforms/xformsList\">")
@@ -50,7 +50,7 @@ class OpenRosaResponseParserImplTest {
     }
 
     @Test
-    fun `when media file hash is empty, parseManifest returns null`() {
+    fun `parseManifest() when media file hash is empty, returns null`() {
         val response = StringBuilder()
             .appendLine("<?xml version='1.0' encoding='UTF-8' ?>")
             .appendLine("<manifest xmlns=\"http://openrosa.org/xforms/xformsManifest\">")
@@ -71,5 +71,18 @@ class OpenRosaResponseParserImplTest {
 
         val mediaFiles = OpenRosaResponseParserImpl().parseManifest(doc)
         assertThat(mediaFiles, equalTo(null))
+    }
+
+    @Test
+    fun `parseManifest() when document is empty, returns null`() {
+        val doc = StringReader("").use { reader ->
+            val parser = KXmlParser()
+            parser.setInput(reader)
+            parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
+            Document().also { it.parse(parser) }
+        }
+
+        val formList = OpenRosaResponseParserImpl().parseManifest(doc)
+        assertThat(formList, equalTo(null))
     }
 }


### PR DESCRIPTION
Fixes [this crash](https://console.firebase.google.com/u/0/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/b83e21cddf29a69153f532aebf1309a0?time=last-seven-days&versions=v2023.1.0%20(4611)&types=crash&sessionEventKey=6422868B002800017FAD76CB9E9D5A4F_1793925023023129356).

#### What has been done to verify that this works as intended?

New tests.

#### Why is this the best possible solution? Were any other approaches considered?

I did look at being able to detect that there is an empty `Document` rather than needing to catch a `RuntimeException`, but it didn't seem like there was a good way to do that with kxml2. It might be worth making a contribution there to change it so that we get a specific exception, but I'm also not sure if we should be using that library at all.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There's not really much we can verify here without a broken server (I don't think there's a way to get empty 200 responses back from Central or Aggregate). Best thing to verify here is downloading and updating form - there shouldn't have been any changes in behaviour.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
