### PR TITLE
Improved handling errors when starting new forms or editing existing ones

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FieldListUpdateTest.java
@@ -306,7 +306,7 @@ public class FieldListUpdateTest {
 
         onView(withText("Target10-15")).check(doesNotExist());
 
-        // FormEntryActivity expects an image at a fixed path so copy the app logo there
+        // FormFillingActivity expects an image at a fixed path so copy the app logo there
         Bitmap icon = BitmapFactory.decodeResource(ApplicationProvider.getApplicationContext().getResources(), R.drawable.notes);
         File tmpJpg = new File(new StoragePathProvider().getTmpImageFilePath());
         tmpJpg.createNewFile();

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/FillBlankFormTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
 import org.odk.collect.android.support.ActivityHelpers;
@@ -700,8 +700,8 @@ public class FillBlankFormTest {
     }
 
     private String getQuestionText() {
-        FormEntryActivity formEntryActivity = (FormEntryActivity) ActivityHelpers.getActivity();
-        FrameLayout questionContainer = formEntryActivity.findViewById(R.id.text_container);
+        FormFillingActivity formFillingActivity = (FormFillingActivity) ActivityHelpers.getActivity();
+        FrameLayout questionContainer = formFillingActivity.findViewById(R.id.text_container);
         TextView questionView = (TextView) questionContainer.getChildAt(0);
         return questionView.getText().toString();
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
@@ -64,6 +65,6 @@ class BlankFormTestRule @JvmOverloads constructor(
             val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
                 .getCurrentProject().uuid
 
-            return FormNavigator.newInstanceIntent(application, projectId, form!!.dbId)
+            return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId))
         }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
+import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
@@ -65,6 +66,6 @@ class BlankFormTestRule @JvmOverloads constructor(
             val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
                 .getCurrentProject().uuid
 
-            return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId))
+            return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormEntryActivity::class)
         }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
@@ -8,7 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
 import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.external.FormsContract
-import org.odk.collect.android.formmanagement.FormNavigator
+import org.odk.collect.android.formmanagement.FormFillingIntentFactory
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.StorageUtils
@@ -66,6 +66,6 @@ class BlankFormTestRule @JvmOverloads constructor(
             val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
                 .getCurrentProject().uuid
 
-            return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormFillingActivity::class)
+            return FormFillingIntentFactory.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormFillingActivity::class)
         }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/BlankFormTestRule.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
-import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
@@ -66,6 +66,6 @@ class BlankFormTestRule @JvmOverloads constructor(
             val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
                 .getCurrentProject().uuid
 
-            return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormEntryActivity::class)
+            return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormFillingActivity::class)
         }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
-import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
@@ -98,7 +98,7 @@ class FormEntryActivityTestRule : ExternalResource() {
         val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
             .getCurrentProject().uuid
 
-        return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormEntryActivity::class)
+        return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormFillingActivity::class)
     }
 
     private fun createEditFormIntent(formFilename: String): Intent {
@@ -116,7 +116,7 @@ class FormEntryActivityTestRule : ExternalResource() {
             application,
             projectId,
             instance.dbId,
-            FormEntryActivity::class
+            FormFillingActivity::class
         )
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
+import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
@@ -97,7 +98,7 @@ class FormEntryActivityTestRule : ExternalResource() {
         val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
             .getCurrentProject().uuid
 
-        return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId))
+        return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormEntryActivity::class)
     }
 
     private fun createEditFormIntent(formFilename: String): Intent {
@@ -114,7 +115,8 @@ class FormEntryActivityTestRule : ExternalResource() {
         return FormNavigator.editInstanceIntent(
             application,
             projectId,
-            instance.dbId
+            instance.dbId,
+            FormEntryActivity::class
         )
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
@@ -96,7 +97,7 @@ class FormEntryActivityTestRule : ExternalResource() {
         val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
             .getCurrentProject().uuid
 
-        return FormNavigator.newInstanceIntent(application, projectId, form!!.dbId)
+        return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId))
     }
 
     private fun createEditFormIntent(formFilename: String): Intent {
@@ -113,9 +114,7 @@ class FormEntryActivityTestRule : ExternalResource() {
         return FormNavigator.editInstanceIntent(
             application,
             projectId,
-            instance.dbId,
-            false,
-            instance.status
+            instance.dbId
         )
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/FormEntryActivityTestRule.kt
@@ -11,7 +11,7 @@ import androidx.test.core.app.ApplicationProvider
 import org.junit.rules.ExternalResource
 import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.external.FormsContract
-import org.odk.collect.android.formmanagement.FormNavigator
+import org.odk.collect.android.formmanagement.FormFillingIntentFactory
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.storage.StorageSubdirectory
 import org.odk.collect.android.support.ActivityHelpers
@@ -98,7 +98,7 @@ class FormEntryActivityTestRule : ExternalResource() {
         val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
             .getCurrentProject().uuid
 
-        return FormNavigator.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormFillingActivity::class)
+        return FormFillingIntentFactory.newInstanceIntent(application, FormsContract.getUri(projectId, form!!.dbId), FormFillingActivity::class)
     }
 
     private fun createEditFormIntent(formFilename: String): Intent {
@@ -112,7 +112,7 @@ class FormEntryActivityTestRule : ExternalResource() {
         val projectId = DaggerUtils.getComponent(application).currentProjectProvider()
             .getCurrentProject().uuid
 
-        return FormNavigator.editInstanceIntent(
+        return FormFillingIntentFactory.editInstanceIntent(
             application,
             projectId,
             instance.dbId,

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -119,7 +119,7 @@ the specific language governing permissions and limitations under the License.
             android:stateNotNeeded="true"
             android:windowSoftInputMode="stateAlwaysHidden" />
         <activity
-            android:name=".activities.FormEntryActivity"
+            android:name=".activities.FormFillingActivity"
             android:theme="@style/Theme.Collect.FormEntry"
             android:windowSoftInputMode="adjustResize" />
         <activity
@@ -231,7 +231,7 @@ the specific language governing permissions and limitations under the License.
 
         <activity-alias
             android:name=".activities.FormEntryActivity"
-            android:targetActivity=".activities.FormEntryActivity"
+            android:targetActivity=".external.FormUriActivity"
             tools:ignore="AppLinkUrlError"
             android:exported="true">
         </activity-alias>

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -660,11 +660,6 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
         if (uriMimeType != null && uriMimeType.equals(InstancesContract.CONTENT_ITEM_TYPE)) {
             Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
 
-            if (instance == null) {
-                createErrorDialog(getString(R.string.bad_uri, uri), true);
-                return;
-            }
-
             instancePath = instance.getInstanceFilePath();
             if (!new File(instancePath).exists()) {
                 Analytics.log(AnalyticsEvents.OPEN_DELETED_INSTANCE);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -707,10 +707,6 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
                  */
                 instancePath = loadSavePoint();
             }
-        } else {
-            Timber.i("Unrecognized URI: %s", uri);
-            createErrorDialog(getString(R.string.unrecognized_uri, uri), true);
-            return;
         }
 
         formLoaderTask = new FormLoaderTask(instancePath, null, null, formEntryControllerFactory);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -134,7 +134,6 @@ import org.odk.collect.android.fragments.dialogs.LocationProvidersDisabledDialog
 import org.odk.collect.android.fragments.dialogs.NumberPickerDialog;
 import org.odk.collect.android.fragments.dialogs.RankingWidgetDialog;
 import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
-import org.odk.collect.android.instancemanagement.InstanceDeleter;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.javarosawrapper.RepeatsInFieldListException;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
@@ -661,12 +660,6 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
             Instance instance = new InstancesRepositoryProvider(Collect.getInstance()).get().get(ContentUriHelper.getIdFromUri(uri));
 
             instancePath = instance.getInstanceFilePath();
-            if (!new File(instancePath).exists()) {
-                Analytics.log(AnalyticsEvents.OPEN_DELETED_INSTANCE);
-                new InstanceDeleter(new InstancesRepositoryProvider(Collect.getInstance()).get(), formsRepository).delete(instance.getDbId());
-                createErrorDialog(getString(R.string.instance_deleted_message), true);
-                return;
-            }
 
             List<Form> candidateForms = formsRepository.getAllByFormIdAndVersion(instance.getFormId(), instance.getFormVersion());
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -387,12 +387,8 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        if (getIntent().getData() != null) {
-            Timber.w("onCreate %s", Md5.getMd5Hash(getIntent().getData().toString()));
-        } else {
-            Timber.w("onCreate null");
-        }
-        
+        Timber.w("onCreate %s", Md5.getMd5Hash(getIntent().getData().toString()));
+
         // Workaround for https://issuetracker.google.com/issues/37124582. Some widgets trigger
         // this issue by including WebViews
         if (Build.VERSION.SDK_INT >= 24) {
@@ -805,11 +801,8 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-        if (getIntent().getData() != null) {
-            Timber.w("onSaveInstanceState %s", Md5.getMd5Hash(getIntent().getData().toString()));
-        } else {
-            Timber.w("onSaveInstanceState null");
-        }
+        Timber.w("onSaveInstanceState %s", Md5.getMd5Hash(getIntent().getData().toString()));
+
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_SESSION_ID, sessionId);
@@ -1903,11 +1896,8 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onStart() {
-        if (getIntent().getData() != null) {
-            Timber.w("onStart %s", Md5.getMd5Hash(getIntent().getData().toString()));
-        } else {
-            Timber.w("onStart null");
-        }
+        Timber.w("onStart %s", Md5.getMd5Hash(getIntent().getData().toString()));
+
         super.onStart();
         FormController formController = getFormController();
 
@@ -1926,11 +1916,8 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onPause() {
-        if (getIntent().getData() != null) {
-            Timber.w("onPause %s", Md5.getMd5Hash(getIntent().getData().toString()));
-        } else {
-            Timber.w("onPause null");
-        }
+        Timber.w("onPause %s", Md5.getMd5Hash(getIntent().getData().toString()));
+
         backgroundLocationViewModel.activityHidden();
 
         super.onPause();
@@ -1938,11 +1925,8 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onResume() {
-        if (getIntent().getData() != null) {
-            Timber.w("onResume %s", Md5.getMd5Hash(getIntent().getData().toString()));
-        } else {
-            Timber.w("onResume null");
-        }
+        Timber.w("onResume %s", Md5.getMd5Hash(getIntent().getData().toString()));
+
         super.onResume();
 
         activityDisplayed();
@@ -2045,11 +2029,8 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
     @Override
     protected void onDestroy() {
-        if (getIntent().getData() != null) {
-            Timber.w("onDestroy %s", Md5.getMd5Hash(getIntent().getData().toString()));
-        } else {
-            Timber.w("onDestroy null");
-        }
+        Timber.w("onDestroy %s", Md5.getMd5Hash(getIntent().getData().toString()));
+
         if (formLoaderTask != null) {
             formLoaderTask.setFormLoaderListener(null);
             // We have to call cancel to terminate the thread, otherwise it

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -213,11 +213,13 @@ import timber.log.Timber;
  * FormEntryActivity is responsible for displaying questions, animating
  * transitions between questions, and allowing the user to enter data.
  *
+ * This class should never be started directly. Instead {@link org.odk.collect.android.external.FormUriActivity}
+ * should be used to start form filling.
+ *
  * @author Carl Hartung (carlhartung@gmail.com)
  * @author Thomas Smyth, Sassafras Tech Collective (tom@sassafrastech.com; constraint behavior
  * option)
  */
-
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class FormEntryActivity extends LocalizedActivity implements AnimationListener,
         FormLoaderListener, AdvanceToNextListener, SwipeHandler.OnSwipeListener,

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -666,22 +666,15 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
             formPath = candidateForms.get(0).getFormFilePath();
         } else if (uriMimeType != null && uriMimeType.equals(FormsContract.CONTENT_ITEM_TYPE)) {
             Form form = formsRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri));
-            if (form != null) {
-                formPath = form.getFormFilePath();
-            }
+            formPath = form.getFormFilePath();
 
-            if (formPath == null) {
-                createErrorDialog(getString(R.string.bad_uri, uri), true);
-                return;
-            } else {
-                /**
-                 * This is the fill-blank-form code path.See if there is a savepoint for this form
-                 * that has never been explicitly saved by the user. If there is, open this savepoint(resume this filled-in form).
-                 * Savepoints for forms that were explicitly saved will be recovered when that
-                 * explicitly saved instance is edited via edit-saved-form.
-                 */
-                instancePath = loadSavePoint();
-            }
+            /**
+             * This is the fill-blank-form code path.See if there is a savepoint for this form
+             * that has never been explicitly saved by the user. If there is, open this savepoint(resume this filled-in form).
+             * Savepoints for forms that were explicitly saved will be recovered when that
+             * explicitly saved instance is edited via edit-saved-form.
+             */
+            instancePath = loadSavePoint();
         }
 
         formLoaderTask = new FormLoaderTask(instancePath, null, null, formEntryControllerFactory);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -663,19 +663,6 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
 
             List<Form> candidateForms = formsRepository.getAllByFormIdAndVersion(instance.getFormId(), instance.getFormVersion());
 
-            if (candidateForms.isEmpty()) {
-                createErrorDialog(getString(
-                        R.string.parent_form_not_present,
-                        instance.getFormId())
-                                + ((instance.getFormVersion() == null) ? ""
-                                : "\n" + getString(R.string.version) + " " + instance.getFormVersion()),
-                        true);
-                return;
-            } else if (candidateForms.stream().filter(f -> !f.isDeleted()).count() > 1) {
-                createErrorDialog(getString(R.string.survey_multiple_forms_error), true);
-                return;
-            }
-
             formPath = candidateForms.get(0).getFormFilePath();
         } else if (uriMimeType != null && uriMimeType.equals(FormsContract.CONTENT_ITEM_TYPE)) {
             Form form = formsRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri));

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormFillingActivity.java
@@ -209,7 +209,7 @@ import javax.inject.Named;
 import timber.log.Timber;
 
 /**
- * FormEntryActivity is responsible for displaying questions, animating
+ * FormFillingActivity is responsible for displaying questions, animating
  * transitions between questions, and allowing the user to enter data.
  *
  * This class should never be started directly. Instead {@link org.odk.collect.android.external.FormUriActivity}
@@ -220,7 +220,7 @@ import timber.log.Timber;
  * option)
  */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
-public class FormEntryActivity extends LocalizedActivity implements AnimationListener,
+public class FormFillingActivity extends LocalizedActivity implements AnimationListener,
         FormLoaderListener, AdvanceToNextListener, SwipeHandler.OnSwipeListener,
         SavePointListener, NumberPickerDialog.NumberPickerListener,
         RankingWidgetDialog.RankingListener, SaveFormIndexTask.SaveFormIndexListener,
@@ -254,7 +254,7 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
     // Tracks whether we are autosaving
     public static final String KEY_AUTO_SAVED = "autosaved";
 
-    public static final String TAG_PROGRESS_DIALOG_MEDIA_LOADING = FormEntryActivity.class.getName() + MaterialProgressDialogFragment.class.getName() + "mediaLoading";
+    public static final String TAG_PROGRESS_DIALOG_MEDIA_LOADING = FormFillingActivity.class.getName() + MaterialProgressDialogFragment.class.getName() + "mediaLoading";
 
     private boolean autoSaved;
     private boolean allowMovingBackwards;
@@ -1268,7 +1268,7 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
             @Override
             public void onSaveClicked(boolean markAsFinalized) {
                 if (saveName.length() < 1) {
-                    showShortToast(FormEntryActivity.this, R.string.save_as_error);
+                    showShortToast(FormFillingActivity.this, R.string.save_as_error);
                 } else {
                     if (!saveName.equals(formSaveViewModel.getFormName()) && !saveName.equals(formController.getSubmissionMetadata().instanceName)) {
                         Analytics.log(AnalyticsEvents.MANUALLY_SPECIFIED_INSTANCE_NAME, "form");
@@ -1608,7 +1608,7 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
                 new Thread() {
                     @Override
                     public void run() {
-                        FormEntryActivity.this.runOnUiThread(() -> {
+                        FormFillingActivity.this.runOnUiThread(() -> {
                             try {
                                 Thread.sleep(500);
                             } catch (InterruptedException e) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.R
 import org.odk.collect.android.external.FormsContract
-import org.odk.collect.android.formmanagement.FormNavigator
+import org.odk.collect.android.formmanagement.FormFillingIntentFactory
 import org.odk.collect.android.formmanagement.formmap.FormMapViewModel
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.CurrentProjectProvider
@@ -88,9 +88,9 @@ class FormMapActivity : LocalizedActivity() {
         ) { _: String?, result: Bundle ->
             if (result.containsKey(SelectionMapFragment.RESULT_SELECTED_ITEM)) {
                 val instanceId = result.getLong(SelectionMapFragment.RESULT_SELECTED_ITEM)
-                startActivity(FormNavigator.editInstanceIntent(this, currentProjectProvider.getCurrentProject().uuid, instanceId))
+                startActivity(FormFillingIntentFactory.editInstanceIntent(this, currentProjectProvider.getCurrentProject().uuid, instanceId))
             } else if (result.containsKey(SelectionMapFragment.RESULT_CREATE_NEW_ITEM)) {
-                startActivity(FormNavigator.newInstanceIntent(this, FormsContract.getUri(currentProjectProvider.getCurrentProject().uuid, formId)))
+                startActivity(FormFillingIntentFactory.newInstanceIntent(this, FormsContract.getUri(currentProjectProvider.getCurrentProject().uuid, formId)))
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormMapActivity.kt
@@ -18,6 +18,7 @@ import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.R
+import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.formmanagement.FormNavigator
 import org.odk.collect.android.formmanagement.formmap.FormMapViewModel
 import org.odk.collect.android.injection.DaggerUtils
@@ -81,21 +82,15 @@ class FormMapActivity : LocalizedActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.form_map_activity)
 
-        val formNavigator = FormNavigator(
-            currentProjectProvider.getCurrentProject().uuid,
-            settingsProvider,
-            instancesRepositoryProvider::get
-        )
-
         supportFragmentManager.setFragmentResultListener(
             SelectionMapFragment.REQUEST_SELECT_ITEM,
             this
         ) { _: String?, result: Bundle ->
             if (result.containsKey(SelectionMapFragment.RESULT_SELECTED_ITEM)) {
                 val instanceId = result.getLong(SelectionMapFragment.RESULT_SELECTED_ITEM)
-                formNavigator.editInstance(this, instanceId)
+                startActivity(FormNavigator.editInstanceIntent(this, currentProjectProvider.getCurrentProject().uuid, instanceId))
             } else if (result.containsKey(SelectionMapFragment.RESULT_CREATE_NEW_ITEM)) {
-                formNavigator.newInstance(this, formId)
+                startActivity(FormNavigator.newInstanceIntent(this, FormsContract.getUri(currentProjectProvider.getCurrentProject().uuid, formId)))
             }
         }
     }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -37,6 +37,7 @@ import org.odk.collect.android.analytics.AnalyticsEvents;
 import org.odk.collect.android.analytics.AnalyticsUtils;
 import org.odk.collect.android.dao.CursorLoaderFactory;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
+import org.odk.collect.android.external.FormUriActivity;
 import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.formlists.sorting.FormListSortingOption;
 import org.odk.collect.android.injection.DaggerUtils;
@@ -172,7 +173,7 @@ public class InstanceChooserList extends InstanceListActivity implements Adapter
                     }
                     // caller wants to view/edit a form, so launch formentryactivity
                     Intent parentIntent = this.getIntent();
-                    Intent intent = new Intent(this, FormEntryActivity.class);
+                    Intent intent = new Intent(this, FormUriActivity.class);
                     intent.setAction(Intent.ACTION_EDIT);
                     intent.setData(instanceUri);
                     String formMode = parentIntent.getStringExtra(ApplicationConstants.BundleKeys.FORM_MODE);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceChooserList.java
@@ -171,7 +171,7 @@ public class InstanceChooserList extends InstanceListActivity implements Adapter
                                 DO_NOT_EXIT);
                         return;
                     }
-                    // caller wants to view/edit a form, so launch formentryactivity
+                    // caller wants to view/edit a form, so launch FormFillingActivity
                     Intent parentIntent = this.getIntent();
                     Intent intent = new Intent(this, FormUriActivity.class);
                     intent.setAction(Intent.ACTION_EDIT);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderActivity.java
@@ -126,7 +126,7 @@ public class InstanceUploaderActivity extends LocalizedActivity implements Insta
             selectedInstanceIDs = savedInstanceState.getLongArray(TO_SEND);
             dataBundle = savedInstanceState;
         } else {
-            selectedInstanceIDs = getIntent().getLongArrayExtra(FormEntryActivity.KEY_INSTANCES);
+            selectedInstanceIDs = getIntent().getLongArrayExtra(FormFillingActivity.KEY_INSTANCES);
             dataBundle = getIntent().getExtras();
 
             boolean missingInstances = stream(selectedInstanceIDs).anyMatch(id -> instancesRepository.get(id) == null);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/InstanceUploaderListActivity.java
@@ -230,7 +230,7 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
             // first make sure we have a google account selected
             if (new PlayServicesChecker().isGooglePlayServicesAvailable(this)) {
                 Intent i = new Intent(this, GoogleSheetsUploaderActivity.class);
-                i.putExtra(FormEntryActivity.KEY_INSTANCES, instanceIds);
+                i.putExtra(FormFillingActivity.KEY_INSTANCES, instanceIds);
                 startActivityForResult(i, INSTANCE_UPLOADER);
             } else {
                 new PlayServicesChecker().showGooglePlayServicesAvailabilityErrorDialog(this);
@@ -238,7 +238,7 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
         } else {
             // otherwise, do the normal aggregate/other thing.
             Intent i = new Intent(this, InstanceUploaderActivity.class);
-            i.putExtra(FormEntryActivity.KEY_INSTANCES, instanceIds);
+            i.putExtra(FormFillingActivity.KEY_INSTANCES, instanceIds);
             startActivityForResult(i, INSTANCE_UPLOADER);
         }
     }
@@ -300,7 +300,7 @@ public class InstanceUploaderListActivity extends InstanceListActivity implement
         switch (requestCode) {
             // returns with a form path, start entry
             case INSTANCE_UPLOADER:
-                if (intent.getBooleanExtra(FormEntryActivity.KEY_SUCCESS, false)) {
+                if (intent.getBooleanExtra(FormFillingActivity.KEY_SUCCESS, false)) {
                     listView.clearChoices();
                     if (listAdapter.isEmpty()) {
                         finish();

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -155,16 +155,25 @@ class FormUriActivity : ComponentActivity() {
         val uri = intent.data!!
         val uriMimeType = contentResolver.getType(uri)
 
-        val formBlankOrIncomplete = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
+//        val formBlankOrIncomplete = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
+//            val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
+//            instance!!.status == Instance.STATUS_INCOMPLETE
+//        } else {
+//            true
+//        }
+
+        val formBlankOrUnsent = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
             val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
-            instance!!.status == Instance.STATUS_INCOMPLETE
+            instance!!.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_COMPLETE
         } else {
             true
         }
 
         val formEditingEnabled = settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
 
-        return formBlankOrIncomplete && formEditingEnabled
+//        return formBlankOrIncomplete && formEditingEnabled
+
+        return formBlankOrUnsent && formEditingEnabled
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -187,13 +187,6 @@ class FormUriActivity : ComponentActivity() {
         val uri = intent.data!!
         val uriMimeType = contentResolver.getType(uri)
 
-//        val formBlankOrIncomplete = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
-//            val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
-//            instance!!.status == Instance.STATUS_INCOMPLETE
-//        } else {
-//            true
-//        }
-
         val formBlankOrUnsent = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
             val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
             instance!!.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_COMPLETE
@@ -202,8 +195,6 @@ class FormUriActivity : ComponentActivity() {
         }
 
         val formEditingEnabled = settingsProvider.getProtectedSettings().getBoolean(ProtectedProjectKeys.KEY_EDIT_SAVED)
-
-//        return formBlankOrIncomplete && formEditingEnabled
 
         return formBlankOrUnsent && formEditingEnabled
     }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -114,7 +114,9 @@ class FormUriActivity : ComponentActivity() {
         val uriMimeType = contentResolver.getType(uri)
 
         val doesFormExist = if (uriMimeType == FormsContract.CONTENT_ITEM_TYPE) {
-            formsRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri)) != null
+            formsRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))?.let {
+                File(it.formFilePath).exists()
+            } ?: false
         } else {
             instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))?.let {
                 if (!File(it.instanceFilePath).exists()) {
@@ -140,7 +142,7 @@ class FormUriActivity : ComponentActivity() {
                     return false
                 }
 
-                return true
+                true
             } ?: false
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -9,6 +9,9 @@ import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.utilities.ContentUriHelper
+import org.odk.collect.android.utilities.FormsRepositoryProvider
+import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.projects.ProjectsRepository
 import javax.inject.Inject
 
@@ -19,6 +22,12 @@ class FormUriActivity : ComponentActivity() {
 
     @Inject
     lateinit var projectsRepository: ProjectsRepository
+
+    @Inject
+    lateinit var formsRepositoryProvider: FormsRepositoryProvider
+
+    @Inject
+    lateinit var instanceRepositoryProvider: InstancesRepositoryProvider
 
     private var formFillingAlreadyStarted = false
 
@@ -36,6 +45,7 @@ class FormUriActivity : ComponentActivity() {
             !assertProjectListNotEmpty() -> Unit
             !assertCurrentProjectUsed() -> Unit
             !assertValidUri() -> Unit
+            !assertFormExists() -> Unit
             !assertFormFillingNotAlreadyStarted(savedInstanceState) -> Unit
             else -> startForm()
         }
@@ -86,6 +96,28 @@ class FormUriActivity : ComponentActivity() {
         return if (!isUriValid) {
             MaterialAlertDialogBuilder(this)
                 .setMessage(R.string.unrecognized_uri)
+                .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                .create()
+                .show()
+            false
+        } else {
+            true
+        }
+    }
+
+    private fun assertFormExists(): Boolean {
+        val uri = intent.data!!
+        val uriMimeType = contentResolver.getType(uri)
+
+        val doesFormExist = if (uriMimeType == FormsContract.CONTENT_ITEM_TYPE) {
+            formsRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri)) != null
+        } else {
+            instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri)) != null
+        }
+
+        return if (!doesFormExist) {
+            MaterialAlertDialogBuilder(this)
+                .setMessage(R.string.bad_uri)
                 .setPositiveButton(R.string.ok) { _, _ -> finish() }
                 .create()
                 .show()

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -16,6 +16,10 @@ import org.odk.collect.forms.instances.Instance
 import org.odk.collect.projects.ProjectsRepository
 import javax.inject.Inject
 
+/**
+ * This class serves as a firewall for starting form filling. It should be used to do that
+ * rather than [FormEntryActivity] directly as it ensures that the required data is valid.
+ */
 class FormUriActivity : ComponentActivity() {
 
     @Inject

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -56,11 +56,7 @@ class FormUriActivity : ComponentActivity() {
     private fun assertProjectListNotEmpty(): Boolean {
         val projects = projectsRepository.getAll()
         return if (projects.isEmpty()) {
-            MaterialAlertDialogBuilder(this)
-                .setMessage(R.string.app_not_configured)
-                .setPositiveButton(R.string.ok) { _, _ -> finish() }
-                .create()
-                .show()
+            displayErrorDialog(R.string.app_not_configured)
             false
         } else {
             true
@@ -74,11 +70,7 @@ class FormUriActivity : ComponentActivity() {
         val projectId = uriProjectId ?: firstProject.uuid
 
         return if (projectId != currentProjectProvider.getCurrentProject().uuid) {
-            MaterialAlertDialogBuilder(this)
-                .setMessage(R.string.wrong_project_selected_for_form)
-                .setPositiveButton(R.string.ok) { _, _ -> finish() }
-                .create()
-                .show()
+            displayErrorDialog(R.string.wrong_project_selected_for_form)
             false
         } else {
             true
@@ -96,11 +88,7 @@ class FormUriActivity : ComponentActivity() {
         } ?: false
 
         return if (!isUriValid) {
-            MaterialAlertDialogBuilder(this)
-                .setMessage(R.string.unrecognized_uri)
-                .setPositiveButton(R.string.ok) { _, _ -> finish() }
-                .create()
-                .show()
+            displayErrorDialog(R.string.unrecognized_uri)
             false
         } else {
             true
@@ -118,11 +106,7 @@ class FormUriActivity : ComponentActivity() {
         }
 
         return if (!doesFormExist) {
-            MaterialAlertDialogBuilder(this)
-                .setMessage(R.string.bad_uri)
-                .setPositiveButton(R.string.ok) { _, _ -> finish() }
-                .create()
-                .show()
+            displayErrorDialog(R.string.bad_uri)
             false
         } else {
             true
@@ -141,11 +125,7 @@ class FormUriActivity : ComponentActivity() {
         }
 
         return if (!formBlankOrIncomplete) {
-            MaterialAlertDialogBuilder(this)
-                .setMessage(R.string.form_complete)
-                .setPositiveButton(R.string.ok) { _, _ -> finish() }
-                .create()
-                .show()
+            displayErrorDialog(R.string.form_complete)
             false
         } else {
             true
@@ -168,6 +148,14 @@ class FormUriActivity : ComponentActivity() {
                 intent.extras?.let { sourceExtras -> it.putExtras(sourceExtras) }
             }
         )
+    }
+
+    private fun displayErrorDialog(message: Int) {
+        MaterialAlertDialogBuilder(this)
+            .setMessage(message)
+            .setPositiveButton(R.string.ok) { _, _ -> finish() }
+            .create()
+            .show()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -7,7 +7,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
-import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.instancemanagement.InstanceDeleter
@@ -26,7 +26,7 @@ import javax.inject.Inject
 
 /**
  * This class serves as a firewall for starting form filling. It should be used to do that
- * rather than [FormEntryActivity] directly as it ensures that the required data is valid.
+ * rather than [FormFillingActivity] directly as it ensures that the required data is valid.
  */
 class FormUriActivity : ComponentActivity() {
 
@@ -164,7 +164,7 @@ class FormUriActivity : ComponentActivity() {
     private fun startForm() {
         formFillingAlreadyStarted = true
         openForm.launch(
-            Intent(this, FormEntryActivity::class.java).apply {
+            Intent(this, FormFillingActivity::class.java).apply {
                 action = intent.action
                 data = intent.data
                 intent.extras?.let { sourceExtras -> putExtras(sourceExtras) }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -12,6 +12,7 @@ import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.utilities.ContentUriHelper
 import org.odk.collect.android.utilities.FormsRepositoryProvider
 import org.odk.collect.android.utilities.InstancesRepositoryProvider
+import org.odk.collect.forms.instances.Instance
 import org.odk.collect.projects.ProjectsRepository
 import javax.inject.Inject
 
@@ -46,6 +47,7 @@ class FormUriActivity : ComponentActivity() {
             !assertCurrentProjectUsed() -> Unit
             !assertValidUri() -> Unit
             !assertFormExists() -> Unit
+            !assertFormCanBeEdited() -> Unit
             !assertFormFillingNotAlreadyStarted(savedInstanceState) -> Unit
             else -> startForm()
         }
@@ -118,6 +120,29 @@ class FormUriActivity : ComponentActivity() {
         return if (!doesFormExist) {
             MaterialAlertDialogBuilder(this)
                 .setMessage(R.string.bad_uri)
+                .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                .create()
+                .show()
+            false
+        } else {
+            true
+        }
+    }
+
+    private fun assertFormCanBeEdited(): Boolean {
+        val uri = intent.data!!
+        val uriMimeType = contentResolver.getType(uri)
+
+        val formBlankOrIncomplete = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
+            val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
+            instance!!.status == Instance.STATUS_INCOMPLETE
+        } else {
+            true
+        }
+
+        return if (!formBlankOrIncomplete) {
+            MaterialAlertDialogBuilder(this)
+                .setMessage(R.string.form_complete)
                 .setPositiveButton(R.string.ok) { _, _ -> finish() }
                 .create()
                 .show()

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -35,6 +35,7 @@ class FormUriActivity : ComponentActivity() {
         when {
             !assertProjectListNotEmpty() -> Unit
             !assertCurrentProjectUsed() -> Unit
+            !assertValidUri() -> Unit
             !assertFormFillingNotAlreadyStarted(savedInstanceState) -> Unit
             else -> startForm()
         }
@@ -63,6 +64,28 @@ class FormUriActivity : ComponentActivity() {
         return if (projectId != currentProjectProvider.getCurrentProject().uuid) {
             MaterialAlertDialogBuilder(this)
                 .setMessage(R.string.wrong_project_selected_for_form)
+                .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                .create()
+                .show()
+            false
+        } else {
+            true
+        }
+    }
+
+    private fun assertValidUri(): Boolean {
+        val isUriValid = intent.data?.let {
+            val uriMimeType = contentResolver.getType(it)
+            if (uriMimeType == null) {
+                return@let false
+            } else {
+                return@let uriMimeType == FormsContract.CONTENT_ITEM_TYPE || uriMimeType == InstancesContract.CONTENT_ITEM_TYPE
+            }
+        } ?: false
+
+        return if (!isUriValid) {
+            MaterialAlertDialogBuilder(this)
+                .setMessage(R.string.unrecognized_uri)
                 .setPositiveButton(R.string.ok) { _, _ -> finish() }
                 .create()
                 .show()

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationHelper.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationHelper.java
@@ -4,6 +4,7 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_BACKGROUND_LOCATION;
 
 import android.location.Location;
 
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.formentry.audit.AuditConfig;
 import org.odk.collect.android.formentry.audit.AuditEvent;
@@ -22,7 +23,7 @@ import java.util.function.Supplier;
  * The methods on the {@link FormController} are wrapped here rather
  * than the form controller being passed in when constructing the {@link BackgroundLocationManager}
  * because the form controller isn't set until
- * {@link org.odk.collect.android.activities.FormEntryActivity}'s onCreate.
+ * {@link FormFillingActivity}'s onCreate.
  */
 public class BackgroundLocationHelper {
 

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationViewModel.java
@@ -5,12 +5,12 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_BACKGROUND_LOCATION;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
 
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.shared.settings.Settings;
 
 /**
  * Ensures that background location tracking continues throughout the activity lifecycle. Builds
- * location-related dependency, receives activity events from #{@link FormEntryActivity} and
+ * location-related dependency, receives activity events from #{@link FormFillingActivity} and
  * forwards those events to the location manager.
  *
  * The current goal is to keep this component very thin but this may evolve as it is involved in

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
@@ -10,7 +10,7 @@ import androidx.activity.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormMapActivity
-import org.odk.collect.android.formmanagement.FormNavigator
+import org.odk.collect.android.formmanagement.FormFillingIntentFactory
 import org.odk.collect.android.injection.DaggerUtils
 import org.odk.collect.android.preferences.dialogs.ServerAuthDialogFragment
 import org.odk.collect.androidshared.network.NetworkStateProvider
@@ -57,7 +57,7 @@ class BlankFormListActivity : LocalizedActivity(), OnFormItemClickListener {
             setResult(RESULT_OK, Intent().setData(formUri))
         } else {
             // caller wants to view/edit a form, so launch FormFillingActivity
-            startActivity(FormNavigator.newInstanceIntent(this, formUri))
+            startActivity(FormFillingIntentFactory.newInstanceIntent(this, formUri))
         }
         finish()
     }

--- a/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formlists/blankformlist/BlankFormListActivity.kt
@@ -56,7 +56,7 @@ class BlankFormListActivity : LocalizedActivity(), OnFormItemClickListener {
             // caller is waiting on a picked form
             setResult(RESULT_OK, Intent().setData(formUri))
         } else {
-            // caller wants to view/edit a form, so launch formentryactivity
+            // caller wants to view/edit a form, so launch FormFillingActivity
             startActivity(FormNavigator.newInstanceIntent(this, formUri))
         }
         finish()

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormFillingIntentFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormFillingIntentFactory.kt
@@ -8,7 +8,7 @@ import org.odk.collect.android.external.FormUriActivity
 import org.odk.collect.android.external.InstancesContract
 import kotlin.reflect.KClass
 
-object FormNavigator {
+object FormFillingIntentFactory {
     fun newInstanceIntent(
         context: Context,
         uri: Uri?,

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
@@ -3,7 +3,7 @@ package org.odk.collect.android.formmanagement
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.external.FormUriActivity
 import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.utilities.ApplicationConstants.BundleKeys.FORM_MODE
@@ -36,7 +36,7 @@ class FormNavigator(
 
     companion object {
         fun newInstanceIntent(context: Context, uri: Uri?): Intent {
-            return Intent(context, FormEntryActivity::class.java).also {
+            return Intent(context, FormUriActivity::class.java).also {
                 it.action = Intent.ACTION_EDIT
                 it.data = uri
             }
@@ -55,7 +55,7 @@ class FormNavigator(
         ): Intent {
             val uri = InstancesContract.getUri(projectId, instanceId)
 
-            return Intent(context, FormEntryActivity::class.java).also {
+            return Intent(context, FormUriActivity::class.java).also {
                 it.action = Intent.ACTION_EDIT
                 it.data = uri
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
@@ -1,14 +1,20 @@
 package org.odk.collect.android.formmanagement
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import org.odk.collect.android.external.FormUriActivity
 import org.odk.collect.android.external.InstancesContract
+import kotlin.reflect.KClass
 
 object FormNavigator {
-    fun newInstanceIntent(context: Context, uri: Uri?): Intent {
-        return Intent(context, FormUriActivity::class.java).also {
+    fun newInstanceIntent(
+        context: Context,
+        uri: Uri?,
+        clazz: KClass<out Activity> = FormUriActivity::class
+    ): Intent {
+        return Intent(context, clazz.java).also {
             it.action = Intent.ACTION_EDIT
             it.data = uri
         }
@@ -17,9 +23,10 @@ object FormNavigator {
     fun editInstanceIntent(
         context: Context,
         projectId: String,
-        instanceId: Long
+        instanceId: Long,
+        clazz: KClass<out Activity> = FormUriActivity::class
     ): Intent {
-        return Intent(context, FormUriActivity::class.java).also {
+        return Intent(context, clazz.java).also {
             it.action = Intent.ACTION_EDIT
             it.data = InstancesContract.getUri(projectId, instanceId)
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/FormNavigator.kt
@@ -4,68 +4,24 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import org.odk.collect.android.external.FormUriActivity
-import org.odk.collect.android.external.FormsContract
 import org.odk.collect.android.external.InstancesContract
-import org.odk.collect.android.utilities.ApplicationConstants.BundleKeys.FORM_MODE
-import org.odk.collect.android.utilities.ApplicationConstants.FormModes.VIEW_SENT
-import org.odk.collect.forms.instances.Instance
-import org.odk.collect.forms.instances.InstancesRepository
-import org.odk.collect.settings.SettingsProvider
-import org.odk.collect.settings.keys.ProtectedProjectKeys.KEY_EDIT_SAVED
 
-class FormNavigator(
-    private val projectId: String,
-    private val settingsProvider: SettingsProvider,
-    private val instancesRepositoryProvider: () -> InstancesRepository
-) {
-
-    fun editInstance(context: Context, instanceId: Long) {
-        val editingDisabled = !settingsProvider.getProtectedSettings().getBoolean(KEY_EDIT_SAVED)
-        val status = instancesRepositoryProvider().get(instanceId)?.status
-
-        context.startActivity(
-            editInstanceIntent(context, projectId, instanceId, editingDisabled, status)
-        )
+object FormNavigator {
+    fun newInstanceIntent(context: Context, uri: Uri?): Intent {
+        return Intent(context, FormUriActivity::class.java).also {
+            it.action = Intent.ACTION_EDIT
+            it.data = uri
+        }
     }
 
-    fun newInstance(context: Context, formId: Long) {
-        context.startActivity(
-            newInstanceIntent(context, projectId, formId)
-        )
-    }
-
-    companion object {
-        fun newInstanceIntent(context: Context, uri: Uri?): Intent {
-            return Intent(context, FormUriActivity::class.java).also {
-                it.action = Intent.ACTION_EDIT
-                it.data = uri
-            }
-        }
-
-        fun newInstanceIntent(context: Context, projectId: String, formId: Long): Intent {
-            return newInstanceIntent(context, FormsContract.getUri(projectId, formId))
-        }
-
-        fun editInstanceIntent(
-            context: Context,
-            projectId: String,
-            instanceId: Long,
-            editingDisabled: Boolean,
-            status: String?
-        ): Intent {
-            val uri = InstancesContract.getUri(projectId, instanceId)
-
-            return Intent(context, FormUriActivity::class.java).also {
-                it.action = Intent.ACTION_EDIT
-                it.data = uri
-
-                if (editingDisabled ||
-                    status == Instance.STATUS_SUBMITTED ||
-                    status == Instance.STATUS_SUBMISSION_FAILED
-                ) {
-                    it.putExtra(FORM_MODE, VIEW_SENT)
-                }
-            }
+    fun editInstanceIntent(
+        context: Context,
+        projectId: String,
+        instanceId: Long
+    ): Intent {
+        return Intent(context, FormUriActivity::class.java).also {
+            it.action = Intent.ACTION_EDIT
+            it.data = InstancesContract.getUri(projectId, instanceId)
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/fragments/MediaLoadingFragment.java
+++ b/collect_app/src/main/java/org/odk/collect/android/fragments/MediaLoadingFragment.java
@@ -8,7 +8,7 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import org.jetbrains.annotations.NotNull;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.javarosawrapper.FormController;
 import org.odk.collect.android.tasks.MediaLoadingTask;
 
@@ -17,7 +17,7 @@ public class MediaLoadingFragment extends Fragment {
     private MediaLoadingTask mediaLoadingTask;
 
     public void beginMediaLoadingTask(Uri uri, FormController formController) {
-        mediaLoadingTask = new MediaLoadingTask((FormEntryActivity) getActivity(), formController.getInstanceFile());
+        mediaLoadingTask = new MediaLoadingTask((FormFillingActivity) getActivity(), formController.getInstanceFile());
         mediaLoadingTask.execute(uri);
     }
 
@@ -31,7 +31,7 @@ public class MediaLoadingFragment extends Fragment {
     public void onAttach(@NotNull Context context) {
         super.onAttach(context);
         if (mediaLoadingTask != null) {
-            mediaLoadingTask.onAttach((FormEntryActivity) getActivity());
+            mediaLoadingTask.onAttach((FormFillingActivity) getActivity());
         }
     }
 

--- a/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/gdrive/GoogleSheetsUploaderActivity.java
@@ -36,7 +36,7 @@ import com.google.android.gms.auth.UserRecoverableAuthException;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.listeners.InstanceUploaderListener;
 import org.odk.collect.androidshared.network.NetworkStateProvider;
@@ -121,7 +121,7 @@ public class GoogleSheetsUploaderActivity extends LocalizedActivity implements I
         long[] selectedInstanceIDs;
 
         Intent intent = getIntent();
-        selectedInstanceIDs = intent.getLongArrayExtra(FormEntryActivity.KEY_INSTANCES);
+        selectedInstanceIDs = intent.getLongArrayExtra(FormFillingActivity.KEY_INSTANCES);
 
         instancesToSend = ArrayUtils.toObject(selectedInstanceIDs);
 

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyComponent.java
@@ -8,7 +8,7 @@ import org.odk.collect.android.activities.AppListActivity;
 import org.odk.collect.android.activities.DeleteSavedFormActivity;
 import org.odk.collect.android.activities.FirstLaunchActivity;
 import org.odk.collect.android.activities.FormDownloadListActivity;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.activities.FormHierarchyActivity;
 import org.odk.collect.android.activities.FormMapActivity;
 import org.odk.collect.android.activities.InstanceChooserList;
@@ -147,7 +147,7 @@ public interface AppDependencyComponent {
 
     void inject(SavedFormListFragment savedFormListFragment);
 
-    void inject(FormEntryActivity formEntryActivity);
+    void inject(FormFillingActivity formFillingActivity);
 
     void inject(InstanceServerUploaderTask uploader);
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/MediaLoadingTask.java
@@ -5,7 +5,7 @@ import static org.odk.collect.settings.keys.ProjectKeys.KEY_IMAGE_SIZE;
 import android.net.Uri;
 import android.os.AsyncTask;
 
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.application.Collect;
 import org.odk.collect.android.injection.DaggerUtils;
 import org.odk.collect.android.utilities.ContentUriHelper;
@@ -30,16 +30,16 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
     @Inject
     ImageCompressionController imageCompressionController;
 
-    private WeakReference<FormEntryActivity> formEntryActivity;
+    private WeakReference<FormFillingActivity> formFillingActivity;
 
-    public MediaLoadingTask(FormEntryActivity formEntryActivity, File instanceFile) {
+    public MediaLoadingTask(FormFillingActivity formFillingActivity, File instanceFile) {
         this.instanceFile = instanceFile;
-        onAttach(formEntryActivity);
+        onAttach(formFillingActivity);
     }
 
-    public void onAttach(FormEntryActivity formEntryActivity) {
-        this.formEntryActivity = new WeakReference<>(formEntryActivity);
-        DaggerUtils.getComponent(this.formEntryActivity.get()).inject(this);
+    public void onAttach(FormFillingActivity formFillingActivity) {
+        this.formFillingActivity = new WeakReference<>(formFillingActivity);
+        DaggerUtils.getComponent(this.formFillingActivity.get()).inject(this);
     }
 
     @Override
@@ -49,12 +49,12 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
 
             File newFile = FileUtils.createDestinationMediaFile(instanceFile.getParent(), extension);
             FileUtils.saveAnswerFileFromUri(uris[0], newFile, Collect.getInstance());
-            QuestionWidget questionWidget = formEntryActivity.get().getWidgetWaitingForBinaryData();
+            QuestionWidget questionWidget = formFillingActivity.get().getWidgetWaitingForBinaryData();
 
             // apply image conversion if the widget is an image widget
             if (questionWidget instanceof BaseImageWidget) {
                 String imageSizeMode = settingsProvider.getUnprotectedSettings().getString(KEY_IMAGE_SIZE);
-                imageCompressionController.execute(newFile.getPath(), questionWidget, formEntryActivity.get(), imageSizeMode);
+                imageCompressionController.execute(newFile.getPath(), questionWidget, formFillingActivity.get(), imageSizeMode);
             }
             return newFile;
         }
@@ -63,8 +63,8 @@ public class MediaLoadingTask extends AsyncTask<Uri, Void, File> {
 
     @Override
     protected void onPostExecute(File result) {
-        FormEntryActivity activity = this.formEntryActivity.get();
-        DialogFragmentUtils.dismissDialog(FormEntryActivity.TAG_PROGRESS_DIALOG_MEDIA_LOADING, activity.getSupportFragmentManager());
+        FormFillingActivity activity = this.formFillingActivity.get();
+        DialogFragmentUtils.dismissDialog(FormFillingActivity.TAG_PROGRESS_DIALOG_MEDIA_LOADING, activity.getSupportFragmentManager());
         activity.setWidgetData(result);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/interfaces/WidgetDataReceiver.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/interfaces/WidgetDataReceiver.java
@@ -14,11 +14,11 @@
 
 package org.odk.collect.android.widgets.interfaces;
 
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 
 public interface WidgetDataReceiver {
     /**
-     * Allows answer to be set externally in {@link FormEntryActivity}.
+     * Allows answer to be set externally in {@link FormFillingActivity}.
      */
     void setData(Object answer);
 }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/RankingWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/RankingWidget.java
@@ -30,7 +30,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.formentry.questions.WidgetViewUtils;
 import org.odk.collect.android.fragments.dialogs.RankingWidgetDialog;
@@ -109,7 +109,7 @@ public class RankingWidget extends QuestionWidget implements WidgetDataReceiver,
         waitingForDataRegistry.waitForData(getFormEntryPrompt().getIndex());
 
         RankingWidgetDialog rankingWidgetDialog = new RankingWidgetDialog(savedItems == null ? items : savedItems, getFormEntryPrompt());
-        rankingWidgetDialog.show(((FormEntryActivity) getContext()).getSupportFragmentManager(), "RankingDialog");
+        rankingWidgetDialog.show(((FormFillingActivity) getContext()).getSupportFragmentManager(), "RankingDialog");
     }
 
     private List<SelectChoice> getOrderedItems() {

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectMultiMinimalWidget.java
@@ -9,7 +9,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
 import org.odk.collect.android.fragments.dialogs.SelectMultiMinimalDialog;
@@ -51,7 +51,7 @@ public class SelectMultiMinimalWidget extends SelectMinimalWidget {
                 getFormEntryPrompt(), getReferenceManager(),
                 getPlayColor(getFormEntryPrompt(), themeUtils), numColumns, noButtonsMode, mediaUtils);
 
-        DialogFragmentUtils.showIfNotShowing(dialog, SelectMinimalDialog.class, ((FormEntryActivity) getContext()).getSupportFragmentManager());
+        DialogFragmentUtils.showIfNotShowing(dialog, SelectMinimalDialog.class, ((FormFillingActivity) getContext()).getSupportFragmentManager());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneImageMapWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneImageMapWidget.java
@@ -24,7 +24,7 @@ import androidx.annotation.Nullable;
 
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.listeners.AdvanceToNextListener;
 import org.odk.collect.android.utilities.SelectOneWidgetUtils;
@@ -75,7 +75,7 @@ public class SelectOneImageMapWidget extends SelectImageMapWidget {
     protected void selectArea(String areaId) {
         super.selectArea(areaId);
 
-        ((FormEntryActivity) getContext()).runOnUiThread(() -> {
+        ((FormFillingActivity) getContext()).runOnUiThread(() -> {
             if (autoAdvance && listener != null) {
                 listener.advance();
             }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/items/SelectOneMinimalWidget.java
@@ -9,7 +9,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.SelectOneData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.fragments.dialogs.SelectMinimalDialog;
 import org.odk.collect.android.fragments.dialogs.SelectOneMinimalDialog;
@@ -52,7 +52,7 @@ public class SelectOneMinimalWidget extends SelectMinimalWidget {
                 getFormEntryPrompt(), getReferenceManager(),
                 getPlayColor(getFormEntryPrompt(), themeUtils), numColumns, noButtonsMode, mediaUtils);
 
-        DialogFragmentUtils.showIfNotShowing(dialog, SelectMinimalDialog.class, ((FormEntryActivity) getContext()).getSupportFragmentManager());
+        DialogFragmentUtils.showIfNotShowing(dialog, SelectMinimalDialog.class, ((FormFillingActivity) getContext()).getSupportFragmentManager());
     }
 
     @Override

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangePickerDecimalWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangePickerDecimalWidget.java
@@ -10,7 +10,7 @@ import org.javarosa.core.model.data.DecimalData;
 import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.databinding.RangePickerWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.QuestionWidget;
@@ -46,7 +46,7 @@ public class RangePickerDecimalWidget extends QuestionWidget {
         RangeWidgetUtils.setUpRangePickerWidget(context, binding, prompt);
         progress = RangePickerWidgetUtils.getProgressFromPrompt(prompt, displayedValuesForNumberPicker);
         binding.widgetButton.setOnClickListener(v -> RangeWidgetUtils.showNumberPickerDialog(
-                (FormEntryActivity) getContext(), displayedValuesForNumberPicker, getId(), progress));
+                (FormFillingActivity) getContext(), displayedValuesForNumberPicker, getId(), progress));
 
         return binding.getRoot();
     }

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangePickerIntegerWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/range/RangePickerIntegerWidget.java
@@ -10,7 +10,7 @@ import org.javarosa.core.model.data.IAnswerData;
 import org.javarosa.core.model.data.IntegerData;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.FormEntryActivity;
+import org.odk.collect.android.activities.FormFillingActivity;
 import org.odk.collect.android.databinding.RangePickerWidgetAnswerBinding;
 import org.odk.collect.android.formentry.questions.QuestionDetails;
 import org.odk.collect.android.widgets.QuestionWidget;
@@ -47,7 +47,7 @@ public class RangePickerIntegerWidget extends QuestionWidget {
 
         progress = RangePickerWidgetUtils.getProgressFromPrompt(prompt, displayedValuesForNumberPicker);
         binding.widgetButton.setOnClickListener(v -> RangeWidgetUtils.showNumberPickerDialog(
-                (FormEntryActivity) getContext(), displayedValuesForNumberPicker, getId(), progress));
+                (FormFillingActivity) getContext(), displayedValuesForNumberPicker, getId(), progress));
 
         return binding.getRoot();
     }

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
-import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.activities.FormFillingActivity
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.storage.StoragePathProvider
@@ -399,7 +399,7 @@ class FormUriActivityTest {
         val scenario = launcherRule.launch<FormUriActivity>(getBlankFormIntent(project.uuid, form.dbId))
         scenario.recreate()
 
-        Intents.intended(hasComponent(FormEntryActivity::class.java.name), Intents.times(1))
+        Intents.intended(hasComponent(FormFillingActivity::class.java.name), Intents.times(1))
     }
 
     @Test
@@ -521,7 +521,7 @@ class FormUriActivityTest {
     }
 
     private fun assertStartBlankFormIntent(projectId: String?, dbId: Long) {
-        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+        Intents.intended(hasComponent(FormFillingActivity::class.java.name))
         if (projectId == null) {
             Intents.intended(hasData(getFormsUriInOldFormatWithNoProjectId(dbId)))
         } else {
@@ -531,7 +531,7 @@ class FormUriActivityTest {
     }
 
     private fun assertStartSavedFormIntent(projectId: String?, dbId: Long, canBeEdited: Boolean) {
-        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+        Intents.intended(hasComponent(FormFillingActivity::class.java.name))
         if (projectId == null) {
             Intents.intended(hasData(getInstancesUriInOldFormatWithNoProjectId(dbId)))
         } else {

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -333,17 +333,6 @@ class FormUriActivityTest {
         assertStartSavedFormIntent(project.uuid, instance.dbId, false)
     }
 
-//    @Test
-//    fun `When attempting to edit a finalized form then start form for view only`() {
-//        saveTestProjects()
-//
-//        launcherRule.launchForResult<FormUriActivity>(
-//            getSavedIntent(currentProject.uuid, formDbId = 2)
-//        )
-//
-//        assertStartSavedFormIntent(false, 2)
-//    }
-
     @Test
     fun `When attempting to edit a submitted form then start form for view only`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -195,6 +195,20 @@ class FormUriActivityTest {
     }
 
     @Test
+    fun `When uri represents a blank with non existing form file then display alert dialog`() {
+        val project = Project.Saved("123", "First project", "A", "#cccccc")
+        projectsRepository.save(project)
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
+
+        val form = formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+
+        File(form.formFilePath).delete()
+        val scenario = launcherRule.launchForResult<FormUriActivity>(getBlankFormIntent(project.uuid, form.dbId))
+
+        assertErrorDialog(scenario, context.getString(R.string.bad_uri))
+    }
+
+    @Test
     fun `When uri represents a saved form that does not exist then display alert dialog`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -226,16 +226,16 @@ class FormUriActivityTest {
         assertStartSavedFormIntent(false)
     }
 
-    @Test
-    fun `When attempting to edit a finalized form then start form for view only`() {
-        saveTestProjects()
-
-        launcherRule.launchForResult<FormUriActivity>(
-            getSavedIntent(currentProject.uuid, formDbId = 2)
-        )
-
-        assertStartSavedFormIntent(false, 2)
-    }
+//    @Test
+//    fun `When attempting to edit a finalized form then start form for view only`() {
+//        saveTestProjects()
+//
+//        launcherRule.launchForResult<FormUriActivity>(
+//            getSavedIntent(currentProject.uuid, formDbId = 2)
+//        )
+//
+//        assertStartSavedFormIntent(false, 2)
+//    }
 
     @Test
     fun `When attempting to edit a submitted form then start form for view only`() {

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -195,7 +195,7 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When uri represents a blank with non existing form file then display alert dialog`() {
+    fun `When uri represents a blank form with non existing form file then display alert dialog`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)
         whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -159,6 +159,40 @@ class FormUriActivityTest {
         Intents.intended(hasExtra("KEY_1", "Text"))
     }
 
+    @Test
+    fun `When uri is null then display alert dialog`() {
+        saveTestProjects()
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(
+            getIntent().apply {
+                data = null
+            }
+        )
+
+        onView(withText(R.string.unrecognized_uri)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When uri is invalid then display alert dialog`() {
+        saveTestProjects()
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(
+            getIntent().apply {
+                data = Uri.parse("blah")
+            }
+        )
+
+        onView(withText(R.string.unrecognized_uri)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
     // TODO: Replace the explicit FormUriActivity intent with an implicit one Intent.ACTION_EDIT once it's possible https://github.com/android/android-test/issues/496
     private fun getIntent(projectId: String? = null) =
         Intent(context, FormUriActivity::class.java).apply {

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -2,6 +2,7 @@ package org.odk.collect.android.external
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
@@ -25,19 +26,26 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.FormEntryActivity
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.CollectHelpers
+import org.odk.collect.android.utilities.FormsRepositoryProvider
+import org.odk.collect.android.utilities.InstancesRepositoryProvider
 import org.odk.collect.androidtest.ActivityScenarioLauncherRule
 import org.odk.collect.androidtest.RecordedIntentsRule
+import org.odk.collect.forms.instances.Instance
+import org.odk.collect.formstest.FormUtils
+import org.odk.collect.formstest.InMemFormsRepository
+import org.odk.collect.formstest.InMemInstancesRepository
 import org.odk.collect.projects.InMemProjectsRepository
 import org.odk.collect.projects.Project
 import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.shared.TempFiles
 import org.odk.collect.shared.strings.UUIDGenerator
 
 @RunWith(AndroidJUnit4::class)
@@ -47,6 +55,14 @@ class FormUriActivityTest {
     private val context = ApplicationProvider.getApplicationContext<Application>()
     private val firstProject = Project.DEMO_PROJECT
     private val secondProject = Project.Saved("123", "Second project", "S", "#cccccc")
+    private val formsRepository = InMemFormsRepository()
+    private val instancesRepository = InMemInstancesRepository()
+    private val formsRepositoryProvider = mock<FormsRepositoryProvider>().apply {
+        whenever(get()).thenReturn(formsRepository)
+    }
+    private val instancesRepositoryProvider = mock<InstancesRepositoryProvider>().apply {
+        whenever(get()).thenReturn(instancesRepository)
+    }
 
     @get:Rule
     val activityRule = RecordedIntentsRule()
@@ -57,6 +73,18 @@ class FormUriActivityTest {
     @Before
     fun setup() {
         projectsRepository = InMemProjectsRepository()
+
+        formsRepository.save(
+            FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build()
+        )
+
+        instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .status(Instance.STATUS_INCOMPLETE)
+                .build()
+        )
 
         CollectHelpers.overrideAppDependencyModule(object : AppDependencyModule() {
             override fun providesProjectsRepository(
@@ -73,6 +101,17 @@ class FormUriActivityTest {
             ): CurrentProjectProvider {
                 return currentProjectProvider
             }
+
+            override fun providesFormsRepositoryProvider(application: Application?): FormsRepositoryProvider {
+                return formsRepositoryProvider
+            }
+
+            override fun providesInstancesRepositoryProvider(
+                context: Context?,
+                storagePathProvider: StoragePathProvider?
+            ): InstancesRepositoryProvider {
+                return instancesRepositoryProvider
+            }
         })
     }
 
@@ -87,10 +126,10 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When there is project id specified in uri and it does not match current project id then display alert dialog`() {
+    fun `When there is project id specified in uri but it does not match current project id then display alert dialog`() {
         saveTestProjects()
 
-        val scenario = launcherRule.launchForResult<FormUriActivity>(getIntent(secondProject.uuid))
+        val scenario = launcherRule.launchForResult<FormUriActivity>(getBlankFormIntent(secondProject.uuid))
 
         onView(withText(R.string.wrong_project_selected_for_form)).inRoot(isDialog())
             .check(matches(isDisplayed()))
@@ -100,21 +139,85 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When there is project id specified in uri and it matches current project id then start form filling`() {
+    fun `When there is no project id specified in uri and first available project id does not match current project id then display alert dialog`() {
         saveTestProjects()
 
-        launcherRule.launch<FormUriActivity>(getIntent(firstProject.uuid))
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(secondProject)
 
-        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
-        Intents.intended(hasData(FormsContract.getUri(firstProject.uuid, 1)))
-        Intents.intended(hasExtra("KEY_1", "Text"))
+        val scenario = launcherRule.launchForResult<FormUriActivity>(getBlankFormIntent())
+
+        onView(withText(R.string.wrong_project_selected_for_form)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When uri is null then display alert dialog`() {
+        saveTestProjects()
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(
+            getBlankFormIntent().apply {
+                data = null
+            }
+        )
+
+        onView(withText(R.string.unrecognized_uri)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When uri is invalid then display alert dialog`() {
+        saveTestProjects()
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(
+            getBlankFormIntent().apply {
+                data = Uri.parse("blah")
+            }
+        )
+
+        onView(withText(R.string.unrecognized_uri)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When uri represents a blank form that does not exist then display alert dialog`() {
+        saveTestProjects()
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(getBlankFormIntent(firstProject.uuid, 2))
+
+        onView(withText(R.string.bad_uri)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun `When uri represents a saved form that does not exist then display alert dialog`() {
+        saveTestProjects()
+
+        val scenario = launcherRule.launchForResult<FormUriActivity>(getSavedIntent(firstProject.uuid, 2))
+
+        onView(withText(R.string.bad_uri)).inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withId(android.R.id.button1)).perform(click())
+
+        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
     }
 
     @Test
     fun `Form filling should not be started again after recreating the activity or getting back to it`() {
         saveTestProjects()
 
-        val scenario = launcherRule.launch<FormUriActivity>(getIntent(firstProject.uuid))
+        val scenario = launcherRule.launch<FormUriActivity>(getBlankFormIntent(firstProject.uuid))
 
         scenario.recreate()
 
@@ -124,25 +227,32 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When there is no project id specified in uri and first available project id does not match current project id then display alert dialog`() {
+    fun `When there is project id specified in uri that represents a blank form and it matches current project id then start form filling`() {
         saveTestProjects()
 
-        whenever(currentProjectProvider.getCurrentProject()).thenReturn(secondProject)
+        launcherRule.launch<FormUriActivity>(getBlankFormIntent(firstProject.uuid))
 
-        val scenario = launcherRule.launchForResult<FormUriActivity>(getIntent())
-
-        onView(withText(R.string.wrong_project_selected_for_form)).inRoot(isDialog())
-            .check(matches(isDisplayed()))
-        onView(withId(android.R.id.button1)).perform(click())
-
-        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+        Intents.intended(hasData(FormsContract.getUri(firstProject.uuid, 1)))
+        Intents.intended(hasExtra("KEY_1", "Text"))
     }
 
     @Test
-    fun `When there is no project id specified in uri and first available project id matches current project id then start form filling`() {
+    fun `When there is project id specified in uri that represents a saved form and it matches current project id then start form filling`() {
         saveTestProjects()
 
-        launcherRule.launch<FormUriActivity>(getIntent())
+        launcherRule.launch<FormUriActivity>(getSavedIntent(firstProject.uuid))
+
+        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+        Intents.intended(hasData(InstancesContract.getUri(firstProject.uuid, 1)))
+        Intents.intended(hasExtra("KEY_1", "Text"))
+    }
+
+    @Test
+    fun `When there is no project id specified in uri that represents a blank form and first available project id matches current project id then start form filling`() {
+        saveTestProjects()
+
+        launcherRule.launch<FormUriActivity>(getBlankFormIntent())
 
         Intents.intended(hasComponent(FormEntryActivity::class.java.name))
         val uri = FormsContract.getUri("", 1)
@@ -160,44 +270,31 @@ class FormUriActivityTest {
     }
 
     @Test
-    fun `When uri is null then display alert dialog`() {
+    fun `When there is no project id specified in uri that represents a saved form and first available project id matches current project id then start form filling`() {
         saveTestProjects()
 
-        val scenario = launcherRule.launchForResult<FormUriActivity>(
-            getIntent().apply {
-                data = null
-            }
+        launcherRule.launch<FormUriActivity>(getSavedIntent())
+
+        Intents.intended(hasComponent(FormEntryActivity::class.java.name))
+        val uri = InstancesContract.getUri("", 1)
+        Intents.intended(
+            hasData(
+                Uri.Builder()
+                    .scheme(uri.scheme)
+                    .authority(uri.authority)
+                    .path(uri.path)
+                    .query(null)
+                    .build()
+            )
         )
-
-        onView(withText(R.string.unrecognized_uri)).inRoot(isDialog())
-            .check(matches(isDisplayed()))
-        onView(withId(android.R.id.button1)).perform(click())
-
-        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
-    }
-
-    @Test
-    fun `When uri is invalid then display alert dialog`() {
-        saveTestProjects()
-
-        val scenario = launcherRule.launchForResult<FormUriActivity>(
-            getIntent().apply {
-                data = Uri.parse("blah")
-            }
-        )
-
-        onView(withText(R.string.unrecognized_uri)).inRoot(isDialog())
-            .check(matches(isDisplayed()))
-        onView(withId(android.R.id.button1)).perform(click())
-
-        assertThat(scenario.result.resultCode, `is`(Activity.RESULT_CANCELED))
+        Intents.intended(hasExtra("KEY_1", "Text"))
     }
 
     // TODO: Replace the explicit FormUriActivity intent with an implicit one Intent.ACTION_EDIT once it's possible https://github.com/android/android-test/issues/496
-    private fun getIntent(projectId: String? = null) =
+    private fun getBlankFormIntent(projectId: String? = null, formDbId: Long = 1) =
         Intent(context, FormUriActivity::class.java).apply {
             data = if (projectId == null) {
-                val uri = FormsContract.getUri("", 1)
+                val uri = FormsContract.getUri("", formDbId)
                 Uri.Builder()
                     .scheme(uri.scheme)
                     .authority(uri.authority)
@@ -205,7 +302,23 @@ class FormUriActivityTest {
                     .query(null)
                     .build()
             } else {
-                FormsContract.getUri(projectId, 1)
+                FormsContract.getUri(projectId, formDbId)
+            }
+            putExtra("KEY_1", "Text")
+        }
+
+    private fun getSavedIntent(projectId: String? = null, formDbId: Long = 1) =
+        Intent(context, FormUriActivity::class.java).apply {
+            data = if (projectId == null) {
+                val uri = InstancesContract.getUri("", formDbId)
+                Uri.Builder()
+                    .scheme(uri.scheme)
+                    .authority(uri.authority)
+                    .path(uri.path)
+                    .query(null)
+                    .build()
+            } else {
+                InstancesContract.getUri(projectId, formDbId)
             }
             putExtra("KEY_1", "Text")
         }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationManagerTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/backgroundlocation/BackgroundLocationManagerTest.java
@@ -44,7 +44,7 @@ public class BackgroundLocationManagerTest {
     }
 
     /**
-     * activityDisplayed is called from both onStart and loadingComplete in FormEntryActivity. This
+     * activityDisplayed is called from both onStart and loadingComplete in FormFillingActivity. This
      * test confirms that it doesn't matter how many times activityDisplayed is called until the
      * form has been loaded.
      */
@@ -445,16 +445,16 @@ public class BackgroundLocationManagerTest {
         backgroundLocationManager.activityHidden();
         backgroundLocationManager.activityDisplayed();
 
-        // not possible through FormEntryActivity because menu doesn't show toggle
+        // not possible through FormFillingActivity because menu doesn't show toggle
         backgroundLocationManager.backgroundLocationPreferenceToggled();
 
-        // not possible through FormEntryActivity because provider not registered
+        // not possible through FormFillingActivity because provider not registered
         backgroundLocationManager.locationProvidersChanged();
 
-        // not possible through FormEntryActivity because listener not set
+        // not possible through FormFillingActivity because listener not set
         backgroundLocationManager.onLocationChanged(LocationTestUtils.createLocation("GPS", 1, 2, 3, 4));
 
-        // not possible through FormEntryActivity because location request never needed
+        // not possible through FormFillingActivity because location request never needed
         backgroundLocationManager.locationPermissionGranted();
         backgroundLocationManager.locationPermissionDenied();
 

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormFillingIntentFactoryTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormFillingIntentFactoryTest.kt
@@ -20,7 +20,7 @@ import org.odk.collect.androidtest.RecordedIntentsRule
 import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
-class FormNavigatorTest {
+class FormFillingIntentFactoryTest {
 
     @get:Rule
     val recordedIntentsRule = RecordedIntentsRule()
@@ -29,7 +29,7 @@ class FormNavigatorTest {
 
     @Test
     fun `newInstance starts FormUriActivity with instance URI`() {
-        activity.startActivity(FormNavigator.newInstanceIntent(activity, InstancesContract.getUri("projectId", 101)))
+        activity.startActivity(FormFillingIntentFactory.newInstanceIntent(activity, InstancesContract.getUri("projectId", 101)))
 
         intended(hasAction(ACTION_EDIT))
         intended(hasComponent(FormUriActivity::class.java.name))
@@ -39,7 +39,7 @@ class FormNavigatorTest {
 
     @Test
     fun `editInstance starts FormUriActivity with instance URI`() {
-        activity.startActivity(FormNavigator.editInstanceIntent(activity, "projectId", 101))
+        activity.startActivity(FormFillingIntentFactory.editInstanceIntent(activity, "projectId", 101))
 
         intended(hasAction(ACTION_EDIT))
         intended(hasComponent(FormUriActivity::class.java.name))

--- a/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormNavigatorTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formmanagement/FormNavigatorTest.kt
@@ -12,7 +12,7 @@ import org.hamcrest.Matchers.not
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.odk.collect.android.activities.FormEntryActivity
+import org.odk.collect.android.external.FormUriActivity
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.utilities.ApplicationConstants.BundleKeys.FORM_MODE
 import org.odk.collect.android.utilities.ApplicationConstants.FormModes.VIEW_SENT
@@ -36,31 +36,31 @@ class FormNavigatorTest {
     private val navigator = FormNavigator("projectId", settingsProvider) { instancesRepository }
 
     @Test
-    fun `editInstance starts FormEntryActivity with instance URI`() {
+    fun `editInstance starts FormUriActivity with instance URI`() {
         settingsProvider.getProtectedSettings().save(KEY_EDIT_SAVED, true)
 
         navigator.editInstance(activity, 101)
 
         intended(hasAction(ACTION_EDIT))
-        intended(hasComponent(FormEntryActivity::class.java.name))
+        intended(hasComponent(FormUriActivity::class.java.name))
         intended(hasData(InstancesContract.getUri("projectId", 101)))
         intended(not(hasExtra(FORM_MODE, VIEW_SENT)))
     }
 
     @Test
-    fun `editInstance stars FormEntryActivity in view only mode when editing is disabled`() {
+    fun `editInstance stars FormUriActivity in view only mode when editing is disabled`() {
         settingsProvider.getProtectedSettings().save(KEY_EDIT_SAVED, false)
 
         navigator.editInstance(activity, 101)
 
         intended(hasAction(ACTION_EDIT))
-        intended(hasComponent(FormEntryActivity::class.java.name))
+        intended(hasComponent(FormUriActivity::class.java.name))
         intended(hasData(InstancesContract.getUri("projectId", 101)))
         intended(hasExtra(FORM_MODE, VIEW_SENT))
     }
 
     @Test
-    fun `editInstance stars FormEntryActivity in view only mode when instance has been sent`() {
+    fun `editInstance stars FormUriActivity in view only mode when instance has been sent`() {
         settingsProvider.getProtectedSettings().save(KEY_EDIT_SAVED, true)
         val instance = instancesRepository.save(
             Instance.Builder()
@@ -71,13 +71,13 @@ class FormNavigatorTest {
         navigator.editInstance(activity, instance.dbId)
 
         intended(hasAction(ACTION_EDIT))
-        intended(hasComponent(FormEntryActivity::class.java.name))
+        intended(hasComponent(FormUriActivity::class.java.name))
         intended(hasData(InstancesContract.getUri("projectId", instance.dbId)))
         intended(hasExtra(FORM_MODE, VIEW_SENT))
     }
 
     @Test
-    fun `editInstance stars FormEntryActivity in view only mode when instance has failed to send`() {
+    fun `editInstance stars FormUriActivity in view only mode when instance has failed to send`() {
         settingsProvider.getProtectedSettings().save(KEY_EDIT_SAVED, true)
         val instance = instancesRepository.save(
             Instance.Builder()
@@ -88,7 +88,7 @@ class FormNavigatorTest {
         navigator.editInstance(activity, instance.dbId)
 
         intended(hasAction(ACTION_EDIT))
-        intended(hasComponent(FormEntryActivity::class.java.name))
+        intended(hasComponent(FormUriActivity::class.java.name))
         intended(hasData(InstancesContract.getUri("projectId", instance.dbId)))
         intended(hasExtra(FORM_MODE, VIEW_SENT))
     }

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -19,8 +19,8 @@ and update this document as the code evolves.
 * App has mixture of unit tests, ["Local tests" and "Instrumented tests"](https://developer.android.com/training/testing/fundamentals#instrumented-vs-local) but coverage is far from complete
 * Local tests are a mixture of classic Robolectric and AndroidX Test/Espresso (backed by Robolectric)
 * UI is "iconic" (old) but with a lot of inconsistencies and quirks and is best adapted to small screens (although often used on tablets)
-* A lot of code lives in between one "god" Activity (`FormEntryActivity`) and a process singleton (`FormController`)
-* Core form entry flow uses custom side-to-side swipe view (in `FormEntryActivity` made up of `ODKView`)
+* A lot of code lives in between one "god" Activity (`FormFillingActivity`) and a process singleton (`FormController`)
+* Core form entry flow uses custom side-to-side swipe view (in `FormFillingActivity` made up of `ODKView`)
 * Questions are rendered using a view "framework" of implementations inheriting from `QuestionWidget` (which is documented at in [WIDGETS.MD](WIDGETS.md))
 * Async/reactivity handled with a mixture of callbacks and LiveData
 * App mostly stores data in flat files indexed in SQLite
@@ -38,7 +38,7 @@ and update this document as the code evolves.
 ## Where we're going
 
 * General effort to increase test coverage and quality while working on anything and pushing more for tests in PR review
-* Slowly moving responsibilities out of `FormEntryActivity`
+* Slowly moving responsibilities out of `FormFillingActivity`
 * Writing pretty much all new code in Kotlin
 * Writing new code using a [multi-module approach](CODE-GUIDELINES.md#gradle-sub-modules) (feature modules, mini frameworks etc) and breaking old code out into modules when opportunities come up
 * Trying to remove technical debt flagged with `@Deprecated`

--- a/externalapp/src/main/java/org/odk/collect/externalapp/ExternalAppUtils.kt
+++ b/externalapp/src/main/java/org/odk/collect/externalapp/ExternalAppUtils.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 
 /**
- * Helpers for returning answers to [FormEntryActivity] via [Activity.onActivityResult] and also
+ * Helpers for returning answers to [FormFillingActivity] via [Activity.onActivityResult] and also
  * for dealing with those answers in [Activity.onActivityResult] itself.
  */
 object ExternalAppUtils {

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -189,8 +189,6 @@
     <string name="bad_uri">Bad URI: %s</string>
     <!-- Displayed when form filling is attempted to be launched by intent but the intent URI mime type is unknown -->
     <string name="unrecognized_uri">Unrecognized URI: %s</string>
-    <!-- Displayed when form filling is attempted to be launched by intent but the form is already finalized or sent -->
-    <string name="form_complete">Can not edit a form that is already finalized or sent</string>
 
     <!-- Text displayed when audio recording fails to start -->
     <string name="start_recording_failed">Could not start recording.</string>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -189,6 +189,8 @@
     <string name="bad_uri">Bad URI: %s</string>
     <!-- Displayed when form filling is attempted to be launched by intent but the intent URI mime type is unknown -->
     <string name="unrecognized_uri">Unrecognized URI: %s</string>
+    <!-- Displayed when form filling is attempted to be launched by intent but the form is already finalized or sent -->
+    <string name="form_complete">Can not edit a form that is already finalized or sent</string>
 
     <!-- Text displayed when audio recording fails to start -->
     <string name="start_recording_failed">Could not start recording.</string>


### PR DESCRIPTION
Work towards #5419 

#### What has been done to verify that this works as intended?
I've tested the changes manually with the tester app: https://github.com/grzesiek2010/collectTester and added automated tests.

#### Why is this the best possible solution? Were any other approaches considered?
The goal of this issue was to block editing of finalized or sent forms via Content Provider. I've handled that in [FormUriActivity](https://github.com/getodk/collect/pull/5542/files#diff-a532d550e83f9eec4e173ec28c7f1cf7835d5096a8d0f1fafa8fd853059464d2R120).
As we discussed earlier `FormUriActivity` should be like a gate to form filling where we check if it makes sense to start the process at all (data validation). I've taken the opportunity and improved that class by validating other cases as well so that now the class contains a [series of methods asserting that everything is ok and form filling can be started](https://github.com/getodk/collect/pull/5542/files#diff-a532d550e83f9eec4e173ec28c7f1cf7835d5096a8d0f1fafa8fd853059464d2R60).
I've also made sure `FormEntryActivity` is not used directly in our app but only by `FormUriActivity` after validating all cases: https://github.com/getodk/collect/pull/5542/commits/29ebf511cab2a22e25ee725696e4e83ce401fd05
<s>I could remove some duplicate validations from `FormEntryActivity` now as it is checked in `FormUriActivity` but there is one problem... `FormEntryActivity` is an exported activity and can be started from an external app by its name (see [the tester app](https://github.com/grzesiek2010/collectTester/blob/master/app/src/main/java/org/odk/collectTester/activities/FillFormActivity.java#L26)). It shouldn't work like that because now even if we block editing of finalized or sent forms via Content Provider it is still possible using `FormEntryActivity` directly. I was a little bit afraid of changing this state and making the activity not exported because maybe there are some projects that rely on it so I decided to leave it as is for now and add analytics: https://github.com/getodk/collect/pull/5542/commits/a120365c94fe9d0ed9a3695ab501c9101ff4fb75</s>

**Initially, I wanted to disable editing finalized and sent forms as described in the issue but I ended up with a lot of failing tests and the UI where those finalized forms were still in the list of forms to edit but couldn't be edited. We have a separate issue for that: https://github.com/getodk/collect/issues/5418
Since the pr contains a lot of improvements in `FormUriActivity` as described above I think it would be good to test it and merge and disable editing finalized forms in a separate one. That's why in the last commit I brought back the original behavior (editing finalized forms).**

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Please test editing forms using the tester app: https://github.com/grzesiek2010/collectTester. I've implemented some refactoring so it probably would make sense to test starting forms using that app (including some weird scenarios when forms should not be started see what cases should block starting a form `FormUriActivityTest`)

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
