### PR TITLE
Deprecate settings keys that we no longer support (but do migrate)

### DIFF
--- a/settings/src/main/resources/client-settings.schema.json
+++ b/settings/src/main/resources/client-settings.schema.json
@@ -157,7 +157,8 @@
           "type": "boolean"
         },
         "default_completed": {
-          "type": "boolean"
+          "type": "boolean",
+          "deprecated": true
         },
         "constraint_behavior": {
           "type": "string",
@@ -313,7 +314,8 @@
           "type": "boolean"
         },
         "mark_as_finalized": {
-          "type": "boolean"
+          "type": "boolean",
+          "deprecated": true
         },
         "save_as_draft": {
           "type": "boolean"


### PR DESCRIPTION
It turns out JSON schema has built in [deprecation "annotation"](http://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.3) support for properties. This will let consumers of the spec (like a hypothetical settings generator) avoid deprecated keys while still allowing us to support them for migration.

This can be merged without QA as there is no behaviour change here - it just flags the deprecation in the spec.