### PR TITLE
Prevent editing of finalized forms

### DIFF
--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -1,7 +1,6 @@
 package org.odk.collect.android.feature.external
 
 import android.content.Intent
-import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -9,12 +8,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.R
 import org.odk.collect.android.external.InstancesContract
 import org.odk.collect.android.support.ContentProviderUtils
 import org.odk.collect.android.support.pages.AppClosedPage
 import org.odk.collect.android.support.pages.FormHierarchyPage
-import org.odk.collect.android.support.pages.OkDialog
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain
 
@@ -67,71 +64,5 @@ class InstanceEditActionTest {
         }
 
         assertThat(result.resultData.data, equalTo(uri))
-    }
-
-    @Test
-    fun whenInstanceIsNotCurrentProject_showsWarningAndExits() {
-        rule.startAtMainMenu()
-            .copyAndSyncForm("one-question.xml")
-            .startBlankForm("One Question")
-            .swipeToEndScreen()
-            .clickFinalize()
-            .addAndSwitchToProject("https://example.com")
-
-        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
-        val uri = InstancesContract.getUri("DEMO", instanceId)
-
-        val intent = Intent(Intent.ACTION_EDIT).also { it.data = uri }
-        rule.launch(intent, OkDialog())
-            .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(AppClosedPage())
-    }
-
-    @Test
-    fun whenUriDoesNotHaveProjectId_andCurrentProjectIsFirstOne_opensForm() {
-        rule.startAtMainMenu()
-            .copyAndSyncForm("one-question.xml")
-            .startBlankForm("One Question")
-            .swipeToEndScreen()
-            .clickFinalize()
-            .addAndSwitchToProject("https://example.com")
-            .openProjectSettingsDialog()
-            .selectProject("Demo project")
-
-        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
-        val uri = InstancesContract.getUri("DEMO", instanceId)
-        val uriWithoutProjectId = Uri.Builder()
-            .scheme(uri.scheme)
-            .authority(uri.authority)
-            .path(uri.path)
-            .query(null)
-            .build()
-
-        val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
-        rule.launch(intent, FormHierarchyPage("One Question"))
-    }
-
-    @Test
-    fun whenUriDoesNotHaveProjectId_andCurrentProjectIsNotFirstOne_showsWarningAndExits() {
-        rule.startAtMainMenu()
-            .copyAndSyncForm("one-question.xml")
-            .startBlankForm("One Question")
-            .swipeToEndScreen()
-            .clickFinalize()
-            .addAndSwitchToProject("https://example.com")
-
-        val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
-        val uri = InstancesContract.getUri("DEMO", instanceId)
-        val uriWithoutProjectId = Uri.Builder()
-            .scheme(uri.scheme)
-            .authority(uri.authority)
-            .path(uri.path)
-            .query(null)
-            .build()
-
-        val intent = Intent(Intent.ACTION_EDIT).also { it.data = uriWithoutProjectId }
-        rule.launch(intent, OkDialog())
-            .assertText(R.string.wrong_project_selected_for_form)
-            .clickOK(AppClosedPage())
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstanceEditActionTest.kt
@@ -30,7 +30,7 @@ class InstanceEditActionTest {
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
         val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         val uri = InstancesContract.getUri("DEMO", instanceId)
@@ -52,7 +52,7 @@ class InstanceEditActionTest {
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
         val instanceId = ContentProviderUtils.getInstanceDatabaseId("DEMO", "one_question")
         val uri = InstancesContract.getUri("DEMO", instanceId)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/external/InstancePickActionTest.kt
@@ -29,7 +29,7 @@ class InstancePickActionTest {
             .copyAndSyncForm("one-question.xml")
             .startBlankForm("One Question")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
         val intent = Intent(Intent.ACTION_PICK)
         intent.type = InstancesContract.CONTENT_TYPE

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/EncryptedFormTest.java
@@ -38,21 +38,6 @@ public class EncryptedFormTest {
             .around(rule);
 
     @Test
-    public void instanceOfEncryptedForm_cantBeEditedWhenFinalized() {
-        rule.startAtMainMenu()
-                .copyForm("encrypted.xml")
-                .startBlankForm("encrypted")
-                .assertQuestion("Question 1")
-                .swipeToEndScreen()
-                .clickFinalize()
-                .checkIsToastWithMessageDisplayed(R.string.data_saved_ok)
-                .clickEditSavedForm()
-                .checkInstanceState("encrypted", Instance.STATUS_COMPLETE)
-                .clickOnFormWithDialog("encrypted")
-                .assertText(R.string.cannot_edit_completed_form);
-    }
-
-    @Test
     public void instanceOfEncryptedForm_cantBeViewedAfterSending() {
         rule.startAtMainMenu()
                 .copyForm("encrypted.xml")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/FormFinalizingTest.kt
@@ -40,7 +40,7 @@ class FormFinalizingTest {
             .startBlankForm("One Question")
             .swipeToEndScreen()
             .clickFinalize()
-            .assertNumberOfEditableForms(1)
+            .assertNumberOfEditableForms(0)
             .assertNumberOfFinalizedForms(1)
     }
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuickSaveTest.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.R;
 import org.odk.collect.android.support.pages.FormEntryPage.QuestionAndAnswer;
 import org.odk.collect.android.support.rules.CollectTestRule;
 import org.odk.collect.android.support.rules.TestRuleChain;
@@ -73,61 +72,5 @@ public class QuickSaveTest {
                 .clickEditSavedForm(1)
                 .clickOnForm("Two Question Required")
                 .assertText("Another Reuben");
-    }
-
-    @Test
-    public void whenEditingAFinalizedForm_withViolatedConstraintsOnCurrentScreen_clickingSaveIcon_showsError() {
-        rule.startAtMainMenu()
-                .copyForm("two-question-required.xml")
-                .startBlankForm("Two Question Required")
-                .fillOutAndFinalize(
-                        new QuestionAndAnswer("What is your name?", "Reuben"),
-                        new QuestionAndAnswer("What is your age?", "32", true)
-                )
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .clickGoToStart()
-                .answerQuestion("What is your name?", "Another Reuben")
-                .swipeToNextQuestion("What is your age?", true)
-                .longPressOnQuestion("What is your age?", true)
-                .removeResponse()
-                .clickSaveWithError(R.string.required_answer_error)
-
-                .pressBackAndDiscardChanges()
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .assertText("Reuben")
-                .assertText("32");
-    }
-
-    @Test
-    public void whenEditingAFinalizedForm_withViolatedConstraintsOnAnotherScreen_clickingSaveIcon_showsConstraintViolation() {
-        rule.startAtMainMenu()
-                .copyForm("two-question-required.xml")
-                .startBlankForm("Two Question Required")
-                .fillOutAndFinalize(
-                        new QuestionAndAnswer("What is your name?", "Reuben"),
-                        new QuestionAndAnswer("What is your age?", "32", true)
-                )
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .clickGoToStart()
-                .answerQuestion("What is your name?", "Another Reuben")
-                .swipeToNextQuestion("What is your age?", true)
-                .longPressOnQuestion("What is your age?", true)
-                .removeResponse()
-                .swipeToPreviousQuestion("What is your name?")
-                .clickSave()
-                .assertConstraintDisplayed("Sorry, this response is required!")
-                .assertQuestion("What is your age?", true)
-                .pressBackAndDiscardChanges()
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .assertText("Reuben")
-                .assertText("32");
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/QuittingFormTest.java
@@ -8,8 +8,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.odk.collect.android.R;
-import org.odk.collect.android.support.pages.FormEntryPage;
 import org.odk.collect.android.support.pages.MainMenuPage;
 import org.odk.collect.android.support.pages.SaveOrDiscardFormDialog;
 import org.odk.collect.android.support.rules.CollectTestRule;
@@ -108,63 +106,5 @@ public class QuittingFormTest {
                 .clickEditSavedForm(1)
                 .clickOnForm("Two Question Required")
                 .assertText("Another Reuben");
-    }
-
-    @Test
-    public void whenEditingAFinalizedForm_withViolatedConstraintsOnCurrentScreen_pressingBack_andClickingSaveChanges_showsError() {
-        rule.startAtMainMenu()
-                .copyForm("two-question-required.xml")
-                .startBlankForm("Two Question Required")
-                .fillOutAndFinalize(
-                        new QuestionAndAnswer("What is your name?", "Reuben"),
-                        new QuestionAndAnswer("What is your age?", "32", true)
-                )
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .clickGoToStart()
-                .answerQuestion("What is your name?", "Another Reuben")
-                .swipeToNextQuestion("What is your age?", true)
-                .longPressOnQuestion("What is your age?", true)
-                .removeResponse()
-                .closeSoftKeyboard()
-                .pressBack(new SaveOrDiscardFormDialog<>("Two Question Required", new FormEntryPage("Two Question Required")))
-                .clickSaveChangesWithError(R.string.required_answer_error)
-                .pressBackAndDiscardChanges()
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .assertText("Reuben")
-                .assertText("32");
-    }
-
-    @Test
-    public void whenEditingAFinalizedForm_withViolatedConstraintsOnAnotherScreen_pressingBack_andClickingSaveChanges_showsViolatedConstraint() {
-        rule.startAtMainMenu()
-                .copyForm("two-question-required.xml")
-                .startBlankForm("Two Question Required")
-                .fillOutAndFinalize(
-                        new QuestionAndAnswer("What is your name?", "Reuben"),
-                        new QuestionAndAnswer("What is your age?", "32", true)
-                )
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .clickGoToStart()
-                .answerQuestion("What is your name?", "Another Reuben")
-                .swipeToNextQuestion("What is your age?", true)
-                .longPressOnQuestion("What is your age?", true)
-                .removeResponse()
-                .swipeToPreviousQuestion("What is your name?")
-                .closeSoftKeyboard()
-                .pressBack(new SaveOrDiscardFormDialog<>("Two Question Required", new FormEntryPage("Two Question Required")))
-                .clickSaveChangesWithError(R.string.required_answer_error)
-                .assertQuestion("What is your age?", true)
-                .pressBackAndDiscardChanges()
-
-                .clickEditSavedForm(1)
-                .clickOnForm("Two Question Required")
-                .assertText("Reuben")
-                .assertText("32");
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveIncompleteTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/SaveIncompleteTest.kt
@@ -5,7 +5,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.odk.collect.android.support.pages.FormEntryPage.QuestionAndAnswer
 import org.odk.collect.android.support.rules.CollectTestRule
 import org.odk.collect.android.support.rules.TestRuleChain.chain
 
@@ -44,57 +43,5 @@ class SaveIncompleteTest {
             .clickEditSavedForm(1)
             .clickOnForm("Two Question Save Incomplete Required")
             .assertText("Dez")
-    }
-
-    @Test
-    fun whenEditingAFinalizedForm_viewingSaveIncompleteQuestion_savesCurrentAnswers_andUnfinalizesForm() {
-        rule.startAtMainMenu()
-            .copyForm("two-question-save-incomplete-required.xml")
-            .startBlankForm("Two Question Save Incomplete Required")
-            .fillOutAndFinalize(
-                QuestionAndAnswer("What is your name?", "Dez"),
-                QuestionAndAnswer("[saveIncomplete] What is your age?", "56", true)
-            )
-            .assertNumberOfFinalizedForms(1)
-
-            .clickEditSavedForm(1)
-            .clickOnForm("Two Question Save Incomplete Required")
-            .clickGoToStart()
-            .answerQuestion("What is your name?", "Meg")
-            .swipeToNextQuestion("[saveIncomplete] What is your age?", true)
-            .pressBackAndDiscardChanges()
-
-            .assertNumberOfFinalizedForms(0)
-            .clickEditSavedForm(1)
-            .clickOnForm("Two Question Save Incomplete Required")
-            .assertText("Meg")
-            .assertText("56")
-    }
-
-    @Test
-    fun whenEditingAFinalizedForm_viewingSaveIncompleteQuestion_whenConstrainsAreViolated_savesCurrentAnswers_andUnfinalizesForm() {
-        rule.startAtMainMenu()
-            .copyForm("two-question-save-incomplete-required.xml")
-            .startBlankForm("Two Question Save Incomplete Required")
-            .fillOutAndFinalize(
-                QuestionAndAnswer("What is your name?", "Dez"),
-                QuestionAndAnswer("[saveIncomplete] What is your age?", "56", true)
-            )
-            .assertNumberOfFinalizedForms(1)
-
-            .clickEditSavedForm(1)
-            .clickOnForm("Two Question Save Incomplete Required")
-            .clickOnQuestion("[saveIncomplete] What is your age?", true)
-            .longPressOnQuestion("[saveIncomplete] What is your age?", true)
-            .removeResponse()
-            .swipeToPreviousQuestion("What is your name?")
-            .answerQuestion("What is your name?", "Bradley")
-            .swipeToNextQuestion("[saveIncomplete] What is your age?")
-            .pressBackAndDiscardChanges()
-
-            .assertNumberOfFinalizedForms(0)
-            .clickEditSavedForm(1)
-            .clickOnForm("Two Question Save Incomplete Required")
-            .assertText("Bradley")
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/AuditTest.kt
@@ -26,9 +26,11 @@ class AuditTest {
         rule.startAtMainMenu()
             .copyForm("one-question-audit.xml")
             .startBlankForm("One Question Audit")
-            .fillOutAndFinalize(
+            .fillOut(
                 FormEntryPage.QuestionAndAnswer("what is your age", "31")
             )
+            .swipeToEndScreen()
+            .clickSaveAsDraft()
             .clickEditSavedForm(1)
             .clickOnForm("One Question Audit")
             .clickGoToStart()
@@ -37,21 +39,20 @@ class AuditTest {
             )
 
         val auditLog = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLog.size, equalTo(13))
+        assertThat(auditLog.size, equalTo(12))
 
         assertThat(auditLog[0].get("event"), equalTo("form start"))
         assertThat(auditLog[1].get("event"), equalTo("question"))
         assertThat(auditLog[2].get("event"), equalTo("end screen"))
         assertThat(auditLog[3].get("event"), equalTo("form save"))
         assertThat(auditLog[4].get("event"), equalTo("form exit"))
-        assertThat(auditLog[5].get("event"), equalTo("form finalize"))
 
-        assertThat(auditLog[6].get("event"), equalTo("form resume"))
-        assertThat(auditLog[7].get("event"), equalTo("jump"))
-        assertThat(auditLog[8].get("event"), equalTo("question"))
-        assertThat(auditLog[9].get("event"), equalTo("end screen"))
-        assertThat(auditLog[10].get("event"), equalTo("form save"))
-        assertThat(auditLog[11].get("event"), equalTo("form exit"))
-        assertThat(auditLog[12].get("event"), equalTo("form finalize"))
+        assertThat(auditLog[5].get("event"), equalTo("form resume"))
+        assertThat(auditLog[6].get("event"), equalTo("jump"))
+        assertThat(auditLog[7].get("event"), equalTo("question"))
+        assertThat(auditLog[8].get("event"), equalTo("end screen"))
+        assertThat(auditLog[9].get("event"), equalTo("form save"))
+        assertThat(auditLog[10].get("event"), equalTo("form exit"))
+        assertThat(auditLog[11].get("event"), equalTo("form finalize"))
     }
 }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/IdentifyUserTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/IdentifyUserTest.java
@@ -59,7 +59,7 @@ public class IdentifyUserTest {
                 .enterIdentity("Lucius")
                 .clickKeyboardEnter(new FormEntryPage("Identify User"))
                 .swipeToEndScreen()
-                .clickFinalize()
+                .clickSaveAsDraft()
 
                 .clickEditSavedForm()
                 .clickOnFormWithIdentityPrompt("Identify User")
@@ -69,7 +69,7 @@ public class IdentifyUserTest {
                 .clickFinalize();
 
             List<CSVRecord> auditLog = StorageUtils.getAuditLogForFirstInstance();
-            CSVRecord formResumeEvent = auditLog.get(6);
+            CSVRecord formResumeEvent = auditLog.get(5);
             assertThat(formResumeEvent.get(0), equalTo("form resume"));
             assertThat(formResumeEvent.get(4), equalTo("Jack"));
     }

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formentry/audit/TrackChangesReasonTest.kt
@@ -31,7 +31,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
             .clickEditSavedForm()
             .clickOnForm("Track Changes Reason")
@@ -41,9 +41,9 @@ class TrackChangesReasonTest {
             .clickSave()
 
         val auditLogForFirstInstance = StorageUtils.getAuditLogForFirstInstance()
-        assertThat(auditLogForFirstInstance[9].get("event"), equalTo("change reason"))
+        assertThat(auditLogForFirstInstance[8].get("event"), equalTo("change reason"))
         assertThat(
-            auditLogForFirstInstance[9].get("change-reason"),
+            auditLogForFirstInstance[8].get("change-reason"),
             equalTo("Needed to be more exciting and less mysterious")
         )
     }
@@ -55,7 +55,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
             .clickEditSavedForm()
 
             .clickOnForm("Track Changes Reason")
@@ -72,7 +72,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
             .clickEditSavedForm()
             .clickOnForm("Track Changes Reason")
@@ -89,7 +89,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
             .clickEditSavedForm()
             .clickOnForm("Track Changes Reason")
@@ -109,7 +109,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
             .clickEditSavedForm()
             .clickOnForm("Track Changes Reason")
@@ -131,7 +131,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
             .clickEditSavedForm()
             .clickOnForm("Track Changes Reason")
@@ -148,7 +148,7 @@ class TrackChangesReasonTest {
             .startBlankForm("Track Changes Reason")
             .inputText("Nothing much...")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
             .clickEditSavedForm()
             .clickOnForm("Track Changes Reason")

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/formmanagement/DeleteBlankFormTest.java
@@ -43,7 +43,7 @@ public class DeleteBlankFormTest {
                 .startBlankForm("One Question")
                 .answerQuestion("what is your age", "22")
                 .swipeToEndScreen()
-                .clickFinalize()
+                .clickSaveAsDraft()
 
                 .clickDeleteSavedForm()
                 .clickBlankForms()

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/InstancesAdbTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/instancemanagement/InstancesAdbTest.kt
@@ -30,7 +30,7 @@ class InstancesAdbTest {
             .clickFillBlankForm() // Add form via disk sync
             .copyInstance("One Question_2021-06-22_15-55-50.xml")
             .pressBack(MainMenuPage()) // Return to main menu to trigger instance disk sync
-            .clickEditSavedForm(1)
+            .clickSendFinalizedForm(1)
             .assertText("One Question")
     }
 
@@ -40,7 +40,7 @@ class InstancesAdbTest {
             .copyForm("one-question.xml")
             .startBlankForm("One Question")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
 
         val instancesDir =
             testDependencies.storagePathProvider.getOdkDirPath(StorageSubdirectory.INSTANCES)

--- a/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/feature/projects/SwitchProjectTest.kt
@@ -56,7 +56,7 @@ class SwitchProjectTest {
             .startBlankForm("Two Question")
             .swipeToNextQuestion("What is your age?")
             .swipeToEndScreen()
-            .clickFinalize()
+            .clickSaveAsDraft()
             .clickEditSavedForm(1)
             .assertText("Two Question")
             .pressBack(MainMenuPage())
@@ -79,7 +79,7 @@ class SwitchProjectTest {
             // Fill form
             .startBlankForm("One Question Entity")
             .fillOutAndFinalize(FormEntryPage.QuestionAndAnswer("Name", "Alice"))
-            .clickEditSavedForm(1)
+            .clickSendFinalizedForm(1)
             .assertText("One Question Entity")
             .pressBack(MainMenuPage())
 
@@ -111,7 +111,7 @@ class SwitchProjectTest {
             .pressBack(MainMenuPage())
 
             // Check instances
-            .clickSendFinalizedForm(1)
+            .clickEditSavedForm(1)
             .assertText("Two Question")
             .pressBack(MainMenuPage())
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/regression/ResetApplicationTest.java
@@ -46,7 +46,7 @@ public class ResetApplicationTest {
                 .startBlankForm("All widgets")
                 .clickGoToArrow()
                 .clickJumpEndButton()
-                .clickFinalize()
+                .clickSaveAsDraft()
                 .clickEditSavedForm()
                 .assertText("All widgets")
                 .pressBack(new MainMenuPage())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/pages/FormEndPage.java
@@ -25,6 +25,11 @@ public class FormEndPage extends Page<FormEndPage> {
         return this;
     }
 
+    public <D extends Page<D>> D clickSaveAsDraft(D destination) {
+        clickOnString(R.string.save_as_draft);
+        return destination.assertOnPage();
+    }
+
     public MainMenuPage clickSaveAsDraft() {
         clickOnString(R.string.save_as_draft);
         return new MainMenuPage().assertOnPage();
@@ -45,7 +50,7 @@ public class FormEndPage extends Page<FormEndPage> {
     }
 
     public FormMapPage clickSaveAndExitBackToMap() {
-        return clickFinalize(new FormMapPage(formName));
+        return clickSaveAsDraft(new FormMapPage(formName));
     }
 
     public FormEntryPage clickSaveAndExitWithError(String errorText) {

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -46,12 +46,8 @@ public class CursorLoaderFactory {
     }
 
     public CursorLoader createEditableInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + " !=? " +
-                "and " + DatabaseInstanceColumns.STATUS + " !=? ";
-        String[] selectionArgs = {
-                Instance.STATUS_SUBMITTED,
-                Instance.STATUS_SUBMISSION_FAILED
-        };
+        String selection = DatabaseInstanceColumns.STATUS + " =? ";
+        String[] selectionArgs = {Instance.STATUS_INCOMPLETE};
 
         return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
     }
@@ -61,13 +57,12 @@ public class CursorLoaderFactory {
         if (charSequence.length() == 0) {
             cursorLoader = createEditableInstancesCursorLoader(sortOrder);
         } else {
-            String selection = DatabaseInstanceColumns.STATUS + " !=? " +
-                    "and " + DatabaseInstanceColumns.STATUS + " !=? " +
+            String selection = DatabaseInstanceColumns.STATUS + " =? " +
                     "and " + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
             String[] selectionArgs = {
-                    Instance.STATUS_SUBMITTED,
-                    Instance.STATUS_SUBMISSION_FAILED,
-                    "%" + charSequence + "%"};
+                    Instance.STATUS_INCOMPLETE,
+                    "%" + charSequence + "%"
+            };
 
             cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
+++ b/collect_app/src/main/java/org/odk/collect/android/dao/CursorLoaderFactory.java
@@ -5,9 +5,7 @@ import android.net.Uri;
 import androidx.loader.content.CursorLoader;
 
 import org.odk.collect.android.application.Collect;
-import org.odk.collect.android.database.forms.DatabaseFormColumns;
 import org.odk.collect.android.database.instances.DatabaseInstanceColumns;
-import org.odk.collect.android.external.FormsContract;
 import org.odk.collect.android.external.InstancesContract;
 import org.odk.collect.android.projects.CurrentProjectProvider;
 import org.odk.collect.forms.instances.Instance;
@@ -45,17 +43,13 @@ public class CursorLoaderFactory {
         return cursorLoader;
     }
 
-    public CursorLoader createEditableInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + " =? ";
-        String[] selectionArgs = {Instance.STATUS_INCOMPLETE};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-    }
-
     public CursorLoader createEditableInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            cursorLoader = createEditableInstancesCursorLoader(sortOrder);
+            String selection = DatabaseInstanceColumns.STATUS + " =? ";
+            String[] selectionArgs = {Instance.STATUS_INCOMPLETE};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         } else {
             String selection = DatabaseInstanceColumns.STATUS + " =? " +
                     "and " + DatabaseInstanceColumns.DISPLAY_NAME + " LIKE ?";
@@ -70,16 +64,11 @@ public class CursorLoaderFactory {
         return cursorLoader;
     }
 
-    public CursorLoader createSavedInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.DELETED_DATE + " IS NULL ";
-
-        return getInstancesCursorLoader(selection, null, sortOrder);
-    }
-
     public CursorLoader createSavedInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            cursorLoader = createSavedInstancesCursorLoader(sortOrder);
+            String selection = DatabaseInstanceColumns.DELETED_DATE + " IS NULL ";
+            cursorLoader = getInstancesCursorLoader(selection, null, sortOrder);
         } else {
             String selection =
                     DatabaseInstanceColumns.DELETED_DATE + " IS NULL and "
@@ -91,17 +80,13 @@ public class CursorLoaderFactory {
         return cursorLoader;
     }
 
-    public CursorLoader createFinalizedInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.STATUS + "=? or " + DatabaseInstanceColumns.STATUS + "=?";
-        String[] selectionArgs = {Instance.STATUS_COMPLETE, Instance.STATUS_SUBMISSION_FAILED};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-    }
-
     public CursorLoader createFinalizedInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            cursorLoader = createFinalizedInstancesCursorLoader(sortOrder);
+            String selection = DatabaseInstanceColumns.STATUS + "=? or " + DatabaseInstanceColumns.STATUS + "=?";
+            String[] selectionArgs = {Instance.STATUS_COMPLETE, Instance.STATUS_SUBMISSION_FAILED};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         } else {
             String selection =
                     "(" + DatabaseInstanceColumns.STATUS + "=? or "
@@ -118,23 +103,19 @@ public class CursorLoaderFactory {
         return cursorLoader;
     }
 
-    public CursorLoader createCompletedUndeletedInstancesCursorLoader(String sortOrder) {
-        String selection = DatabaseInstanceColumns.DELETED_DATE + " IS NULL and ("
-                + DatabaseInstanceColumns.STATUS + "=? or "
-                + DatabaseInstanceColumns.STATUS + "=? or "
-                + DatabaseInstanceColumns.STATUS + "=?)";
-
-        String[] selectionArgs = {Instance.STATUS_COMPLETE,
-                Instance.STATUS_SUBMISSION_FAILED,
-                Instance.STATUS_SUBMITTED};
-
-        return getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-    }
-
     public CursorLoader createCompletedUndeletedInstancesCursorLoader(CharSequence charSequence, String sortOrder) {
         CursorLoader cursorLoader;
         if (charSequence.length() == 0) {
-            cursorLoader = createCompletedUndeletedInstancesCursorLoader(sortOrder);
+            String selection = DatabaseInstanceColumns.DELETED_DATE + " IS NULL and ("
+                    + DatabaseInstanceColumns.STATUS + "=? or "
+                    + DatabaseInstanceColumns.STATUS + "=? or "
+                    + DatabaseInstanceColumns.STATUS + "=?)";
+
+            String[] selectionArgs = {Instance.STATUS_COMPLETE,
+                    Instance.STATUS_SUBMISSION_FAILED,
+                    Instance.STATUS_SUBMITTED};
+
+            cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
         } else {
             String selection = DatabaseInstanceColumns.DELETED_DATE + " IS NULL and ("
                     + DatabaseInstanceColumns.STATUS + "=? or "
@@ -149,30 +130,6 @@ public class CursorLoaderFactory {
                     "%" + charSequence + "%"};
 
             cursorLoader = getInstancesCursorLoader(selection, selectionArgs, sortOrder);
-        }
-        return cursorLoader;
-    }
-
-    /**
-     * Returns a loader filtered by the specified charSequence in the specified sortOrder. If
-     * newestByFormId is true, only the most recently-downloaded version of each form is included.
-     */
-    public CursorLoader getFormsCursorLoader(CharSequence charSequence, String sortOrder, boolean newestByFormId) {
-        CursorLoader cursorLoader;
-
-        if (charSequence.length() == 0) {
-            Uri formUri = newestByFormId ?
-                    FormsContract.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
-                    FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
-            cursorLoader = new CursorLoader(Collect.getInstance(), getUriWithAnalyticsParam(formUri), null, DatabaseFormColumns.DELETED_DATE + " IS NULL", new String[]{}, sortOrder);
-        } else {
-            String selection = DatabaseFormColumns.DISPLAY_NAME + " LIKE ? AND " + DatabaseFormColumns.DELETED_DATE + " IS NULL";
-            String[] selectionArgs = {"%" + charSequence + "%"};
-
-            Uri formUri = newestByFormId ?
-                    FormsContract.getContentNewestFormsByFormIdUri(currentProjectProvider.getCurrentProject().getUuid()) :
-                    FormsContract.getUri(currentProjectProvider.getCurrentProject().getUuid());
-            cursorLoader = new CursorLoader(Collect.getInstance(), getUriWithAnalyticsParam(formUri), null, selection, selectionArgs, sortOrder);
         }
         return cursorLoader;
     }

--- a/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/external/FormUriActivity.kt
@@ -189,7 +189,7 @@ class FormUriActivity : ComponentActivity() {
 
         val formBlankOrUnsent = if (uriMimeType == InstancesContract.CONTENT_ITEM_TYPE) {
             val instance = instanceRepositoryProvider.get().get(ContentUriHelper.getIdFromUri(uri))
-            instance!!.status == Instance.STATUS_INCOMPLETE || instance.status == Instance.STATUS_COMPLETE
+            instance!!.status == Instance.STATUS_INCOMPLETE
         } else {
             true
         }

--- a/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesAppState.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/formmanagement/InstancesAppState.kt
@@ -38,10 +38,7 @@ class InstancesAppState(
             Instance.STATUS_SUBMISSION_FAILED
         )
         val sentInstances = instancesRepository.getCountByStatus(Instance.STATUS_SUBMITTED, Instance.STATUS_SUBMISSION_FAILED)
-        val editableInstances = instancesRepository.getCountByStatus(
-            Instance.STATUS_INCOMPLETE,
-            Instance.STATUS_COMPLETE
-        )
+        val editableInstances = instancesRepository.getCountByStatus(Instance.STATUS_INCOMPLETE)
 
         _sendable.postValue(sendableInstances)
         _sent.postValue(sentInstances)

--- a/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/external/FormUriActivityTest.kt
@@ -334,6 +334,28 @@ class FormUriActivityTest {
     }
 
     @Test
+    fun `When attempting to edit a finalized form then start form for view only`() {
+        val project = Project.Saved("123", "First project", "A", "#cccccc")
+        projectsRepository.save(project)
+        whenever(currentProjectProvider.getCurrentProject()).thenReturn(project)
+
+        formsRepository.save(FormUtils.buildForm("1", "1", TempFiles.createTempDir().absolutePath).build())
+
+        val instance = instancesRepository.save(
+            Instance.Builder()
+                .formId("1")
+                .formVersion("1")
+                .instanceFilePath(TempFiles.createTempFile(TempFiles.createTempDir()).absolutePath)
+                .status(Instance.STATUS_COMPLETE)
+                .build()
+        )
+
+        launcherRule.launchForResult<FormUriActivity>(getSavedIntent(project.uuid, instance.dbId))
+
+        assertStartSavedFormIntent(project.uuid, instance.dbId, false)
+    }
+
+    @Test
     fun `When attempting to edit a submitted form then start form for view only`() {
         val project = Project.Saved("123", "First project", "A", "#cccccc")
         projectsRepository.save(project)


### PR DESCRIPTION
Closes #5418 
Closes #5419 

#### What has been done to verify that this works as intended?
I've improved automated tests and tested the changes manually + using the tester app (see: https://github.com/grzesiek2010/collectTester)

#### Why is this the best possible solution? Were any other approaches considered?
There is nothing big to discuss here.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
We need to test editing forms in ODK Collect but also using external apps like the tester app. Editing forms with a status other than `incomplete` should not be possible.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.
No.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
