### PR TITLE
Don't flush audit log when constraints fail

### DIFF
--- a/collect_app/src/androidTest/assets/forms/one-question-audit-constraint.xml
+++ b/collect_app/src/androidTest/assets/forms/one-question-audit-constraint.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<h:html xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.w3.org/2002/xforms">
+    <h:head>
+        <h:title>One Question Audit Constraint</h:title>
+        <model>
+            <instance>
+                <data id="one_question_audit" orx:version="1">
+                    <age />
+                    <meta>
+                        <audit />
+                    </meta>
+                </data>
+            </instance>
+            <bind constraint=". &lt; 120" nodeset="age" type="int" jr:constraintMsg="Too old!" />
+            <bind nodeset="/data/meta/audit" type="binary" odk:track-changes="true" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/age">
+            <label>What is your age?</label>
+        </input>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -54,4 +54,31 @@ class AuditTest {
         assertThat(auditLog[11].get("event"), equalTo("form exit"))
         assertThat(auditLog[12].get("event"), equalTo("form finalize"))
     }
+
+    @Test
+    fun fillingFormWithTrackChanges_withConstraint_andViolatingConstraint_andCorrectingAnswer_tracksCorrectedAnswer() {
+        rule.startAtMainMenu()
+            .copyForm("one-question-audit-constraint.xml")
+            .startBlankForm("One Question Audit Constraint")
+            .answerQuestion("What is your age?", "120")
+            .swipeToNextQuestionWithConstraintViolation("Too old!")
+            .answerQuestion("What is your age?", "119")
+            .swipeToEndScreen()
+            .clickSaveAndExit()
+
+        val auditLog = StorageUtils.getAuditLogForFirstInstance()
+        assertThat(auditLog.size, equalTo(6))
+
+        assertThat(auditLog[0].get("event"), equalTo("form start"))
+
+        val questionEvent = auditLog[1]
+        assertThat(questionEvent.get("event"), equalTo("question"))
+        assertThat(questionEvent.get("old-value"), equalTo(""))
+        assertThat(questionEvent.get("new-value"), equalTo("119"))
+
+        assertThat(auditLog[2].get("event"), equalTo("end screen"))
+        assertThat(auditLog[3].get("event"), equalTo("form save"))
+        assertThat(auditLog[4].get("event"), equalTo("form exit"))
+        assertThat(auditLog[5].get("event"), equalTo("form finalize"))
+    }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -54,31 +54,4 @@ class AuditTest {
         assertThat(auditLog[11].get("event"), equalTo("form exit"))
         assertThat(auditLog[12].get("event"), equalTo("form finalize"))
     }
-
-    @Test
-    fun fillingFormWithTrackChanges_withConstraint_andViolatingConstraint_andCorrectingAnswer_tracksCorrectedAnswer() {
-        rule.startAtMainMenu()
-            .copyForm("one-question-audit-constraint.xml")
-            .startBlankForm("One Question Audit Constraint")
-            .answerQuestion("What is your age?", "120")
-            .swipeToNextQuestionWithConstraintViolation("Too old!")
-            .answerQuestion("What is your age?", "119")
-            .swipeToEndScreen()
-            .clickSaveAndExit()
-
-        val auditLog = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLog.size, equalTo(6))
-
-        assertThat(auditLog[0].get("event"), equalTo("form start"))
-
-        val questionEvent = auditLog[1]
-        assertThat(questionEvent.get("event"), equalTo("question"))
-        assertThat(questionEvent.get("old-value"), equalTo(""))
-        assertThat(questionEvent.get("new-value"), equalTo("119"))
-
-        assertThat(auditLog[2].get("event"), equalTo("end screen"))
-        assertThat(auditLog[3].get("event"), equalTo("form save"))
-        assertThat(auditLog[4].get("event"), equalTo("form exit"))
-        assertThat(auditLog[5].get("event"), equalTo("form finalize"))
-    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
+++ b/collect_app/src/main/java/org/odk/collect/android/formentry/FormEntryViewModel.java
@@ -188,8 +188,6 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
         }, updateSuccess -> {
             isLoading.setValue(false);
 
-            formController.getAuditEventLogger().flush();
-
             if (updateSuccess) {
                 try {
                     formController.stepToNextScreenEvent();
@@ -210,8 +208,6 @@ public class FormEntryViewModel extends ViewModel implements SelectChoiceLoader 
             return saveScreenAnswersToFormController(answers, false);
         }, updateSuccess -> {
             isLoading.setValue(false);
-
-            formController.getAuditEventLogger().flush();
 
             if (updateSuccess) {
                 try {

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -196,7 +196,6 @@ public class FormEntryViewModelTest {
         scheduler.runBackground();
         InOrder verifier = inOrder(formController, auditEventLogger);
         verifier.verify(formController).saveAllScreenAnswers(answers, false);
-        verifier.verify(auditEventLogger).flush();
         verifier.verify(formController).stepToNextScreenEvent();
         verifier.verify(auditEventLogger).flush();
     }
@@ -297,7 +296,6 @@ public class FormEntryViewModelTest {
         scheduler.runBackground();
         InOrder verifier = inOrder(formController, auditEventLogger);
         verifier.verify(formController).saveAllScreenAnswers(answers, false);
-        verifier.verify(auditEventLogger).flush();
         verifier.verify(formController).stepToPreviousScreenEvent();
         verifier.verify(auditEventLogger).flush();
     }

--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEntryViewModelTest.java
@@ -237,6 +237,20 @@ public class FormEntryViewModelTest {
         assertThat(getOrAwaitValue(viewModel.getFailedConstraint()), equalTo(failedConstraint));
     }
 
+    /**
+     * We don't want to flush the log before answers are actually committed.
+     */
+    @Test
+    public void moveForward_whenThereIsAFailedConstraint_doesNotFlushAuditLog() throws Exception {
+        FailedConstraint failedConstraint = new FailedConstraint(startingIndex, 0);
+        when(formController.saveAllScreenAnswers(any(), anyBoolean())).thenReturn(failedConstraint);
+
+        viewModel.moveForward(new HashMap<>());
+        scheduler.runBackground();
+
+        verify(auditEventLogger, never()).flush();
+    }
+
     @Test
     public void moveForward_whenThereIsAFailedConstraint_doesNotStepToNextEvent() throws Exception {
         FailedConstraint failedConstraint = new FailedConstraint(startingIndex, 0);


### PR DESCRIPTION
Closes #5543

This changes how we push to the audit log when navigating between screens. Previously, we'd write out any `question` events and their values changes (if tracked) before and after "committing" the answers. In the scenario described in the issue, this causes a correction to a constraint fail to never be logged. Only writing to the audit log after committing answers fixes that, but it's unclear if that change might introduce other problems.

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Another possible solution would have been to log another `question` event when returning to a screen from a constraint fail. That felt like it had even more possible ramifications than removing the mysterious extra `flush()`, so I went with that instead.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

I wouldn't be surprised if this changes something for the worse that we just don't have a test for. Thoroughly testing forms with the audit log with `track-changes` and [other options configured](https://docs.getodk.org/form-audit-log/) is a must here. There's not a lot of well-defined "correct" behaviours for auditing in Collect, so if weirdness does come up, I'd suggest comparing it to older versions of Collect to see if it's a regression or just something else we might need to fix (both would be good to know about).

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
