### PR TITLE
Make sure all foreground services have a type

### DIFF
--- a/audiorecorder/src/main/AndroidManifest.xml
+++ b/audiorecorder/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>
-        <service android:name=".recording.AudioRecorderService" />
+        <service android:name=".recording.AudioRecorderService"
+            android:foregroundServiceType="microphone"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
This will be required for [apps targeting Android 14](https://developer.android.com/guide/components/foreground-services#types), and it sounds like it's part of an effort to make foreground services [more resilient on Samsung phones](https://www.androidcentral.com/apps-software/samsung-improving-background-apps-with-android-14).

Fixing this was simpler than writing an issue.

#### What has been done to verify that this works as intended?

Ran tests.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Checking background audio recording (not part of question) would be worthwhile here. Nothing else has been touched.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
