### PR TITLE
Force older version of commons-io to prevent problems with new versions

### DIFF
--- a/collect_app/build.gradle
+++ b/collect_app/build.gradle
@@ -225,8 +225,11 @@ configurations.all {
 
         force 'org.objenesis:objenesis:2.6'
 
-        // Newer Jackson versions cannot be ued until Collect minSDK >= 26 (https://github.com/FasterXML/jackson-databind#android)
+        // Newer Jackson versions cannot be used until Collect minSDK >= 26 (https://github.com/FasterXML/jackson-databind#android)
         force 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
+
+        // Newer Commons IO versions cannot be used until Collect minSDK >= 26
+        force 'commons-io:commons-io:2.5'
     }
     
     transitive = true


### PR DESCRIPTION
Closes #5579

#### What has been done to verify that this works as intended?

Ran tests on older API version.

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/getodk/docs/issues/new) and include the link below.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [ ] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [ ] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
