### PR TITLE
Add max width for form end view for wider screens

### DIFF
--- a/collect_app/src/main/res/layout/form_entry_end.xml
+++ b/collect_app/src/main/res/layout/form_entry_end.xml
@@ -31,7 +31,7 @@ the specific language governing permissions and limitations under the License.
             android:textSize="21sp"
             android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@+id/form_edits_warning"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/form_edits_warning"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
             tools:text="You are at the end of All widgets" />
@@ -39,14 +39,15 @@ the specific language governing permissions and limitations under the License.
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/form_edits_warning"
             style="@style/Widget.Material3.CardView.Filled"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_large"
             app:cardBackgroundColor="?colorSurfaceContainerHighest"
+            app:layout_constraintBottom_toTopOf="@+id/save_as_draft"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/description"
-            app:layout_constraintBottom_toTopOf="@+id/save_as_draft"
+            app:layout_constraintWidth_max="640dp"
             tools:visibility="visible">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -80,12 +81,12 @@ the specific language governing permissions and limitations under the License.
             style="@style/Widget.Material3.Button.OutlinedButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginTop="64dp"
             android:layout_marginEnd="@dimen/margin_small"
             android:text="@string/save_as_draft"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/finalize"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/form_edits_warning"
             app:layout_constraintTop_toBottomOf="@+id/form_edits_warning" />
 
         <com.google.android.material.button.MaterialButton
@@ -96,8 +97,8 @@ the specific language governing permissions and limitations under the License.
             android:layout_marginStart="@dimen/margin_small"
             android:text="@string/finalize"
             app:layout_constraintBottom_toBottomOf="@id/save_as_draft"
+            app:layout_constraintEnd_toEndOf="@id/form_edits_warning"
             app:layout_constraintStart_toEndOf="@id/save_as_draft"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/save_as_draft" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Gives the warning a max width and then have all other elements constrained by it:

![image](https://github.com/getodk/collect/assets/556280/326ea7a8-b704-45d4-9bdd-c53e0a8c2be8)

The view will still fill the screen on most phones, but this stops it expanding to fill wider screens like tablets. 

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

I considered creating a specific layout for wider screens, but using a max width constraint feels like it will be a lot easier to maintain.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

It'd be good to check the form end screen on a view different screens, but not a lot of risk here.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
