### PR TITLE
Use Title Large as base for Label Extra Large

### DIFF
--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -60,7 +60,7 @@
 
         <item name="textAppearanceBodyLarge">?textAppearanceBody1</item>
         <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
-        <item name="textAppearanceLabelExtraLarge">@style/TextAppearanceLabelExtraLarge</item>
+        <item name="textAppearanceLabelExtraLarge">@style/TextAppearance.Collect.LabelExtraLarge</item>
         <item name="textAppearanceTitleLarge">@style/TextAppearance.Material3.TitleLarge</item>
 
         <item name="shapeAppearanceCornerMedium">@style/ShapeAppearance.Material3.Corner.Medium</item>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -44,7 +44,7 @@
         <item name="android:textColor">?colorPrimary</item>
     </style>
 
-    <style name="TextAppearanceLabelExtraLarge" parent="TextAppearance.Material3.TitleLarge">
+    <style name="TextAppearance.Collect.LabelExtraLarge" parent="TextAppearance.Material3.TitleLarge">
         <item name="android:textSize">18sp</item>
     </style>
 </resources>

--- a/collect_app/src/main/res/values/typography.xml
+++ b/collect_app/src/main/res/values/typography.xml
@@ -44,7 +44,7 @@
         <item name="android:textColor">?colorPrimary</item>
     </style>
 
-    <style name="TextAppearanceLabelExtraLarge" parent="TextAppearance.Material3.LabelLarge">
+    <style name="TextAppearanceLabelExtraLarge" parent="TextAppearance.Material3.TitleLarge">
         <item name="android:textSize">18sp</item>
     </style>
 </resources>


### PR DESCRIPTION
Closes #5583

#### What has been done to verify that this works as intended?

Verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

I could have just modified the font weight of the existing style, but it seemed like everyone was happier with what they'd seen with `textAppearanceTitleLarge` and a modified size, so I did that instead. I think we want to keep our custom style as we're still very much introducing a repeated text style that doesn't fit in to Material 3's typographic tokens.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Not much risk here. This can be merged after a quick visual review rather than any QA.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
