### PR TITLE
Use Collect theme because of custom attr

### DIFF
--- a/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/formentry/FormEndViewTest.kt
@@ -18,7 +18,7 @@ import org.odk.collect.android.R
 class FormEndViewTest {
     private val context: Application =
         ApplicationProvider.getApplicationContext<Application>().also {
-            it.setTheme(R.style.Theme_Material3_Light)
+            it.setTheme(R.style.Theme_Collect) // Needed for ?colorSurfaceContainerHighest
         }
     private val formEndViewModel = mock<FormEndViewModel>()
     private val listener = mock<FormEndView.Listener>()


### PR DESCRIPTION
This test was previously using a default Material theme (usually the right choice for a test), but we need to use our own theme due to the view using a custom (but soon to be official in Material) theme attribute.