### PR TITLE
Remove next branch from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,6 @@ workflows:
             branches:
               ignore:
                 - master
-                - next
       - test_smoke_instrumented:
           requires:
             - compile
@@ -379,7 +378,6 @@ workflows:
             branches:
               only:
                 - master
-                - next
 
   nightly:
     triggers:
@@ -389,7 +387,6 @@ workflows:
             branches:
               only:
                 - master
-                - next
     jobs:
       - compile
       - test_instrumented:


### PR DESCRIPTION
I think we might want to experiment with a different branching strategy for the next release. Either way, we don't need nightly builds of `next` for the time being.