### PR TITLE
Improved handling invalid geo answers

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/GeoPointWidget.java
@@ -63,11 +63,13 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
 
         answerText = prompt.getAnswerText();
 
-        if (answerText != null && !answerText.isEmpty()) {
-            binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
-            binding.simpleButton.setText(R.string.change_location);
-        } else {
+        String answerToDisplay = GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText);
+        if (answerToDisplay.isEmpty()) {
             binding.simpleButton.setText(R.string.get_point);
+            answerText = null;
+        } else {
+            binding.geoAnswerText.setText(answerToDisplay);
+            binding.simpleButton.setText(R.string.change_location);
         }
 
         return binding.getRoot();
@@ -75,9 +77,10 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
 
     @Override
     public IAnswerData getAnswer() {
-        return answerText == null || answerText.isEmpty()
+        double[] parsedGeometryPoint = GeoWidgetUtils.parseGeometryPoint(answerText);
+        return parsedGeometryPoint == null
                 ? null
-                : new GeoPointData(GeoWidgetUtils.parseGeometryPoint(answerText));
+                : new GeoPointData(parsedGeometryPoint);
     }
 
     @Override
@@ -103,9 +106,16 @@ public class GeoPointWidget extends QuestionWidget implements WidgetDataReceiver
 
     @Override
     public void setData(Object answer) {
-        answerText = answer.toString();
-        binding.geoAnswerText.setText(GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answerText));
-        binding.simpleButton.setText(answerText == null || answerText.isEmpty() ? R.string.get_point : R.string.change_location);
+        String answerToDisplay = GeoWidgetUtils.getGeoPointAnswerToDisplay(getContext(), answer.toString());
+        if (answerToDisplay.isEmpty()) {
+            answerText = null;
+            binding.geoAnswerText.setText("");
+            binding.simpleButton.setText(R.string.get_point);
+        } else {
+            answerText = answer.toString();
+            binding.geoAnswerText.setText(answerToDisplay);
+            binding.simpleButton.setText(R.string.change_location);
+        }
         widgetValueChanged();
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequester.kt
@@ -35,10 +35,11 @@ class ActivityGeoDataRequester(
                     waitingForDataRegistry.waitForData(prompt.index)
 
                     val bundle = Bundle().also {
-                        if (!answerText.isNullOrEmpty()) {
+                        val parsedGeometry = GeoWidgetUtils.parseGeometry(answerText)
+                        if (parsedGeometry.isNotEmpty()) {
                             it.putParcelable(
                                 GeoPointMapActivity.EXTRA_LOCATION,
-                                GeoWidgetUtils.parseGeometry(answerText)[0],
+                                parsedGeometry[0],
                             )
                         }
 

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointMapWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointMapWidgetTest.java
@@ -5,6 +5,7 @@ import android.view.View;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.core.model.data.GeoPointData;
+import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +52,19 @@ public class GeoPointMapWidgetTest {
         GeoPointMapWidget widget = createWidget(promptWithAnswer(answer));
         assertEquals(widget.getAnswer().getDisplayText(),
                 new GeoPointData(GeoWidgetUtils.parseGeometryPoint(answer.getDisplayText())).getDisplayText());
+    }
+
+    @Test
+    public void getAnswer_whenPromptHasInvalidAnswer_returnsNull() {
+        GeoPointMapWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        assertNull(widget.getAnswer());
+    }
+
+    @Test
+    public void creatingWidgetWithInvalidValue_doesNotUpdateWidgetDisplayedAnswer() {
+        GeoPointMapWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        assertEquals(widget.binding.geoAnswerText.getText(), "");
+        assertEquals(widget.binding.simpleButton.getText(), widget.getContext().getString(R.string.get_point));
     }
 
     @Test
@@ -108,12 +122,26 @@ public class GeoPointMapWidgetTest {
         assertEquals(widget.getAnswer().getDisplayText(), answer.getDisplayText());
     }
 
+    @Test
+    public void setDataWithInvalidValue_doesNotUpdateWidgetAnswer() {
+        GeoPointMapWidget widget = createWidget(promptWithAnswer(null));
+        widget.setData("blah");
+        assertEquals(widget.getAnswer(), null);
+    }
 
     @Test
     public void setData_updatesWidgetDisplayedAnswer() {
         GeoPointMapWidget widget = createWidget(promptWithAnswer(null));
         widget.setData(answer.getDisplayText());
         assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getGeoPointAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
+    }
+
+    @Test
+    public void setDataWithInvalidValue_doesNotUpdateWidgetDisplayedAnswer() {
+        GeoPointMapWidget widget = createWidget(promptWithAnswer(null));
+        widget.setData("blah");
+        assertEquals(widget.binding.geoAnswerText.getText(), "");
+        assertEquals(widget.binding.simpleButton.getText(), widget.getContext().getString(R.string.get_point));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/GeoPointWidgetTest.java
@@ -5,6 +5,7 @@ import android.view.View;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.javarosa.core.model.data.GeoPointData;
+import org.javarosa.core.model.data.StringData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +56,19 @@ public class GeoPointWidgetTest {
     public void getAnswer_whenPromptHasAnswer_returnsAnswer() {
         GeoPointWidget widget = createWidget(promptWithAnswer(answer));
         assertEquals(widget.getAnswer().getDisplayText(), answer.getDisplayText());
+    }
+
+    @Test
+    public void getAnswer_whenPromptHasInvalidAnswer_returnsNull() {
+        GeoPointWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        assertNull(widget.getAnswer());
+    }
+
+    @Test
+    public void creatingWidgetWithInvalidValue_doesNotUpdateWidgetDisplayedAnswer() {
+        GeoPointWidget widget = createWidget(promptWithAnswer(new StringData("blah")));
+        assertEquals(widget.binding.geoAnswerText.getText(), "");
+        assertEquals(widget.binding.simpleButton.getText(), widget.getContext().getString(R.string.get_point));
     }
 
     @Test
@@ -114,10 +128,25 @@ public class GeoPointWidgetTest {
     }
 
     @Test
+    public void setDataWithInvalidValue_doesNotUpdateWidgetAnswer() {
+        GeoPointWidget widget = createWidget(promptWithAnswer(null));
+        widget.setData("blah");
+        assertEquals(widget.getAnswer(), null);
+    }
+
+    @Test
     public void setData_updatesWidgetDisplayedAnswer() {
         GeoPointWidget widget = createWidget(promptWithAnswer(null));
         widget.setData(answer.getDisplayText());
         assertEquals(widget.binding.geoAnswerText.getText(), GeoWidgetUtils.getGeoPointAnswerToDisplay(widget.getContext(), answer.getDisplayText()));
+    }
+
+    @Test
+    public void setDataWithInvalidValue_doesNotUpdateWidgetDisplayedAnswer() {
+        GeoPointWidget widget = createWidget(promptWithAnswer(null));
+        widget.setData("blah");
+        assertEquals(widget.binding.geoAnswerText.getText(), "");
+        assertEquals(widget.binding.simpleButton.getText(), widget.getContext().getString(R.string.get_point));
     }
 
     @Test

--- a/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequesterTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/widgets/utilities/ActivityGeoDataRequesterTest.java
@@ -148,6 +148,18 @@ public class ActivityGeoDataRequesterTest {
     }
 
     @Test
+    public void requestGeoPoint_whenAnswerIsPresentButInvalid_doesNotAddToIntent() {
+        activityGeoDataRequester.requestGeoPoint(prompt, "something", waitingForDataRegistry);
+        Intent startedIntent = shadowActivity.getNextStartedActivity();
+
+        assertEquals(startedIntent.getComponent(), new ComponentName(testActivity, GeoPointActivity.class));
+        assertEquals(shadowActivity.getNextStartedActivityForResult().requestCode, LOCATION_CAPTURE);
+
+        Bundle bundle = startedIntent.getExtras();
+        assertThat(bundle.getParcelable(GeoPointMapActivity.EXTRA_LOCATION), equalTo(null));
+    }
+
+    @Test
     public void whenWidgetHasAccuracyValue_requestGeoPoint_launchesCorrectIntent() {
         when(questionDef.getAdditionalAttribute(null, "accuracyThreshold")).thenReturn("10");
 


### PR DESCRIPTION
Closes #5532 

#### What has been done to verify that this works as intended?
I've added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
I wasn't able to reproduce the issue in real world (only hardcoding invalid answers or using tests). I believe the problem was in `setData()` methods where we didn't protect from injecting invalid answers. I've fixed those methods and also fixed reading answers when widgets are created. 
I think that after introducing those improvements this issue https://console.firebase.google.com/u/1/project/api-project-322300403941/crashlytics/app/android:org.odk.collect.android/issues/324b108b1880c264d9c3f01101110e03?time=last-seven-days&versions=v2023.1.0%20(4611)&types=crash&sessionEventKey=642570CE003900014975C8483B90F492_1794743691754173217 was also handled but just in case I've added improvements there too in the last commit.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I wasn't able to reproduce the issue so we can focus on testing the [GeoPoint](https://docs.getodk.org/form-question-types/#geopoint-widget) and [GeoPointMapWidget](https://docs.getodk.org/form-question-types/#geopoint-with-map-display) widgets for regression.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
