### PR TITLE
CI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,10 @@ jobs:
           name: Assemble self signed release build
           command: ./gradlew assembleSelfSignedRelease
 
+      - run:
+          name: Check release size
+          command: if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10734563 ]; then exit 1; fi
+
   test_smoke_instrumented:
     <<: *android_config
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
           command: ./gradlew assembleSelfSignedRelease
 
       - run:
-          name: Check release size
+          name: Check APK size hasn't increased by more than 100kb
           command: if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10734563 ]; then exit 1; fi
 
   test_smoke_instrumented:


### PR DESCRIPTION
Add a check on APK size to CI. If the APK size increases by over 100kb, the build will fail.