### PR TITLE
Increase memory available to compile only CI tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile-only.properties ~/.gradle/gradle.properties
 
       - run:
           name: Download Robolectric deps
@@ -87,7 +87,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile-only.properties ~/.gradle/gradle.properties
 
       - run:
           name: Run code quality checks
@@ -203,7 +203,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile-only.properties ~/.gradle/gradle.properties
 
       - run:
           name: Assemble connected test build
@@ -229,7 +229,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile-only.properties ~/.gradle/gradle.properties
 
       - run:
           name: Assemble self signed release build
@@ -251,7 +251,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile-only.properties ~/.gradle/gradle.properties
 
       - run:
           name: Assemble test build
@@ -301,7 +301,7 @@ jobs:
 
       - run:
           name: Copy gradle config
-          command: mkdir -p ~/.gradle && cp .circleci/gradle.properties ~/.gradle/gradle.properties
+          command: mkdir -p ~/.gradle && cp .circleci/gradle-compile-only.properties ~/.gradle/gradle.properties
 
       - run:
           name: Assemble test build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ references:
   android_config: &android_config
     working_directory: ~/work
     docker:
-      - image: cimg/android:2022.12.1
+      - image: cimg/android:2023.03.1
     resource_class: medium+
 
 jobs:

--- a/.circleci/gradle-compile-only.properties
+++ b/.circleci/gradle-compile-only.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx5g -Dkotlin.compiler.execution.strategy="in-process"
+org.gradle.jvmargs=-Xmx4g -Dkotlin.compiler.execution.strategy="in-process"
 org.gradle.daemon=false
 org.gradle.parallel=true
 org.gradle.workers.max=3

--- a/.circleci/gradle-compile-only.properties
+++ b/.circleci/gradle-compile-only.properties
@@ -1,4 +1,4 @@
 org.gradle.jvmargs=-Xmx5g -Dkotlin.compiler.execution.strategy="in-process"
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=2
+org.gradle.workers.max=3

--- a/.circleci/gradle-compile-only.properties
+++ b/.circleci/gradle-compile-only.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx5g -Dkotlin.compiler.execution.strategy="in-process"
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=2


### PR DESCRIPTION
Closes #

<!-- 
Thank you for contributing to ODK Collect!

Before sending this PR, please read
https://github.com/getodk/collect/blob/master/CONTRIBUTING.md
-->

#### What has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
