### PR TITLE
Store self signed release as artifact on commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,12 @@ jobs:
           name: Check APK size hasn't increased by more than 100kb
           command: if [ $(ls -l collect_app/build/outputs/apk/selfSignedRelease/*.apk | awk '{print $5}') -gt 10734563 ]; then exit 1; fi
 
+      - run:
+          name: Copy APK to predictable path for artifact storage
+          command: cp collect_app/build/outputs/apk/selfSignedRelease/*.apk selfSignedRelease.apk
+      - store_artifacts:
+          path: selfSignedRelease.apk
+
   test_smoke_instrumented:
     <<: *android_config
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,6 @@ jobs:
       - run:
           name: Run code quality checks
           command: ./gradlew checkCode
-      - store_artifacts:
-          path: collect_app/build/reports
-          destination: reports
 
   test_modules:
     <<: *android_config
@@ -127,9 +124,6 @@ jobs:
           command: |
             ./gradlew $(cat .circleci/fork_test_modules.txt | awk '{for (i=1; i<=NF; i++) printf "%s ",$i}')
 
-      - store_artifacts:
-          path: collect_app/build/reports
-          destination: reports
       - store_test_results:
           path: collect_app/build/test-results
 


### PR DESCRIPTION
This will allow reviewers to download an APK for the PR changes from the artifacts in the `build-release` job. As part of working on this, I wanted to double-check that we wouldn't end up hitting a storage limit on Circle CI. It turns out that workspaces, caches and artifact retention time can be customized in Circle CI's "Usage Controls" settings and that by default they are all deleted after 30 days.