### PR TITLE
Enable predicate caching by default

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ChangesReasonPromptPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/ChangesReasonPromptPage.java
@@ -24,6 +24,8 @@ public class ChangesReasonPromptPage extends Page<ChangesReasonPromptPage> {
 
     @Override
     public ChangesReasonPromptPage assertOnPage() {
+        closeSoftKeyboard(); // Might open before assertion has a chance to run
+
         assertToolbarTitle(formName);
         onView(withText(getTranslatedString(R.string.reason_for_changes))).check(matches(isDisplayed()));
         return this;

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/PrepDeviceForTestsRule.kt
@@ -6,12 +6,16 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-class DisableDeviceAnimationsRule : TestRule {
+/**
+ * Disables animations and sets long press timeout to 3 seconds in an attempt to avoid flakiness.
+ */
+class PrepDeviceForTestsRule : TestRule {
 
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
                 ANIMATIONS.forEach { executeShellCommand("settings put global $it 0") }
+                executeShellCommand("settings put secure long_press_timeout 3000")
                 base.evaluate()
             }
         }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -28,7 +28,7 @@ object TestRuleChain {
                 )
             )
             .around(ResetRotationRule())
-            .around(DisableDeviceAnimationsRule())
+            .around(PrepDeviceForTestsRule())
             .around(ResetStateRule(testDependencies))
             .around(countingTaskExecutorIdlingResource)
             .around(

--- a/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/preferences/Defaults.kt
@@ -56,7 +56,7 @@ object Defaults {
             hashMap[ProjectKeys.KEY_GOOGLE_MAP_STYLE] = GoogleMap.MAP_TYPE_NORMAL.toString()
             hashMap[ProjectKeys.KEY_MAPBOX_MAP_STYLE] = "mapbox://styles/mapbox/streets-v11"
             // experimental_preferences.xml
-            hashMap[ProjectKeys.KEY_PREDICATE_CACHING] = false
+            hashMap[ProjectKeys.KEY_PREDICATE_CACHING] = true
             return hashMap
         }
 


### PR DESCRIPTION
I also packaged in some tweaks to UI tests to make them more stable after running into problems getting a clean run.