### PR TITLE
Request notification permissions on Android 13+

### DIFF
--- a/androidshared/src/main/res/values/dimens.xml
+++ b/androidshared/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
     <dimen name="margin_standard">16dp</dimen>
     <dimen name="margin_large">24dp</dimen>
     <dimen name="margin_extra_large">32dp</dimen>
+    <dimen name="margin_extra_extra_large">48dp</dimen>
 
     <dimen name="max_content_width">640dp</dimen>
 

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -24,7 +24,8 @@ object TestRuleChain {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.CAMERA,
                     Manifest.permission.RECORD_AUDIO,
-                    Manifest.permission.GET_ACCOUNTS
+                    Manifest.permission.GET_ACCOUNTS,
+                    Manifest.permission.POST_NOTIFICATIONS
                 )
             )
             .around(ResetRotationRule())

--- a/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/support/rules/TestRuleChain.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.support.rules
 
 import android.Manifest
+import android.os.Build
 import androidx.test.rule.GrantPermissionRule
 import org.junit.rules.RuleChain
 import org.odk.collect.android.support.CountingTaskExecutorIdlingResource
@@ -17,17 +18,7 @@ object TestRuleChain {
 
         return RuleChain
             .outerRule(RetryOnDeviceErrorRule())
-            .around(
-                GrantPermissionRule.grant(
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                    Manifest.permission.ACCESS_COARSE_LOCATION,
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
-                    Manifest.permission.CAMERA,
-                    Manifest.permission.RECORD_AUDIO,
-                    Manifest.permission.GET_ACCOUNTS,
-                    Manifest.permission.POST_NOTIFICATIONS
-                )
-            )
+            .around(createGrantPermissionRule())
             .around(ResetRotationRule())
             .around(PrepDeviceForTestsRule())
             .around(ResetStateRule(testDependencies))
@@ -38,4 +29,26 @@ object TestRuleChain {
                 )
             )
     }
+
+    private fun createGrantPermissionRule() =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            GrantPermissionRule.grant(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.GET_ACCOUNTS,
+                Manifest.permission.POST_NOTIFICATIONS
+            )
+        } else {
+            GrantPermissionRule.grant(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.CAMERA,
+                Manifest.permission.RECORD_AUDIO,
+                Manifest.permission.GET_ACCOUNTS
+            )
+        }
 }

--- a/collect_app/src/main/AndroidManifest.xml
+++ b/collect_app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@ the specific language governing permissions and limitations under the License.
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- Normal permissions -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/analytics/AnalyticsEvents.kt
@@ -156,4 +156,11 @@ object AnalyticsEvents {
      */
     const val TEXT_NUMBER_WIDGET = "TextNumberWidget"
     const val TEXT_NUMBER_WIDGET_WITH_THOUSANDS_SEPARATOR = "TextNumberWidgetWithThousandsSeparator"
+
+    /**
+     * Tracks how many users cancel the permission dialog vs how many go through the permissions
+     * request flow.
+     */
+    const val PERMISSIONS_DIALOG_CANCEL = "PermissionsDialogCancel"
+    const val PERMISSIONS_DIALOG_OK = "PermissionsDialogOK"
 }

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -26,8 +26,6 @@ import org.odk.collect.analytics.BlockableFirebaseAnalytics;
 import org.odk.collect.analytics.NoopAnalytics;
 import org.odk.collect.android.BuildConfig;
 import org.odk.collect.android.R;
-import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel;
-import org.odk.collect.android.mainmenu.MainMenuViewModel;
 import org.odk.collect.android.application.CollectSettingsChangeHandler;
 import org.odk.collect.android.application.MapboxClassInstanceCreator;
 import org.odk.collect.android.application.initialization.AnalyticsInitializer;
@@ -68,6 +66,7 @@ import org.odk.collect.android.instancemanagement.autosend.AutoSendSettingsProvi
 import org.odk.collect.android.instancemanagement.autosend.InstanceAutoSendFetcher;
 import org.odk.collect.android.instancemanagement.autosend.InstanceAutoSender;
 import org.odk.collect.android.itemsets.FastExternalItemsetsRepository;
+import org.odk.collect.android.mainmenu.MainMenuViewModelFactory;
 import org.odk.collect.android.notifications.NotificationManagerNotifier;
 import org.odk.collect.android.notifications.Notifier;
 import org.odk.collect.android.openrosa.CollectThenSystemContentTypeMapper;
@@ -493,20 +492,15 @@ public class AppDependencyModule {
     }
 
     @Provides
-    public MainMenuViewModel.Factory providesMainMenuViewModelFactory(VersionInformation versionInformation, Application application,
-                                                                      SettingsProvider settingsProvider, InstancesAppState instancesAppState,
-                                                                      Scheduler scheduler) {
-        return new MainMenuViewModel.Factory(versionInformation, application, settingsProvider, instancesAppState, scheduler);
+    public MainMenuViewModelFactory providesMainMenuViewModelFactory(VersionInformation versionInformation, Application application,
+                                                                     SettingsProvider settingsProvider, InstancesAppState instancesAppState,
+                                                                     Scheduler scheduler, CurrentProjectProvider currentProjectProvider, AnalyticsInitializer analyticsInitializer) {
+        return new MainMenuViewModelFactory(versionInformation, application, settingsProvider, instancesAppState, scheduler, currentProjectProvider, analyticsInitializer);
     }
 
     @Provides
     public AnalyticsInitializer providesAnalyticsInitializer(Analytics analytics, VersionInformation versionInformation, SettingsProvider settingsProvider) {
         return new AnalyticsInitializer(analytics, versionInformation, settingsProvider);
-    }
-
-    @Provides
-    public CurrentProjectViewModel.Factory providesCurrentProjectViewModel(CurrentProjectProvider currentProjectProvider, AnalyticsInitializer analyticsInitializer, StoragePathProvider storagePathProvider, ProjectsRepository projectsRepository) {
-        return new CurrentProjectViewModel.Factory(currentProjectProvider, analyticsInitializer);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
+++ b/collect_app/src/main/java/org/odk/collect/android/injection/config/AppDependencyModule.java
@@ -494,8 +494,9 @@ public class AppDependencyModule {
     @Provides
     public MainMenuViewModelFactory providesMainMenuViewModelFactory(VersionInformation versionInformation, Application application,
                                                                      SettingsProvider settingsProvider, InstancesAppState instancesAppState,
-                                                                     Scheduler scheduler, CurrentProjectProvider currentProjectProvider, AnalyticsInitializer analyticsInitializer) {
-        return new MainMenuViewModelFactory(versionInformation, application, settingsProvider, instancesAppState, scheduler, currentProjectProvider, analyticsInitializer);
+                                                                     Scheduler scheduler, CurrentProjectProvider currentProjectProvider,
+                                                                     AnalyticsInitializer analyticsInitializer, PermissionsChecker permissionChecker) {
+        return new MainMenuViewModelFactory(versionInformation, application, settingsProvider, instancesAppState, scheduler, currentProjectProvider, analyticsInitializer, permissionChecker);
     }
 
     @Provides

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/CurrentProjectViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/CurrentProjectViewModel.kt
@@ -1,7 +1,6 @@
-package org.odk.collect.android.activities.viewmodels
+package org.odk.collect.android.mainmenu
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.analytics.AnalyticsEvents
 import org.odk.collect.android.application.initialization.AnalyticsInitializer
@@ -37,19 +36,6 @@ class CurrentProjectViewModel(
             true
         } catch (e: IllegalStateException) {
             false
-        }
-    }
-
-    open class Factory(
-        private val currentProjectProvider: CurrentProjectProvider,
-        private val analyticsInitializer: AnalyticsInitializer
-    ) :
-        ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return CurrentProjectViewModel(
-                currentProjectProvider,
-                analyticsInitializer
-            ) as T
         }
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -78,9 +78,8 @@ class MainMenuActivity : LocalizedActivity() {
         this.supportFragmentManager.fragmentFactory = FragmentFactoryBuilder()
             .forClass(PermissionsDialogFragment::class) {
                 PermissionsDialogFragment(
-                    settingsProvider,
                     permissionsProvider,
-                    permissionChecker
+                    RequestPermissionsViewModel(settingsProvider, permissionChecker)
                 )
             }
             .build()

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.mainmenu
 
+import android.Manifest
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -33,6 +34,8 @@ import org.odk.collect.android.utilities.ThemeUtils
 import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard.allowClick
 import org.odk.collect.crashhandler.CrashHandler
+import org.odk.collect.permissions.PermissionListener
+import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.Project.Saved
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.ProjectKeys
@@ -40,6 +43,7 @@ import org.odk.collect.strings.localization.LocalizedActivity
 import javax.inject.Inject
 
 class MainMenuActivity : LocalizedActivity() {
+
     @Inject
     lateinit var viewModelFactory: MainMenuViewModel.Factory
 
@@ -48,6 +52,9 @@ class MainMenuActivity : LocalizedActivity() {
 
     @Inject
     lateinit var settingsProvider: SettingsProvider
+
+    @Inject
+    lateinit var permissionsProvider: PermissionsProvider
 
     private lateinit var binding: MainMenuBinding
     private lateinit var mainMenuViewModel: MainMenuViewModel
@@ -90,6 +97,14 @@ class MainMenuActivity : LocalizedActivity() {
         initMapbox()
         initButtons()
         initAppName()
+
+        permissionsProvider.requestPermissions(
+            this,
+            object : PermissionListener {
+                override fun granted() { }
+            },
+            Manifest.permission.POST_NOTIFICATIONS
+        )
     }
 
     override fun onResume() {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -18,7 +18,6 @@ import org.odk.collect.android.activities.FormDownloadListActivity
 import org.odk.collect.android.activities.InstanceChooserList
 import org.odk.collect.android.activities.InstanceUploaderListActivity
 import org.odk.collect.android.activities.WebViewActivity
-import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel
 import org.odk.collect.android.application.MapboxClassInstanceCreator.createMapBoxInitializationFragment
 import org.odk.collect.android.application.MapboxClassInstanceCreator.isMapboxAvailable
 import org.odk.collect.android.databinding.MainMenuBinding
@@ -45,10 +44,7 @@ import javax.inject.Inject
 class MainMenuActivity : LocalizedActivity() {
 
     @Inject
-    lateinit var viewModelFactory: MainMenuViewModel.Factory
-
-    @Inject
-    lateinit var currentProjectViewModelFactory: CurrentProjectViewModel.Factory
+    lateinit var viewModelFactory: MainMenuViewModelFactory
 
     @Inject
     lateinit var settingsProvider: SettingsProvider
@@ -82,6 +78,9 @@ class MainMenuActivity : LocalizedActivity() {
                     RequestPermissionsViewModel(settingsProvider, permissionChecker)
                 )
             }
+            .forClass(ProjectSettingsDialog::class) {
+                ProjectSettingsDialog(viewModelFactory)
+            }
             .build()
 
         super.onCreate(savedInstanceState)
@@ -89,11 +88,9 @@ class MainMenuActivity : LocalizedActivity() {
 
         ThemeUtils(this).setDarkModeForCurrentProject()
 
-        mainMenuViewModel = ViewModelProvider(this, viewModelFactory)[MainMenuViewModel::class.java]
-        currentProjectViewModel = ViewModelProvider(
-            this,
-            currentProjectViewModelFactory
-        )[CurrentProjectViewModel::class.java]
+        val viewModelProvider = ViewModelProvider(this, viewModelFactory)
+        mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]
+        currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
 
         if (!currentProjectViewModel.hasCurrentProject()) {
             ActivityUtils.startActivityAndCloseAllOthers(this, FirstLaunchActivity::class.java)

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -33,7 +33,6 @@ import org.odk.collect.androidshared.ui.DialogFragmentUtils.showIfNotShowing
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.androidshared.ui.multiclicksafe.MultiClickGuard.allowClick
 import org.odk.collect.crashhandler.CrashHandler
-import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.Project.Saved
 import org.odk.collect.settings.SettingsProvider
@@ -51,9 +50,6 @@ class MainMenuActivity : LocalizedActivity() {
 
     @Inject
     lateinit var permissionsProvider: PermissionsProvider
-
-    @Inject
-    lateinit var permissionChecker: PermissionsChecker
 
     private lateinit var binding: MainMenuBinding
     private lateinit var mainMenuViewModel: MainMenuViewModel

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -71,11 +71,17 @@ class MainMenuActivity : LocalizedActivity() {
         }
 
         DaggerUtils.getComponent(this).inject(this)
+
+        val viewModelProvider = ViewModelProvider(this, viewModelFactory)
+        mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]
+        currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
+        val permissionsViewModel = viewModelProvider[RequestPermissionsViewModel::class.java]
+
         this.supportFragmentManager.fragmentFactory = FragmentFactoryBuilder()
             .forClass(PermissionsDialogFragment::class) {
                 PermissionsDialogFragment(
                     permissionsProvider,
-                    RequestPermissionsViewModel(settingsProvider, permissionChecker)
+                    permissionsViewModel
                 )
             }
             .forClass(ProjectSettingsDialog::class) {
@@ -87,10 +93,6 @@ class MainMenuActivity : LocalizedActivity() {
         binding = MainMenuBinding.inflate(layoutInflater)
 
         ThemeUtils(this).setDarkModeForCurrentProject()
-
-        val viewModelProvider = ViewModelProvider(this, viewModelFactory)
-        mainMenuViewModel = viewModelProvider[MainMenuViewModel::class.java]
-        currentProjectViewModel = viewModelProvider[CurrentProjectViewModel::class.java]
 
         if (!currentProjectViewModel.hasCurrentProject()) {
             ActivityUtils.startActivityAndCloseAllOthers(this, FirstLaunchActivity::class.java)
@@ -109,7 +111,9 @@ class MainMenuActivity : LocalizedActivity() {
         initButtons()
         initAppName()
 
-        showIfNotShowing(PermissionsDialogFragment::class.java, this.supportFragmentManager)
+        if (permissionsViewModel.shouldAskForPermissions()) {
+            showIfNotShowing(PermissionsDialogFragment::class.java, this.supportFragmentManager)
+        }
     }
 
     override fun onResume() {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -79,7 +79,8 @@ class MainMenuActivity : LocalizedActivity() {
             .forClass(PermissionsDialogFragment::class) {
                 PermissionsDialogFragment(
                     settingsProvider,
-                    permissionsProvider
+                    permissionsProvider,
+                    permissionChecker
                 )
             }
             .build()

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuActivity.kt
@@ -78,7 +78,7 @@ class MainMenuActivity : LocalizedActivity() {
         this.supportFragmentManager.fragmentFactory = FragmentFactoryBuilder()
             .forClass(PermissionsDialogFragment::class) {
                 PermissionsDialogFragment(
-                    permissionChecker,
+                    settingsProvider,
                     permissionsProvider
                 )
             }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModel.kt
@@ -3,7 +3,6 @@ package org.odk.collect.android.mainmenu
 import android.app.Application
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import org.odk.collect.android.formmanagement.InstancesAppState
 import org.odk.collect.android.instancemanagement.InstanceDiskSynchronizer
 import org.odk.collect.android.preferences.utilities.FormUpdateMode
@@ -94,22 +93,4 @@ class MainMenuViewModel(
 
     val sentInstancesCount: LiveData<Int>
         get() = instancesAppState.sentCount
-
-    open class Factory(
-        private val versionInformation: VersionInformation,
-        private val application: Application,
-        private val settingsProvider: SettingsProvider,
-        private val instancesAppState: InstancesAppState,
-        private val scheduler: Scheduler
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return MainMenuViewModel(
-                application,
-                versionInformation,
-                settingsProvider,
-                instancesAppState,
-                scheduler
-            ) as T
-        }
-    }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModelFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModelFactory.kt
@@ -8,6 +8,7 @@ import org.odk.collect.android.formmanagement.InstancesAppState
 import org.odk.collect.android.projects.CurrentProjectProvider
 import org.odk.collect.android.version.VersionInformation
 import org.odk.collect.async.Scheduler
+import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.settings.SettingsProvider
 
 open class MainMenuViewModelFactory(
@@ -17,7 +18,8 @@ open class MainMenuViewModelFactory(
     private val instancesAppState: InstancesAppState,
     private val scheduler: Scheduler,
     private val currentProjectProvider: CurrentProjectProvider,
-    private val analyticsInitializer: AnalyticsInitializer
+    private val analyticsInitializer: AnalyticsInitializer,
+    private val permissionChecker: PermissionsChecker
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return when (modelClass) {
@@ -29,7 +31,16 @@ open class MainMenuViewModelFactory(
                 scheduler
             )
 
-            CurrentProjectViewModel::class.java -> CurrentProjectViewModel(currentProjectProvider, analyticsInitializer)
+            CurrentProjectViewModel::class.java -> CurrentProjectViewModel(
+                currentProjectProvider,
+                analyticsInitializer
+            )
+
+            RequestPermissionsViewModel::class.java -> RequestPermissionsViewModel(
+                settingsProvider,
+                permissionChecker
+            )
+
             else -> throw IllegalArgumentException()
         } as T
     }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModelFactory.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/MainMenuViewModelFactory.kt
@@ -1,0 +1,36 @@
+package org.odk.collect.android.mainmenu
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import org.odk.collect.android.application.initialization.AnalyticsInitializer
+import org.odk.collect.android.formmanagement.InstancesAppState
+import org.odk.collect.android.projects.CurrentProjectProvider
+import org.odk.collect.android.version.VersionInformation
+import org.odk.collect.async.Scheduler
+import org.odk.collect.settings.SettingsProvider
+
+open class MainMenuViewModelFactory(
+    private val versionInformation: VersionInformation,
+    private val application: Application,
+    private val settingsProvider: SettingsProvider,
+    private val instancesAppState: InstancesAppState,
+    private val scheduler: Scheduler,
+    private val currentProjectProvider: CurrentProjectProvider,
+    private val analyticsInitializer: AnalyticsInitializer
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return when (modelClass) {
+            MainMenuViewModel::class.java -> MainMenuViewModel(
+                application,
+                versionInformation,
+                settingsProvider,
+                instancesAppState,
+                scheduler
+            )
+
+            CurrentProjectViewModel::class.java -> CurrentProjectViewModel(currentProjectProvider, analyticsInitializer)
+            else -> throw IllegalArgumentException()
+        } as T
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -1,0 +1,46 @@
+package org.odk.collect.android.mainmenu
+
+import android.Manifest
+import android.app.Dialog
+import android.content.Context
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.odk.collect.android.R
+import org.odk.collect.permissions.PermissionListener
+import org.odk.collect.permissions.PermissionsChecker
+import org.odk.collect.permissions.PermissionsProvider
+
+class PermissionsDialogFragment(
+    private val permissionChecker: PermissionsChecker,
+    private val permissionsProvider: PermissionsProvider
+) : DialogFragment() {
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        val shouldAskForPermission = permissionChecker.shouldAskForPermission(
+                requireActivity(),
+                Manifest.permission.POST_NOTIFICATIONS
+            )
+        if (!shouldAskForPermission) {
+            dismiss()
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Permissions update")
+            .setView(R.layout.permissions_dialog_layout)
+            .setPositiveButton(R.string.ok) { _, _ ->
+                permissionsProvider.requestPermissions(
+                    requireActivity(),
+                    object : PermissionListener {
+                        override fun granted() {}
+                    },
+                    Manifest.permission.POST_NOTIFICATIONS
+                )
+            }
+            .create()
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.mainmenu
 
-import android.Manifest
 import android.app.Dialog
 import android.os.Build
 import android.os.Bundle
@@ -9,30 +8,18 @@ import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
 import org.odk.collect.permissions.PermissionListener
-import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
-import org.odk.collect.settings.SettingsProvider
-import org.odk.collect.settings.keys.MetaKeys
 
-class PermissionsDialogFragment constructor(
-    private val settingsProvider: SettingsProvider,
+class PermissionsDialogFragment(
     private val permissionsProvider: PermissionsProvider,
-    private val permissionChecker: PermissionsChecker
+    private val requestPermissionsViewModel: RequestPermissionsViewModel
 ) : DialogFragment() {
 
     override fun onResume() {
         super.onResume()
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        if (!requestPermissionsViewModel.shouldAskForPermissions()) {
             dismiss()
-        } else {
-            val permissionsAlreadyRequested =
-                settingsProvider.getMetaSettings().getBoolean(MetaKeys.PERMISSIONS_REQUESTED)
-            val permissionsGranted = permissionChecker.isPermissionGranted(*permissions)
-
-            if (permissionsAlreadyRequested || permissionsGranted) {
-                dismiss()
-            }
         }
     }
 
@@ -42,21 +29,16 @@ class PermissionsDialogFragment constructor(
             .setTitle(R.string.permission_dialog_title)
             .setView(R.layout.permissions_dialog_layout)
             .setPositiveButton(R.string.ok) { _, _ ->
-                settingsProvider.getMetaSettings().save(MetaKeys.PERMISSIONS_REQUESTED, true)
+                requestPermissionsViewModel.permissionsRequested()
 
                 permissionsProvider.requestPermissions(
                     requireActivity(),
                     object : PermissionListener {
                         override fun granted() {}
                     },
-                    *permissions
+                    *requestPermissionsViewModel.permissions
                 )
             }
             .create()
-    }
-
-    companion object {
-        @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-        private val permissions = arrayOf(Manifest.permission.POST_NOTIFICATIONS)
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -7,7 +7,10 @@ import android.os.Bundle
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.odk.collect.analytics.Analytics
 import org.odk.collect.android.R
+import org.odk.collect.android.analytics.AnalyticsEvents.PERMISSIONS_DIALOG_CANCEL
+import org.odk.collect.android.analytics.AnalyticsEvents.PERMISSIONS_DIALOG_OK
 import org.odk.collect.permissions.PermissionListener
 import org.odk.collect.permissions.PermissionsProvider
 
@@ -22,8 +25,9 @@ class PermissionsDialogFragment(
             .setTitle(R.string.permission_dialog_title)
             .setView(R.layout.permissions_dialog_layout)
             .setPositiveButton(R.string.ok) { _, _ ->
-                requestPermissionsViewModel.permissionsRequested()
+                Analytics.log(PERMISSIONS_DIALOG_OK)
 
+                requestPermissionsViewModel.permissionsRequested()
                 permissionsProvider.requestPermissions(
                     requireActivity(),
                     object : PermissionListener {
@@ -36,6 +40,7 @@ class PermissionsDialogFragment(
     }
 
     override fun onCancel(dialog: DialogInterface) {
+        Analytics.log(PERMISSIONS_DIALOG_CANCEL)
         requestPermissionsViewModel.permissionsRequested()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -15,14 +15,6 @@ class PermissionsDialogFragment(
     private val requestPermissionsViewModel: RequestPermissionsViewModel
 ) : DialogFragment() {
 
-    override fun onResume() {
-        super.onResume()
-
-        if (!requestPermissionsViewModel.shouldAskForPermissions()) {
-            dismiss()
-        }
-    }
-
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext())

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -33,7 +33,7 @@ class PermissionsDialogFragment(
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext())
-            .setTitle("About permissions")
+            .setTitle(R.string.permission_dialog_title)
             .setView(R.layout.permissions_dialog_layout)
             .setPositiveButton(R.string.ok) { _, _ ->
                 settingsProvider.getMetaSettings().save(MetaKeys.PERMISSIONS_REQUESTED, true)

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -4,40 +4,40 @@ import android.Manifest
 import android.app.Dialog
 import android.os.Build
 import android.os.Bundle
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
 import org.odk.collect.permissions.PermissionListener
-import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.MetaKeys
 
 class PermissionsDialogFragment(
-    private val permissionChecker: PermissionsChecker,
+    private val settingsProvider: SettingsProvider,
     private val permissionsProvider: PermissionsProvider
 ) : DialogFragment() {
 
     override fun onResume() {
         super.onResume()
 
-        val shouldAskForPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            permissionChecker.shouldAskForPermission(
-                requireActivity(),
-                Manifest.permission.POST_NOTIFICATIONS
-            )
-        } else {
-            false
-        }
+        val oldAPI = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+        val permissionsAlreadyRequested =
+            settingsProvider.getMetaSettings().getBoolean(MetaKeys.PERMISSIONS_REQUESTED)
 
-        if (!shouldAskForPermission) {
+        if (oldAPI || permissionsAlreadyRequested) {
             dismiss()
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return MaterialAlertDialogBuilder(requireContext())
-            .setTitle("Permissions update")
+            .setTitle("About permissions")
             .setView(R.layout.permissions_dialog_layout)
             .setPositiveButton(R.string.ok) { _, _ ->
+                settingsProvider.getMetaSettings().save(MetaKeys.PERMISSIONS_REQUESTED, true)
+
                 permissionsProvider.requestPermissions(
                     requireActivity(),
                     object : PermissionListener {

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -2,7 +2,7 @@ package org.odk.collect.android.mainmenu
 
 import android.Manifest
 import android.app.Dialog
-import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -16,13 +16,18 @@ class PermissionsDialogFragment(
     private val permissionsProvider: PermissionsProvider
 ) : DialogFragment() {
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
+    override fun onResume() {
+        super.onResume()
 
-        val shouldAskForPermission = permissionChecker.shouldAskForPermission(
+        val shouldAskForPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            permissionChecker.shouldAskForPermission(
                 requireActivity(),
                 Manifest.permission.POST_NOTIFICATIONS
             )
+        } else {
+            false
+        }
+
         if (!shouldAskForPermission) {
             dismiss()
         }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/PermissionsDialogFragment.kt
@@ -1,6 +1,7 @@
 package org.odk.collect.android.mainmenu
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
@@ -32,5 +33,9 @@ class PermissionsDialogFragment(
                 )
             }
             .create()
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        requestPermissionsViewModel.permissionsRequested()
     }
 }

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModel.kt
@@ -1,0 +1,34 @@
+package org.odk.collect.android.mainmenu
+
+import android.Manifest
+import android.os.Build
+import androidx.annotation.RequiresApi
+import org.odk.collect.permissions.PermissionsChecker
+import org.odk.collect.settings.SettingsProvider
+import org.odk.collect.settings.keys.MetaKeys
+
+class RequestPermissionsViewModel(
+    private val settingsProvider: SettingsProvider,
+    private val permissionChecker: PermissionsChecker
+) {
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    val permissions = arrayOf(Manifest.permission.POST_NOTIFICATIONS)
+
+    fun shouldAskForPermissions(): Boolean {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            false
+        } else {
+            val permissionsAlreadyRequested =
+                settingsProvider.getMetaSettings().getBoolean(MetaKeys.PERMISSIONS_REQUESTED)
+            val permissionsGranted =
+                permissionChecker.isPermissionGranted(*permissions)
+
+            !(permissionsAlreadyRequested || permissionsGranted)
+        }
+    }
+
+    fun permissionsRequested() {
+        settingsProvider.getMetaSettings().save(MetaKeys.PERMISSIONS_REQUESTED, true)
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModel.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModel.kt
@@ -3,6 +3,7 @@ package org.odk.collect.android.mainmenu
 import android.Manifest
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.lifecycle.ViewModel
 import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.settings.SettingsProvider
 import org.odk.collect.settings.keys.MetaKeys
@@ -10,7 +11,7 @@ import org.odk.collect.settings.keys.MetaKeys
 class RequestPermissionsViewModel(
     private val settingsProvider: SettingsProvider,
     private val permissionChecker: PermissionsChecker
-) {
+) : ViewModel() {
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     val permissions = arrayOf(Manifest.permission.POST_NOTIFICATIONS)

--- a/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
+++ b/collect_app/src/main/java/org/odk/collect/android/projects/ProjectSettingsDialog.kt
@@ -13,9 +13,9 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.odk.collect.android.R
 import org.odk.collect.android.activities.AboutActivity
 import org.odk.collect.android.activities.ActivityUtils
-import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel
 import org.odk.collect.android.databinding.ProjectSettingsDialogLayoutBinding
 import org.odk.collect.android.injection.DaggerUtils
+import org.odk.collect.android.mainmenu.CurrentProjectViewModel
 import org.odk.collect.android.mainmenu.MainMenuActivity
 import org.odk.collect.android.preferences.screens.ProjectPreferencesActivity
 import org.odk.collect.androidshared.ui.DialogFragmentUtils
@@ -25,13 +25,10 @@ import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
 import javax.inject.Inject
 
-class ProjectSettingsDialog : DialogFragment() {
+class ProjectSettingsDialog(private val viewModelFactory: ViewModelProvider.Factory) : DialogFragment() {
 
     @Inject
     lateinit var projectsRepository: ProjectsRepository
-
-    @Inject
-    lateinit var currentProjectViewModelFactory: CurrentProjectViewModel.Factory
 
     @Inject
     lateinit var settingsProvider: SettingsProvider
@@ -46,7 +43,7 @@ class ProjectSettingsDialog : DialogFragment() {
 
         currentProjectViewModel = ViewModelProvider(
             requireActivity(),
-            currentProjectViewModelFactory
+            viewModelFactory
         )[CurrentProjectViewModel::class.java]
     }
 

--- a/collect_app/src/main/res/drawable/ic_baseline_notifications_24.xml
+++ b/collect_app/src/main/res/drawable/ic_baseline_notifications_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+</vector>

--- a/collect_app/src/main/res/drawable/ic_baseline_notifications_24.xml
+++ b/collect_app/src/main/res/drawable/ic_baseline_notifications_24.xml
@@ -1,5 +1,10 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?colorOnSurface"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?colorSurface"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
 </vector>

--- a/collect_app/src/main/res/layout/permissions_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/permissions_dialog_layout.xml
@@ -3,7 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/margin_large">
+    android:paddingHorizontal="@dimen/margin_large"
+    android:paddingTop="@dimen/margin_standard"
+    android:paddingBottom="@dimen/margin_large">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/permission_text"
@@ -19,7 +21,7 @@
         android:id="@+id/notifications_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginTop="@dimen/margin_extra_extra_large"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/permission_text"
         app:srcCompat="@drawable/ic_baseline_notifications_24" />

--- a/collect_app/src/main/res/layout/permissions_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/permissions_dialog_layout.xml
@@ -47,6 +47,7 @@
         android:textAppearance="?textAppearanceBodyMedium"
         android:textColor="@color/color_on_surface_medium_emphasis"
         app:layout_constraintBottom_toBottomOf="@id/notifications_icon"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/notifications_icon"
         app:layout_constraintTop_toBottomOf="@id/notifications_title" />
 

--- a/collect_app/src/main/res/layout/permissions_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/permissions_dialog_layout.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/margin_large">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/permission_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/permission_text"
+        android:textAppearance="?textAppearanceBodyMedium"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/notification_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/permission_text"
+        app:srcCompat="@drawable/ic_baseline_notifications_24" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin"
+        android:text="@string/allow_to_show_notifications"
+        android:textAppearance="?textAppearanceBodyLarge"
+        app:layout_constraintBottom_toBottomOf="@id/notification_icon"
+        app:layout_constraintStart_toEndOf="@id/notification_icon"
+        app:layout_constraintTop_toTopOf="@id/notification_icon" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/permissions_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/permissions_dialog_layout.xml
@@ -16,7 +16,7 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/notification_icon"
+        android:id="@+id/notifications_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
@@ -25,13 +25,27 @@
         app:srcCompat="@drawable/ic_baseline_notifications_24" />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/notifications_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin"
-        android:text="@string/allow_to_show_notifications"
+        android:text="@string/notifications"
         android:textAppearance="?textAppearanceBodyLarge"
-        app:layout_constraintBottom_toBottomOf="@id/notification_icon"
-        app:layout_constraintStart_toEndOf="@id/notification_icon"
-        app:layout_constraintTop_toTopOf="@id/notification_icon" />
+        app:layout_constraintBottom_toTopOf="@id/notification_description"
+        app:layout_constraintStart_toEndOf="@id/notifications_icon"
+        app:layout_constraintTop_toTopOf="@id/notifications_icon" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/notification_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin"
+        android:layout_marginTop="@dimen/margin_extra_small"
+        android:text="@string/required_for_notifications"
+        android:textAppearance="?textAppearanceBodyMedium"
+        android:textColor="@color/color_on_surface_medium_emphasis"
+        app:layout_constraintBottom_toBottomOf="@id/notifications_icon"
+        app:layout_constraintStart_toEndOf="@id/notifications_icon"
+        app:layout_constraintTop_toBottomOf="@id/notifications_title" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/collect_app/src/main/res/layout/permissions_dialog_layout.xml
+++ b/collect_app/src/main/res/layout/permissions_dialog_layout.xml
@@ -9,7 +9,7 @@
         android:id="@+id/permission_text"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/permission_text"
+        android:text="@string/permission_dialog_text"
         android:textAppearance="?textAppearanceBodyMedium"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/collect_app/src/main/res/values/theme.xml
+++ b/collect_app/src/main/res/values/theme.xml
@@ -58,6 +58,7 @@
 
         <item name="colorOnPrimaryContainer">?colorOnPrimary</item>
 
+        <item name="textAppearanceBodyMedium">@style/TextAppearance.Material3.BodyMedium</item>
         <item name="textAppearanceBodyLarge">?textAppearanceBody1</item>
         <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
         <item name="textAppearanceLabelExtraLarge">@style/TextAppearance.Collect.LabelExtraLarge</item>

--- a/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionsProvider.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/fakes/FakePermissionsProvider.kt
@@ -16,23 +16,20 @@ class FakePermissionsProvider :
     PermissionsProvider(ContextCompatPermissionChecker(InstrumentationRegistry.getInstrumentation().targetContext)) {
     private var isPermissionGranted = false
 
-    var cameraPermissionRequested = false
+    val requestedPermissions = mutableListOf<String>()
 
     override fun requestPermissions(
         activity: Activity,
         listener: PermissionListener,
         vararg permissions: String
     ) {
+        requestedPermissions.addAll(permissions)
+
         if (isPermissionGranted) {
             listener.granted()
         } else {
             listener.denied()
         }
-    }
-
-    override fun requestCameraPermission(activity: Activity, action: PermissionListener) {
-        super.requestCameraPermission(activity, action)
-        cameraPermissionRequested = true
     }
 
     fun setPermissionGranted(permissionGranted: Boolean) {

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/CurrentProjectViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/CurrentProjectViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.odk.collect.android.activities.viewmodels
+package org.odk.collect.android.mainmenu
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import org.hamcrest.MatcherAssert.assertThat

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.mainmenu
 
-import android.Manifest
 import android.app.Application
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
@@ -14,7 +13,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -403,12 +404,13 @@ class MainMenuActivityTest {
     }
 
     @Test
-    fun `asks for notification permissions`() {
-        launcherRule.launch(MainMenuActivity::class.java)
+    @Ignore("Need to record fragment as it dismisses")
+    fun `asks for permissions`() {
+        val scenario = launcherRule.launch(MainMenuActivity::class.java)
 
-        assertThat(
-            permissionsProvider.requestedPermissions,
-            equalTo(listOf(Manifest.permission.POST_NOTIFICATIONS))
-        )
+        scenario.onActivity {
+            val fragments = it.supportFragmentManager.fragments
+            assertThat(fragments[0].javaClass, Matchers.equalTo(PermissionsDialogFragment::class.java))
+        }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -13,9 +13,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers
+import org.hamcrest.Matchers.*
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -400,17 +399,6 @@ class MainMenuActivityTest {
         scenario.onActivity { activity: MainMenuActivity ->
             val editSavedFormButton = activity.findViewById<MainMenuButton>(R.id.manage_forms)
             assertThat(editSavedFormButton.visibility, equalTo(View.GONE))
-        }
-    }
-
-    @Test
-    @Ignore("Need to record fragment as it dismisses")
-    fun `asks for permissions`() {
-        val scenario = launcherRule.launch(MainMenuActivity::class.java)
-
-        scenario.onActivity {
-            val fragments = it.supportFragmentManager.fragments
-            assertThat(fragments[0].javaClass, Matchers.equalTo(PermissionsDialogFragment::class.java))
         }
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -409,4 +409,16 @@ class MainMenuActivityTest {
             assertThat(dialog, notNullValue())
         }
     }
+
+    @Test
+    fun `when shouldAskForPermissions is false, does not show permissions dialog`() {
+        whenever(permissionsViewModel.shouldAskForPermissions()).doReturn(false)
+
+        val scenario = launcherRule.launch(MainMenuActivity::class.java)
+        scenario.onActivity {
+            val dialog =
+                it.supportFragmentManager.findFragmentByTag(PermissionsDialogFragment::class.java.name)
+            assertThat(dialog, equalTo(null))
+        }
+    }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -25,14 +25,12 @@ import org.odk.collect.android.activities.DeleteSavedFormActivity
 import org.odk.collect.android.activities.FormDownloadListActivity
 import org.odk.collect.android.activities.InstanceChooserList
 import org.odk.collect.android.activities.InstanceUploaderListActivity
-import org.odk.collect.android.activities.viewmodels.CurrentProjectViewModel
 import org.odk.collect.android.application.initialization.AnalyticsInitializer
 import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.android.formlists.blankformlist.BlankFormListActivity
 import org.odk.collect.android.formmanagement.InstancesAppState
 import org.odk.collect.android.injection.config.AppDependencyModule
 import org.odk.collect.android.projects.CurrentProjectProvider
-import org.odk.collect.android.storage.StoragePathProvider
 import org.odk.collect.android.support.CollectHelpers
 import org.odk.collect.android.utilities.ApplicationConstants
 import org.odk.collect.android.version.VersionInformation
@@ -42,7 +40,6 @@ import org.odk.collect.async.Scheduler
 import org.odk.collect.permissions.PermissionsChecker
 import org.odk.collect.permissions.PermissionsProvider
 import org.odk.collect.projects.Project
-import org.odk.collect.projects.ProjectsRepository
 import org.odk.collect.settings.SettingsProvider
 
 @RunWith(AndroidJUnit4::class)
@@ -74,33 +71,25 @@ class MainMenuActivityTest {
                 application: Application,
                 settingsProvider: SettingsProvider,
                 instancesAppState: InstancesAppState,
-                scheduler: Scheduler
-            ): MainMenuViewModel.Factory {
-                return object : MainMenuViewModel.Factory(
+                scheduler: Scheduler,
+                currentProjectProvider: CurrentProjectProvider,
+                analyticsInitializer: AnalyticsInitializer
+            ): MainMenuViewModelFactory {
+                return object : MainMenuViewModelFactory(
                     versionInformation,
                     application,
                     settingsProvider,
                     instancesAppState,
-                    scheduler
-                ) {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        return mainMenuViewModel as T
-                    }
-                }
-            }
-
-            override fun providesCurrentProjectViewModel(
-                currentProjectProvider: CurrentProjectProvider,
-                analyticsInitializer: AnalyticsInitializer,
-                storagePathProvider: StoragePathProvider,
-                projectsRepository: ProjectsRepository
-            ): CurrentProjectViewModel.Factory {
-                return object : CurrentProjectViewModel.Factory(
+                    scheduler,
                     currentProjectProvider,
                     analyticsInitializer
                 ) {
                     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        return currentProjectViewModel as T
+                        return when (modelClass) {
+                            MainMenuViewModel::class.java -> mainMenuViewModel
+                            CurrentProjectViewModel::class.java -> currentProjectViewModel
+                            else -> throw IllegalArgumentException()
+                        } as T
                     }
                 }
             }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/MainMenuActivityTest.kt
@@ -13,7 +13,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -1,0 +1,65 @@
+package org.odk.collect.android.mainmenu
+
+import android.Manifest
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.android.R
+import org.odk.collect.android.fakes.FakePermissionsProvider
+import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
+import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
+import org.odk.collect.permissions.PermissionsChecker
+
+@RunWith(AndroidJUnit4::class)
+class PermissionsDialogFragmentTest {
+
+    private val permissionsProvider = FakePermissionsProvider()
+    private val permissionChecker = mock<PermissionsChecker>() {
+        on { shouldAskForPermission(any()) } doReturn true
+    }
+
+    private val fragmentFactory = FragmentFactoryBuilder()
+        .forClass(PermissionsDialogFragment::class) { PermissionsDialogFragment(permissionChecker, permissionsProvider) }
+        .build()
+
+    @get:Rule
+    val launcherRule = FragmentScenarioLauncherRule(
+        defaultThemeResId = R.style.Theme_MaterialComponents,
+        defaultFactory = fragmentFactory
+    )
+
+    @Test
+    @Ignore("Need getState() for FragmentScenario")
+    fun whenShouldNotAskForNotificationPermission_dismisses() {
+        whenever(permissionChecker.shouldAskForPermission(any(), Manifest.permission.POST_NOTIFICATIONS))
+            .doReturn(false)
+
+        val scenario = launcherRule.launch(PermissionsDialogFragment::class.java)
+        scenario.onFragment {
+            assertThat(it.isVisible, equalTo(true))
+        }
+    }
+
+    @Test
+    fun clickingOK_asksForNotificationPermissions() {
+        launcherRule.launch(PermissionsDialogFragment::class.java)
+
+        onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
+        assertThat(
+            permissionsProvider.requestedPermissions,
+            equalTo(listOf(Manifest.permission.POST_NOTIFICATIONS))
+        )
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -19,10 +19,8 @@ import org.odk.collect.android.R
 import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
-import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [33])
 class PermissionsDialogFragmentTest {
 
     private val permissionsProvider = FakePermissionsProvider()

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -1,19 +1,20 @@
 package org.odk.collect.android.mainmenu
 
 import android.Manifest
+import androidx.lifecycle.Lifecycle
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
+import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
@@ -21,17 +22,24 @@ import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
 import org.odk.collect.permissions.PermissionsChecker
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
 class PermissionsDialogFragmentTest {
 
     private val permissionsProvider = FakePermissionsProvider()
     private val permissionChecker = mock<PermissionsChecker>() {
-        on { shouldAskForPermission(any()) } doReturn true
+        on { shouldAskForPermission(any(), any()) } doReturn true
     }
 
     private val fragmentFactory = FragmentFactoryBuilder()
-        .forClass(PermissionsDialogFragment::class) { PermissionsDialogFragment(permissionChecker, permissionsProvider) }
+        .forClass(PermissionsDialogFragment::class) {
+            PermissionsDialogFragment(
+                permissionChecker,
+                permissionsProvider
+            )
+        }
         .build()
 
     @get:Rule
@@ -41,14 +49,36 @@ class PermissionsDialogFragmentTest {
     )
 
     @Test
-    @Ignore("Need getState() for FragmentScenario")
     fun whenShouldNotAskForNotificationPermission_dismisses() {
-        whenever(permissionChecker.shouldAskForPermission(any(), Manifest.permission.POST_NOTIFICATIONS))
-            .doReturn(false)
+        whenever(
+            permissionChecker.shouldAskForPermission(
+                any(),
+                eq(Manifest.permission.POST_NOTIFICATIONS)
+            )
+        ).doReturn(false)
 
-        val scenario = launcherRule.launch(PermissionsDialogFragment::class.java)
+        val scenario = launcherRule.launch(
+            initialState = Lifecycle.State.INITIALIZED,
+            fragmentClass = PermissionsDialogFragment::class.java
+        )
+
         scenario.onFragment {
-            assertThat(it.isVisible, equalTo(true))
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            assertThat(it.isVisible, equalTo(false))
+        }
+    }
+
+    @Test
+    @Config(sdk = [32])
+    fun whenNoNeedToAskForNotificationPermission_dismisses() {
+        val scenario = launcherRule.launch(
+            initialState = Lifecycle.State.INITIALIZED,
+            fragmentClass = PermissionsDialogFragment::class.java
+        )
+
+        scenario.onFragment {
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            assertThat(it.isVisible, equalTo(false))
         }
     }
 

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -1,9 +1,6 @@
 package org.odk.collect.android.mainmenu
 
-import android.Manifest
-import android.Manifest.permission.POST_NOTIFICATIONS
 import androidx.lifecycle.Lifecycle
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -14,33 +11,29 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
 import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
 import org.odk.collect.fragmentstest.FragmentScenarioLauncherRule
-import org.odk.collect.permissions.PermissionsChecker
-import org.odk.collect.settings.InMemSettingsProvider
-import org.odk.collect.settings.keys.MetaKeys
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [33])
 class PermissionsDialogFragmentTest {
 
-    private val permissionChecker = mock<PermissionsChecker>() {
-        on { isPermissionGranted(any()) } doReturn false
-    }
-
     private val permissionsProvider = FakePermissionsProvider()
-    private val settingsProvider = InMemSettingsProvider()
+    private val requestPermissionsViewModel = mock<RequestPermissionsViewModel>() {
+        on { permissions } doReturn arrayOf("blah")
+        on { shouldAskForPermissions() } doReturn true
+    }
 
     private val fragmentFactory = FragmentFactoryBuilder()
         .forClass(PermissionsDialogFragment::class) {
-            PermissionsDialogFragment(settingsProvider, permissionsProvider, permissionChecker)
+            PermissionsDialogFragment(permissionsProvider, requestPermissionsViewModel)
         }
         .build()
 
@@ -51,37 +44,8 @@ class PermissionsDialogFragmentTest {
     )
 
     @Test
-    @Config(sdk = [32])
-    fun whenNoNeedToAskForNotificationPermission_dismisses() {
-        val scenario = launcherRule.launch(
-            initialState = Lifecycle.State.INITIALIZED,
-            fragmentClass = PermissionsDialogFragment::class.java
-        )
-
-        scenario.onFragment {
-            scenario.moveToState(Lifecycle.State.RESUMED)
-            assertThat(it.dialog?.isShowing, equalTo(false))
-        }
-    }
-
-    @Test
-    fun whenPermissionsHaveAlreadyBeenGranted_dismisses() {
-        whenever(permissionChecker.isPermissionGranted(POST_NOTIFICATIONS)).doReturn(true)
-
-        val scenario = launcherRule.launch(
-            initialState = Lifecycle.State.INITIALIZED,
-            fragmentClass = PermissionsDialogFragment::class.java
-        )
-
-        scenario.onFragment {
-            scenario.moveToState(Lifecycle.State.RESUMED)
-            assertThat(it.dialog?.isShowing, equalTo(false))
-        }
-    }
-
-    @Test
     fun whenPermissionsHaveAlreadyBeenAskedFor_dismisses() {
-        settingsProvider.getMetaSettings().save(MetaKeys.PERMISSIONS_REQUESTED, true)
+        whenever(requestPermissionsViewModel.shouldAskForPermissions()).doReturn(false)
 
         val scenario = launcherRule.launch(
             initialState = Lifecycle.State.INITIALIZED,
@@ -95,35 +59,21 @@ class PermissionsDialogFragmentTest {
     }
 
     @Test
-    fun clickingOK_asksForNotificationPermissions() {
+    fun clickingOK_asksForPermissions() {
         launcherRule.launch(PermissionsDialogFragment::class.java)
 
         onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
         assertThat(
             permissionsProvider.requestedPermissions,
-            equalTo(listOf(Manifest.permission.POST_NOTIFICATIONS))
+            equalTo(listOf("blah"))
         )
     }
 
     @Test
-    fun clickingOK_marksPermissionsRequestedInSettings() {
+    fun clickingOK_callsPermissionRequested() {
         launcherRule.launch(PermissionsDialogFragment::class.java)
 
         onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
-        assertThat(
-            settingsProvider.getMetaSettings().getBoolean(MetaKeys.PERMISSIONS_REQUESTED),
-            equalTo(true)
-        )
-    }
-
-    @Test
-    fun dismissing_doesNotMarkPermissionsRequestedInSettings() {
-        launcherRule.launch(PermissionsDialogFragment::class.java)
-
-        Espresso.pressBack()
-        assertThat(
-            settingsProvider.getMetaSettings().getBoolean(MetaKeys.PERMISSIONS_REQUESTED),
-            equalTo(false)
-        )
+        verify(requestPermissionsViewModel).permissionsRequested()
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -1,6 +1,5 @@
 package org.odk.collect.android.mainmenu
 
-import androidx.lifecycle.Lifecycle
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -14,7 +13,6 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.odk.collect.android.R
 import org.odk.collect.android.fakes.FakePermissionsProvider
 import org.odk.collect.androidshared.ui.FragmentFactoryBuilder
@@ -42,21 +40,6 @@ class PermissionsDialogFragmentTest {
         defaultThemeResId = R.style.Theme_MaterialComponents,
         defaultFactory = fragmentFactory
     )
-
-    @Test
-    fun whenPermissionsHaveAlreadyBeenAskedFor_dismisses() {
-        whenever(requestPermissionsViewModel.shouldAskForPermissions()).doReturn(false)
-
-        val scenario = launcherRule.launch(
-            initialState = Lifecycle.State.INITIALIZED,
-            fragmentClass = PermissionsDialogFragment::class.java
-        )
-
-        scenario.onFragment {
-            scenario.moveToState(Lifecycle.State.RESUMED)
-            assertThat(it.dialog?.isShowing, equalTo(false))
-        }
-    }
 
     @Test
     fun clickingOK_asksForPermissions() {

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/PermissionsDialogFragmentTest.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.mainmenu
 
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -12,6 +13,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.odk.collect.android.R
 import org.odk.collect.android.fakes.FakePermissionsProvider
@@ -58,5 +60,19 @@ class PermissionsDialogFragmentTest {
 
         onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
         verify(requestPermissionsViewModel).permissionsRequested()
+    }
+
+    @Test
+    fun dismissing_callsPermissionRequested() {
+        launcherRule.launch(PermissionsDialogFragment::class.java)
+
+        Espresso.pressBack()
+        verify(requestPermissionsViewModel).permissionsRequested()
+    }
+
+    @Test
+    fun recreating_doesNotCallPermissionsRequested() {
+        launcherRule.launch(PermissionsDialogFragment::class.java).recreate()
+        verify(requestPermissionsViewModel, never()).permissionsRequested()
     }
 }

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModelTest.kt
@@ -16,7 +16,6 @@ import org.odk.collect.settings.keys.MetaKeys
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [33])
 class RequestPermissionsViewModelTest {
 
     private val permissionChecker = mock<PermissionsChecker>() {

--- a/collect_app/src/test/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModelTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/mainmenu/RequestPermissionsViewModelTest.kt
@@ -1,0 +1,67 @@
+package org.odk.collect.android.mainmenu
+
+import android.Manifest.permission.POST_NOTIFICATIONS
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.odk.collect.permissions.PermissionsChecker
+import org.odk.collect.settings.InMemSettingsProvider
+import org.odk.collect.settings.keys.MetaKeys
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class RequestPermissionsViewModelTest {
+
+    private val permissionChecker = mock<PermissionsChecker>() {
+        on { isPermissionGranted(any()) } doReturn false
+    }
+
+    private val settingsProvider = InMemSettingsProvider()
+
+    @Test
+    fun shouldAskForPermissions_returnsTrue() {
+        val viewModel = RequestPermissionsViewModel(settingsProvider, permissionChecker)
+        assertThat(viewModel.shouldAskForPermissions(), equalTo(true))
+    }
+
+    @Test
+    @Config(sdk = [32])
+    fun shouldAskForPermissions_whenAPIDoesNotNeedNotificationPermissions_returnsFalse() {
+        val viewModel = RequestPermissionsViewModel(settingsProvider, permissionChecker)
+        assertThat(viewModel.shouldAskForPermissions(), equalTo(false))
+    }
+
+    @Test
+    fun shouldAskForPermissions_whenPermissionsHaveAlreadyBeenGranted_returnsFalse() {
+        whenever(permissionChecker.isPermissionGranted(POST_NOTIFICATIONS)).doReturn(true)
+
+        val viewModel = RequestPermissionsViewModel(settingsProvider, permissionChecker)
+        assertThat(viewModel.shouldAskForPermissions(), equalTo(false))
+    }
+
+    @Test
+    fun shouldAskForPermissions_whenPermissionsHaveAlreadyBeenAskFor_returnsFalse() {
+        settingsProvider.getMetaSettings().save(MetaKeys.PERMISSIONS_REQUESTED, true)
+
+        val viewModel = RequestPermissionsViewModel(settingsProvider, permissionChecker)
+        assertThat(viewModel.shouldAskForPermissions(), equalTo(false))
+    }
+
+    @Test
+    fun permissionsRequested_marksPermissionsAsRequestedInSettings() {
+        val viewModel = RequestPermissionsViewModel(settingsProvider, permissionChecker)
+        viewModel.permissionsRequested()
+
+        assertThat(
+            settingsProvider.getMetaSettings().getBoolean(MetaKeys.PERMISSIONS_REQUESTED),
+            equalTo(true)
+        )
+    }
+}

--- a/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
+++ b/collect_app/src/test/java/org/odk/collect/android/projects/QrCodeProjectCreatorDialogTest.kt
@@ -1,5 +1,6 @@
 package org.odk.collect.android.projects
 
+import android.Manifest
 import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
@@ -16,10 +17,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.journeyapps.barcodescanner.BarcodeResult
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.notNullValue
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -80,11 +80,14 @@ class QrCodeProjectCreatorDialogTest {
     fun `requestCameraPermission() should be called in onStart() to make sure it is called after returning to the dialog`() {
         val scenario = launcherRule.launch(fragmentClass = QrCodeProjectCreatorDialog::class.java, initialState = Lifecycle.State.CREATED)
 
-        assertFalse(permissionsProvider.cameraPermissionRequested)
+        assertThat(permissionsProvider.requestedPermissions, equalTo(emptyList()))
 
         scenario.moveToState(Lifecycle.State.STARTED)
 
-        assertTrue(permissionsProvider.cameraPermissionRequested)
+        assertThat(
+            permissionsProvider.requestedPermissions,
+            equalTo(listOf(Manifest.permission.CAMERA))
+        )
     }
 
     @Test

--- a/download-robolectric-deps.sh
+++ b/download-robolectric-deps.sh
@@ -7,6 +7,7 @@ wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/11-robolectric-6757853-i3/android-all-instrumented-11-robolectric-6757853-i3.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/12-robolectric-7732740-i3/android-all-instrumented-12-robolectric-7732740-i3.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/12-robolectric-7732740-i4/android-all-instrumented-12-robolectric-7732740-i4.jar -P robolectric-deps
+wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/12.1-robolectric-8229987-i4/android-all-instrumented-12.1-robolectric-8229987-i4.jar -P robolectric-deps
 wget -nc https://repo1.maven.org/maven2/org/robolectric/android-all-instrumented/13-robolectric-9030017-i4/android-all-instrumented-13-robolectric-9030017-i4.jar -P robolectric-deps
 
 mkdir -p collect_app/src/test/resources && cp robolectric-deps.properties "$_"

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsChecker.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsChecker.kt
@@ -1,11 +1,14 @@
 package org.odk.collect.permissions
 
+import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.content.ContextCompat
 
 interface PermissionsChecker {
     fun isPermissionGranted(vararg permissions: String): Boolean
+    fun shouldAskForPermission(activity: Activity, vararg permissions: String): Boolean
 }
 
 open class ContextCompatPermissionChecker(private val context: Context) : PermissionsChecker {
@@ -17,5 +20,15 @@ open class ContextCompatPermissionChecker(private val context: Context) : Permis
             }
         }
         return true
+    }
+
+    override fun shouldAskForPermission(activity: Activity, vararg permissions: String): Boolean {
+        return permissions.any {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                activity.shouldShowRequestPermissionRationale(it)
+            } else {
+                true
+            }
+        }
     }
 }

--- a/permissions/src/main/java/org/odk/collect/permissions/PermissionsChecker.kt
+++ b/permissions/src/main/java/org/odk/collect/permissions/PermissionsChecker.kt
@@ -1,14 +1,11 @@
 package org.odk.collect.permissions
 
-import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import androidx.core.content.ContextCompat
 
 interface PermissionsChecker {
     fun isPermissionGranted(vararg permissions: String): Boolean
-    fun shouldAskForPermission(activity: Activity, vararg permissions: String): Boolean
 }
 
 open class ContextCompatPermissionChecker(private val context: Context) : PermissionsChecker {
@@ -20,15 +17,5 @@ open class ContextCompatPermissionChecker(private val context: Context) : Permis
             }
         }
         return true
-    }
-
-    override fun shouldAskForPermission(activity: Activity, vararg permissions: String): Boolean {
-        return permissions.any {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                activity.shouldShowRequestPermissionRationale(it)
-            } else {
-                true
-            }
-        }
     }
 }

--- a/robolectric-deps.properties
+++ b/robolectric-deps.properties
@@ -5,4 +5,5 @@ org.robolectric\:android-all-instrumented\:7.0.0_r1-robolectric-r1-i4=../../../.
 org.robolectric\:android-all-instrumented\:11-robolectric-6757853-i3=../../../../../../robolectric-deps/android-all-instrumented-11-robolectric-6757853-i3.jar
 org.robolectric\:android-all-instrumented\:12-robolectric-7732740-i3=../../../../../../robolectric-deps/android-all-instrumented-12-robolectric-7732740-i3.jar
 org.robolectric\:android-all-instrumented\:12-robolectric-7732740-i4=../../../../../../robolectric-deps/android-all-instrumented-12-robolectric-7732740-i4.jar
+org.robolectric\:android-all-instrumented\:12.1-robolectric-8229987-i4=../../../../../../robolectric-deps/android-all-instrumented-12.1-robolectric-8229987-i4.jar
 org.robolectric\:android-all-instrumented\:13-robolectric-9030017-i4=../../../../../../robolectric-deps/android-all-instrumented-13-robolectric-9030017-i4.jar

--- a/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
+++ b/settings/src/main/java/org/odk/collect/settings/keys/MetaKeys.kt
@@ -10,4 +10,5 @@ object MetaKeys {
     const val EXISTING_PROJECT_IMPORTED = "existing_project_imported"
     const val LAST_LAUNCHED = "last_launched"
     const val LAST_USED_PEN_COLOR = "last_used_pen_color"
+    const val PERMISSIONS_REQUESTED = "permissions_requested"
 }

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1191,6 +1191,6 @@
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
     <string name="notifications">Notifications</string>
-    <string name="required_for_notifications">Required for notifications</string>
+    <string name="required_for_notifications">Required for showing updates when forms are download, updated and sent.</string>
 
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1191,6 +1191,6 @@
     <string name="permission_dialog_title">About permissions</string>
     <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
     <string name="notifications">Notifications</string>
-    <string name="required_for_notifications">Required for showing updates when forms are download, updated and sent.</string>
+    <string name="required_for_notifications">Required for showing updates when forms are downloaded, updated and sent.</string>
 
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1188,4 +1188,7 @@
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
     <string name="predicate_caching">Predicate caching</string>
 
+    <string name="permission_text">On the next screen, you will be asked if you want to allow ODK Collect access to the features below.\n\nIf you want to allow access, select “Allow” on the next screen.</string>
+    <string name="allow_to_show_notifications">Allow to show notifications</string>
+
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1188,7 +1188,8 @@
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
     <string name="predicate_caching">Predicate caching</string>
 
-    <string name="permission_text">On the next screen, you will be asked if you want to allow ODK Collect access to the features below.\n\nIf you want to allow access, select “Allow” on the next screen.</string>
-    <string name="allow_to_show_notifications">Allow to show notifications</string>
+    <string name="permission_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
+    <string name="notifications">Notifications</string>
+    <string name="required_for_notifications">Required for notifications</string>
 
 </resources>

--- a/strings/src/main/res/values/strings.xml
+++ b/strings/src/main/res/values/strings.xml
@@ -1188,7 +1188,8 @@
     <string name="crash_app_summary">Force an uncaught exception causing the app to crash</string>
     <string name="predicate_caching">Predicate caching</string>
 
-    <string name="permission_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
+    <string name="permission_dialog_title">About permissions</string>
+    <string name="permission_dialog_text">You will be asked to allow ODK Collect access to the features below, select “allow” if you want to use them.</string>
     <string name="notifications">Notifications</string>
     <string name="required_for_notifications">Required for notifications</string>
 


### PR DESCRIPTION
Closes #5574 

Show a dialog about notification permissions (and request permissions if the hit "OK") the first time the user sees the main menu. Once the user has seen the dialog (even if they dismiss it), it won't be shown again. It also won't be shown if the user has already granted notification permissions (only possible through system settings before configuring a project). The dialog will stay on screen if the device changes configuration (rotation, theme, screen size). To be very clear, the new flow for a first time user (on Android 13) will be:

1. See launch screen
2. Go through "Scan QR code" (they will see a system camera permission request here), "Manually enter..." or "Try a demo"
3. See "About permissions" dialog informing them about notification permissions
4. Click OK on dialog
    - Alternatively they dismiss the dialog and just go straight to the Main Menu
6. See a system permission request for notifications

As discussed in the issue, we decided to let the camera permission request show on its own without an explanation as it's requested in an understandable context (scanning a QR code needs the camera).

#### What has been done to verify that this works as intended?

New tests and verified manually.

#### Why is this the best possible solution? Were any other approaches considered?

Comments inline.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

There should only be changes on Android 13, so one of the most important things to check is that the experience isn't affected on any other OS versions. It'd also be good to put the new experience through its paces to check the new behaviour on Android 13 makes sense.

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/getodk/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/getodk/collect/blob/master/docs/CODE-GUIDELINES.md#ui-components-style-guidelines)
