### PR TITLE
Introduce predicate caching as an opt-in setting

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/java/dependencies/Dependencies.kt
@@ -43,7 +43,7 @@ object Dependencies {
     const val rarepebble_colorpicker = "com.github.martin-stone:hsv-alpha-color-picker-android:3.0.1"
     const val commons_io = "commons-io:commons-io:2.5" // Commons 2.6+ introduce java.nio usage that we can't access until our minSdkVersion >= 26 (https://developer.android.com/reference/java/io/File#toPath())
     const val opencsv = "com.opencsv:opencsv:5.7.1"
-    const val javarosa = "org.getodk:javarosa:4.1.0"
+    const val javarosa = "org.getodk:javarosa:4.2.0-SNAPSHOT"
     const val javarosa_local = "org.getodk:javarosa:local"
     const val karumi_dexter = "com.karumi:dexter:6.2.3"
     const val zxing_android_embedded = "com.journeyapps:zxing-android-embedded:4.3.0"

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/forms/FormNavigationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/forms/FormNavigationTest.java
@@ -16,11 +16,15 @@
 
 package org.odk.collect.android.instrumented.forms;
 
+import static junit.framework.Assert.assertEquals;
+
 import android.app.Application;
 
 import androidx.test.core.app.ApplicationProvider;
 
 import org.javarosa.core.model.FormDef;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -46,8 +50,6 @@ import java.util.concurrent.ExecutionException;
 
 import timber.log.Timber;
 
-import static junit.framework.Assert.assertEquals;
-
 /**
  * This test has been created in order to check indices while navigating through a form.
  * It's especially important while navigating through a form that contains nested groups and if we
@@ -58,6 +60,13 @@ import static junit.framework.Assert.assertEquals;
  */
 @RunWith(Parameterized.class)
 public class FormNavigationTest {
+
+    private final FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory = new FormLoaderTask.FormEntryControllerFactory() {
+        @Override
+        public FormEntryController create(FormDef formDef) {
+            return new FormEntryController(new FormEntryModel(formDef));
+        }
+    };
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()
@@ -120,7 +129,7 @@ public class FormNavigationTest {
             Timber.i(e);
         }
 
-        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath(formName), null, null);
+        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath(formName), null, null, formEntryControllerFactory);
         formLoaderTask.setFormLoaderListener(new FormLoaderListener() {
             @Override
             public void loadingComplete(FormLoaderTask task, FormDef fd, String warningMsg) {

--- a/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/forms/FormUtilsTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/instrumented/forms/FormUtilsTest.java
@@ -1,18 +1,21 @@
 package org.odk.collect.android.instrumented.forms;
 
+import org.javarosa.core.model.FormDef;
 import org.javarosa.core.reference.RootTranslator;
+import org.javarosa.form.api.FormEntryController;
+import org.javarosa.form.api.FormEntryModel;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.odk.collect.android.support.rules.CollectTestRule;
-import org.odk.collect.android.support.rules.TestRuleChain;
-import org.odk.collect.android.utilities.FormUtils;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
+import org.odk.collect.android.support.rules.CollectTestRule;
+import org.odk.collect.android.support.rules.TestRuleChain;
 import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.utilities.FileUtils;
+import org.odk.collect.android.utilities.FormUtils;
 
 import java.io.File;
 import java.util.List;
@@ -20,6 +23,13 @@ import java.util.List;
 public class FormUtilsTest {
     private static final String BASIC_FORM = "basic.xml";
     private final CollectTestRule rule = new CollectTestRule();
+
+    private final FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory = new FormLoaderTask.FormEntryControllerFactory() {
+        @Override
+        public FormEntryController create(FormDef formDef) {
+            return new FormEntryController(new FormEntryModel(formDef));
+        }
+    };
 
     @Rule
     public RuleChain copyFormChain = TestRuleChain.chain()
@@ -38,7 +48,7 @@ public class FormUtilsTest {
     public void sessionRootTranslatorOrderDoesNotMatter() throws Exception {
         final String formPath = new StoragePathProvider().getOdkDirPath(StorageSubdirectory.FORMS) + File.separator + BASIC_FORM;
         // Load the form in order to populate the ReferenceManager
-        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null);
+        FormLoaderTask formLoaderTask = new FormLoaderTask(formPath, null, null, formEntryControllerFactory);
         formLoaderTask.execute(formPath).get();
 
         final File formXml = new File(formPath);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormEntryActivity.java
@@ -359,6 +359,9 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
     @Inject
     public AudioHelperFactory audioHelperFactory;
 
+    @Inject
+    public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory;
+
     private final LocationProvidersReceiver locationProvidersReceiver = new LocationProvidersReceiver();
 
     private SwipeHandler swipeHandler;
@@ -634,7 +637,7 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
                     formEntryViewModel.refresh();
                 } else {
                     Timber.w("Reloading form and restoring state.");
-                    formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath);
+                    formLoaderTask = new FormLoaderTask(instancePath, startingXPath, waitingXPath, formEntryControllerFactory);
                     showIfNotShowing(FormLoadingDialogFragment.class, getSupportFragmentManager());
                     formLoaderTask.execute(formPath);
                 }
@@ -713,7 +716,7 @@ public class FormEntryActivity extends LocalizedActivity implements AnimationLis
             return;
         }
 
-        formLoaderTask = new FormLoaderTask(instancePath, null, null);
+        formLoaderTask = new FormLoaderTask(instancePath, null, null, formEntryControllerFactory);
         formLoaderTask.setFormLoaderListener(this);
         showIfNotShowing(FormLoadingDialogFragment.class, getSupportFragmentManager());
         formLoaderTask.execute(formPath);

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -5,6 +5,7 @@ import org.javarosa.entities.EntityFormFinalizationProcessor
 import org.javarosa.form.api.FormEntryController
 import org.javarosa.form.api.FormEntryModel
 import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
+import org.odk.collect.settings.keys.ProjectKeys
 import org.odk.collect.shared.settings.Settings
 
 class CollectFormEntryControllerFactory constructor(private val settings: Settings) :
@@ -13,7 +14,7 @@ class CollectFormEntryControllerFactory constructor(private val settings: Settin
         return FormEntryController(FormEntryModel(formDef)).also {
             it.addPostProcessor(EntityFormFinalizationProcessor())
 
-            if (!settings.getBoolean("predicate_caching")) {
+            if (!settings.getBoolean(ProjectKeys.KEY_PREDICATE_CACHING)) {
                 it.disablePredicateCaching()
             }
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -10,7 +10,7 @@ import org.odk.collect.shared.settings.Settings
 
 class CollectFormEntryControllerFactory constructor(private val settings: Settings) :
     FormEntryControllerFactory {
-    override fun create(formDef: FormDef?): FormEntryController {
+    override fun create(formDef: FormDef): FormEntryController {
         return FormEntryController(FormEntryModel(formDef)).also {
             it.addPostProcessor(EntityFormFinalizationProcessor())
 

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/CollectFormEntryControllerFactory.kt
@@ -1,0 +1,21 @@
+package org.odk.collect.android.formmanagement
+
+import org.javarosa.core.model.FormDef
+import org.javarosa.entities.EntityFormFinalizationProcessor
+import org.javarosa.form.api.FormEntryController
+import org.javarosa.form.api.FormEntryModel
+import org.odk.collect.android.tasks.FormLoaderTask.FormEntryControllerFactory
+import org.odk.collect.shared.settings.Settings
+
+class CollectFormEntryControllerFactory constructor(private val settings: Settings) :
+    FormEntryControllerFactory {
+    override fun create(formDef: FormDef?): FormEntryController {
+        return FormEntryController(FormEntryModel(formDef)).also {
+            it.addPostProcessor(EntityFormFinalizationProcessor())
+
+            if (!settings.getBoolean("predicate_caching")) {
+                it.disablePredicateCaching()
+            }
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -50,6 +50,7 @@ import org.odk.collect.android.formentry.FormSessionRepository;
 import org.odk.collect.android.formentry.media.AudioHelperFactory;
 import org.odk.collect.android.formentry.media.ScreenContextAudioHelperFactory;
 import org.odk.collect.android.formlists.blankformlist.BlankFormListViewModel;
+import org.odk.collect.android.formmanagement.CollectFormEntryControllerFactory;
 import org.odk.collect.android.formmanagement.FormDownloader;
 import org.odk.collect.android.formmanagement.FormMetadataParser;
 import org.odk.collect.android.formmanagement.FormSourceProvider;
@@ -84,6 +85,7 @@ import org.odk.collect.android.projects.ProjectDeleter;
 import org.odk.collect.android.projects.ProjectDependencyProviderFactory;
 import org.odk.collect.android.storage.StoragePathProvider;
 import org.odk.collect.android.storage.StorageSubdirectory;
+import org.odk.collect.android.tasks.FormLoaderTask;
 import org.odk.collect.android.utilities.AdminPasswordProvider;
 import org.odk.collect.android.utilities.AndroidUserAgent;
 import org.odk.collect.android.utilities.ChangeLockProvider;
@@ -632,5 +634,10 @@ public class AppDependencyModule {
     @Singleton
     public ImageCompressionController providesImageCompressorManager() {
         return new ImageCompressionController(ImageCompressor.INSTANCE);
+    }
+
+    @Provides
+    public FormLoaderTask.FormEntryControllerFactory formEntryControllerFactory(SettingsProvider settingsProvider) {
+        return new CollectFormEntryControllerFactory(settingsProvider.getUnprotectedSettings());
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -55,6 +55,8 @@ object Defaults {
             hashMap[ProjectKeys.KEY_USGS_MAP_STYLE] = "topographic"
             hashMap[ProjectKeys.KEY_GOOGLE_MAP_STYLE] = GoogleMap.MAP_TYPE_NORMAL.toString()
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
+            // experimental_preferences.xml
+            hashMap["predicate_caching"] = false
             return hashMap
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -56,7 +56,7 @@ object Defaults {
             hashMap[ProjectKeys.KEY_GOOGLE_MAP_STYLE] = GoogleMap.MAP_TYPE_NORMAL.toString()
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
             // experimental_preferences.xml
-            hashMap["predicate_caching"] = false
+            hashMap[ProjectKeys.KEY_PREDICATE_CACHING] = false
             return hashMap
         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -22,6 +22,8 @@ import android.database.Cursor;
 import android.database.SQLException;
 import android.os.AsyncTask;
 
+import androidx.annotation.NonNull;
+
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvValidationException;
 
@@ -574,6 +576,6 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
     }
 
     public interface FormEntryControllerFactory {
-        FormEntryController create(FormDef formDef);
+        FormEntryController create(@NonNull FormDef formDef);
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -32,9 +32,7 @@ import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.instance.utils.DefaultAnswerResolver;
 import org.javarosa.core.reference.ReferenceManager;
-import org.javarosa.entities.EntityFormFinalizationProcessor;
 import org.javarosa.form.api.FormEntryController;
-import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.util.XFormUtils;
 import org.javarosa.xpath.XPathTypeMismatchException;
@@ -81,6 +79,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
     private String instancePath;
     private final String xpath;
     private final String waitingXPath;
+    private FormEntryControllerFactory formEntryControllerFactory;
     private boolean pendingActivityResult;
     private int requestCode;
     private int resultCode;
@@ -112,10 +111,11 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
 
     FECWrapper data;
 
-    public FormLoaderTask(String instancePath, String xpath, String waitingXPath) {
+    public FormLoaderTask(String instancePath, String xpath, String waitingXPath, FormEntryControllerFactory formEntryControllerFactory) {
         this.instancePath = instancePath;
         this.xpath = xpath;
         this.waitingXPath = waitingXPath;
+        this.formEntryControllerFactory = formEntryControllerFactory;
     }
 
     /**
@@ -176,9 +176,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
 
         // create FormEntryController from formdef
-        final FormEntryModel fem = new FormEntryModel(formDef);
-        final FormEntryController fec = new FormEntryController(fem);
-        fec.addPostProcessor(new EntityFormFinalizationProcessor());
+        final FormEntryController fec = formEntryControllerFactory.create(formDef);
 
         boolean usedSavepoint = false;
 
@@ -573,5 +571,9 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
 
     public FormDef getFormDef() {
         return formDef;
+    }
+
+    public interface FormEntryControllerFactory {
+        FormEntryController create(FormDef formDef);
     }
 }

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -2,6 +2,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/experimental">
 
+    <SwitchPreferenceCompat
+        android:title="Predicate caching"
+        android:key="predicate_caching" />
+
     <Preference
         android:icon="@drawable/ic_person_black_24dp"
         android:title="@string/entities_title"

--- a/collect_app/src/main/res/xml/experimental_preferences.xml
+++ b/collect_app/src/main/res/xml/experimental_preferences.xml
@@ -3,7 +3,7 @@
     android:title="@string/experimental">
 
     <SwitchPreferenceCompat
-        android:title="Predicate caching"
+        android:title="@string/predicate_caching"
         android:key="predicate_caching" />
 
     <Preference

--- a/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/ProjectKeys.kt
@@ -55,6 +55,9 @@ object ProjectKeys {
     const val KEY_BACKGROUND_LOCATION = "background_location"
     const val KEY_BACKGROUND_RECORDING = "background_recording"
 
+    // experimental_preferences.xml
+    const val KEY_PREDICATE_CACHING = "predicate_caching"
+
     // values
     const val PROTOCOL_SERVER = "odk_default"
     const val PROTOCOL_GOOGLE_SHEETS = "google_sheets"

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1196,5 +1196,6 @@
     <string name="crash_app">Crash app</string>
     <!-- An uncaught exception is an exception that is not handled by ODK Collect and so will force the application to close -->
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
+    <string name="predicate_caching">Predicate caching</string>
 
 </resources>


### PR DESCRIPTION
Work towards #5410
~~Blocked by getodk/javarosa#713~~

For the moment, predicate caching is off by default and can be enabled from "Experimental" settings.

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Not a lot to discuss here. I introduced a new `FormEntryControllerFactory` component to allow us to isolate building/configuring a `FormEntryController`. I expect we'll end up with even more configuration down the line as part of this work, so that should hopefully become an important foundation.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The only change in behaviour we should see is that switching between screens during form entry should now be faster for forms like the example in https://github.com/getodk/javarosa/issues/689. We'll want to discuss some strategies for trying to break the caching introduced here, but for now our plan is to merge without QA to get as many people testing it as possible. As the feature is a beta only opt-in the risk is very limited and we shouldn't see this breaking anything for real projects.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
